### PR TITLE
[ENG-4139] - peerly existential checks

### DIFF
--- a/prisma/schema/migrations/20251007194653_remove_cv_id/migration.sql
+++ b/prisma/schema/migrations/20251007194653_remove_cv_id/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `peerly_cv_verification_id` on the `tcr_compliance` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "tcr_compliance_peerly_cv_verification_id_key";
+
+-- AlterTable
+ALTER TABLE "tcr_compliance" DROP COLUMN "peerly_cv_verification_id";

--- a/prisma/schema/tcrCompliance.prisma
+++ b/prisma/schema/tcrCompliance.prisma
@@ -33,7 +33,6 @@ model TcrCompliance {
   peerlyRegistrationLink        String? @map("peerly_registration_link")
   peerlyIdentityProfileLink     String? @map("peerly_identity_profile_link")
   peerly10DLCBrandSubmissionKey String? @unique @map("peerly_10dlc_brand_submission_key")
-  peerlyCvVerificationId        String? @unique @map("peerly_cv_verification_id")
 
   @@map("tcr_compliance")
 }

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -130,27 +130,27 @@ export class CampaignTcrComplianceService extends createPrismaBase(
       )) ||
       null
 
-    let exitingIdentityProfileResponse: PeerlyIdentityProfileResponseBody | null =
+    let existingIdentityProfileResponse: PeerlyIdentityProfileResponseBody | null =
       null
     try {
-      exitingIdentityProfileResponse =
+      existingIdentityProfileResponse =
         await this.peerlyIdentityService.getIdentityProfile(
           tcrComplianceIdentity!.identity_id,
           campaign,
         )
     } catch (error) {
       if (error instanceof NotFoundException) {
-        exitingIdentityProfileResponse = null
+        existingIdentityProfileResponse = null
       } else {
         throw error
       }
     }
 
-    exitingIdentityProfileResponse &&
+    existingIdentityProfileResponse &&
       this.logger.debug(`Existing Identity Profile found, skipping creation`)
 
     const peerlyIdentityProfileResponse: PeerlyIdentityProfileResponseBody | null =
