### PR TITLE
fix: catch error

### DIFF
--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -26,23 +26,27 @@ export class AnalyticsService {
   }
 
   async trackProPayment(userId: number, session: Stripe.Checkout.Session) {
-    const subscription = session.subscription as Stripe.Subscription
-    const item = subscription.items.data[0]
-    const price = item?.price?.unit_amount_decimal
-      ? Number(item.price.unit_amount_decimal) / 100
-      : 0
-    const intent = session.payment_intent as Stripe.PaymentIntent
-    const pm = intent.payment_method as Stripe.PaymentMethod
+    try {
+      const subscription = session.subscription as Stripe.Subscription
+      const item = subscription?.items?.data[0]
+      const price = item?.price?.unit_amount_decimal
+        ? Number(item.price.unit_amount_decimal) / 100
+        : 0
+      const intent = session.payment_intent as Stripe.PaymentIntent
+      const pm = intent.payment_method as Stripe.PaymentMethod
 
-    const paymentMethod =
-      pm.type === 'card' ? (pm.card?.wallet?.type ?? 'credit card') : pm.type
+      const paymentMethod =
+        pm.type === 'card' ? (pm.card?.wallet?.type ?? 'credit card') : pm.type
 
-    this.segment.trackEvent(userId, EVENTS.Account.ProSubscriptionConfirmed, {
-      price,
-      paymentMethod,
-      renewalDate: new Date(
-        subscription.current_period_end * 1000,
-      ).toISOString(),
-    })
+      this.segment.trackEvent(userId, EVENTS.Account.ProSubscriptionConfirmed, {
+        price,
+        paymentMethod,
+        renewalDate: new Date(
+          subscription.current_period_end * 1000,
+        ).toISOString(),
+      })
+    } catch (e) {
+      this.logger.error('Error tracking pro payment', e)
+    }
   }
 }


### PR DESCRIPTION
Seeing this in the logs:

<img width="1342" height="520" alt="Screenshot 2025-08-26 at 3 56 18 PM" src="https://github.com/user-attachments/assets/2ded0329-e6e4-465c-b23f-29e8678bede7" />


```
	
2025-08-26T19:21:28.036Z
	
/app/dist/src/analytics/analytics.service.js:31
	
2025-08-26T19:21:28.036Z
	
const item = subscription.items.data[0];
	
2025-08-26T19:21:28.036Z
	
^
	
2025-08-26T19:21:28.036Z
	
	
2025-08-26T19:21:28.036Z
	
TypeError: Cannot read properties of undefined (reading 'data')
	
2025-08-26T19:21:28.036Z
	
at AnalyticsService.trackProPayment (/app/dist/src/analytics/analytics.service.js:31:41)
	
2025-08-26T19:21:28.036Z
	
at PaymentEventsService.checkoutSessionCompletedHandler (/app/dist/src/payments/services/paymentEventsService.js:187:24)
	
2025-08-26T19:21:28.036Z
	
at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
	
2025-08-26T19:21:28.036Z
	
at async PaymentEventsService.handleEvent (/app/dist/src/payments/services/paymentEventsService.js:58:24)
	
2025-08-26T19:21:28.036Z
	
at async PaymentsController.handleStripeEvent (/app/dist/src/payments/payments.controller.js:47:13) 

```