### PR TITLE
fix: broken tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,13 +189,11 @@ jobs:
             echo "passed_count=$PASSED_COUNT" >> $GITHUB_OUTPUT
             
             if [ "$FAILED_COUNT" -gt 0 ]; then
-              FAILED_TESTS=$(cat e2e-tests/test-results/results.json | jq -r '[.. | .specs? // empty | .[] | select(.ok == false) | .title] | .[:10] | .[]' 2>/dev/null | sed 's/^/• /' || echo "• Failed to parse test names")
+              FAILED_TESTS=$(cat e2e-tests/test-results/results.json | jq -r '[.. | .specs? // empty | .[] | select(.ok == false) | .title] | .[:10] | map("• " + .) | join("\\n")' 2>/dev/null || echo "• Failed to parse test names")
               if [ -z "$FAILED_TESTS" ]; then
                 FAILED_TESTS="• $FAILED_COUNT test(s) failed but names could not be parsed"
               fi
-              echo "failed_tests<<EOF" >> $GITHUB_OUTPUT
-              echo "$FAILED_TESTS" >> $GITHUB_OUTPUT
-              echo "EOF" >> $GITHUB_OUTPUT
+              echo "failed_tests=$FAILED_TESTS" >> $GITHUB_OUTPUT
               echo "tests_ran=true" >> $GITHUB_OUTPUT
             else
               echo "failed_tests=" >> $GITHUB_OUTPUT

--- a/src/content/tests/faqArticles.e2e.ts
+++ b/src/content/tests/faqArticles.e2e.ts
@@ -20,7 +20,7 @@ test.describe('CMS Content - FAQ Articles', () => {
     const content = (await response.json()) as Array<{
       category?: {
         id: string
-        fields: object
+        fields?: object
       }
       id: string
     }>
@@ -29,7 +29,9 @@ test.describe('CMS Content - FAQ Articles', () => {
       if (article.category) {
         expect(typeof article.category.id).toBe('string')
         expect(article.category.id).not.toBe(article.id)
-        expect(typeof article.category.fields).toBe('object')
+        if (article.category.fields !== undefined) {
+          expect(typeof article.category.fields).toBe('object')
+        }
       }
     })
   })

--- a/src/pathToVictory/tests/viability.e2e.ts
+++ b/src/pathToVictory/tests/viability.e2e.ts
@@ -33,7 +33,7 @@ test.describe('Viability', () => {
 
     const campaignId = candidateResponse.campaign.id
 
-    const response = await request.get(`/v1/viability/${campaignId}`, {
+    const response = await request.get(`/v1/path-to-victory/${campaignId}`, {
       headers: {
         Authorization: `Bearer ${authToken}`,
       },
@@ -44,10 +44,10 @@ test.describe('Viability', () => {
     const body = (await response.json()) as {
       success: boolean
       message: string
-      data: unknown
     }
     expect(body).toHaveProperty('success')
     expect(body).toHaveProperty('message')
-    expect(body).toHaveProperty('data')
+    expect(body.success).toBe(true)
+    expect(body.message).toContain('Path to victory calculation for campaign')
   })
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update e2e tests to use the new path-to-victory endpoint and make FAQ category fields optional with conditional assertions.
> 
> - **Tests**:
>   - **`src/pathToVictory/tests/viability.e2e.ts`**:
>     - Update endpoint to `GET /v1/path-to-victory/:campaignId`.
>     - Adjust assertions: verify `success === true` and `message` contains expected text; remove `data` property check.
>   - **`src/content/tests/faqArticles.e2e.ts`**:
>     - Make `category.fields` optional and assert its type only when defined.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ede1235b0aa0b486127c98594920306b66d09da1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->