### PR TITLE
[ENG-6562] - users listing endpoint only accessible by M2M tokenized requests

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -171,6 +171,9 @@ REQUIRED BEHAVIOR:
 - If asked to create a service, create ONLY the service file
 - Wait for explicit instructions before adding any additional functionality
 - Ask for clarification if the scope is unclear rather than assuming
+- When modifying existing code, preserve the existing code structure and patterns — do NOT refactor, reorganize, or "improve" surrounding code that is not directly related to the requested change
+- If existing code uses inline awaits in a return statement, keep that pattern — do NOT restructure it into Promise.all, destructured variables, or any other form
+- Only touch the lines necessary to fulfill the request
 
 ## Rule 6: Use Available Libraries
 
@@ -680,6 +683,69 @@ model BlogArticle {
 ```
 
 Before adding a JSON column, ask: "Can I model this with proper columns and relations?" If yes, use proper columns.
+
+## Rule 26: Use Library-Provided Enums and Constants Over Magic Strings
+
+CRITICAL REQUIREMENT:
+
+- Before using ANY string literal or numeric literal as a function argument, object property value, or configuration value, ALWAYS check whether the library provides an enum, constant, or type for that value
+- This applies to ALL libraries: Prisma, NestJS, http-constants-ts, Zod, and any other dependency
+
+REQUIRED WORKFLOW:
+
+1. Identify the library that owns the function/method/property you are calling
+2. Inspect the library's type definitions for enums, constants, or literal union types
+3. Use the library's provided constant instead of a magic string
+
+EXAMPLES:
+
+**Prisma:**
+
+```typescript
+import { Prisma } from '@prisma/client'
+
+// ❌ Bad: magic string
+{ mode: 'insensitive' }
+
+// ✅ Good: Prisma enum
+{ mode: Prisma.QueryMode.insensitive }
+
+// ❌ Bad: magic string for sort direction
+{ orderBy: { createdAt: 'desc' } }
+
+// ✅ Good: Prisma enum
+{ orderBy: { createdAt: Prisma.SortOrder.desc } }
+```
+
+**NestJS:**
+
+```typescript
+import { HttpStatus } from '@nestjs/common'
+
+// ❌ Bad: magic number
+expect(response.status).toBe(200)
+
+// ✅ Good: NestJS enum
+expect(response.status).toBe(HttpStatus.OK)
+```
+
+**http-constants-ts:**
+
+```typescript
+import { MediaType } from 'http-constants-ts'
+
+// ❌ Bad: magic string
+const contentType = 'application/json'
+
+// ✅ Good: library constant
+const contentType = MediaType.APPLICATION_JSON
+```
+
+ENFORCEMENT:
+
+- This rule applies to ALL code: controllers, services, schemas, tests, utilities
+- Review every string/number literal to determine if a library constant exists
+- When in doubt, inspect the library's type definitions before using a literal value
 
 ## General NestJS Patterns
 

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 generated/
+dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "gp-api",
       "version": "0.0.1",
-      "hasInstallScript": true,
       "license": "CC0-1.0",
       "dependencies": {
         "@amplitude/experiment-node-server": "1.11.0",

--- a/prisma/schema/migrations/20260210180920_user_first_last_indexes/migration.sql
+++ b/prisma/schema/migrations/20260210180920_user_first_last_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "user_first_name_idx" ON "user"("first_name");
+
+-- CreateIndex
+CREATE INDEX "user_last_name_idx" ON "user"("last_name");

--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -28,5 +28,7 @@ model User {
   aiChats               AiChat[]
   electedOffices       ElectedOffice[]
 
+  @@index([firstName])
+  @@index([lastName])
   @@map("user")
 }

--- a/src/authentication/authentication.consts.ts
+++ b/src/authentication/authentication.consts.ts
@@ -1,0 +1,1 @@
+export const M2M_TOKEN_PREFIX = 'mt_'

--- a/src/authentication/guards/ClerkM2MAuth.guard.ts
+++ b/src/authentication/guards/ClerkM2MAuth.guard.ts
@@ -10,6 +10,7 @@ import { ClerkClient } from '@clerk/backend'
 import { routeIsPublicAndNoRoles } from '@/authentication/util/routeIsPublicAndNoRoles.util'
 import { IncomingRequest } from '@/authentication/authentication.types'
 import { verifyM2MToken } from '@/authentication/util/VerifyM2MToken.util'
+import { M2M_TOKEN_PREFIX } from '../authentication.consts'
 
 @Injectable()
 export class ClerkM2MAuthGuard implements CanActivate {
@@ -27,7 +28,7 @@ export class ClerkM2MAuthGuard implements CanActivate {
     // and does not have role restrictions
     if (
       !token ||
-      !token.startsWith('mt_') ||
+      !token.startsWith(M2M_TOKEN_PREFIX) ||
       routeIsPublicAndNoRoles(context, this.reflector)
     ) {
       return true

--- a/src/authentication/guards/M2MOnly.guard.ts
+++ b/src/authentication/guards/M2MOnly.guard.ts
@@ -4,33 +4,24 @@ import {
   Inject,
   Injectable,
 } from '@nestjs/common'
-import { Reflector } from '@nestjs/core'
 import { CLERK_CLIENT_PROVIDER_TOKEN } from '@/authentication/providers/clerk-client.provider'
 import { ClerkClient } from '@clerk/backend'
-import { routeIsPublicAndNoRoles } from '@/authentication/util/routeIsPublicAndNoRoles.util'
 import { IncomingRequest } from '@/authentication/authentication.types'
 import { verifyM2MToken } from '@/authentication/util/VerifyM2MToken.util'
 
 @Injectable()
-export class ClerkM2MAuthGuard implements CanActivate {
+export class M2MOnly implements CanActivate {
   constructor(
     @Inject(CLERK_CLIENT_PROVIDER_TOKEN)
     private clerkClient: ClerkClient,
-    private reflector: Reflector,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<IncomingRequest>()
     const token = request.headers.authorization?.replace('Bearer ', '')
 
-    // Skip M2M authentication if this isn't a M2M token or the route is public
-    // and does not have role restrictions
-    if (
-      !token ||
-      !token.startsWith('mt_') ||
-      routeIsPublicAndNoRoles(context, this.reflector)
-    ) {
-      return true
+    if (!token || !token.startsWith('mt_')) {
+      return false
     }
 
     request.m2mToken = await verifyM2MToken(token, this.clerkClient)

--- a/src/authentication/guards/M2MOnly.guard.ts
+++ b/src/authentication/guards/M2MOnly.guard.ts
@@ -1,30 +1,13 @@
-import {
-  CanActivate,
-  ExecutionContext,
-  Inject,
-  Injectable,
-} from '@nestjs/common'
-import { CLERK_CLIENT_PROVIDER_TOKEN } from '@/authentication/providers/clerk-client.provider'
-import { ClerkClient } from '@clerk/backend'
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common'
 import { IncomingRequest } from '@/authentication/authentication.types'
-import { verifyM2MToken } from '@/authentication/util/VerifyM2MToken.util'
 
 @Injectable()
 export class M2MOnly implements CanActivate {
-  constructor(
-    @Inject(CLERK_CLIENT_PROVIDER_TOKEN)
-    private clerkClient: ClerkClient,
-  ) {}
+  constructor() {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<IncomingRequest>()
-    const token = request.headers.authorization?.replace('Bearer ', '')
 
-    if (!token || !token.startsWith('mt_')) {
-      return false
-    }
-
-    request.m2mToken = await verifyM2MToken(token, this.clerkClient)
-    return true
+    return Boolean(request.m2mToken)
   }
 }

--- a/src/authentication/util/VerifyM2MToken.util.ts
+++ b/src/authentication/util/VerifyM2MToken.util.ts
@@ -20,8 +20,6 @@ export const verifyM2MToken = async (
       machineSecretKey: GP_WEBAPP_MACHINE_SECRET,
     })
   } catch (error) {
-    console.dir(error, { depth: 4, colors: true })
-    console.error(error instanceof Error ? error.message : 'Unknown error')
-    throw new UnauthorizedException('Invalid M2M token')
+    throw new UnauthorizedException('M2M token verification failed')
   }
 }

--- a/src/authentication/util/VerifyM2MToken.util.ts
+++ b/src/authentication/util/VerifyM2MToken.util.ts
@@ -1,7 +1,7 @@
 import { UnauthorizedException } from '@nestjs/common'
 import { ClerkClient } from '@clerk/backend'
 
-export const { GP_WEBAPP_MACHINE_SECRET } = process.env
+const { GP_WEBAPP_MACHINE_SECRET } = process.env
 
 if (!GP_WEBAPP_MACHINE_SECRET)
   throw new Error(

--- a/src/authentication/util/VerifyM2MToken.util.ts
+++ b/src/authentication/util/VerifyM2MToken.util.ts
@@ -14,6 +14,7 @@ export const verifyM2MToken = async (
 ) => {
   try {
     // Verify M2M token using your NestJS machine's secret
+    console.debug(`Verifying M2M token: ${token}`)
     return await clerkClient.m2m.verify({
       token,
       machineSecretKey: GP_WEBAPP_MACHINE_SECRET,

--- a/src/authentication/util/VerifyM2MToken.util.ts
+++ b/src/authentication/util/VerifyM2MToken.util.ts
@@ -1,0 +1,26 @@
+import { UnauthorizedException } from '@nestjs/common'
+import { ClerkClient } from '@clerk/backend'
+
+export const { GP_WEBAPP_MACHINE_SECRET } = process.env
+
+if (!GP_WEBAPP_MACHINE_SECRET)
+  throw new Error(
+    'CLERK_SECRET_KEY and GP_WEBAPP_MACHINE_SECRET must be set in the environment variables',
+  )
+
+export const verifyM2MToken = async (
+  token: string,
+  clerkClient: ClerkClient,
+) => {
+  try {
+    // Verify M2M token using your NestJS machine's secret
+    return await clerkClient.m2m.verify({
+      token,
+      machineSecretKey: GP_WEBAPP_MACHINE_SECRET,
+    })
+  } catch (error) {
+    console.dir(error, { depth: 4, colors: true })
+    console.error(error instanceof Error ? error.message : 'Unknown error')
+    throw new UnauthorizedException('Invalid M2M token')
+  }
+}

--- a/src/authentication/util/VerifyM2MToken.util.ts
+++ b/src/authentication/util/VerifyM2MToken.util.ts
@@ -5,7 +5,7 @@ const { GP_WEBAPP_MACHINE_SECRET } = process.env
 
 if (!GP_WEBAPP_MACHINE_SECRET)
   throw new Error(
-    'CLERK_SECRET_KEY and GP_WEBAPP_MACHINE_SECRET must be set in the environment variables',
+    'GP_WEBAPP_MACHINE_SECRET must be set in the environment variables',
   )
 
 export const verifyM2MToken = async (

--- a/src/authentication/util/VerifyM2MToken.util.ts
+++ b/src/authentication/util/VerifyM2MToken.util.ts
@@ -13,8 +13,6 @@ export const verifyM2MToken = async (
   clerkClient: ClerkClient,
 ) => {
   try {
-    // Verify M2M token using your NestJS machine's secret
-    console.debug(`Verifying M2M token: ${token}`)
     return await clerkClient.m2m.verify({
       token,
       machineSecretKey: GP_WEBAPP_MACHINE_SECRET,

--- a/src/shared/constants/paginationOptions.consts.ts
+++ b/src/shared/constants/paginationOptions.consts.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_PAGINATION_OFFSET: number = 0
+export const DEFAULT_PAGINATION_LIMIT: number = 100

--- a/src/shared/schemas/Pagination.schema.ts
+++ b/src/shared/schemas/Pagination.schema.ts
@@ -1,11 +1,29 @@
 import { z } from 'zod'
 
-export const PaginationSchema = <T extends [string, ...string[]]>(
-  sortKeys: T,
-) =>
-  z.object({
-    page: z.coerce.number().optional(),
-    limit: z.coerce.number().optional(),
-    sortBy: z.enum(sortKeys).optional(),
-    sortOrder: z.enum(['asc', 'desc']).optional(),
+const basePaginationSchema = z.object({
+  offset: z.coerce.number().optional(),
+  limit: z.coerce.number().optional(),
+  sortOrder: z.enum(['asc', 'desc']).optional(),
+})
+
+export const PaginationSchema = () => basePaginationSchema
+
+export const SortablePaginationSchema = (sortKeys: readonly string[]) => {
+  const [first, ...rest] = sortKeys
+  if (!first) {
+    throw new Error('sortKeys must contain at least one value')
+  }
+  return basePaginationSchema.extend({
+    sortBy: z.enum([first, ...rest]).optional(),
   })
+}
+
+export const paginationFilter = z.string().optional()
+
+export const FilterablePaginationSchema = <F extends z.ZodRawShape>({
+  sortKeys,
+  filterFields,
+}: {
+  sortKeys: readonly string[]
+  filterFields: F
+}) => SortablePaginationSchema(sortKeys).extend(filterFields)

--- a/src/shared/types/utility.types.ts
+++ b/src/shared/types/utility.types.ts
@@ -9,3 +9,19 @@ export type WithOptional<T, F extends keyof T> = Omit<T, F> &
  */
 export type WithRequired<T, F extends keyof T> = Omit<T, F> &
   Required<Pick<T, F>>
+
+export type PaginationOptions = {
+  offset?: number
+  limit?: number
+}
+
+export type PaginationMeta = {
+  total: number
+  offset: number
+  limit: number
+}
+
+export type PaginatedResults<T> = {
+  data: T[]
+  meta: PaginationMeta
+}

--- a/src/users/schemas/ListUsersPagination.schema.ts
+++ b/src/users/schemas/ListUsersPagination.schema.ts
@@ -1,0 +1,19 @@
+import { Prisma } from '@prisma/client'
+import { createZodDto } from 'nestjs-zod'
+import {
+  FilterablePaginationSchema,
+  paginationFilter,
+} from '@/shared/schemas/Pagination.schema'
+
+const FIELDS = Prisma.UserScalarFieldEnum
+
+export class ListUsersPaginationSchema extends createZodDto(
+  FilterablePaginationSchema({
+    sortKeys: Object.values(FIELDS),
+    filterFields: {
+      firstName: paginationFilter,
+      lastName: paginationFilter,
+      email: paginationFilter,
+    },
+  }),
+) {}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -11,6 +11,7 @@ import {
   Param,
   Post,
   Put,
+  Query,
   UnauthorizedException,
   UseGuards,
   UseInterceptors,
@@ -33,6 +34,8 @@ import { MimeTypes } from 'http-constants-ts'
 import { UpdatePasswordSchemaDto } from './schemas/UpdatePassword.schema'
 import { AuthenticationService } from '../authentication/authentication.service'
 import { UpdateUserInputSchema } from './schemas/UpdateUserInput.schema'
+import { M2MOnly } from '@/authentication/guards/M2MOnly.guard'
+import { ListUsersPaginationSchema } from '@/users/schemas/ListUsersPagination.schema'
 
 @Controller('users')
 @UsePipes(ZodValidationPipe)
@@ -44,6 +47,12 @@ export class UsersController {
     private readonly filesService: FilesService,
     private readonly authenticationService: AuthenticationService,
   ) {}
+
+  @UseGuards(M2MOnly)
+  @Get()
+  async list(@Query() query: ListUsersPaginationSchema) {
+    return this.usersService.listUsers(query)
+  }
 
   @UseGuards(UserOwnerOrAdminGuard)
   @Get(':id')

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -51,7 +51,11 @@ export class UsersController {
   @UseGuards(M2MOnly)
   @Get()
   async list(@Query() query: ListUsersPaginationSchema) {
-    return this.usersService.listUsers(query)
+    const { data, meta } = await this.usersService.listUsers(query)
+    return {
+      data: data.map((user) => ReadUserOutputSchema.parse(user)),
+      meta,
+    }
   }
 
   @UseGuards(UserOwnerOrAdminGuard)

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -5,6 +5,7 @@ import { AuthenticationModule } from '@/authentication/authentication.module'
 import { CrmModule } from '@/crm/crmModule'
 import { SlackModule } from '@/vendors/slack/slack.module'
 import { StripeModule } from '@/vendors/stripe/stripe.module'
+import { ClerkClientProvider } from '@/authentication/providers/clerk-client.provider'
 import { CrmUsersService } from './services/crmUsers.service'
 import { UsersService } from './services/users.service'
 import { UsersController } from './users.controller'
@@ -12,7 +13,7 @@ import { UsersController } from './users.controller'
 @Global()
 @Module({
   controllers: [UsersController],
-  providers: [UsersService, CrmUsersService],
+  providers: [UsersService, CrmUsersService, ClerkClientProvider],
   exports: [UsersService, CrmUsersService],
   imports: [
     FilesModule,

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -109,17 +109,20 @@ export class WebsitesController {
       where: { campaignId },
     })
 
-    const total = await this.contacts.count({
-      where: { websiteId: website.id },
-    })
-
-    return {
-      contacts: await this.contacts.findMany({
+    const [contacts, total] = await Promise.all([
+      this.contacts.findMany({
         where: { websiteId: website.id },
         take: limit,
         skip: offset,
         ...(sortBy ? { orderBy: { [sortBy]: sortOrder } } : {}),
       }),
+      this.contacts.count({
+        where: { websiteId: website.id },
+      }),
+    ])
+
+    return {
+      contacts,
       total,
       page,
       limit,

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -101,7 +101,7 @@ export class WebsitesController {
       sortBy,
       sortOrder = 'desc',
       limit = 25,
-      page = 1,
+      offset = 0,
     }: GetWebsiteContactsSchema,
   ) {
     const website = await this.websites.findUniqueOrThrow({
@@ -111,9 +111,9 @@ export class WebsitesController {
     const [contacts, total] = await Promise.all([
       this.contacts.findMany({
         where: { websiteId: website.id },
-        orderBy: sortBy ? { [sortBy]: sortOrder } : undefined,
         take: limit,
-        skip: (page - 1) * limit,
+        skip: offset,
+        ...(sortBy ? { orderBy: { [sortBy]: sortOrder } } : {}),
       }),
       this.contacts.count({
         where: { websiteId: website.id },
@@ -123,7 +123,7 @@ export class WebsitesController {
     return {
       contacts,
       total,
-      page,
+      offset,
       limit,
       totalPages: Math.ceil(total / limit),
     }

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -101,29 +101,27 @@ export class WebsitesController {
       sortBy,
       sortOrder = 'desc',
       limit = 25,
-      offset = 0,
+      page = 1,
     }: GetWebsiteContactsSchema,
   ) {
+    const offset = (page - 1) * limit
     const website = await this.websites.findUniqueOrThrow({
       where: { campaignId },
     })
 
-    const [contacts, total] = await Promise.all([
-      this.contacts.findMany({
+    const total = await this.contacts.count({
+      where: { websiteId: website.id },
+    })
+
+    return {
+      contacts: await this.contacts.findMany({
         where: { websiteId: website.id },
         take: limit,
         skip: offset,
         ...(sortBy ? { orderBy: { [sortBy]: sortOrder } } : {}),
       }),
-      this.contacts.count({
-        where: { websiteId: website.id },
-      }),
-    ])
-
-    return {
-      contacts,
       total,
-      offset,
+      page,
       limit,
       totalPages: Math.ceil(total / limit),
     }

--- a/src/websites/schemas/GetWebsiteContacts.schema.ts
+++ b/src/websites/schemas/GetWebsiteContacts.schema.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client'
 import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
 import { SortablePaginationSchema } from 'src/shared/schemas/Pagination.schema'
 
 const FIELDS = Prisma.WebsiteContactScalarFieldEnum
@@ -12,5 +13,7 @@ export class GetWebsiteContactsSchema extends createZodDto(
     FIELDS.email,
     FIELDS.phone,
     FIELDS.smsConsent,
-  ]),
+  ]).extend({
+    page: z.coerce.number().min(1).optional(),
+  }),
 ) {}

--- a/src/websites/schemas/GetWebsiteContacts.schema.ts
+++ b/src/websites/schemas/GetWebsiteContacts.schema.ts
@@ -1,11 +1,11 @@
 import { Prisma } from '@prisma/client'
 import { createZodDto } from 'nestjs-zod'
-import { PaginationSchema } from 'src/shared/schemas/Pagination.schema'
+import { SortablePaginationSchema } from 'src/shared/schemas/Pagination.schema'
 
 const FIELDS = Prisma.WebsiteContactScalarFieldEnum
 
 export class GetWebsiteContactsSchema extends createZodDto(
-  PaginationSchema([
+  SortablePaginationSchema([
     FIELDS.createdAt,
     FIELDS.updatedAt,
     FIELDS.name,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new auth guard and an M2M-restricted endpoint, plus changes pagination semantics for an existing contacts endpoint; mistakes could cause unintended access or client breakage.
> 
> **Overview**
> Adds a new `GET /users` endpoint that is **restricted to Clerk M2M tokens only** via a new `M2MOnly` guard, returning paginated results from `UsersService.listUsers` with sorting plus `firstName`/`lastName`/`email` contains filters.
> 
> Standardizes pagination around **offset/limit** by expanding shared Zod pagination schemas (sortable + filterable variants), introducing shared pagination constants/types, and updating website contacts listing to use `offset` instead of `page`. Also adds DB indexes on `user.first_name` and `user.last_name` to support the new filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1aa7f4a29d02a0fd36b6a0ae28043ce3565d3729. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->