### PR TITLE
[WEB-4583] Re-enable requesting canvassers

### DIFF
--- a/src/peerly/services/peerlyP2pJob.service.ts
+++ b/src/peerly/services/peerlyP2pJob.service.ts
@@ -91,11 +91,9 @@ export class PeerlyP2pJobService {
       await this.peerlyP2pSmsService.assignListToJob(jobId, listId)
       this.logger.log('List assigned successfully')
 
-      // TODO: Re-enable once Peerly supports account configuration
-      // See WEB-4583 https://goodparty.atlassian.net/browse/WEB-4583
-      // this.logger.log(`Requesting canvassers for job ${jobId}`)
-      // await this.peerlyP2pSmsService.requestCanvassers(jobId)
-      // this.logger.log('Canvassers requested successfully')
+      this.logger.log(`Requesting canvassers for job ${jobId}`)
+      await this.peerlyP2pSmsService.requestCanvassers(jobId)
+      this.logger.log('Canvassers requested successfully')
 
       this.logger.log(
         `P2P job creation completed successfully for campaign ${campaignId}`,


### PR DESCRIPTION
On-hold until Peerly changes account configuration for requesting canvassers