### PR TITLE
WEB-3995: update ai content template data / api response

### DIFF
--- a/src/campaigns/tasks/campaignTasks.types.ts
+++ b/src/campaigns/tasks/campaignTasks.types.ts
@@ -26,6 +26,7 @@ export type CampaignTask = {
   proRequired?: boolean
   /** Number of days before election, after which the task is no longer available */
   deadline?: number
-  /** Whether to skip counting voter contacts for this task */
-  skipVoterCount?: boolean
+
+  /** CMS ID of the default AI template to use for the task */
+  defaultAiTemplateId?: string
 }

--- a/src/campaigns/tasks/fixtures/tasks-week-1.ts
+++ b/src/campaigns/tasks/fixtures/tasks-week-1.ts
@@ -10,6 +10,7 @@ const tasksWeek1: CampaignTask[] = [
     flowType: CampaignTaskType.text,
     deadline: 3,
     proRequired: true,
+    defaultAiTemplateId: '5b6W9pYlX796TBI2HV7HlQ',
   },
   {
     id: '5fc21abd-2792-4c09-96f1-de94a28b2b3c',
@@ -20,6 +21,7 @@ const tasksWeek1: CampaignTask[] = [
     flowType: CampaignTaskType.robocall,
     deadline: 3,
     proRequired: true,
+    defaultAiTemplateId: '2GMO6bQoQermNhdRmRe1fh',
   },
   {
     id: '83cb4a9e-ae02-4c30-a0d9-27b9672ce556',
@@ -29,6 +31,7 @@ const tasksWeek1: CampaignTask[] = [
     week: 1,
     flowType: CampaignTaskType.doorKnocking,
     proRequired: true,
+    defaultAiTemplateId: '2p3mztAVPhuDHOYJetmdWJ',
   },
   {
     id: 'cf0b27bc-fd6b-48f1-8ce0-e69e3b0c16d5',
@@ -39,6 +42,7 @@ const tasksWeek1: CampaignTask[] = [
     flowType: CampaignTaskType.phoneBanking,
     deadline: 14,
     proRequired: true,
+    defaultAiTemplateId: '1HcpEmwIcXMCSW26ilxQP7',
   },
   {
     id: '1a9fcb0d-ce37-46a0-87e2-3e8c8bdcca5d',
@@ -47,6 +51,7 @@ const tasksWeek1: CampaignTask[] = [
     cta: 'Write Post',
     week: 1,
     flowType: CampaignTaskType.socialMedia,
+    defaultAiTemplateId: 'GpWsRql46Nif2wYroxj81',
   },
   {
     id: '62efdb34-5865-4c2d-85a0-c71d7650a8a7',

--- a/src/campaigns/tasks/fixtures/tasks-week-2.ts
+++ b/src/campaigns/tasks/fixtures/tasks-week-2.ts
@@ -9,6 +9,7 @@ const tasksWeek2: CampaignTask[] = [
     week: 2,
     flowType: CampaignTaskType.text,
     proRequired: true,
+    defaultAiTemplateId: '5NbCRs4cIhti8pxnI8IM0P',
   },
   {
     id: 'a5f07d6c-8e3d-49e2-b131-92103c2be07e',
@@ -18,6 +19,7 @@ const tasksWeek2: CampaignTask[] = [
     week: 2,
     flowType: CampaignTaskType.robocall,
     proRequired: true,
+    defaultAiTemplateId: '6ZH4tMYcZNXshFOcLtjMJB',
   },
   {
     id: 'd92e5b8c-7ac0-4e1a-9b87-562f5824dfe9',
@@ -27,6 +29,7 @@ const tasksWeek2: CampaignTask[] = [
     week: 2,
     flowType: CampaignTaskType.doorKnocking,
     proRequired: true,
+    defaultAiTemplateId: '2p3mztAVPhuDHOYJetmdWJ',
   },
   {
     id: 'b41c6e7f-29e8-438d-89d3-6ed28742c4a5',
@@ -36,6 +39,7 @@ const tasksWeek2: CampaignTask[] = [
     week: 2,
     flowType: CampaignTaskType.phoneBanking,
     proRequired: true,
+    defaultAiTemplateId: '1HcpEmwIcXMCSW26ilxQP7',
   },
   {
     id: 'e718329f-8b47-4e18-9f3b-8c7dfa96021c',
@@ -45,6 +49,7 @@ const tasksWeek2: CampaignTask[] = [
     cta: 'Write Post',
     week: 2,
     flowType: CampaignTaskType.socialMedia,
+    defaultAiTemplateId: '2X5rPGVz0sneUZ06w0ezcl',
   },
   {
     id: '17a6ceb8-5f9d-4e83-80c7-2f8e41736104',

--- a/src/campaigns/tasks/fixtures/tasks-week-3.ts
+++ b/src/campaigns/tasks/fixtures/tasks-week-3.ts
@@ -9,6 +9,7 @@ const tasksWeek3: CampaignTask[] = [
     week: 3,
     flowType: CampaignTaskType.doorKnocking,
     proRequired: true,
+    defaultAiTemplateId: 'wgbnDDTxrf8OrresVE1HU',
   },
   {
     id: '4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a',
@@ -18,6 +19,7 @@ const tasksWeek3: CampaignTask[] = [
     week: 3,
     flowType: CampaignTaskType.phoneBanking,
     proRequired: true,
+    defaultAiTemplateId: '5N93cglp3cvq62EIwu1IOa',
   },
   {
     id: 'b0c1d2e3-f4a5-6b7c-8d9e-0f1a2b3c4d5e',
@@ -26,6 +28,7 @@ const tasksWeek3: CampaignTask[] = [
     cta: 'Write Post',
     week: 3,
     flowType: CampaignTaskType.socialMedia,
+    defaultAiTemplateId: 'Xboqgh6Ye3SgSwO6moujw',
   },
 ]
 

--- a/src/campaigns/tasks/fixtures/tasks-week-4.ts
+++ b/src/campaigns/tasks/fixtures/tasks-week-4.ts
@@ -9,6 +9,7 @@ const tasksWeek4: CampaignTask[] = [
     week: 4,
     flowType: CampaignTaskType.text,
     proRequired: true,
+    defaultAiTemplateId: '6Adu3kct9uvZ0YNCXLPUvd',
   },
   {
     id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
@@ -18,6 +19,7 @@ const tasksWeek4: CampaignTask[] = [
     week: 4,
     flowType: CampaignTaskType.robocall,
     proRequired: true,
+    defaultAiTemplateId: '452l4TPYpWdQZYxHHJsdUb',
   },
   {
     id: 'd1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a',
@@ -27,6 +29,7 @@ const tasksWeek4: CampaignTask[] = [
     week: 4,
     flowType: CampaignTaskType.doorKnocking,
     proRequired: true,
+    defaultAiTemplateId: 'wgbnDDTxrf8OrresVE1HU',
   },
   {
     id: 'd4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a',
@@ -36,6 +39,7 @@ const tasksWeek4: CampaignTask[] = [
     week: 4,
     flowType: CampaignTaskType.phoneBanking,
     proRequired: true,
+    defaultAiTemplateId: '5N93cglp3cvq62EIwu1IOa',
   },
   {
     id: '4b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e',
@@ -44,6 +48,7 @@ const tasksWeek4: CampaignTask[] = [
     cta: 'Write Post',
     week: 4,
     flowType: CampaignTaskType.socialMedia,
+    defaultAiTemplateId: 'Xboqgh6Ye3SgSwO6moujw',
   },
   {
     id: '4c5d6e7f-8g9h-0i1j-2k3l-4m5n6o7p8q9r',
@@ -53,7 +58,6 @@ const tasksWeek4: CampaignTask[] = [
     cta: 'Learn More',
     week: 4,
     flowType: CampaignTaskType.education,
-    skipVoterCount: true,
     link: 'https://goodparty.org/blog/article/turning-support-into-victory-vote-phase-of-a-political-campaign',
   },
 ]

--- a/src/campaigns/tasks/fixtures/tasks-week-5.ts
+++ b/src/campaigns/tasks/fixtures/tasks-week-5.ts
@@ -9,6 +9,7 @@ const tasksWeek5: CampaignTask[] = [
     week: 5,
     flowType: CampaignTaskType.doorKnocking,
     proRequired: true,
+    defaultAiTemplateId: 'wgbnDDTxrf8OrresVE1HU',
   },
   {
     id: '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d',
@@ -18,6 +19,7 @@ const tasksWeek5: CampaignTask[] = [
     week: 5,
     flowType: CampaignTaskType.phoneBanking,
     proRequired: true,
+    defaultAiTemplateId: '5N93cglp3cvq62EIwu1IOa',
   },
   {
     id: '7e8f9a0b-1c2d-3e4f-5a6b-7c8d9e0f1a2b',
@@ -26,6 +28,7 @@ const tasksWeek5: CampaignTask[] = [
     cta: 'Write Post',
     week: 5,
     flowType: CampaignTaskType.socialMedia,
+    defaultAiTemplateId: 'Xboqgh6Ye3SgSwO6moujw',
   },
   {
     id: '3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f',

--- a/src/campaigns/tasks/fixtures/tasks-week-6.ts
+++ b/src/campaigns/tasks/fixtures/tasks-week-6.ts
@@ -9,6 +9,7 @@ const tasksWeek6: CampaignTask[] = [
     week: 6,
     flowType: CampaignTaskType.doorKnocking,
     proRequired: true,
+    defaultAiTemplateId: 'wgbnDDTxrf8OrresVE1HU',
   },
   {
     id: '5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b',
@@ -18,6 +19,7 @@ const tasksWeek6: CampaignTask[] = [
     week: 6,
     flowType: CampaignTaskType.phoneBanking,
     proRequired: true,
+    defaultAiTemplateId: '5N93cglp3cvq62EIwu1IOa',
   },
   {
     id: '1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f',
@@ -26,6 +28,7 @@ const tasksWeek6: CampaignTask[] = [
     cta: 'Write Post',
     week: 6,
     flowType: CampaignTaskType.socialMedia,
+    defaultAiTemplateId: '3nr6D5fpYfIfywijoE1ITH',
   },
   {
     id: '6d7e8f9a-0b1c-2d3e-4f5g-6h7i8j9k0l1m',

--- a/src/campaigns/tasks/fixtures/tasks-week-7.ts
+++ b/src/campaigns/tasks/fixtures/tasks-week-7.ts
@@ -9,6 +9,7 @@ const tasksWeek7: CampaignTask[] = [
     week: 7,
     flowType: CampaignTaskType.doorKnocking,
     proRequired: true,
+    defaultAiTemplateId: '5jrvZCd28PMH4ipYl9DzTB',
   },
   {
     id: '7b8c9d0e-1f2g-3h4i-5j6k-7l8m9n0o1p2q',
@@ -18,6 +19,7 @@ const tasksWeek7: CampaignTask[] = [
     week: 7,
     flowType: CampaignTaskType.phoneBanking,
     proRequired: true,
+    defaultAiTemplateId: '2QCSobc5r6R7gO5hb0i8Ho',
   },
   {
     id: '7c8d9e0f-1g2h-3i4j-5k6l-7m8n9o0p1q2r',
@@ -27,6 +29,7 @@ const tasksWeek7: CampaignTask[] = [
     cta: 'Write Post',
     week: 7,
     flowType: CampaignTaskType.socialMedia,
+    defaultAiTemplateId: 'NogRPt7eIxTU3ZEIw87LA',
   },
 ]
 

--- a/src/campaigns/tasks/fixtures/tasks-week-8.ts
+++ b/src/campaigns/tasks/fixtures/tasks-week-8.ts
@@ -9,6 +9,7 @@ const tasksWeek8: CampaignTask[] = [
     week: 8,
     flowType: CampaignTaskType.doorKnocking,
     proRequired: true,
+    defaultAiTemplateId: '5jrvZCd28PMH4ipYl9DzTB',
   },
   {
     id: '7c8d9e0f-1a2b-3c4d-5e6f-7a8b9c0d1e2f',
@@ -18,6 +19,7 @@ const tasksWeek8: CampaignTask[] = [
     week: 8,
     flowType: CampaignTaskType.phoneBanking,
     proRequired: true,
+    defaultAiTemplateId: '2QCSobc5r6R7gO5hb0i8Ho',
   },
   {
     id: '3a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d',
@@ -27,6 +29,7 @@ const tasksWeek8: CampaignTask[] = [
     cta: 'Write Post',
     week: 8,
     flowType: CampaignTaskType.socialMedia,
+    defaultAiTemplateId: 'NogRPt7eIxTU3ZEIw87LA',
   },
   {
     id: '9e0f1a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b',
@@ -46,7 +49,6 @@ const tasksWeek8: CampaignTask[] = [
     cta: 'Learn More',
     week: 8,
     flowType: CampaignTaskType.education,
-    skipVoterCount: true,
     link: 'https://goodparty.org/blog/article/engaging-voters-contact-phase-of-a-political-campaign',
   },
 ]

--- a/src/campaigns/tasks/fixtures/tasks-week-9.ts
+++ b/src/campaigns/tasks/fixtures/tasks-week-9.ts
@@ -8,7 +8,6 @@ const tasksWeek9: CampaignTask[] = [
     cta: 'Profile',
     week: 9,
     flowType: CampaignTaskType.education,
-    skipVoterCount: true,
     link: '/dashboard/campaign-details',
   },
   {
@@ -18,7 +17,6 @@ const tasksWeek9: CampaignTask[] = [
     cta: 'Join',
     week: 9,
     flowType: CampaignTaskType.education,
-    skipVoterCount: true,
     link: 'https://goodpartyorg.circle.so/join?invitation_token=cf9d15f0fb50e79770bc6f740406f63580acf703-5834c6b1-be0e-455f-bb7c-5cbc8049fa76',
   },
   {
@@ -28,7 +26,6 @@ const tasksWeek9: CampaignTask[] = [
     cta: 'Take the course',
     week: 9,
     flowType: CampaignTaskType.education,
-    skipVoterCount: true,
     link: 'https://goodpartyorg.circle.so/join?invitation_token=69acce7e89a1064e0fb78bb263ae0630a9d49569-fbb6cc8c-076e-44e6-a359-c0e95ec6d0a5',
   },
   {
@@ -38,7 +35,6 @@ const tasksWeek9: CampaignTask[] = [
     cta: 'Learn more',
     week: 9,
     flowType: CampaignTaskType.education,
-    skipVoterCount: true,
     link: 'https://goodparty.org/blog/article/how-to-win-local-election',
   },
   {
@@ -49,7 +45,6 @@ const tasksWeek9: CampaignTask[] = [
     cta: 'Learn more',
     week: 9,
     flowType: CampaignTaskType.education,
-    skipVoterCount: true,
     link: 'https://goodparty.org/blog/article/how-to-build-campaign-platform-independent',
   },
   {
@@ -60,7 +55,6 @@ const tasksWeek9: CampaignTask[] = [
     cta: 'Learn more',
     week: 9,
     flowType: CampaignTaskType.education,
-    skipVoterCount: true,
     link: 'https://goodparty.org/blog/article/setting-the-stage-awareness-phase-of-political-campaigns',
   },
 ]

--- a/src/content/content.types.ts
+++ b/src/content/content.types.ts
@@ -56,6 +56,7 @@ export type AIContentTemplateRaw = {
         title: string
       }
     }
+    taskOnly: boolean
     requiresAdditionalQuestions: boolean
   }
 }

--- a/src/content/transformers/aiContentCategoriesTransformer.ts
+++ b/src/content/transformers/aiContentCategoriesTransformer.ts
@@ -17,14 +17,19 @@ export const aiContentCategoriesTransformer: Transformer<
 
   for (const aiContent of aiContents) {
     const { order, title } = aiContent.data.category.fields
-    const { name } = aiContent.data
+    const { name, taskOnly } = aiContent.data
     const key = camelCase(name)
 
     if (!aiContentCategoriesHash[title]) {
       aiContentCategoriesHash[title] = []
       aiContentCategories.push({ title, order })
     }
-    aiContentCategoriesHash[title].push({ key, name })
+    aiContentCategoriesHash[title].push({
+      key,
+      name,
+      taskOnly,
+      id: aiContent.id,
+    })
   }
 
   return combineAiContentAndCategories(


### PR DESCRIPTION
- adds ai content tempalte ids from contentful
- removes skipVoterCount, (can just check for education task type instead)
- add `taskOnly` field and `id` to ai content template response