### PR TITLE
fix: stop spamming mailgun with test emails

### DIFF
--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -12,6 +12,7 @@ import {
 } from './email.types'
 import { getUserFullName } from '../users/util/users.util'
 import { WEBAPP_ROOT } from 'src/shared/util/appEnvironment.util'
+import { isTestEmail } from './util/testEmailValidator.util'
 
 @Injectable()
 export class EmailService {
@@ -19,6 +20,9 @@ export class EmailService {
   constructor(private mailgun: MailgunService) {}
 
   async sendEmail({ to, subject, message, from }: SendEmailInput) {
+    if (isTestEmail(to)) {
+      return
+    }
     return await this.sendEmailWithRetry({
       from: from || 'GoodParty.org <noreply@goodparty.org>',
       to,
@@ -36,6 +40,10 @@ export class EmailService {
     from,
     cc,
   }: SendTemplateEmailInput) {
+    if (isTestEmail(to)) {
+      return
+    }
+
     const data: EmailData = {
       from: from || 'GoodParty.org <noreply@goodparty.org>',
       to,
@@ -91,7 +99,7 @@ export class EmailService {
   ) {
     await this.sendTemplateEmail({
       to: user.email,
-      subject: `Your Cancellation Request Has Been Processed – Pro Access Until ${subscriptionEndDate}`,
+      subject: `Your Cancellation Request Has Been Processed - Pro Access Until ${subscriptionEndDate}`,
       template: EmailTemplateName.subscriptionCancellationConfirmation,
       variables: {
         userFullName: getUserFullName(user),

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -14,6 +14,8 @@ import { getUserFullName } from '../users/util/users.util'
 import { WEBAPP_ROOT } from 'src/shared/util/appEnvironment.util'
 import { isTestEmail } from './util/testEmailValidator.util'
 
+const SKIPPED_EMAIL_STATUS = { status: 'test-email-skipped', id: 'test-email' }
+
 @Injectable()
 export class EmailService {
   private readonly logger = new Logger(EmailService.name)
@@ -21,7 +23,7 @@ export class EmailService {
 
   async sendEmail({ to, subject, message, from }: SendEmailInput) {
     if (isTestEmail(to)) {
-      return
+      return SKIPPED_EMAIL_STATUS
     }
     return await this.sendEmailWithRetry({
       from: from || 'GoodParty.org <noreply@goodparty.org>',
@@ -41,7 +43,7 @@ export class EmailService {
     cc,
   }: SendTemplateEmailInput) {
     if (isTestEmail(to)) {
-      return
+      return SKIPPED_EMAIL_STATUS
     }
 
     const data: EmailData = {

--- a/src/email/util/testEmailValidator.util.ts
+++ b/src/email/util/testEmailValidator.util.ts
@@ -1,0 +1,3 @@
+export function isTestEmail(email: string) {
+  return email.startsWith('dustin+test')
+}


### PR DESCRIPTION
Stop sending emails for test automation. Our spam score is spiking on Mailgun.