### PR TITLE
ENG-3695: disable contacts API operations if campaign is not pro

### DIFF
--- a/src/contacts/services/contacts.service.ts
+++ b/src/contacts/services/contacts.service.ts
@@ -128,6 +128,9 @@ export class ContactsService {
     campaign: CampaignWithPathToVictory,
     res: FastifyReply,
   ) {
+    if (!campaign.isPro) {
+      throw new BadRequestException('Campaign is not pro')
+    }
     const segment = dto.segment as string | undefined
 
     const locationData = this.extractLocationFromCampaign(campaign)

--- a/src/voters/voterFile/voterFile.controller.ts
+++ b/src/voters/voterFile/voterFile.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -130,6 +131,9 @@ export class VoterFileController {
     @ReqCampaign() campaign: Campaign,
     @Body() voterFileFilter: CreateVoterFileFilterSchema,
   ) {
+    if (!campaign.isPro) {
+      throw new BadRequestException('Campaign is not pro')
+    }
     return this.voterFileFilterService.create(campaign.id, voterFileFilter)
   }
 
@@ -160,6 +164,9 @@ export class VoterFileController {
     @Body() body: UpdateVoterFileFilterSchema,
     @ReqCampaign() campaign: Campaign,
   ) {
+    if (!campaign.isPro) {
+      throw new BadRequestException('Campaign is not pro')
+    }
     const filter: VoterFileFilter | null =
       await this.voterFileFilterService.findByIdAndCampaignId(id, campaign.id)
     if (!filter) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Require pro campaigns for contacts download and voter file filter create/update; otherwise return BadRequest.
> 
> - **Backend/API**:
>   - **Contacts**: `downloadContacts` now checks `campaign.isPro`; throws `BadRequestException` if false.
>   - **Voter File**:
>     - `POST` `voters/voter-file/filter` and `PUT` `voters/voter-file/filter/:id` now require `campaign.isPro`; throw `BadRequestException` if false.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6bca317308933b5855c616a72df4d06395f37eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->