### PR TITLE
ENG-4062 - fix zod validation for tevyn API

### DIFF
--- a/src/contacts/contacts.controller.ts
+++ b/src/contacts/contacts.controller.ts
@@ -21,8 +21,7 @@ import {
 import { SampleContactsDTO } from './schemas/sampleContacts.schema'
 import { SearchContactsDTO } from './schemas/searchContacts.schema'
 import { ContactsService } from './services/contacts.service'
-import { z } from 'zod'
-import { TevynApiSchema } from './schemas/tevynApi.schema'
+import type { TevynApiDto } from './schemas/tevynApi.schema'
 
 type CampaignWithPathToVictory = Campaign & {
   pathToVictory?: PathToVictory | null
@@ -80,11 +79,10 @@ export class ContactsController {
   }
 
   @Post('tevyn-api')
-  @UsePipes(new ZodValidationPipe(TevynApiSchema))
   sendTevynSlack(
     @ReqUser() user: User,
     @ReqCampaign() campaign: CampaignWithPathToVictory,
-    @Body() { message, csvFileUrl, imageUrl }: z.infer<typeof TevynApiSchema>,
+    @Body() { message, csvFileUrl, imageUrl }: TevynApiDto,
   ) {
     const userInfo = {
       name: `${user.firstName || ''} ${user.lastName || ''}`.trim(),


### PR DESCRIPTION
ENG-4062 - fix zod validation for tevyn API

This is a small zod fix for the temporary flow of sending Image, CSV file and text message to tevyn in slack for Wizard of Oz flow.

This will be replaced when we do the full flow of serve onboarding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Swap per-route Zod schema validation for a DTO type on `tevyn-api` and clean up related imports in `contacts.controller.ts`.
> 
> - **Contacts API**:
>   - Update `POST /contacts/tevyn-api` to use `TevynApiDto` for `@Body` instead of `z.infer`, and remove the per-route `ZodValidationPipe(TevynApiSchema)`.
>   - Switch to a type-only import for `TevynApiDto`; drop direct `zod`/schema imports in controller.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72391c8d8515756acdecaae4a57fe49b28f55aeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->