### PR TITLE
fix: stuck messages

### DIFF
--- a/src/queue/consumer/queueConsumer.service.ts
+++ b/src/queue/consumer/queueConsumer.service.ts
@@ -7,6 +7,7 @@ import {
   QueueType,
   TcrComplianceStatusCheckMessage,
 } from '../queue.types'
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import { AiContentService } from 'src/campaigns/ai/content/aiContent.service'
 import { SlackService } from 'src/shared/services/slack.service'
 import { Campaign, PathToVictory, TcrComplianceStatus } from '@prisma/client'
@@ -58,9 +59,51 @@ export class QueueConsumerService {
       this.logger.debug('Processing queue message: ', message)
       return await this.processMessage(message)
     } catch (error) {
-      this.logger.error('Message processing failed, will requeue:', error)
-      return true // Indicate that we should requeue
+      const shouldRequeue = this.shouldRequeueError(error as Error)
+
+      if (shouldRequeue) {
+        this.logger.error('Message processing failed, will requeue:', error)
+        return true // Indicate that we should requeue
+      } else {
+        this.logger.error(
+          'Message processing failed with non-retryable error, discarding message:',
+          error,
+        )
+
+        // Send error notification to Slack for non-retryable errors
+        await this.slackService.errorMessage({
+          message: 'Queue message discarded due to non-retryable error',
+          error: error as Error,
+        })
+
+        return false // Don't requeue, delete the message
+      }
     }
+  }
+
+  private shouldRequeueError(error: Error): boolean {
+    // Don't retry Prisma errors for missing records - these are permanent failures
+    if (error instanceof PrismaClientKnownRequestError) {
+      // P2025: Record not found
+      if (error.code === 'P2025') {
+        return false
+      }
+      // P2002: Unique constraint violation
+      if (error.code === 'P2002') {
+        return false
+      }
+    }
+
+    // Don't retry validation errors or other client errors
+    if (
+      error.message.includes('validation') ||
+      error.message.includes('Invalid')
+    ) {
+      return false
+    }
+
+    // Retry network errors, timeouts, and other temporary failures
+    return true
   }
 
   // TODO: Each message type should be assigned it's own SQS queue allowing each
@@ -82,7 +125,8 @@ export class QueueConsumerService {
       return false
     }
 
-    const queueMessage: QueueMessage = JSON.parse(message.Body)
+    const parsedBody = JSON.parse(message.Body) as QueueMessage
+    const queueMessage: QueueMessage = parsedBody
     this.logger.log('processing queue message type ', queueMessage.type)
 
     switch (queueMessage.type) {
@@ -90,19 +134,28 @@ export class QueueConsumerService {
         this.logger.log('received generateAiContent message')
         const generateAiContentMessage =
           queueMessage.data as GenerateAiContentMessageData
-        await this.aiContentService.handleGenerateAiContent(
-          generateAiContentMessage,
-        )
 
-        const { userId } = await this.campaignsService.findUniqueOrThrow({
-          where: { slug: generateAiContentMessage.slug },
-        })
+        try {
+          await this.aiContentService.handleGenerateAiContent(
+            generateAiContentMessage,
+          )
 
-        this.analytics.track(userId, EVENTS.AiContent.ContentGenerated, {
-          slug: generateAiContentMessage.slug,
-          key: generateAiContentMessage.key,
-          regenerate: generateAiContentMessage.regenerate,
-        })
+          const { userId } = await this.campaignsService.findUniqueOrThrow({
+            where: { slug: generateAiContentMessage.slug },
+          })
+
+          this.analytics.track(userId, EVENTS.AiContent.ContentGenerated, {
+            slug: generateAiContentMessage.slug,
+            key: generateAiContentMessage.key,
+            regenerate: generateAiContentMessage.regenerate,
+          })
+        } catch (error) {
+          this.logger.error(
+            `Error processing AI content generation for slug: ${generateAiContentMessage.slug}`,
+            error,
+          )
+          throw error
+        }
         break
       case QueueType.PATH_TO_VICTORY:
         this.logger.log('received pathToVictory message')
@@ -210,17 +263,19 @@ export class QueueConsumerService {
         {
           campaign: campaign as Campaign & { pathToVictory: PathToVictory },
           pathToVictoryResponse: p2vResponse.pathToVictoryResponse,
-          officeName: p2vResponse.officeName || '',
-          electionDate: p2vResponse.electionDate || '',
-          electionTerm: p2vResponse.electionTerm || 0,
-          electionLevel: p2vResponse.electionLevel || '',
-          electionState: p2vResponse.electionState || '',
-          electionCounty: p2vResponse.electionCounty || '',
-          electionMunicipality: p2vResponse.electionMunicipality || '',
-          subAreaName: p2vResponse.subAreaName,
-          subAreaValue: p2vResponse.subAreaValue,
-          partisanType: p2vResponse.partisanType || '',
-          priorElectionDates: p2vResponse.priorElectionDates || [],
+          officeName: (p2vResponse.officeName as string) || '',
+          electionDate: (p2vResponse.electionDate as string) || '',
+          electionTerm: (p2vResponse.electionTerm as number) || 0,
+          electionLevel: (p2vResponse.electionLevel as string) || '',
+          electionState: (p2vResponse.electionState as string) || '',
+          electionCounty: (p2vResponse.electionCounty as string) || '',
+          electionMunicipality:
+            (p2vResponse.electionMunicipality as string) || '',
+          subAreaName: p2vResponse.subAreaName as string | undefined,
+          subAreaValue: p2vResponse.subAreaValue as string | undefined,
+          partisanType: (p2vResponse.partisanType as string) || '',
+          priorElectionDates:
+            (p2vResponse.priorElectionDates as string[]) || [],
         },
       )
     } catch (e) {


### PR DESCRIPTION
Summary of Queue Consumer Fixes
I've identified and fixed the main issues causing messages to get stuck in your queue:
🔧 Main Problem Fixed
The queue consumer was requeuing ALL errors indefinitely, including permanent failures like missing campaign records. This created an infinite loop for messages referencing non-existent campaigns.
🛠️ Key Changes Made
Smart Error Classification - Added shouldRequeueError() method that:
❌ Won't retry Prisma errors for missing records (P2025) or constraint violations (P2002)
❌ Won't retry validation errors or invalid input errors
✅ Will retry network errors, timeouts, and other temporary failures
Better Error Handling - Messages with non-retryable errors are now:
Logged with clear error messages
Sent to Slack for monitoring
Removed from the queue instead of being requeued forever
Improved Type Safety - Fixed all TypeScript type safety issues:
Proper typing for JSON.parse operations
Explicit type assertions for P2VResponse properties
Removed unsafe any assignments
Enhanced Logging - Added specific error context for AI content generation failures to help with debugging
🎯 Expected Results
Messages with missing campaigns will be discarded instead of requeued infinitely
You'll get Slack notifications when messages are discarded due to permanent failures
Temporary failures (network issues, etc.) will still be retried appropriately
Better visibility into what's causing queue processing failures
The stuck messages should now be processed and either completed successfully or discarded if they reference non-existent campaigns, clearing your queue backlog.