### PR TITLE
block permissions for searchContacts

### DIFF
--- a/src/contacts/services/contacts.service.ts
+++ b/src/contacts/services/contacts.service.ts
@@ -106,6 +106,12 @@ export class ContactsService {
   ) {
     const { resultsPerPage, page, name, phone, firstName, lastName } = dto
 
+    if (!campaign.isPro) {
+      throw new BadRequestException(
+        'Search contacts is only available for pro campaigns',
+      )
+    }
+
     const locationData = this.extractLocationFromCampaign(campaign)
 
     const params = new URLSearchParams({
@@ -135,10 +141,7 @@ export class ContactsService {
       )
       return this.transformListResponse(response.data)
     } catch (error) {
-      this.logger.error(
-        'Failed to search contacts from people API',
-        JSON.stringify(error),
-      )
+      this.logger.error('Failed to search contacts from people API', error)
       throw new BadGatewayException('Failed to search contacts from people API')
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restricts `searchContacts` to pro campaigns and logs the original error object on failures.
> 
> - **Contacts Service (`src/contacts/services/contacts.service.ts`)**:
>   - **Permissions**: Enforce pro-only access in `searchContacts`; throw `BadRequestException` when `campaign.isPro` is false.
>   - **Logging**: Update `logger.error` in `searchContacts` to pass the error object directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16ea017a0b614023a2d66985ac6a21d08bbd5084. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->