### PR TITLE
[ENG-6707] - Fixes a build error in SDK related to CJS named exports missing

### DIFF
--- a/contracts/.changeset/fix-cjs-validator-import.md
+++ b/contracts/.changeset/fix-cjs-validator-import.md
@@ -1,0 +1,13 @@
+---
+"@goodparty_org/contracts": patch
+---
+
+Use default imports for CJS-only `validator` package to fix ESM interop in consumer test runners
+
+- Switch `import { isMobilePhone } from 'validator'` to `import validator from 'validator'` in PhoneSchema
+- Switch `import { isPostalCode } from 'validator'` to `import validator from 'validator'` in ZipSchema
+- Add const enum objects for campaign enums (CampaignCreatedBy, OnboardingStep, etc.) with declaration merging
+- Add CampaignStatus enum to contracts
+- Export campaign enums as both type and value from contracts index
+- Fix CI change detection to compare full PR diff against base branch
+- Update RC version naming to include PR number or branch name

--- a/contracts/src/shared/Phone.schema.ts
+++ b/contracts/src/shared/Phone.schema.ts
@@ -1,6 +1,6 @@
-import { isMobilePhone } from 'validator'
+import validator from 'validator'
 import { z } from 'zod'
 
 export const PhoneSchema = z
   .string()
-  .refine((val) => isMobilePhone(val), 'Must be valid phone number')
+  .refine((val) => validator.isMobilePhone(val), 'Must be valid phone number')

--- a/contracts/src/shared/Zip.schema.ts
+++ b/contracts/src/shared/Zip.schema.ts
@@ -1,6 +1,6 @@
-import { isPostalCode } from 'validator'
+import validator from 'validator'
 import { z } from 'zod'
 
 export const ZipSchema = z
   .string()
-  .refine((val) => isPostalCode(val, 'US'), 'Must be valid Zip code')
+  .refine((val) => validator.isPostalCode(val, 'US'), 'Must be valid Zip code')


### PR DESCRIPTION
Fixes https://github.com/thegoodparty/gp-admin/actions/runs/22460528910/job/65053275740?pr=38#step:5:197

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to schema validation imports; main risk is subtle behavior differences if `validator` export shape varies across bundlers.
> 
> **Overview**
> Fixes ESM/CJS interop issues with the CJS-only `validator` dependency by switching `PhoneSchema` and `ZipSchema` to use a default import (`import validator from 'validator'`) and calling `validator.isMobilePhone` / `validator.isPostalCode` instead of named imports.
> 
> Adds a patch changeset documenting the import change for `@goodparty_org/contracts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15237ff6cef877e594a35969fe81462fb184acde. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->