### PR TITLE
WEB-3846 ecanvasser-sync

### DIFF
--- a/src/ecanvasser/ecanvasser.controller.ts
+++ b/src/ecanvasser/ecanvasser.controller.ts
@@ -62,10 +62,14 @@ export class EcanvasserController {
     return this.ecanvasserService.remove(campaignId)
   }
 
-  @Post(':campaignId/sync')
-  @Roles('admin')
-  sync(@Param('campaignId', ParseIntPipe) campaignId: number) {
-    return this.ecanvasserService.sync(campaignId)
+  @Post(':id/sync')
+  @UseGuards(CampaignOwnerOrAdminGuard)
+  sync(
+    @Param('id', ParseIntPipe) campaignId: number,
+    @Body() body: { force?: boolean },
+  ) {
+    const force = body.force === true
+    return this.ecanvasserService.sync(campaignId, force)
   }
 
   @Get('list')

--- a/src/ecanvasser/ecanvasser.service.ts
+++ b/src/ecanvasser/ecanvasser.service.ts
@@ -288,12 +288,11 @@ export class EcanvasserService extends createPrismaBase(MODELS.Ecanvasser) {
     if (!ecanvasser) {
       throw new NotFoundException('Ecanvasser integration not found')
     }
-
     // Check if we should sync based on last sync time
     if (!force && ecanvasser.lastSync) {
       const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000)
       const lastSyncDate = new Date(ecanvasser.lastSync)
-      if (lastSyncDate < thirtyMinutesAgo) {
+      if (lastSyncDate > thirtyMinutesAgo) {
         return ecanvasser // Return existing data if last sync was less than 30 minutes ago
       }
     }

--- a/src/ecanvasser/ecanvasser.types.ts
+++ b/src/ecanvasser/ecanvasser.types.ts
@@ -139,6 +139,7 @@ export interface EcanvasserSummaryResponse {
     [key: string]: number
   }
   interactionsByDay: InteractionsByDay
+  lastSync: Date | null
 }
 
 export interface PaginationParams {


### PR DESCRIPTION
Logic:
sync without force will only sync if the lastSync was 30 minutes ago or more.
Sync with force=true will sync ecanvasser 

this allows us to sync the data when the user with ecanvasser visits the dashboard so they see fresh data and also allow the user to force sync their data.