### PR TITLE
Fix: slugify filenames instead of uri encoding for S3 uploads

### DIFF
--- a/src/aws/aws.service.ts
+++ b/src/aws/aws.service.ts
@@ -8,6 +8,7 @@ import {
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { Upload } from '@aws-sdk/lib-storage'
 import { ASSET_DOMAIN } from 'src/shared/util/appEnvironment.util'
+import slugify from 'slugify'
 
 export type UploadOptions = {
   cacheControl?: string // Cache-Control header value
@@ -48,7 +49,10 @@ export class AwsService {
     fileType: string,
     options?: UploadOptions,
   ) {
-    const filePath = `${bucket}/${encodeURIComponent(fileName)}`
+    const filePath = `${bucket}/${slugify(fileName, {
+      lower: true,
+      trim: true,
+    })}`
 
     try {
       const upload = new Upload({


### PR DESCRIPTION
- issue seems to be with S3 double encoding URI encoded characters, so we request a file with `%20` in the name, but the actual encoded value S3 expects is `%2520`. 
- Files without any spaces have been working correctly. Updated to just slugify the filename to make them consistent and avoid this 