### PR TITLE
WEB-4202: Fix download voter file link

### DIFF
--- a/src/voters/voterFile/schemas/GetVoterFile.schema.ts
+++ b/src/voters/voterFile/schemas/GetVoterFile.schema.ts
@@ -34,5 +34,6 @@ export class GetVoterFileSchema extends createZodDto(
         .optional(),
     ),
     countOnly: z.coerce.boolean().optional(),
+    slug: z.string().optional(),
   }),
 ) {}


### PR DESCRIPTION
- properly load campaign specified by slug param for voter file downloads
- If the user is not an admin and tries to load by slug, it will throw an error

[Postman VoterData tests](https://goodpartyorg.postman.co/workspace/GP-API~66e2b59d-bf6a-4380-81c2-1cbf2d01bddf/run/38094541-c06140dc-72f0-48ca-8285-a85c8102a4cf)