### PR TITLE
WEB-3364, WEB-3365: NestJS migrate topIssues/positions and topIssues/candidatePositions CRUD

### DIFF
--- a/seed/campaigns.ts
+++ b/seed/campaigns.ts
@@ -13,7 +13,6 @@ export default async function seedCampaigns(
   prisma: PrismaClient,
   existingUsers: User[],
 ) {
-  const fakeCampaigns: any[] = []
   const fakeP2Vs: any[] = []
   const fakeUpdateHistory: any[] = []
 
@@ -31,13 +30,14 @@ export default async function seedCampaigns(
         },
       })
     }
-    const campaign = campaignFactory({
-      userId: user.id,
-      slug: buildSlug(getFullName(user)),
+    const campaign = await prisma.campaign.create({
+      data: campaignFactory({
+        userId: user.id,
+        slug: buildSlug(getFullName(user)),
+      }),
     })
 
     campaignIds.push(campaign.id)
-    fakeCampaigns.push(campaign)
     fakeP2Vs.push(pathToVictoryFactory({ campaignId: campaign.id }))
 
     for (let j = 0; j < NUM_UPDATE_HISTORY; j++) {
@@ -50,14 +50,10 @@ export default async function seedCampaigns(
     }
   }
 
-  const { count } = await prisma.campaign.createMany({ data: fakeCampaigns })
-  await prisma.pathToVictory.createMany({
-    data: fakeP2Vs,
-  })
-
+  await prisma.pathToVictory.createMany({ data: fakeP2Vs })
   await prisma.campaignUpdateHistory.createMany({ data: fakeUpdateHistory })
 
-  console.log(`Created ${count} campaigns`)
+  console.log(`Created ${campaignIds.length} campaigns`)
 
   return campaignIds
 }

--- a/seed/factories/campaign.factory.ts
+++ b/seed/factories/campaign.factory.ts
@@ -7,7 +7,6 @@ import { generateFactory } from './generate'
 export const campaignFactory = generateFactory<Campaign>(() => {
   const electionDate = faker.date.past()
   return {
-    id: faker.number.int({ max: 2147483647 }),
     createdAt: new Date(),
     updatedAt: faker.date.anytime(),
     slug: faker.lorem.words(5),

--- a/seed/factories/campaignPosition.factory.ts
+++ b/seed/factories/campaignPosition.factory.ts
@@ -1,14 +1,20 @@
-import { TopIssue, Position, CampaignPosition } from '@prisma/client'
+import { CampaignPosition } from '@prisma/client'
 import { faker } from '@faker-js/faker'
 import { generateFactory } from './generate'
 
-export const campaignPositionFactory = generateFactory<CampaignPosition>((args?: unknown) => {
-  const overrides = (args as Partial<CampaignPosition>) || {};
-  return {
-    id: faker.number.int({ max: 2147483647 }),
-    description: faker.helpers.maybe(() => faker.lorem.sentence(), { probability: 0.7 }),
-    order: faker.helpers.maybe(() => faker.number.int({ min: 1, max: 100 }), { probability: 0.5 }),
-    topIssueId: overrides.topIssueId || null,
-    ...overrides,
-  }
-})
+export const campaignPositionFactory = generateFactory<CampaignPosition>(
+  (args?: unknown) => {
+    const overrides = (args as Partial<CampaignPosition>) || {}
+    return {
+      id: faker.number.int({ max: 2147483647 }),
+      description: faker.helpers.maybe(() => faker.lorem.sentence(), {
+        probability: 0.7,
+      }),
+      order: faker.helpers.maybe(() => faker.number.int({ min: 1, max: 100 }), {
+        probability: 0.5,
+      }),
+      topIssueId: overrides.topIssueId || null,
+      ...overrides,
+    }
+  },
+)

--- a/seed/factories/position.factory.ts
+++ b/seed/factories/position.factory.ts
@@ -1,16 +1,18 @@
-import { TopIssue, Position, CampaignPosition } from '@prisma/client'
+import { Position } from '@prisma/client'
 import { faker } from '@faker-js/faker'
 import { generateFactory } from './generate'
 
-const uniquePositionNames = faker.helpers.uniqueArray(() => faker.lorem.slug(), 20);
+const uniquePositionNames = faker.helpers.uniqueArray(
+  () => faker.lorem.slug(),
+  20,
+)
 
 export const positionFactory = generateFactory<Position>((args?: unknown) => {
-  const overrides = (args as Partial<Position>) || {};
-  
+  const overrides = (args as Partial<Position>) || {}
+
   return {
-    id: faker.number.int({ max: 2147483647 }),
     name: uniquePositionNames.pop() || `fallback-${faker.string.uuid()}`,
     topIssueId: overrides.topIssueId || null,
-    ...overrides, 
+    ...overrides,
   }
 })

--- a/seed/factories/topIssue.factory.ts
+++ b/seed/factories/topIssue.factory.ts
@@ -1,13 +1,17 @@
-import { TopIssue, Position, CampaignPosition } from '@prisma/client'
+import { TopIssue } from '@prisma/client'
 import { faker } from '@faker-js/faker'
 import { generateFactory } from './generate'
 
-const uniqueTopIssueNames = faker.helpers.uniqueArray(() => faker.lorem.slug(), 20);
+const uniqueTopIssueNames = faker.helpers.uniqueArray(
+  () => faker.lorem.slug(),
+  20,
+)
 
 export const topIssueFactory = generateFactory<TopIssue>((overrides = {}) => {
   return {
-    id: faker.number.int({ max: 2147483647 }),
     name: uniqueTopIssueNames.pop() || `fallback-${faker.string.uuid()}`,
-    icon: faker.helpers.maybe(() => faker.image.url(), { probability: 0.5 }) || null,
+    icon:
+      faker.helpers.maybe(() => faker.image.url(), { probability: 0.5 }) ||
+      null,
   }
 })

--- a/seed/topIssues.ts
+++ b/seed/topIssues.ts
@@ -1,31 +1,32 @@
 import { PrismaClient } from '@prisma/client'
-import { campaignFactory } from './factories/campaign.factory'
-import { campaignUpdateHistoryFactory } from './factories/campaignUpdateHistory.factory'
 import { topIssueFactory } from './factories/topIssue.factory'
 import { positionFactory } from './factories/position.factory'
 import { campaignPositionFactory } from './factories/campaignPosition.factory'
 
-export default async function seedTopIssues(prisma: PrismaClient, campaignIds: number[]) {
-  const NUM_TOP_ISSUES = 5;
-  const NUM_POSITIONS_PER_ISSUE = 3;
-  const NUM_CAMPAIGN_POSITIONS_PER_ISSUE = 2;
+export default async function seedTopIssues(
+  prisma: PrismaClient,
+  campaignIds: number[],
+) {
+  const NUM_TOP_ISSUES = 5
+  const NUM_POSITIONS_PER_ISSUE = 3
+  const NUM_CAMPAIGN_POSITIONS_PER_ISSUE = 2
 
   for (let i = 0; i < NUM_TOP_ISSUES; i++) {
     const topIssue = await prisma.topIssue.create({
-      data: topIssueFactory()
-    });
+      data: topIssueFactory(),
+    })
 
     for (let j = 0; j < NUM_POSITIONS_PER_ISSUE; j++) {
       const position = await prisma.position.create({
-        data: positionFactory({ topIssueId: topIssue.id})
-      });
+        data: positionFactory({ topIssueId: topIssue.id }),
+      })
 
       for (let k = 0; k < NUM_CAMPAIGN_POSITIONS_PER_ISSUE; k++) {
         await prisma.campaignPosition.create({
-          data: campaignPositionFactory({ 
+          data: campaignPositionFactory({
             positionId: position.id,
-            topIssueId: topIssue.id, 
-            campaignId: campaignIds[i]
+            topIssueId: topIssue.id,
+            campaignId: campaignIds[i],
           }),
         })
       }

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -4,11 +4,17 @@ import { CampaignsService } from './services/campaigns.service'
 import { CampaignsAiModule } from './ai/campaignsAi.module'
 import { CampaignPlanVersionsService } from './services/campaignPlanVersions.service'
 import { EmailModule } from 'src/email/email.module'
+import { CampaignPositionsController } from './positions/campaignPositions.controller'
+import { CampaignPositionsService } from './positions/campaignPositions.service'
 
 @Module({
   imports: [EmailModule, forwardRef(() => CampaignsAiModule)],
-  controllers: [CampaignsController],
-  providers: [CampaignsService, CampaignPlanVersionsService],
+  controllers: [CampaignsController, CampaignPositionsController],
+  providers: [
+    CampaignsService,
+    CampaignPlanVersionsService,
+    CampaignPositionsService,
+  ],
   exports: [CampaignsService],
 })
 export class CampaignsModule {}

--- a/src/campaigns/guards/CampaignOwnerOrAdmin.guard.ts
+++ b/src/campaigns/guards/CampaignOwnerOrAdmin.guard.ts
@@ -1,11 +1,12 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common'
 import { CampaignsService } from '../services/campaigns.service'
+import { UserRole } from '@prisma/client'
 
 // TODO: I'm not a fan of this. But I've spent way too much time on it for now.
 //  I'd prefer to have a more idiomatic way of composing Guards to accomplish this. But this works for now.
 //  More info: https://github.com/nestjs/nest/issues/873#issue-341260645
 @Injectable()
-export class CampaignOwnersOrAdminGuard implements CanActivate {
+export class CampaignOwnerOrAdminGuard implements CanActivate {
   constructor(private campaignService: CampaignsService) {}
   async canActivate(context: ExecutionContext) {
     const { user, params } = context.switchToHttp().getRequest()
@@ -13,7 +14,6 @@ export class CampaignOwnersOrAdminGuard implements CanActivate {
     const campaign = await this.campaignService.findOne({
       id: parseInt(campaignId),
     })
-    //TODO: This will need to be updated to handle campaign managers as well when we get there
-    return user.id === campaign?.userId || user.roles.includes('admin')
+    return user.id === campaign?.userId || user.roles.includes(UserRole.admin)
   }
 }

--- a/src/campaigns/positions/campaignPositions.controller.ts
+++ b/src/campaigns/positions/campaignPositions.controller.ts
@@ -31,7 +31,7 @@ export class CampaignPositionsController {
 
   @Get()
   findByCampaign(@Param('id', ParseIntPipe) id: number) {
-    return this.campaignPositionsService.findByCampaign(id)
+    return this.campaignPositionsService.findByCampaignId(id)
   }
 
   @Post()

--- a/src/campaigns/positions/campaignPositions.controller.ts
+++ b/src/campaigns/positions/campaignPositions.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Controller,
+  UsePipes,
+  Logger,
+  Get,
+  Post,
+  Put,
+  Param,
+  ParseIntPipe,
+  Delete,
+  Body,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common'
+import { ZodValidationPipe } from 'nestjs-zod'
+import { CampaignPositionsService } from './campaignPositions.service'
+import { CreateCampaignPositionSchema } from './schemas/CreateCampaignPosition.schema'
+import { CampaignOwnerOrAdminGuard } from '../guards/CampaignOwnerOrAdmin.guard'
+import { UpdateCampaignPositionSchema } from './schemas/UpdateCampaignPosition.schema'
+
+@Controller('campaigns/:id/positions')
+@UseGuards(CampaignOwnerOrAdminGuard)
+@UsePipes(ZodValidationPipe)
+export class CampaignPositionsController {
+  private readonly logger = new Logger(CampaignPositionsController.name)
+
+  constructor(
+    private readonly campaignPositionsService: CampaignPositionsService,
+  ) {}
+
+  @Get()
+  findByCampaign(@Param('id', ParseIntPipe) id: number) {
+    return this.campaignPositionsService.findByCampaign(id)
+  }
+
+  @Post()
+  create(@Body() body: CreateCampaignPositionSchema) {
+    return this.campaignPositionsService.create(body)
+  }
+
+  @Put(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() body: UpdateCampaignPositionSchema,
+  ) {
+    return this.campaignPositionsService.update(id, body)
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  delete(@Param('id', ParseIntPipe) id: number) {
+    return this.campaignPositionsService.delete(id)
+  }
+}

--- a/src/campaigns/positions/campaignPositions.service.ts
+++ b/src/campaigns/positions/campaignPositions.service.ts
@@ -8,7 +8,7 @@ export class CampaignPositionsService {
   private readonly logger = new Logger(CampaignPositionsService.name)
   constructor(private prisma: PrismaService) {}
 
-  findByCampaign(campaignId: number) {
+  findByCampaignId(campaignId: number) {
     return this.prisma.campaignPosition.findFirstOrThrow({
       where: {
         campaignId,

--- a/src/campaigns/positions/campaignPositions.service.ts
+++ b/src/campaigns/positions/campaignPositions.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { PrismaService } from 'src/prisma/prisma.service'
+import { CreateCampaignPositionSchema } from './schemas/CreateCampaignPosition.schema'
+import { UpdateCampaignPositionSchema } from './schemas/UpdateCampaignPosition.schema'
+
+@Injectable()
+export class CampaignPositionsService {
+  private readonly logger = new Logger(CampaignPositionsService.name)
+  constructor(private prisma: PrismaService) {}
+
+  findByCampaign(campaignId: number) {
+    return this.prisma.campaignPosition.findFirstOrThrow({
+      where: {
+        campaignId,
+      },
+    })
+  }
+
+  create(data: CreateCampaignPositionSchema) {
+    return this.prisma.campaignPosition.create({ data })
+  }
+
+  update(id: number, { description, order }: UpdateCampaignPositionSchema) {
+    return this.prisma.campaignPosition.update({
+      where: { id },
+      data: {
+        description,
+        order,
+      },
+    })
+  }
+
+  delete(id: number) {
+    return this.prisma.campaignPosition.delete({ where: { id } })
+  }
+}

--- a/src/campaigns/positions/schemas/CreateCampaignPosition.schema.ts
+++ b/src/campaigns/positions/schemas/CreateCampaignPosition.schema.ts
@@ -1,0 +1,14 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+export class CreateCampaignPositionSchema extends createZodDto(
+  z
+    .object({
+      description: z.string(),
+      order: z.number(),
+      campaignId: z.number(),
+      positionId: z.number(),
+      topIssueId: z.number(),
+    })
+    .strict(),
+) {}

--- a/src/campaigns/positions/schemas/UpdateCampaignPosition.schema.ts
+++ b/src/campaigns/positions/schemas/UpdateCampaignPosition.schema.ts
@@ -1,0 +1,11 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+export class UpdateCampaignPositionSchema extends createZodDto(
+  z
+    .object({
+      description: z.string(),
+      order: z.number(),
+    })
+    .strict(),
+) {}

--- a/src/topIssues/positions/positions.controller.ts
+++ b/src/topIssues/positions/positions.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UsePipes,
+} from '@nestjs/common'
+import { ZodValidationPipe } from 'nestjs-zod'
+import { PositionsService } from './positions.service'
+import { CreatePositionSchema } from './schemas/CreatePosition.schema'
+import { UpdatePositionSchema } from './schemas/UpdatePosition.schema'
+
+@Controller('positions')
+@UsePipes(ZodValidationPipe)
+export class PositionsController {
+  private readonly logger = new Logger(PositionsController.name)
+
+  constructor(private readonly positionsService: PositionsService) {}
+
+  @Get()
+  list() {
+    return this.positionsService.findAll()
+  }
+
+  @Post()
+  create(@Body() body: CreatePositionSchema) {
+    return this.positionsService.create(body)
+  }
+
+  @Put(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() body: UpdatePositionSchema,
+  ) {
+    return this.positionsService.update(id, body)
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  delete(@Param('id', ParseIntPipe) id: number) {
+    return this.positionsService.delete(id)
+  }
+}

--- a/src/topIssues/positions/positions.service.ts
+++ b/src/topIssues/positions/positions.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { PrismaService } from 'src/prisma/prisma.service'
+import { CreatePositionSchema } from './schemas/CreatePosition.schema'
+import { UpdatePositionSchema } from './schemas/UpdatePosition.schema'
+
+@Injectable()
+export class PositionsService {
+  private readonly logger = new Logger(PositionsService.name)
+  constructor(private prisma: PrismaService) {}
+
+  async findAll() {
+    const positions = await this.prisma.position.findMany({
+      include: {
+        topIssue: true,
+      },
+      orderBy: { name: 'asc' },
+    })
+
+    return positions.filter((pos) => !!pos.topIssue)
+  }
+
+  create({ name, topIssueId }: CreatePositionSchema) {
+    return this.prisma.position.create({
+      data: {
+        name,
+        topIssueId,
+      },
+    })
+  }
+
+  update(id: number, { name }: UpdatePositionSchema) {
+    return this.prisma.position.update({
+      where: { id },
+      data: {
+        name,
+      },
+    })
+  }
+
+  async delete(id: number) {
+    return this.prisma.position.delete({ where: { id } })
+  }
+}

--- a/src/topIssues/positions/schemas/CreatePosition.schema.ts
+++ b/src/topIssues/positions/schemas/CreatePosition.schema.ts
@@ -1,0 +1,11 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+export class CreatePositionSchema extends createZodDto(
+  z
+    .object({
+      name: z.string(),
+      topIssueId: z.number(),
+    })
+    .strict(),
+) {}

--- a/src/topIssues/positions/schemas/UpdatePosition.schema.ts
+++ b/src/topIssues/positions/schemas/UpdatePosition.schema.ts
@@ -1,0 +1,10 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+export class UpdatePositionSchema extends createZodDto(
+  z
+    .object({
+      name: z.string(),
+    })
+    .strict(),
+) {}

--- a/src/topIssues/schemas/topIssues.schema.ts
+++ b/src/topIssues/schemas/topIssues.schema.ts
@@ -1,16 +1,20 @@
-import { createZodDto } from 'nestjs-zod';
-import { z } from 'zod';
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
 
-export const TopIssueSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  icon: z.string().nullable(),
-}).strict()
+export const TopIssueSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+    icon: z.string().nullable(),
+  })
+  .strict()
 
-export const UpdateTopIssueSchema = TopIssueSchema;
-export const CreateTopIssueSchema = TopIssueSchema.omit({id: true});
-export const CreateTopIssueOutputSchema = TopIssueSchema;
+export const UpdateTopIssueSchema = TopIssueSchema
+export const CreateTopIssueSchema = TopIssueSchema.omit({ id: true })
+export const CreateTopIssueOutputSchema = TopIssueSchema
 
-export class UpdateTopIssueDto extends createZodDto(UpdateTopIssueSchema) {};
-export class CreateTopIssueDto extends createZodDto(CreateTopIssueSchema) {};
-export class TopIssueOutputDto extends createZodDto(CreateTopIssueOutputSchema) {};
+export class UpdateTopIssueDto extends createZodDto(UpdateTopIssueSchema) {}
+export class CreateTopIssueDto extends createZodDto(CreateTopIssueSchema) {}
+export class TopIssueOutputDto extends createZodDto(
+  CreateTopIssueOutputSchema,
+) {}

--- a/src/topIssues/topIssues.controller.ts
+++ b/src/topIssues/topIssues.controller.ts
@@ -1,38 +1,52 @@
-import { BadRequestException, Body, Controller, Delete, Get, HttpCode, Param, ParseIntPipe, Post, Put, UsePipes } from '@nestjs/common';
-import { TopIssuesService } from './topIssues.service';
-import { CreateTopIssueDto, UpdateTopIssueDto } from './schemas/topIssues.schema';
-import { ZodValidationPipe } from 'nestjs-zod';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UsePipes,
+} from '@nestjs/common'
+import { TopIssuesService } from './topIssues.service'
+import {
+  CreateTopIssueDto,
+  UpdateTopIssueDto,
+} from './schemas/topIssues.schema'
+import { ZodValidationPipe } from 'nestjs-zod'
 
 @Controller('top-issues')
 @UsePipes(ZodValidationPipe)
 export class TopIssuesController {
   constructor(private readonly topIssuesService: TopIssuesService) {}
-  
+
   @Get()
   listTopIssues() {
-    return this.topIssuesService.list();
+    return this.topIssuesService.list()
   }
 
   @Post()
   async createTopIssue(@Body() body: CreateTopIssueDto) {
-    return await this.topIssuesService.create(body);
+    return await this.topIssuesService.create(body)
   }
 
   @Put(':id')
   async updateTopIssue(
     @Param('id', ParseIntPipe) id: number,
-    @Body() body: UpdateTopIssueDto
+    @Body() body: UpdateTopIssueDto,
   ) {
     if (id !== body.id) {
-      throw new BadRequestException("ID in URL and body must match.");
+      throw new BadRequestException('ID in URL and body must match.')
     }
-    return await this.topIssuesService.update(id, body);
+    return await this.topIssuesService.update(id, body)
   }
 
   @Delete(':id')
   @HttpCode(204)
   async deleteTopIssue(@Param('id', ParseIntPipe) id: number) {
-    await this.topIssuesService.delete(id);
-
+    await this.topIssuesService.delete(id)
   }
 }

--- a/src/topIssues/topIssues.module.ts
+++ b/src/topIssues/topIssues.module.ts
@@ -1,9 +1,9 @@
-import { Module } from '@nestjs/common';
-import { TopIssuesController } from './topIssues.controller';
-import { TopIssuesService } from './topIssues.service';
+import { Module } from '@nestjs/common'
+import { TopIssuesController } from './topIssues.controller'
+import { TopIssuesService } from './topIssues.service'
 
 @Module({
   controllers: [TopIssuesController],
-  providers: [TopIssuesService]
+  providers: [TopIssuesService],
 })
 export class TopIssuesModule {}

--- a/src/topIssues/topIssues.module.ts
+++ b/src/topIssues/topIssues.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common'
 import { TopIssuesController } from './topIssues.controller'
 import { TopIssuesService } from './topIssues.service'
+import { PositionsController } from './positions/positions.controller'
+import { PositionsService } from './positions/positions.service'
 
 @Module({
-  controllers: [TopIssuesController],
-  providers: [TopIssuesService],
+  controllers: [TopIssuesController, PositionsController],
+  providers: [TopIssuesService, PositionsService],
 })
 export class TopIssuesModule {}

--- a/src/topIssues/topIssues.service.ts
+++ b/src/topIssues/topIssues.service.ts
@@ -1,49 +1,50 @@
-import { BadRequestException, Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
-import { CreateTopIssueDto, TopIssueOutputDto, UpdateTopIssueDto } from './schemas/topIssues.schema';
-import { PrismaService } from 'src/prisma/prisma.service';
-import { TopIssue } from '@prisma/client';
-import { PrismaClientValidationError } from '@prisma/client/runtime/library';
+import { Injectable, Logger } from '@nestjs/common'
+import {
+  CreateTopIssueDto,
+  TopIssueOutputDto,
+  UpdateTopIssueDto,
+} from './schemas/topIssues.schema'
+import { PrismaService } from 'src/prisma/prisma.service'
+import { TopIssue } from '@prisma/client'
 
 @Injectable()
 export class TopIssuesService {
-  private readonly logger = new Logger(TopIssuesService.name);
+  private readonly logger = new Logger(TopIssuesService.name)
   constructor(private prismaService: PrismaService) {}
 
   async create(body: CreateTopIssueDto): Promise<TopIssueOutputDto> {
-    const { name, icon } = body;
+    const { name, icon } = body
     return await this.prismaService.topIssue.create({
       data: {
-        name, 
-        icon
-      }
+        name,
+        icon,
+      },
     })
   }
 
   async update(id: number, body: UpdateTopIssueDto): Promise<TopIssue> {
-    const { name, icon } = body;
-      return await this.prismaService.topIssue.update({
-        where: { id },
-        data: { name, icon }
-      });
+    const { name, icon } = body
+    return await this.prismaService.topIssue.update({
+      where: { id },
+      data: { name, icon },
+    })
   }
 
   async delete(id: number): Promise<void> {
     await this.prismaService.topIssue.delete({
       where: { id },
-    });
+    })
   }
 
   async list(): Promise<TopIssue[]> {
     return await this.prismaService.topIssue.findMany({
-      include: { 
+      include: {
         positions: {
           orderBy: {
             name: 'asc',
-          }
-        }
-      }
-    });
+          },
+        },
+      },
+    })
   }
-
-
 }


### PR DESCRIPTION
Combines 3364 + 3365 since they are related models. (In hindsight, I probably could have done separately since prisma handles cascading deletes nicely already)

Postman Tests: https://goodpartyorg.postman.co/workspace/GP-API~66e2b59d-bf6a-4380-81c2-1cbf2d01bddf/run/38094541-be98a465-04b1-4538-bbb3-09561b5ae490