### PR TITLE
[WEB-4426] Order FAQ articles

### DIFF
--- a/src/content/content.types.ts
+++ b/src/content/content.types.ts
@@ -139,6 +139,7 @@ export type ArticleCategories = {
 type ArticleFields = {
   title: string
   id: string
+  order?: number
 }
 
 export type ArticleCategoryRaw = {
@@ -405,6 +406,7 @@ type FaqArticleContentRawData = {
   data: {
     title: string
     category?: FaqArticleCategoryRaw[]
+    order?: number
   }
 }
 
@@ -412,6 +414,7 @@ export type FaqArticleContentRaw = ContentRaw<FaqArticleContentRawData>
 
 export type FaqArticleContentAugmented = ContentAugmented<
   Partial<Content> & {
+    order?: number
     category?: {
       id: string
       fields: {

--- a/src/content/transformers/articleCategoriesTransformer.ts
+++ b/src/content/transformers/articleCategoriesTransformer.ts
@@ -7,6 +7,8 @@ import {
   TYPE_FAQ_ARTICLE,
 } from '../content.types'
 
+const DEFAULT_ORDER = 9999
+
 export const articleCategoriesTransformer: Transformer<
   FaqArticleContentRaw,
   ArticleCategories
@@ -25,7 +27,7 @@ export const articleCategoriesTransformer: Transformer<
         articleCategories.push({
           fields: {
             name: categoryFields.name,
-            order: categoryFields.order ?? 9999,
+            order: categoryFields.order ?? DEFAULT_ORDER,
           },
           name: categoryFields.name,
           id: null,
@@ -33,16 +35,16 @@ export const articleCategoriesTransformer: Transformer<
             {
               title: input.data.title,
               id: input.id,
-              order: input.data.order ?? 9999,
+              order: input.data.order ?? DEFAULT_ORDER,
             },
           ],
-          order: categoryFields.order ?? 9999,
+          order: categoryFields.order ?? DEFAULT_ORDER,
         } as ArticleCategories)
       } else if (categoryFields && foundCategory) {
         foundCategory.articles.push({
           title: input.data.title,
           id: input.id,
-          order: input.data.order ?? 9999,
+          order: input.data.order ?? DEFAULT_ORDER,
         })
       }
     } else if (input.type === TYPE_ARTICLE_CATEGORY) {
@@ -71,15 +73,15 @@ export const articleCategoriesTransformer: Transformer<
   articleCategories.sort(compareArticleCategories)
 
   articleCategories.forEach((category) => {
-    category.articles.sort((a, b) => (a.order ?? 9999) - (b.order ?? 9999))
+    category.articles.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER))
   })
 
   return articleCategories
 }
 
 function compareArticleCategories(a: ArticleCategories, b: ArticleCategories) {
-  const orderA = a.fields.order ?? 9999
-  const orderB = b.fields.order ?? 9999
+  const orderA = a.fields.order ?? DEFAULT_ORDER
+  const orderB = b.fields.order ?? DEFAULT_ORDER
   if (orderA > orderB) {
     return 1
   }

--- a/src/content/transformers/articleCategoriesTransformer.ts
+++ b/src/content/transformers/articleCategoriesTransformer.ts
@@ -25,7 +25,7 @@ export const articleCategoriesTransformer: Transformer<
         articleCategories.push({
           fields: {
             name: categoryFields.name,
-            order: categoryFields.order || 9999,
+            order: categoryFields.order ?? 9999,
           },
           name: categoryFields.name,
           id: null,
@@ -33,16 +33,16 @@ export const articleCategoriesTransformer: Transformer<
             {
               title: input.data.title,
               id: input.id,
-              order: input.data.order || 9999,
+              order: input.data.order ?? 9999,
             },
           ],
-          order: categoryFields.order || 9999,
+          order: categoryFields.order ?? 9999,
         } as ArticleCategories)
       } else if (categoryFields && foundCategory) {
         foundCategory.articles.push({
           title: input.data.title,
           id: input.id,
-          order: input.data.order || 9999,
+          order: input.data.order ?? 9999,
         })
       }
     } else if (input.type === TYPE_ARTICLE_CATEGORY) {
@@ -71,15 +71,15 @@ export const articleCategoriesTransformer: Transformer<
   articleCategories.sort(compareArticleCategories)
 
   articleCategories.forEach((category) => {
-    category.articles.sort((a, b) => (a.order || 9999) - (b.order || 9999))
+    category.articles.sort((a, b) => (a.order ?? 9999) - (b.order ?? 9999))
   })
 
   return articleCategories
 }
 
 function compareArticleCategories(a: ArticleCategories, b: ArticleCategories) {
-  const orderA = a.fields.order || 9999
-  const orderB = b.fields.order || 9999
+  const orderA = a.fields.order ?? 9999
+  const orderB = b.fields.order ?? 9999
   if (orderA > orderB) {
     return 1
   }

--- a/src/content/transformers/articleCategoriesTransformer.ts
+++ b/src/content/transformers/articleCategoriesTransformer.ts
@@ -33,6 +33,7 @@ export const articleCategoriesTransformer: Transformer<
             {
               title: input.data.title,
               id: input.id,
+              order: input.data.order || 9999,
             },
           ],
           order: categoryFields.order || 9999,
