### PR TITLE
WEB-3990 - Allow Codebuild's SG to access RDS for running migrations

### DIFF
--- a/deploy/sst.config.ts
+++ b/deploy/sst.config.ts
@@ -322,6 +322,13 @@ export default $config({
           toPort: 5432,
           cidrBlocks: [vpcCidr],
         },
+        // Allow access from Codebuild's security group
+        {
+          protocol: 'tcp',
+          fromPort: 5432,
+          toPort: 5432,
+          securityGroups: ['sg-01de8d67b0f0ec787'], // Codebuild SG ID
+        },
       ],
       egress: [
         {


### PR DESCRIPTION
This should fix the failing dev deployments. My guess is this might have been done manually in AWS and the rule got changed. Now it'll be handled in code so we can avoid manual rule monitoring