### PR TITLE
fix: update npm ci flag from deprecated --only=production to --omit=dev

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -55,7 +55,7 @@ ENV CACHEBUST=${CACHEBUST:-1}
 RUN echo "Cache bust: $CACHEBUST - copying .package.json and package-lock.json"
 COPY package.json package-lock.json ./
 # Install only production dependencies
-RUN echo "Cache bust: $CACHEBUST" && npm ci --only=production
+RUN echo "Cache bust: $CACHEBUST" && npm ci --omit=dev
 
 # Copy only necessary files to the runtime image
 RUN echo "Cache bust: $CACHEBUST - copying .prisma"


### PR DESCRIPTION
Changes Made:
Updated line 58 in deploy/Dockerfile from npm ci --only=production to npm ci --omit=dev
The Fix:
Old (deprecated): --only=production
New (correct): --omit=dev
Both flags do the same thing (install only production dependencies), but the new syntax is what modern npm versions expect.