### PR TITLE
[ENG-6707] - fix changesets action git push by disabling checkout per…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check contracts changes
         id: contracts-changed


### PR DESCRIPTION
…sist-credentials

actions/checkout persists a read-only extraheader that overrides the GitHub App token used by changesets/action, causing git push to fail with exit code 128 on master.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak limited to GitHub Actions checkout configuration; primary impact is on CI publishing/release steps that rely on pushing to the repo.
> 
> **Overview**
> Disables credential persistence in `actions/checkout` (`persist-credentials: false`) in the main CI workflow.
> 
> This prevents the default checkout auth header from overriding the GitHub App token used by `changesets/action`, unblocking `git push` during release/changeset automation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28a6fc7ce5a2140bce1a4ac6ad82a39127307cf6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->