@@ -41,6 +42,7 @@ export const articleCategoriesTransformer: Transformer<
         foundCategory.articles.push({
           title: input.data.title,
           id: input.id,
+          order: input.data.order || 9999,
         })
       }
     } else if (input.type === TYPE_ARTICLE_CATEGORY) {
@@ -67,6 +69,10 @@ export const articleCategoriesTransformer: Transformer<
   }
 
   articleCategories.sort(compareArticleCategories)
+
+  articleCategories.forEach((category) => {
+    category.articles.sort((a, b) => (a.order || 9999) - (b.order || 9999))
+  })
 
   return articleCategories
 }

--- a/src/content/transformers/articleCategoriesTransformer.ts
+++ b/src/content/transformers/articleCategoriesTransformer.ts
@@ -77,7 +77,7 @@ export const articleCategoriesTransformer: Transformer<
   return articleCategories
 }
 
-function compareArticleCategories(a, b) {
+function compareArticleCategories(a: ArticleCategories, b: ArticleCategories) {
   const orderA = a.fields.order || 9999
   const orderB = b.fields.order || 9999
   if (orderA > orderB) {

--- a/src/content/transformers/faqArticlesTransformer.ts
+++ b/src/content/transformers/faqArticlesTransformer.ts
@@ -14,7 +14,7 @@ export const faqArticlesTransformer: Transformer<
       createdAt,
       updatedAt,
       type,
-      data: { category, ...dataExcludingCategory },
+      data: { category, order, ...dataExcludingCategory },
     } = entry
     const firstCategory = category?.[0]
 
@@ -23,6 +23,7 @@ export const faqArticlesTransformer: Transformer<
       createdAt,
       updatedAt,
       type,
+      order,
       ...dataExcludingCategory,
       ...(firstCategory
         ? {


### PR DESCRIPTION
If there's an order property on an FAQ article, it can be used to order the FAQ article list. Article categories were already ordered, so this just adds that ordering convention to the articles.

Intended to be backwards compatible so order does not have to be set on articles.

Requires corresponding order property update in Contentful. 

<img width="1980" height="758" alt="CleanShot 2025-08-07 at 02 19 46@2x" src="https://github.com/user-attachments/assets/93e5fa8c-aa2d-4869-ad23-817cc2e4a4e0" />

<img width="910" height="632" alt="CleanShot 2025-08-07 at 02 21 04@2x" src="https://github.com/user-attachments/assets/58268249-5878-49a8-98a0-864dd8f2bf3c" />

