### PR TITLE
WEB-3900: admin hub spot campaign not capturing manually entered election date

### DIFF
--- a/src/campaigns/campaigns.controller.ts
+++ b/src/campaigns/campaigns.controller.ts
@@ -179,7 +179,6 @@ export class CampaignsController {
     @ReqCampaign() campaign: Campaign,
     @Body() { slug, ...body }: UpdateCampaignSchema,
   ) {
-    this.logger.debug('Updating campaign', campaign, { slug, body })
     if (
       typeof slug === 'string' &&
       campaign?.slug !== slug &&
@@ -190,6 +189,8 @@ export class CampaignsController {
         where: { slug },
       })
     } else if (!campaign) throw new NotFoundException('Campaign not found')
+
+    this.logger.debug('Updating campaign', campaign, { slug, body })
 
     return this.campaigns.updateJsonFields(campaign.id, body)
   }

--- a/src/campaigns/services/campaigns.service.ts
+++ b/src/campaigns/services/campaigns.service.ts
@@ -118,10 +118,6 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
 
       if (!campaign) return false
 
-      // Track campaign and user
-      this.crm.trackCampaign(campaign.id)
-      campaign.userId && this.usersService.trackUserById(campaign.userId)
-
       // Handle data and details JSON fields
       const campaignUpdateData: Prisma.CampaignUpdateInput = {}
       if (data) {
@@ -183,6 +179,10 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
           })
         }
       }
+
+      // Track campaign and user
+      this.crm.trackCampaign(campaign.id)
+      campaign.userId && this.usersService.trackUserById(campaign.userId)
 
       // Return the updated campaign with pathToVictory included
       return tx.campaign.findFirst({

--- a/src/campaigns/services/crmCampaigns.service.ts
+++ b/src/campaigns/services/crmCampaigns.service.ts
@@ -171,14 +171,9 @@ export class CrmCampaignsService {
           message: `Could not find hubspot company for ${name} with hubspotId ${hubspotId}`,
           error: e,
         })
-        const campaign = await this.campaigns.findFirst({
-          where: {
-            data: {
-              path: ['hubspotId'],
-              equals: hubspotId,
-            },
-          },
-        })
+
+        const campaign = await this.campaigns.findByHubspotId(hubspotId)
+
         campaign &&
           (await this.campaigns.updateJsonFields(campaign.id, {
             data: {

--- a/src/campaigns/services/crmCampaigns.service.ts
+++ b/src/campaigns/services/crmCampaigns.service.ts
@@ -331,6 +331,7 @@ export class CrmCampaignsService {
       candidate_state: longState,
       state: longState,
       city: city ?? undefined,
+      zip: zip ?? undefined,
       created_by_admin:
         createdBy === CampaignCreatedBy.ADMIN
           ? HubSpot.CreatedByAdmin.YES
@@ -345,8 +346,8 @@ export class CrmCampaignsService {
       running: runForOffice ? HubSpot.Running.YES : HubSpot.Running.NO,
 
       // election details
-      br_position_id: campaignDetails?.positionId,
-      br_race_id: campaignDetails?.raceId,
+      br_position_id: campaignDetails?.positionId ?? undefined,
+      br_race_id: campaignDetails?.raceId ?? undefined,
       election_date: electionDateMs,
       filing_deadline: filingEndMs, // TODO: is this different than filing_end?
       filing_start: filingStartMs,
@@ -355,7 +356,7 @@ export class CrmCampaignsService {
 
       // usage details
       last_portal_visit: lastPortalVisit,
-      last_step: isActive ? OnboardingStep.complete : currentStep,
+      last_step: isActive ? OnboardingStep.complete : String(currentStep ?? ''),
       last_step_date: lastStepDateMs,
       campaign_assistant_chats: aiChatCount,
       my_content_pieces_created: aiContent ? Object.keys(aiContent).length : 0,

--- a/src/crm/crm.types.ts
+++ b/src/crm/crm.types.ts
@@ -157,6 +157,7 @@ export namespace HubSpot {
     candidate_state = 'candidate_state',
     state = 'state',
     city = 'city',
+    zip = 'zip',
     created_by_admin = 'created_by_admin',
     admin_user = 'admin_user',
     pledge_status = 'pledge_status',

--- a/src/crm/schemas/CRMCompanyProperties.schema.ts
+++ b/src/crm/schemas/CRMCompanyProperties.schema.ts
@@ -32,6 +32,7 @@ export const CRMCompanyPropertiesSchema = z
     [HS_PROPS.candidate_state]: z.string(),
     [HS_PROPS.state]: z.string(),
     [HS_PROPS.city]: z.string(),
+    [HS_PROPS.zip]: z.string(),
     [HS_PROPS.created_by_admin]: yesNoSchema,
     [HS_PROPS.admin_user]: z.string().email(),
     [HS_PROPS.pledge_status]: yesNoSchema,
@@ -46,7 +47,7 @@ export const CRMCompanyPropertiesSchema = z
     // election details
     [HS_PROPS.br_position_id]: z.string(),
     [HS_PROPS.br_race_id]: z.string(),
-    [HS_PROPS.election_date]: timestampSchema,
+    [HS_PROPS.election_date]: z.string().date(),
     [HS_PROPS.filing_deadline]: timestampSchema,
     [HS_PROPS.filing_start]: timestampSchema,
     [HS_PROPS.filing_end]: timestampSchema,


### PR DESCRIPTION
- hubspot update was getting sent before campaign json updates were completed, so selecting a custom office was not getting the election date to HS
- added zip to HS sync
- Fixed some validation issues for the hubspot sync