-      exitingIdentityProfileResponse ||
+      existingIdentityProfileResponse ||
       (await this.peerlyIdentityService.submitIdentityProfile(
         tcrComplianceIdentity!.identity_id,
         campaign,

--- a/src/campaigns/tcrCompliance/util/trcCompliance.util.ts
+++ b/src/campaigns/tcrCompliance/util/trcCompliance.util.ts
@@ -1,2 +1,0 @@
-export const getTCRIdentityName = (userFullName: string, campaignEIN: string) =>
-  `${userFullName} - ${campaignEIN}`

--- a/src/queue/consumer/queueConsumer.service.ts
+++ b/src/queue/consumer/queueConsumer.service.ts
@@ -24,7 +24,6 @@ import { ViabilityService } from 'src/pathToVictory/services/viability.service'
 import { AnalyticsService } from 'src/analytics/analytics.service'
 import { CampaignsService } from 'src/campaigns/services/campaigns.service'
 import { CampaignTcrComplianceService } from '../../campaigns/tcrCompliance/services/campaignTcrCompliance.service'
-import { QueueProducerService } from '../producer/queueProducer.service'
 import { EVENTS } from '../../vendors/segment/segment.types'
 import { DomainsService } from '../../websites/services/domains.service'
 import { ForwardEmailDomainResponse } from '../../vendors/forwardEmail/forwardEmail.types'
@@ -42,7 +41,6 @@ export class QueueConsumerService {
     private readonly campaignsService: CampaignsService,
     private readonly tcrComplianceService: CampaignTcrComplianceService,
     private readonly domainsService: DomainsService,
-    private readonly queueProducerService: QueueProducerService,
   ) {}
 
   @SqsMessageHandler(process.env.SQS_QUEUE || '', false)

--- a/src/vendors/peerly/peerly.types.ts
+++ b/src/vendors/peerly/peerly.types.ts
@@ -8,16 +8,81 @@ export type PeerlyIdentity = {
   start_date: string
   account_id: string
   tcr_identity_status: string | null
+  vetting_expire_date?: string
+  usecases?: string[]
 }
 export type PeerlyIdentityCreateResponseBody = {
   Data: PeerlyIdentity
 }
-export type PeerlySubmitIdentityProfileResponseBody = {
+
+export interface PeerlyCampaignConfig {
+  autoRenewal: number
+  description: string
+  embeddedLink: number
+  embeddedPhone: number
+  sample1: string
+  subscriberOptin: number
+  subscriberOptout: number
+  usecase: string
+  vertical: string
+}
+
+export interface PeerlyIdentityProfile {
+  account_id: string
+  base_account_id: string
+  campaignVerifyToken: string | null
+  campaigns: Record<string, PeerlyCampaignConfig>
+  city: string
+  companyName: string
+  country: string | null
+  displayName: string
+  ein: string
+  email: string
+  entityType: string
+  is_political: boolean
+  legal_entity_type: string
+  phone: string
+  postalCode: string
+  state: string
+  status: string
+  street: string
+  usecase: string
+  vertical?: string
+  usecases: string[]
+  website: string
+  will_send_over_2k: boolean
+}
+
+export interface PeerlyIdentityProfileResponseBody {
   link: string
+  profile?: PeerlyIdentityProfile
+}
+
+export type PeerlyGetIdentitiesResponseBody = {
+  identities: PeerlyIdentity[]
+}
+
+export interface PeerlyGetCvRequestResponseBody {
+  verification_status: string
 }
 export interface PeerlySubmitCVResponseBody {
   message: string
   verification_id: string
+}
+export interface Peerly10DlcBrandData {
+  entityType: string
+  vertical: string
+  is_political: boolean
+  displayName: string
+  companyName: string
+  ein: string
+  phone: string
+  street?: string
+  city?: string
+  state?: string
+  postalCode?: string
+  website: string
+  email: string
 }
 export type Peerly10DLCBrandSubmitResponseBody = {
   submission_key: string

--- a/src/vendors/peerly/services/peerlyIdentity.service.ts
+++ b/src/vendors/peerly/services/peerlyIdentity.service.ts
@@ -276,7 +276,7 @@ export class PeerlyIdentityService extends PeerlyBaseConfig {
       `Fetching identity profile for identityId: ${peerlyIdentityId}`,
     )
     const requestConfig = {
-      url: `${this.baseUrl}/api/identities/${peerlyIdentityId}/getProfile`,
+      url: `${this.baseUrl}/identities/${peerlyIdentityId}/getProfile`,
       method: this.httpService.get,
       config: (await this.getAxiosRequestConfig()) as AxiosRequestConfig,
     }


### PR DESCRIPTION
Adds checks against Peerly endpoints to ensure that we're not attempting to create duplicate entities in their system upon retries when a user re-submits their TCR Compliance form in the UI.

Since their API doesn't do duplication requests and doesn't respond w/ `409 CONFLICT` responses in the case of duplicate creations, we have to do this manually ourselves.

There is a `TODO` comment added to take a different approach to this in the future w/ a refactor.

Logs showing checks detecting duplication attempts:
<img width="1122" height="100" alt="image" src="https://github.com/user-attachments/assets/847d1f69-905c-4b95-8ab4-8230adf304de" />
<img width="611" height="98" alt="image" src="https://github.com/user-attachments/assets/f0004df7-745a-4a8a-819e-e08f94a69fbc" />
<img width="1053" height="101" alt="image" src="https://github.com/user-attachments/assets/75f3b7dd-73f4-4242-9b49-79cc6cde1539" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate Peerly creations by checking existing identity/profile/brand/CV state and drops the unused `peerly_cv_verification_id` from TCR compliance.
> 
> - **TCR Compliance flow (backend)**:
>   - Check for existing Peerly `identity` before creating; reuse when found.
>   - Fetch existing `identity profile`; submit only if missing; capture `peerlyIdentityProfileLink` from response.
>   - Conditionally submit 10DLC brand based on `profile.vertical` presence.
>   - Check existing Campaign Verify request status; submit only if absent; stop persisting `peerlyCvVerificationId`.
>   - Use `PeerlyIdentityService.getTCRIdentityName` instead of local util; enhanced debug logging.
> - **Peerly service and types**:
>   - Add `getIdentities`, `getIdentityProfile`, `getCampaignVerifyRequest`; adjust `createIdentity` to accept pre-prefixed names via helper.
>   - Expand types: identity profile/response, identities list, CV request status, typed 10DLC brand payload; optional fields on `PeerlyIdentity`.
>   - Update `submitIdentityProfile` to return full response; improved structured logging.
> - **Database schema**:
>   - Drop `tcr_compliance.peerly_cv_verification_id` and its unique index.
> - **Cleanup**:
>   - Remove `getTCRIdentityName` util; minor Queue consumer dependency cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbfd702bb12ca0a8eb1b27fddc311b2a9b0883b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->