### PR TITLE
[ENG-6042] - Allows for domains that were previously paid for, but failed for some reason, to be re-tried

### DIFF
--- a/src/payments/purchase.controller.ts
+++ b/src/payments/purchase.controller.ts
@@ -1,10 +1,12 @@
 import { BadRequestException, Body, Controller, Post } from '@nestjs/common'
-import { User } from '@prisma/client'
+import { Campaign, User } from '@prisma/client'
 import { ReqUser } from '../authentication/decorators/ReqUser.decorator'
 import { UsersService } from '../users/services/users.service'
 import { StripeService } from '../vendors/stripe/services/stripe.service'
 import { CompletePurchaseDto, CreatePurchaseIntentDto } from './purchase.types'
 import { PurchaseService } from './services/purchase.service'
+import { UseCampaign } from '@/campaigns/decorators/UseCampaign.decorator'
+import { ReqCampaign } from '@/campaigns/decorators/ReqCampaign.decorator'
 
 @Controller('payments/purchase')
 export class PurchaseController {
@@ -37,11 +39,13 @@ export class PurchaseController {
   }
 
   @Post('create-intent')
+  @UseCampaign()
   async createPurchaseIntent(
     @ReqUser() user: User,
     @Body() dto: CreatePurchaseIntentDto<unknown>,
+    @ReqCampaign() campaign: Campaign,
   ) {
-    return this.purchaseService.createPurchaseIntent(user, dto)
+    return this.purchaseService.createPurchaseIntent({ user, dto, campaign })
   }
 
   @Post('complete')

--- a/src/payments/purchase.types.ts
+++ b/src/payments/purchase.types.ts
@@ -1,3 +1,4 @@
+import Stripe from 'stripe'
 export enum PurchaseType {
   DOMAIN_REGISTRATION = 'DOMAIN_REGISTRATION',
   TEXT = 'TEXT',
@@ -23,7 +24,7 @@ export type PostPurchaseHandler<Metadata> = (
 ) => Promise<unknown>
 
 export interface PurchaseHandler<Metadata> {
-  validatePurchase(metadata: Metadata): Promise<void>
+  validatePurchase(metadata: Metadata): Promise<void | Stripe.PaymentIntent>
   calculateAmount(metadata: Metadata): Promise<number>
   executePostPurchase?(
     paymentIntentId: string,

--- a/src/payments/services/purchase.service.ts
+++ b/src/payments/services/purchase.service.ts
@@ -14,10 +14,13 @@ import Stripe from 'stripe'
 @Injectable()
 export class PurchaseService {
   private readonly logger = new Logger('PurchaseService')
-  // TODO: Refactor to remove the "handlers" anti-pattern here. It's absolutely
-  //  over-engineered, causes confusion and obfuscation in the code. It also
-  //  tightly couples the purchasing logic flows, with the logic flows of _what_
-  //  is being purchased and _how_ it is being purchased:
+  // TODO: Refactor to remove the "handlers" anti-pattern here along w/
+  //  implementors of the anti-pattern elsewhere.
+  //  It's absolutely over-engineered, causes confusion and obfuscation in the
+  //  code, and makes it very difficult to create type-safe annotations w/o
+  //  having to resort to `any` or `unknown` escape hatches.
+  //  It also tightly couples the purchasing logic flows, with the logic flows of
+  //  _what_ is being purchased and _how_ it is being purchased:
   //  https://app.clickup.com/t/90132012119/ENG-4065
   private handlers: Map<PurchaseType, PurchaseHandler<unknown>> = new Map()
   private postPurchaseHandlers: Map<

--- a/src/payments/services/purchase.service.ts
+++ b/src/payments/services/purchase.service.ts
@@ -14,6 +14,11 @@ import Stripe from 'stripe'
 @Injectable()
 export class PurchaseService {
   private readonly logger = new Logger('PurchaseService')
+  // TODO: Refactor to remove the "handlers" anti-pattern here. It's absolutely
+  //  over-engineered, causes confusion and obfuscation in the code. It also
+  //  tightly couples the purchasing logic flows, with the logic flows of _what_
+  //  is being purchased and _how_ it is being purchased:
+  //  https://app.clickup.com/t/90132012119/ENG-4065
   private handlers: Map<PurchaseType, PurchaseHandler<unknown>> = new Map()
   private postPurchaseHandlers: Map<
     PurchaseType,

--- a/src/websites/controllers/domains.controller.ts
+++ b/src/websites/controllers/domains.controller.ts
@@ -87,7 +87,7 @@ export class DomainsController {
         message = DomainOperationStatus.SUCCESSFUL
         break
       case DomainStatus.inactive:
-        message = DomainOperationStatus.ERROR
+        message = DomainOperationStatus.INACTIVE
         break
       default:
         message = DomainOperationStatus.ERROR

--- a/src/websites/domains.types.ts
+++ b/src/websites/domains.types.ts
@@ -24,6 +24,7 @@ export enum DomainOperationStatus {
   SUBMITTED = 'SUBMITTED',
   IN_PROGRESS = 'IN_PROGRESS',
   SUCCESSFUL = 'SUCCESSFUL',
+  INACTIVE = 'INACTIVE',
   ERROR = 'ERROR',
   NO_DOMAIN = 'NO_DOMAIN',
 }


### PR DESCRIPTION
webapp companion PR: https://github.com/thegoodparty/gp-webapp/pull/1188

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds campaign-aware purchase intent creation that can reuse existing successful domain payments and returns payment intent id/status; introduces INACTIVE domain status mapping.
> 
> - **Payments**:
>   - `purchase.controller`: adds `@UseCampaign`/`@ReqCampaign` to `POST /create-intent` and forwards `campaign` to service.
>   - `PurchaseService.createPurchaseIntent` now accepts `{ user, dto, campaign }`, injects `campaignId` into validation, reuses existing `Stripe.PaymentIntent` when returned by handler, and returns `id`, `clientSecret`, `amount`, `status`.
>   - `PurchaseHandler.validatePurchase` updated to return `void | Stripe.PaymentIntent`.
> - **Websites/Domains**:
>   - `DomainsService.validatePurchase`: if a domain with a successful `paymentId` exists, returns that `PaymentIntent`; otherwise validates availability.
>   - Post-purchase flow: reuse existing domain record if present; create only when missing; mark domain `inactive` on registration failure; improved logging.
>   - `DomainOperationStatus`: adds `INACTIVE`; controller maps `DomainStatus.inactive` to `INACTIVE` in status endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99c2655b42512fe7abae7690c30419e531fb231a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->