### PR TITLE
WEB-3721: updated canddiate map PROD filter to include is_verified

### DIFF
--- a/src/campaigns/map/campaignMap.service.ts
+++ b/src/campaigns/map/campaignMap.service.ts
@@ -75,7 +75,6 @@ export class CampaignMapService {
     ]
 
     const where: Prisma.CampaignWhereInput = {
-      userId: { not: undefined },
       isDemo: false,
       isActive: true,
       AND: combinedAndConditions,

--- a/src/campaigns/map/campaignMap.service.ts
+++ b/src/campaigns/map/campaignMap.service.ts
@@ -47,7 +47,6 @@ export class CampaignMapService {
     ]
 
     const where: Prisma.CampaignWhereInput = {
-      userId: { not: undefined },
       isDemo: false,
       isActive: true,
       AND: combinedAndConditions,

--- a/src/campaigns/util/buildMapFilters.ts
+++ b/src/campaigns/util/buildMapFilters.ts
@@ -107,6 +107,10 @@ export function buildMapFilters(
       'verified_candidates',
     ])
     if (isProdCondition) {
+      isProdCondition.OR.push({
+        isVerified: true,
+      })
+
       andConditions.push(isProdCondition)
     }
   }
@@ -117,7 +121,7 @@ export function buildMapFilters(
 function createJsonOrConditionString(
   filter: string,
   paths: string[] | string[][],
-): Prisma.CampaignWhereInput | null {
+): { OR: Prisma.CampaignWhereInput[] } | null {
   if (!filter) return null
 
   const filterUpper = capitalizeFirstLetter(filter).trim()


### PR DESCRIPTION
- adds an OR to the prod only filter that checks the hubspotUpdates for 'verified_candidates', to also check the `is_verified` field 