### PR TITLE
fix: handle createStep number/string type mismatch in website updates

### DIFF
--- a/src/websites/schemas/UpdateWebsite.schema.ts
+++ b/src/websites/schemas/UpdateWebsite.schema.ts
@@ -10,7 +10,7 @@ export class UpdateWebsiteSchema extends createZodDto(
     status: z.nativeEnum(WebsiteStatus).optional(),
     vanityPath: VanityPathSchema.optional(),
     theme: z.string().optional(),
-    createStep: z.coerce.string().optional(),
+    createStep: z.union([z.string(), z.number()]).transform(val => val.toString()).optional(),
     main: z
       .object({
         title: z.string().optional(),

--- a/src/websites/schemas/UpdateWebsite.schema.ts
+++ b/src/websites/schemas/UpdateWebsite.schema.ts
@@ -10,7 +10,7 @@ export class UpdateWebsiteSchema extends createZodDto(
     status: z.nativeEnum(WebsiteStatus).optional(),
     vanityPath: VanityPathSchema.optional(),
     theme: z.string().optional(),
-    createStep: z.string().optional(),
+    createStep: z.coerce.string().optional(),
     main: z
       .object({
         title: z.string().optional(),


### PR DESCRIPTION
  Use z.coerce.string() to accept both number and string createStep values,
  fixing 400 validation errors that prevented website saves from working.

to test, boot up on develop, try to save websites, expect 400

check out this branch, expect to be able to save