### PR TITLE
Web 3997 - Fix Crashes from prisma errors being uncaught

### DIFF
--- a/src/users/services/sessions.service.ts
+++ b/src/users/services/sessions.service.ts
@@ -5,10 +5,10 @@ import { UsersService } from 'src/users/services/users.service'
 const SESSION_TIMEOUT = 1000 * 60 * 30 // 30 minutes (fullstory's inactivity timeout)
 
 export class SessionsService {
+  private readonly logger = new Logger(SessionsService.name)
   constructor(
     @Inject(forwardRef(() => UsersService))
     private readonly users: UsersService,
-    private readonly logger: Logger,
   ) {}
 
   async trackSession(user: User) {

--- a/src/users/services/sessions.service.ts
+++ b/src/users/services/sessions.service.ts
@@ -1,4 +1,4 @@
-import { Inject, forwardRef } from '@nestjs/common'
+import { Inject, forwardRef, Logger } from '@nestjs/common'
 import { User } from '@prisma/client'
 import { UsersService } from 'src/users/services/users.service'
 
@@ -8,30 +8,40 @@ export class SessionsService {
   constructor(
     @Inject(forwardRef(() => UsersService))
     private readonly users: UsersService,
+    private readonly logger: Logger,
   ) {}
 
   async trackSession(user: User) {
-    const currentTime = Date.now()
+    // We try catch to prevent crashes since trackSession isn't await'd when called
+    try {
+      const currentTime = Date.now()
 
-    // Get current metadata
-    const currentMetaData = user.metaData || {}
-    const lastVisited = currentMetaData.lastVisited || 0
-    const sessionCount = currentMetaData.sessionCount || 0
+      // Get current metadata
+      const currentMetaData = user.metaData || {}
+      const lastVisited = currentMetaData.lastVisited || 0
+      const sessionCount = currentMetaData.sessionCount || 0
 
-    // Check if this is a new session
-    const isNewSession = lastVisited + SESSION_TIMEOUT < currentTime // Time-based check
+      // Check if this is a new session
+      const isNewSession = lastVisited + SESSION_TIMEOUT < currentTime // Time-based check
 
-    if (isNewSession) {
-      // Update user metadata with new session info
-      await this.users.patchUserMetaData(user.id, {
-        lastVisited: currentTime,
-        sessionCount: sessionCount + 1,
-      })
-    } else {
-      // Just update last visited time
-      await this.users.patchUserMetaData(user.id, {
-        lastVisited: currentTime,
-      })
+      if (isNewSession) {
+        // Update user metadata with new session info
+        await this.users.patchUserMetaData(user.id, {
+          lastVisited: currentTime,
+          sessionCount: sessionCount + 1,
+        })
+      } else {
+        // Just update last visited time
+        await this.users.patchUserMetaData(user.id, {
+          lastVisited: currentTime,
+        })
+      }
+    } catch (err) {
+      if (err instanceof Error) {
+        this.logger.warn(
+          `Failed to track session for user ${user?.id}: ${err.message}`,
+        )
+      }
     }
   }
 }

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -156,6 +156,13 @@ export class UsersService extends createPrismaBase(MODELS.User) {
     newMetaData: PrismaJson.UserMetaData,
   ) {
     const currentUser = await this.findUser({ id: userId })
+    if (!currentUser) {
+      this.logger.warn(
+        `User with id ${userId} not found. Skipping metadata update`,
+      )
+      return null
+    }
+
     const currentMetaData = currentUser?.metaData
     return this.updateUser(
       {


### PR DESCRIPTION
Dustin has been getting 503's on dev. 

This is because the server kept crashing due to uncaught Prisma errors - the trackSession call  to updateUserMetaData was trying to update a user that doesn't exist yet. The error is uncaught because the call to trackSession isn't await'd, it's fire and forget, so the error is thrown outside the HTTP request context. 

This fixes the bug by:
1) Try catching the content of trackSession since it isn't await'd
2) Adding a check in updateUserMetaData to make sure the user exists