### PR TITLE
HOTFIX - fixes changesets not being found

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,6 +117,12 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - name: Symlink changeset config for changesets/action
+        if: >-
+          github.ref_name == 'master'
+          && steps.contracts-changed.outputs.contracts == 'true'
+        run: ln -s contracts/.changeset .changeset
+
       - name: Create Release PR or Publish contracts
         if: >-
           github.ref_name == 'master'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change affecting the `master` contracts release flow; main risk is a broken symlink step causing release PR/publish to fail.
> 
> **Overview**
> Fixes contracts publishing on `master` by ensuring `changesets/action` can find its config.
> 
> The workflow now creates a `.changeset` symlink to `contracts/.changeset` right before running `changesets/action`, so release PR creation/publishing works when running from the repo root with `cwd: contracts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17fac14fb2bc9228dd5dc98a524aad1db8ac3ec9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->