### PR TITLE
[WEB-3574] extend MunicipalityType for tgp consistency

### DIFF
--- a/prisma/schema/municipality.prisma
+++ b/prisma/schema/municipality.prisma
@@ -3,6 +3,7 @@ enum MunicipalityType {
   village
   town
   township
+  local
 }
 
 model Municipality {


### PR DESCRIPTION
The tgp-api has the following municipality types:

```sql
select distinct("type")
from municipality;
````
yielding:
| type     |
| -------- |
| local    |
| city     |
| township |
| town     |

This PR adds enum value `local` which is currently missing in `gp-api`.