### PR TITLE
WEB-3826: Candidate upgraded to pro but was not marked as such in HubSpot

### DIFF
--- a/src/campaigns/services/crmCampaigns.service.ts
+++ b/src/campaigns/services/crmCampaigns.service.ts
@@ -195,6 +195,7 @@ export class CrmCampaignsService {
       } else {
         this.slack.errorMessage({
           message: `Error updating company for ${name} with existing hubspotId: ${hubspotId} in hubspot`,
+          error: e,
         })
       }
       return

--- a/src/payments/stripe/stripeEvents.service.ts
+++ b/src/payments/stripe/stripeEvents.service.ts
@@ -4,7 +4,6 @@ import {
   Injectable,
   InternalServerErrorException,
   Logger,
-  NotImplementedException,
 } from '@nestjs/common'
 import { StripeSingleton } from './stripe.service'
 import { WebhookEventType } from '../payments.types'
@@ -62,7 +61,7 @@ export class StripeEventsService {
       case WebhookEventType.CustomerSubscriptionResumed:
         return await this.customerSubscriptionResumedHandler(event)
     }
-    throw new NotImplementedException('event type not supported')
+    this.logger.warn(`Stripe Event type ${event.type} not handled`)
   }
 
   async customerSubscriptionResumedHandler(


### PR DESCRIPTION
- don't throw HTTP error for ignored stripe webhook events
- added error object to hubspot error slack message 
 