### PR TITLE
WEB-3853 - P2V Voter Turnout Bug Fixes

### DIFF
--- a/src/voters/services/voters.service.ts
+++ b/src/voters/services/voters.service.ts
@@ -120,7 +120,8 @@ export class VotersService {
     }
 
     const foundColumns: VoterHistoryColumn[] = []
-    if (electionDates && electionDates.length > 0) {
+    if (electionDates && electionDates.length >= 3) {
+      // If we have less than 3, we won't get accurate turnout counts
       for (let y = 0; y < electionDates.length; y++) {
         // if we know the prior election Dates we use those,
         const columnResults = this.determineHistoryColumn(
@@ -128,7 +129,6 @@ export class VotersService {
           electionState,
           electionTerm * (y + 1),
           columns,
-          partisanRace,
           electionDates[y],
         )
         this.logger.debug('columnResults', columnResults)
@@ -144,7 +144,6 @@ export class VotersService {
           electionState,
           electionTerm * (y + 1),
           columns,
-          partisanRace,
           undefined,
         )
         this.logger.debug('columnResults', columnResults)
@@ -179,7 +178,7 @@ export class VotersService {
 
     // update counts with the average and projected turnouts.
     counts = this.getProjectedTurnout(counts, turnoutCounts)
-    // this.logger.debug('counts', counts);
+    this.logger.debug('counts', counts)
 
     return counts
   }
@@ -497,29 +496,11 @@ export class VotersService {
   }
 
   private getTurnoutDates(electionDate: string, yearOffset: number) {
-    // otherwise we have to guess on the prior election dates.
+    // Per Jared we only need specificity down to the month and day
+    // If necessary, we can later change this to calculate the date based on the law (ex: 2nd Tuesday after the first Sunday of August)
     const turnoutDateObj = new Date(electionDate)
     turnoutDateObj.setFullYear(turnoutDateObj.getFullYear() - yearOffset)
-    const turnoutDates: string[] = []
-    turnoutDates.push(
-      turnoutDateObj.toISOString().slice(0, 10).replace(/-/g, ''),
-    )
-
-    // get 3 calendar days before and after the turnoutDateObj
-    // and add them to turnOutDates array.
-    for (let i = 1; i < 4; i++) {
-      const turnoutDateObjBefore = new Date(turnoutDateObj)
-      const turnoutDateObjAfter = new Date(turnoutDateObj)
-      turnoutDateObjBefore.setDate(turnoutDateObjBefore.getDate() - i)
-      turnoutDateObjAfter.setDate(turnoutDateObjAfter.getDate() + i)
-      turnoutDates.push(
-        turnoutDateObjBefore.toISOString().slice(0, 10).replace(/-/g, ''),
-      )
-      turnoutDates.push(
-        turnoutDateObjAfter.toISOString().slice(0, 10).replace(/-/g, ''),
-      )
-    }
-    return turnoutDates
+    return turnoutDateObj.toISOString().slice(0, 7).replace(/-/g, '')
   }
 
   private determineHistoryColumn(
@@ -527,35 +508,25 @@ export class VotersService {
     electionState: string,
     yearOffset: number,
     columns: L2Column[],
-    partisanRace: boolean,
     priorElectionDate?: string,
   ): VoterHistoryColumn | undefined {
     const turnoutDateObj = new Date(electionDate)
     turnoutDateObj.setFullYear(turnoutDateObj.getFullYear() - yearOffset)
-    if (partisanRace) {
-      // partisan races are easy we use the General Election
-      const adjustedYear = turnoutDateObj.getFullYear()
-      const electionYear = `EG_${adjustedYear}`
-      return {
-        column: electionYear,
-        type: 'General Election',
-      }
-    }
 
-    let turnoutDates: string[] = []
+    let turnoutDate: string
     if (priorElectionDate) {
       // we know the exact election date so we do not have to guess.
       const priorElectionDateObj = new Date(priorElectionDate)
-      turnoutDates.push(
-        priorElectionDateObj.toISOString().slice(0, 10).replace(/-/g, ''),
-      )
+      turnoutDate = priorElectionDateObj
+        .toISOString()
+        .slice(0, 7)
+        .replace(/-/g, '')
     } else {
-      turnoutDates = this.getTurnoutDates(electionDate, yearOffset)
+      turnoutDate = this.getTurnoutDates(electionDate, yearOffset)
     }
 
     let yearColumn: string | undefined
     let yearColumnType: string | undefined
-    let yearIndex: number | undefined
     let dateKey: string | undefined
 
     for (const column of columns) {
@@ -571,6 +542,7 @@ export class VotersService {
             const electionSplit = electionKey.split('_')
             const electionKeyType = electionSplit[0]
             const electionKeyDate = electionSplit[1]
+            const electionKeyYearAndMonth = electionKeyDate.slice(0, 6)
             // we skip primaries and runoffs.
             if (
               electionKeyType === 'EP' ||
@@ -580,21 +552,10 @@ export class VotersService {
             ) {
               continue
             }
-            for (let x = 0; x < turnoutDates.length; x++) {
-              const turnoutDate = turnoutDates[x]
-              // if using turnoutDates (not electionDates)
-              // there is no way to know the exact date of the election,
-              // we prioritize elections that are closer to the electionDate
-              if (turnoutDate === electionKeyDate) {
-                if (!yearIndex || x < yearIndex) {
-                  yearColumn = column.id
-                  yearIndex = x
-                  dateKey = electionKeyDate
-                  yearColumnType =
-                    this.getElectionClassification(electionKeyType)
-                  break
-                }
-              }
+            if (turnoutDate === electionKeyYearAndMonth) {
+              yearColumn = column.id
+              dateKey = electionKeyDate
+              yearColumnType = this.getElectionClassification(electionKeyType)
             }
           }
         }


### PR DESCRIPTION
Fix several bugs relating to voter turnout
1) Searches for past elections by only month and year, instead of trying to guess the specific day (change approved by Jared)
2) Only uses prior election dates if there's at least 3 found

- Not a confirmed bug, but also removes looking at just general elections for partisan races, per Jared
![image](https://github.com/user-attachments/assets/b0dfdba8-599c-4a20-8356-a1913bbf01bb)
