### PR TITLE
WEB-3435

### DIFF
--- a/src/content/content.controller.ts
+++ b/src/content/content.controller.ts
@@ -193,4 +193,26 @@ export class ContentController {
       tagName: selectedArticleSlugsByTag.tagName,
     }
   }
+
+  @Get('article-tags')
+  async articleTags() {
+    const articleSlugsByTag: ArticleSlugsByTag = (
+      await this.findByType(InferredContentTypes.articleTag)
+    )[0]
+
+    return Object.entries(articleSlugsByTag)
+      .map(([tagSlug, tagObj]) => ({
+        slug: tagSlug,
+        name: tagObj.tagName,
+      }))
+      .sort((a, b) => {
+        if (a.name < b.name) {
+          return -1
+        }
+        if (a.name > b.name) {
+          return 1
+        }
+        return 0
+      })
+  }
 }


### PR DESCRIPTION
Adds the article-tags content GET endpoint. This seems a little unnecessary given the new structure of the InferredContentTypes.articleTags, but it took me very little time to do regardless

https://goodpartyorg.postman.co/workspace/GP-API~66e2b59d-bf6a-4380-81c2-1cbf2d01bddf/run/38601784-1a7ed7cc-1902-49fe-8384-860bd76f74ef

One missing test fail is an on-going off by one error