### PR TITLE
WEB-3739 Fix vulnerability, correct findByCampaignId in CampaignPositionsService

### DIFF
--- a/src/campaigns/positions/campaignPositions.controller.ts
+++ b/src/campaigns/positions/campaignPositions.controller.ts
@@ -35,8 +35,14 @@ export class CampaignPositionsController {
   }
 
   @Post()
-  create(@Body() body: CreateCampaignPositionSchema) {
-    return this.campaignPositionsService.create(body)
+  create(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() body: Omit<CreateCampaignPositionSchema, 'campaignId'>,
+  ) {
+    const fullBody: CreateCampaignPositionSchema = { ...body, campaignId: id }
+    // If campaignId is accepted in the body instead, any user can create campaignPositions for any campaign
+    // Thus, we add it into the body from the URL since that ID has already been checked by the CampaignOwnerOrAdminGuard
+    return this.campaignPositionsService.create(fullBody)
   }
 
   @Put(':positionId')

--- a/src/campaigns/positions/campaignPositions.service.ts
+++ b/src/campaigns/positions/campaignPositions.service.ts
@@ -8,9 +8,16 @@ export class CampaignPositionsService extends createPrismaBase(
   MODELS.CampaignPosition,
 ) {
   findByCampaignId(campaignId: number) {
-    return this.findFirstOrThrow({
+    return this.model.findMany({
       where: {
         campaignId,
+      },
+      orderBy: {
+        order: 'asc',
+      },
+      include: {
+        topIssue: true,
+        position: true,
       },
     })
   }


### PR DESCRIPTION
- Fixes a vulnerability where a user could modify **any** campaign's positions
- Changes findByCampaignId in CampaignPositionsService to call findMany in the same way it does in tgp-api (includes, orderBy) instead of findFirstOrThrew. Fixes a lot of bugs due to an object being passed to the frontend instead of an array.
- Dependent on: https://github.com/thegoodparty/gp-webapp/pull/478