### PR TITLE
ENG-5943: Mark backend analytics with impersonation context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ The `QueueConsumerModule` is excluded when `NODE_ENV === 'test'`.
 
 ### Global Interceptors
 
+- `ImpersonationInterceptor` — propagates impersonation state from JWT to AsyncLocalStorage for analytics tagging
 - `AdminAuditInterceptor` — logs all admin route accesses
 - `BlockedStateInterceptor` — records user-blocking failures to New Relic/OpenTelemetry
 

--- a/src/admin/users/adminUsers.controller.test.ts
+++ b/src/admin/users/adminUsers.controller.test.ts
@@ -1,0 +1,95 @@
+import { BadRequestException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AdminUsersController } from './adminUsers.controller'
+import { UsersService } from 'src/users/services/users.service'
+import { CampaignsService } from 'src/campaigns/services/campaigns.service'
+import { AuthenticationService } from 'src/authentication/authentication.service'
+import { SlackService } from 'src/vendors/slack/services/slack.service'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+
+const mockUser = {
+  id: 5,
+  email: 'candidate@example.com',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  phone: '5551234567',
+  avatar: null,
+  hasPassword: false,
+  roles: [],
+  metaData: null,
+}
+
+describe('AdminUsersController', () => {
+  let controller: AdminUsersController
+  let mockUsersService: {
+    findUserByEmail: ReturnType<typeof vi.fn>
+    findMany: ReturnType<typeof vi.fn>
+    findUniqueOrThrow: ReturnType<typeof vi.fn>
+    createUser: ReturnType<typeof vi.fn>
+    deleteUser: ReturnType<typeof vi.fn>
+  }
+  let mockAuthService: {
+    generateAuthToken: ReturnType<typeof vi.fn>
+  }
+  let mockCampaignsService: { deleteAll: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    mockUsersService = {
+      findUserByEmail: vi.fn(),
+      findMany: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
+      createUser: vi.fn(),
+      deleteUser: vi.fn(),
+    }
+
+    mockAuthService = {
+      generateAuthToken: vi.fn().mockResolvedValue('jwt-token'),
+    }
+
+    mockCampaignsService = {
+      deleteAll: vi.fn(),
+    }
+
+    controller = new AdminUsersController(
+      mockUsersService as unknown as UsersService,
+      mockCampaignsService as unknown as CampaignsService,
+      mockAuthService as unknown as AuthenticationService,
+      {} as SlackService,
+      createMockLogger(),
+    )
+  })
+
+  describe('impersonate', () => {
+    it('generates a token with impersonating: true', async () => {
+      mockUsersService.findUserByEmail.mockResolvedValue(mockUser)
+
+      await controller.impersonate({ email: 'candidate@example.com' })
+
+      expect(mockAuthService.generateAuthToken).toHaveBeenCalledWith({
+        email: 'candidate@example.com',
+        sub: 5,
+        impersonating: true,
+      })
+    })
+
+    it('returns the generated token and parsed user', async () => {
+      mockUsersService.findUserByEmail.mockResolvedValue(mockUser)
+      mockAuthService.generateAuthToken.mockResolvedValue('impersonation-jwt')
+
+      const result = await controller.impersonate({
+        email: 'candidate@example.com',
+      })
+
+      expect(result.token).toBe('impersonation-jwt')
+      expect(result.user).toBeDefined()
+    })
+
+    it('throws BadRequestException when user is not found', async () => {
+      mockUsersService.findUserByEmail.mockResolvedValue(null)
+
+      await expect(
+        controller.impersonate({ email: 'nobody@example.com' }),
+      ).rejects.toThrow(BadRequestException)
+    })
+  })
+})

--- a/src/admin/users/adminUsers.controller.ts
+++ b/src/admin/users/adminUsers.controller.ts
@@ -85,6 +85,7 @@ export class AdminUsersController {
     const token = await this.authService.generateAuthToken({
       email: user.email,
       sub: user.id,
+      impersonating: true,
     })
 
     return { user: ReadUserOutputSchema.parse(user), token }

--- a/src/analytics/analytics.service.test.ts
+++ b/src/analytics/analytics.service.test.ts
@@ -42,74 +42,8 @@ describe('AnalyticsService', () => {
     mockUsersService.findFirst.mockResolvedValue(mockUser)
   })
 
-  describe('track - isImpersonating parameter', () => {
-    it('includes impersonation: true in event data when isImpersonating is true', async () => {
-      await service.track(7, 'Test Event', { source: 'test' }, true)
-
-      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
-        7,
-        'Test Event',
-        {
-          email: 'test@example.com',
-          source: 'test',
-          impersonation: true,
-        },
-        { email: 'test@example.com', hubspotId: 'hs-123' },
-      )
-    })
-
-    it('includes impersonation: false in event data when isImpersonating is false', async () => {
-      await service.track(7, 'Test Event', { source: 'test' }, false)
-
-      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
-        7,
-        'Test Event',
-        {
-          email: 'test@example.com',
-          source: 'test',
-          impersonation: false,
-        },
-        { email: 'test@example.com', hubspotId: 'hs-123' },
-      )
-    })
-
-    it('omits impersonation key from event data when isImpersonating is not provided', async () => {
-      await service.track(7, 'Test Event', { source: 'test' })
-
-      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
-        7,
-        'Test Event',
-        {
-          email: 'test@example.com',
-          source: 'test',
-        },
-        { email: 'test@example.com', hubspotId: 'hs-123' },
-      )
-    })
-
-    it('passes user context from UsersService to segment', async () => {
-      await service.track(7, 'Test Event', { source: 'test' }, true)
-
-      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
-        7,
-        'Test Event',
-        expect.any(Object),
-        { email: 'test@example.com', hubspotId: 'hs-123' },
-      )
-    })
-
-    it('re-throws when segment tracking fails', async () => {
-      const error = new Error('Segment service down')
-      mockSegment.trackEvent.mockRejectedValueOnce(error)
-
-      await expect(
-        service.track(7, 'Test Event', { source: 'test' }),
-      ).rejects.toThrow('Segment service down')
-    })
-  })
-
-  describe('track - AsyncLocalStorage fallback', () => {
-    it('reads impersonation from AsyncLocalStorage when param is undefined', async () => {
+  describe('track - impersonation via AsyncLocalStorage', () => {
+    it('includes impersonation: true when context is impersonating', async () => {
       await runWithImpersonation(true, async () => {
         await service.track(7, 'Test Event', { source: 'test' })
       })
@@ -126,9 +60,9 @@ describe('AnalyticsService', () => {
       )
     })
 
-    it('explicit param takes precedence over AsyncLocalStorage', async () => {
-      await runWithImpersonation(true, async () => {
-        await service.track(7, 'Test Event', { source: 'test' }, false)
+    it('includes impersonation: false when context is not impersonating', async () => {
+      await runWithImpersonation(false, async () => {
+        await service.track(7, 'Test Event', { source: 'test' })
       })
 
       expect(mockSegment.trackEvent).toHaveBeenCalledWith(
@@ -143,7 +77,7 @@ describe('AnalyticsService', () => {
       )
     })
 
-    it('omits impersonation when both param and AsyncLocalStorage are undefined', async () => {
+    it('omits impersonation when no context is set', async () => {
       await service.track(7, 'Test Event', { source: 'test' })
 
       expect(mockSegment.trackEvent).toHaveBeenCalledWith(
@@ -155,6 +89,28 @@ describe('AnalyticsService', () => {
         },
         { email: 'test@example.com', hubspotId: 'hs-123' },
       )
+    })
+
+    it('passes user context from UsersService to segment', async () => {
+      await runWithImpersonation(true, async () => {
+        await service.track(7, 'Test Event', { source: 'test' })
+      })
+
+      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
+        7,
+        'Test Event',
+        expect.any(Object),
+        { email: 'test@example.com', hubspotId: 'hs-123' },
+      )
+    })
+
+    it('re-throws when segment tracking fails', async () => {
+      const error = new Error('Segment service down')
+      mockSegment.trackEvent.mockRejectedValueOnce(error)
+
+      await expect(
+        service.track(7, 'Test Event', { source: 'test' }),
+      ).rejects.toThrow('Segment service down')
     })
   })
 })

--- a/src/analytics/analytics.service.test.ts
+++ b/src/analytics/analytics.service.test.ts
@@ -1,0 +1,160 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AnalyticsService } from './analytics.service'
+import { SegmentService } from 'src/vendors/segment/segment.service'
+import { UsersService } from 'src/users/services/users.service'
+import { PinoLogger } from 'nestjs-pino'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { runWithImpersonation } from './impersonation-context'
+
+const mockUser = {
+  id: 7,
+  email: 'test@example.com',
+  metaData: { hubspotId: 'hs-123' },
+}
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService
+  let mockSegment: { trackEvent: ReturnType<typeof vi.fn> }
+  let mockUsersService: { findFirst: ReturnType<typeof vi.fn> }
+
+  beforeEach(async () => {
+    mockSegment = {
+      trackEvent: vi.fn().mockResolvedValue(undefined),
+    }
+
+    mockUsersService = {
+      findFirst: vi.fn().mockResolvedValue(mockUser),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsService,
+        { provide: SegmentService, useValue: mockSegment },
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: PinoLogger, useValue: createMockLogger() },
+      ],
+    }).compile()
+
+    service = module.get<AnalyticsService>(AnalyticsService)
+
+    vi.clearAllMocks()
+    mockUsersService.findFirst.mockResolvedValue(mockUser)
+  })
+
+  describe('track - isImpersonating parameter', () => {
+    it('includes impersonation: true in event data when isImpersonating is true', async () => {
+      await service.track(7, 'Test Event', { source: 'test' }, true)
+
+      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
+        7,
+        'Test Event',
+        {
+          email: 'test@example.com',
+          source: 'test',
+          impersonation: true,
+        },
+        { email: 'test@example.com', hubspotId: 'hs-123' },
+      )
+    })
+
+    it('includes impersonation: false in event data when isImpersonating is false', async () => {
+      await service.track(7, 'Test Event', { source: 'test' }, false)
+
+      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
+        7,
+        'Test Event',
+        {
+          email: 'test@example.com',
+          source: 'test',
+          impersonation: false,
+        },
+        { email: 'test@example.com', hubspotId: 'hs-123' },
+      )
+    })
+
+    it('omits impersonation key from event data when isImpersonating is not provided', async () => {
+      await service.track(7, 'Test Event', { source: 'test' })
+
+      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
+        7,
+        'Test Event',
+        {
+          email: 'test@example.com',
+          source: 'test',
+        },
+        { email: 'test@example.com', hubspotId: 'hs-123' },
+      )
+    })
+
+    it('passes user context from UsersService to segment', async () => {
+      await service.track(7, 'Test Event', { source: 'test' }, true)
+
+      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
+        7,
+        'Test Event',
+        expect.any(Object),
+        { email: 'test@example.com', hubspotId: 'hs-123' },
+      )
+    })
+
+    it('re-throws when segment tracking fails', async () => {
+      const error = new Error('Segment service down')
+      mockSegment.trackEvent.mockRejectedValueOnce(error)
+
+      await expect(
+        service.track(7, 'Test Event', { source: 'test' }),
+      ).rejects.toThrow('Segment service down')
+    })
+  })
+
+  describe('track - AsyncLocalStorage fallback', () => {
+    it('reads impersonation from AsyncLocalStorage when param is undefined', async () => {
+      await runWithImpersonation(true, async () => {
+        await service.track(7, 'Test Event', { source: 'test' })
+      })
+
+      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
+        7,
+        'Test Event',
+        {
+          email: 'test@example.com',
+          source: 'test',
+          impersonation: true,
+        },
+        { email: 'test@example.com', hubspotId: 'hs-123' },
+      )
+    })
+
+    it('explicit param takes precedence over AsyncLocalStorage', async () => {
+      await runWithImpersonation(true, async () => {
+        await service.track(7, 'Test Event', { source: 'test' }, false)
+      })
+
+      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
+        7,
+        'Test Event',
+        {
+          email: 'test@example.com',
+          source: 'test',
+          impersonation: false,
+        },
+        { email: 'test@example.com', hubspotId: 'hs-123' },
+      )
+    })
+
+    it('omits impersonation when both param and AsyncLocalStorage are undefined', async () => {
+      await service.track(7, 'Test Event', { source: 'test' })
+
+      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
+        7,
+        'Test Event',
+        {
+          email: 'test@example.com',
+          source: 'test',
+        },
+        { email: 'test@example.com', hubspotId: 'hs-123' },
+      )
+    })
+  })
+})

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -57,7 +57,6 @@ export class AnalyticsService {
     userId: number,
     eventName: string,
     properties?: SegmentTrackEventProperties,
-    isImpersonating?: boolean,
   ) {
     this.logger.debug(
       `[ANALYTICS] Starting event tracking - Event: ${eventName}, User: ${userId}`,
@@ -65,7 +64,7 @@ export class AnalyticsService {
 
     const userContext = await this.getUserContext(userId)
 
-    const impersonationState = isImpersonating ?? getImpersonationContext()
+    const impersonationState = getImpersonationContext()
 
     const eventData = {
       ...(userContext?.email ? { email: userContext.email as string } : {}),

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -10,6 +10,7 @@ import {
 import { WrapperType } from '../shared/types/utility.types'
 import { UsersService } from '../users/services/users.service'
 import { PinoLogger } from 'nestjs-pino'
+import { getImpersonationContext } from './impersonation-context'
 
 @Injectable()
 export class AnalyticsService {
@@ -56,6 +57,7 @@ export class AnalyticsService {
     userId: number,
     eventName: string,
     properties?: SegmentTrackEventProperties,
+    isImpersonating?: boolean,
   ) {
     this.logger.debug(
       `[ANALYTICS] Starting event tracking - Event: ${eventName}, User: ${userId}`,
@@ -63,9 +65,14 @@ export class AnalyticsService {
 
     const userContext = await this.getUserContext(userId)
 
+    const impersonationState = isImpersonating ?? getImpersonationContext()
+
     const eventData = {
       ...(userContext?.email ? { email: userContext.email as string } : {}),
       ...properties,
+      ...(impersonationState !== undefined
+        ? { impersonation: impersonationState }
+        : {}),
     }
 
     try {

--- a/src/analytics/impersonation-context.test.ts
+++ b/src/analytics/impersonation-context.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getImpersonationContext,
+  runWithImpersonation,
+} from './impersonation-context'
+
+describe('impersonation-context', () => {
+  describe('getImpersonationContext', () => {
+    it('returns undefined when called outside runWithImpersonation', () => {
+      expect(getImpersonationContext()).toBeUndefined()
+    })
+
+    it('returns true when run inside runWithImpersonation(true)', () => {
+      runWithImpersonation(true, () => {
+        expect(getImpersonationContext()).toBe(true)
+      })
+    })
+
+    it('returns false when run inside runWithImpersonation(false)', () => {
+      runWithImpersonation(false, () => {
+        expect(getImpersonationContext()).toBe(false)
+      })
+    })
+  })
+
+  describe('runWithImpersonation', () => {
+    it('returns the value from the callback', () => {
+      const result = runWithImpersonation(true, () => 'hello')
+      expect(result).toBe('hello')
+    })
+
+    it('does not leak context outside the callback', () => {
+      runWithImpersonation(true, () => {
+        expect(getImpersonationContext()).toBe(true)
+      })
+      expect(getImpersonationContext()).toBeUndefined()
+    })
+
+    it('supports nested calls with different values', () => {
+      runWithImpersonation(true, () => {
+        expect(getImpersonationContext()).toBe(true)
+        runWithImpersonation(false, () => {
+          expect(getImpersonationContext()).toBe(false)
+        })
+        expect(getImpersonationContext()).toBe(true)
+      })
+    })
+  })
+})

--- a/src/analytics/impersonation-context.ts
+++ b/src/analytics/impersonation-context.ts
@@ -1,0 +1,19 @@
+import { AsyncLocalStorage } from 'async_hooks'
+
+interface ImpersonationStore {
+  isImpersonating: boolean
+}
+
+export const impersonationStorage =
+  new AsyncLocalStorage<ImpersonationStore>()
+
+export function getImpersonationContext(): boolean | undefined {
+  return impersonationStorage.getStore()?.isImpersonating
+}
+
+export function runWithImpersonation<T>(
+  isImpersonating: boolean,
+  fn: () => T,
+): T {
+  return impersonationStorage.run({ isImpersonating }, fn)
+}

--- a/src/analytics/impersonation-context.ts
+++ b/src/analytics/impersonation-context.ts
@@ -4,8 +4,7 @@ interface ImpersonationStore {
   isImpersonating: boolean
 }
 
-export const impersonationStorage =
-  new AsyncLocalStorage<ImpersonationStore>()
+export const impersonationStorage = new AsyncLocalStorage<ImpersonationStore>()
 
 export function getImpersonationContext(): boolean | undefined {
   return impersonationStorage.getStore()?.isImpersonating

--- a/src/analytics/interceptors/Impersonation.interceptor.test.ts
+++ b/src/analytics/interceptors/Impersonation.interceptor.test.ts
@@ -1,0 +1,66 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common'
+import { of, lastValueFrom } from 'rxjs'
+import { describe, expect, it, vi } from 'vitest'
+import { ImpersonationInterceptor } from './Impersonation.interceptor'
+import { getImpersonationContext } from '../impersonation-context'
+
+function createMockContext(user?: {
+  impersonating?: boolean
+}): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+  } as unknown as ExecutionContext
+}
+
+function createMockHandler(fn?: () => unknown): CallHandler {
+  return {
+    handle: () => of(fn ? fn() : 'ok'),
+  }
+}
+
+describe('ImpersonationInterceptor', () => {
+  const interceptor = new ImpersonationInterceptor()
+
+  it('sets isImpersonating to true when JWT has impersonating claim', async () => {
+    let captured: boolean | undefined
+
+    const context = createMockContext({ impersonating: true })
+    const handler = createMockHandler(() => {
+      captured = getImpersonationContext()
+      return 'result'
+    })
+
+    const result$ = interceptor.intercept(context, handler)
+    const result = await lastValueFrom(result$)
+
+    expect(captured).toBe(true)
+    expect(result).toBe('result')
+  })
+
+  it('sets isImpersonating to false when no user on request', async () => {
+    let captured: boolean | undefined
+
+    const context = createMockContext(undefined)
+    const handler = createMockHandler(() => {
+      captured = getImpersonationContext()
+      return 'result'
+    })
+
+    const result$ = interceptor.intercept(context, handler)
+    await lastValueFrom(result$)
+
+    expect(captured).toBe(false)
+  })
+
+  it('does not leak context after the observable completes', async () => {
+    const context = createMockContext({ impersonating: true })
+    const handler = createMockHandler(() => 'done')
+
+    const result$ = interceptor.intercept(context, handler)
+    await lastValueFrom(result$)
+
+    expect(getImpersonationContext()).toBeUndefined()
+  })
+})

--- a/src/analytics/interceptors/Impersonation.interceptor.test.ts
+++ b/src/analytics/interceptors/Impersonation.interceptor.test.ts
@@ -1,5 +1,5 @@
 import { CallHandler, ExecutionContext } from '@nestjs/common'
-import { of, lastValueFrom } from 'rxjs'
+import { of, lastValueFrom, from } from 'rxjs'
 import { describe, expect, it } from 'vitest'
 import { ImpersonationInterceptor } from './Impersonation.interceptor'
 import { getImpersonationContext } from '../impersonation-context'
@@ -62,5 +62,27 @@ describe('ImpersonationInterceptor', () => {
     await lastValueFrom(result$)
 
     expect(getImpersonationContext()).toBeUndefined()
+  })
+
+  it('propagates context through async handler', async () => {
+    let captured: boolean | undefined
+
+    const context = createMockContext({ impersonating: true })
+    const handler: CallHandler = {
+      handle: () =>
+        from(
+          (async () => {
+            await new Promise((r) => setTimeout(r, 1))
+            captured = getImpersonationContext()
+            return 'async-result'
+          })(),
+        ),
+    }
+
+    const result$ = interceptor.intercept(context, handler)
+    const result = await lastValueFrom(result$)
+
+    expect(captured).toBe(true)
+    expect(result).toBe('async-result')
   })
 })

--- a/src/analytics/interceptors/Impersonation.interceptor.test.ts
+++ b/src/analytics/interceptors/Impersonation.interceptor.test.ts
@@ -1,6 +1,6 @@
 import { CallHandler, ExecutionContext } from '@nestjs/common'
 import { of, lastValueFrom } from 'rxjs'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { ImpersonationInterceptor } from './Impersonation.interceptor'
 import { getImpersonationContext } from '../impersonation-context'
 

--- a/src/analytics/interceptors/Impersonation.interceptor.ts
+++ b/src/analytics/interceptors/Impersonation.interceptor.ts
@@ -19,9 +19,11 @@ export class ImpersonationInterceptor implements NestInterceptor {
     const isImpersonating = user?.impersonating === true
 
     return new Observable((subscriber) => {
+      let inner: ReturnType<Observable<unknown>['subscribe']> | undefined
       runWithImpersonation(isImpersonating, () => {
-        next.handle().subscribe(subscriber)
+        inner = next.handle().subscribe(subscriber)
       })
+      return () => inner?.unsubscribe()
     })
   }
 }

--- a/src/analytics/interceptors/Impersonation.interceptor.ts
+++ b/src/analytics/interceptors/Impersonation.interceptor.ts
@@ -4,18 +4,16 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common'
-import { FastifyRequest } from 'fastify'
 import { Observable } from 'rxjs'
 import { runWithImpersonation } from '../impersonation-context'
 
 @Injectable()
 export class ImpersonationInterceptor implements NestInterceptor {
-  intercept(
-    context: ExecutionContext,
-    next: CallHandler,
-  ): Observable<unknown> {
-    const request = context.switchToHttp().getRequest()
-    const user = (request as { user?: { impersonating?: boolean } }).user
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context
+      .switchToHttp()
+      .getRequest<{ user?: { impersonating?: boolean } }>()
+    const user = request.user
     const isImpersonating = user?.impersonating === true
 
     return new Observable((subscriber) => {

--- a/src/analytics/interceptors/Impersonation.interceptor.ts
+++ b/src/analytics/interceptors/Impersonation.interceptor.ts
@@ -1,0 +1,27 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common'
+import { FastifyRequest } from 'fastify'
+import { Observable } from 'rxjs'
+import { runWithImpersonation } from '../impersonation-context'
+
+@Injectable()
+export class ImpersonationInterceptor implements NestInterceptor {
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<unknown> {
+    const request = context.switchToHttp().getRequest()
+    const user = (request as { user?: { impersonating?: boolean } }).user
+    const isImpersonating = user?.impersonating === true
+
+    return new Observable((subscriber) => {
+      runWithImpersonation(isImpersonating, () => {
+        next.handle().subscribe(subscriber)
+      })
+    })
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { JwtAuthStrategy } from '@/authentication/auth-strategies/JwtAuth.strate
 import { AuthenticationModule } from '@/authentication/authentication.module'
 import { ClerkM2MAuthGuard } from '@/authentication/guards/ClerkM2MAuth.guard'
 import { JwtAuthGuard } from '@/authentication/guards/JwtAuth.guard'
+import { ImpersonationInterceptor } from '@/analytics/interceptors/Impersonation.interceptor'
 import { AdminAuditInterceptor } from '@/authentication/interceptors/AdminAudit.interceptor'
 import { ClerkClientProvider } from '@/authentication/providers/clerk-client.provider'
 import { CampaignsModule } from '@/campaigns/campaigns.module'
@@ -94,6 +95,10 @@ import { loggerModule } from './observability/logging/logger-module'
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ImpersonationInterceptor,
     },
     {
       provide: APP_INTERCEPTOR,

--- a/src/authentication/auth-strategies/JwtAuth.strategy.test.ts
+++ b/src/authentication/auth-strategies/JwtAuth.strategy.test.ts
@@ -20,9 +20,7 @@ describe('JwtAuthStrategy', () => {
       findUser: vi.fn().mockResolvedValue(mockUser),
     }
 
-    strategy = new JwtAuthStrategy(
-      mockUsersService as unknown as UsersService,
-    )
+    strategy = new JwtAuthStrategy(mockUsersService as unknown as UsersService)
   })
 
   describe('validate - impersonation claim', () => {

--- a/src/authentication/auth-strategies/JwtAuth.strategy.test.ts
+++ b/src/authentication/auth-strategies/JwtAuth.strategy.test.ts
@@ -1,0 +1,61 @@
+import { UnauthorizedException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { JwtAuthStrategy } from './JwtAuth.strategy'
+import { UsersService } from '../../users/services/users.service'
+
+const mockUser = {
+  id: 42,
+  email: 'voter@example.com',
+  name: 'Test User',
+}
+
+describe('JwtAuthStrategy', () => {
+  let strategy: JwtAuthStrategy
+  let mockUsersService: { findUser: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    vi.stubEnv('AUTH_SECRET', 'test-secret')
+
+    mockUsersService = {
+      findUser: vi.fn().mockResolvedValue(mockUser),
+    }
+
+    strategy = new JwtAuthStrategy(
+      mockUsersService as unknown as UsersService,
+    )
+  })
+
+  describe('validate - impersonation claim', () => {
+    it('returns user with impersonating: true when JWT has impersonating: true', async () => {
+      const result = await strategy.validate({
+        sub: '42',
+        impersonating: true,
+      })
+
+      expect(result).toEqual({ ...mockUser, impersonating: true })
+    })
+
+    it('returns user with impersonating: false when JWT has no impersonating claim', async () => {
+      const result = await strategy.validate({ sub: '42' })
+
+      expect(result).toEqual({ ...mockUser, impersonating: false })
+    })
+
+    it('returns user with impersonating: false when JWT has impersonating: false', async () => {
+      const result = await strategy.validate({
+        sub: '42',
+        impersonating: false,
+      })
+
+      expect(result).toEqual({ ...mockUser, impersonating: false })
+    })
+
+    it('throws UnauthorizedException when user is not found', async () => {
+      mockUsersService.findUser.mockResolvedValue(null)
+
+      await expect(strategy.validate({ sub: '999' })).rejects.toThrow(
+        UnauthorizedException,
+      )
+    })
+  })
+})

--- a/src/authentication/auth-strategies/JwtAuth.strategy.ts
+++ b/src/authentication/auth-strategies/JwtAuth.strategy.ts
@@ -14,7 +14,7 @@ export class JwtAuthStrategy extends PassportStrategy(Strategy) {
     })
   }
 
-  async validate({ sub: userId }: JwtPayload) {
+  async validate({ sub: userId, impersonating }: JwtPayload) {
     if (!userId) {
       throw new UnauthorizedException()
     }
@@ -24,6 +24,6 @@ export class JwtAuthStrategy extends PassportStrategy(Strategy) {
     if (!user) {
       throw new UnauthorizedException()
     }
-    return user
+    return { ...user, impersonating: impersonating === true }
   }
 }

--- a/src/authentication/authentication.service.test.ts
+++ b/src/authentication/authentication.service.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuthenticationService } from './authentication.service'
+import { JwtService } from '@nestjs/jwt'
+import { UsersService } from '../users/services/users.service'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+
+describe('AuthenticationService', () => {
+  describe('generateAuthToken - impersonation claim', () => {
+    let service: AuthenticationService
+    let signedPayload: Record<string, unknown>
+
+    const mockJwtService = {
+      sign: vi.fn((payload: Record<string, unknown>) => {
+        signedPayload = payload
+        return 'signed-token'
+      }),
+    }
+
+    beforeEach(() => {
+      service = new AuthenticationService(
+        {} as UsersService,
+        mockJwtService as unknown as JwtService,
+        createMockLogger(),
+      )
+      vi.clearAllMocks()
+    })
+
+    it('includes impersonating: true in JWT payload when impersonating is true', () => {
+      service.generateAuthToken({
+        email: 'admin@example.com',
+        sub: 1,
+        impersonating: true,
+      })
+
+      expect(signedPayload).toEqual(
+        expect.objectContaining({ impersonating: true }),
+      )
+    })
+
+    it('does not include impersonating in JWT payload when omitted', () => {
+      service.generateAuthToken({
+        email: 'user@example.com',
+        sub: 2,
+      })
+
+      expect(signedPayload).not.toHaveProperty('impersonating')
+    })
+
+    it('includes impersonating: false in JWT payload when explicitly false', () => {
+      service.generateAuthToken({
+        email: 'user@example.com',
+        sub: 3,
+        impersonating: false,
+      })
+
+      expect(signedPayload).toEqual(
+        expect.objectContaining({ impersonating: false }),
+      )
+    })
+  })
+})

--- a/src/authentication/authentication.service.ts
+++ b/src/authentication/authentication.service.ts
@@ -79,7 +79,11 @@ export class AuthenticationService {
     this.logger.setContext(AuthenticationService.name)
   }
 
-  generateAuthToken(payload: { email: string; sub: number }) {
+  generateAuthToken(payload: {
+    email: string
+    sub: number
+    impersonating?: boolean
+  }) {
     return this.jwtService.sign({ ...payload, iss: GP_API_ISSUER })
   }
 


### PR DESCRIPTION
## Summary

- Add `impersonating: true` JWT claim when admin impersonates a user
- Extract claim in JwtAuth strategy and forward on `request.user`
- Add global ImpersonationInterceptor to propagate impersonation state via AsyncLocalStorage
- Tag Segment track events with `impersonation` property in AnalyticsService

## Changes

| File | Change |
|------|--------|
| `src/authentication/authentication.service.ts` | Accept optional `impersonating` in token payload |
| `src/admin/users/adminUsers.controller.ts` | Pass `impersonating: true` when generating impersonation token |
| `src/authentication/auth-strategies/JwtAuth.strategy.ts` | Extract `impersonating` from JWT, forward on user object |
| `src/analytics/impersonation-context.ts` | AsyncLocalStorage helpers for request-scoped impersonation state |
| `src/analytics/interceptors/Impersonation.interceptor.ts` | Global interceptor reading `request.user.impersonating` |
| `src/app.module.ts` | Register ImpersonationInterceptor globally |
| `src/analytics/analytics.service.ts` | Add `impersonation` property to Segment events |

## Test plan

- [ ] 27 unit tests passing across 6 test files
- [ ] Manual: impersonate a candidate, trigger a backend-tracked action, verify Segment event includes `impersonation: true`
- [ ] Manual: normal (non-impersonated) action should include `impersonation: false` or omit it

## Companion PR

- gp-webapp: https://github.com/thegoodparty/gp-webapp/pull/1562

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/JWT payload shape and adds a global interceptor using `AsyncLocalStorage`, which can impact request-scoped behavior and analytics tagging if mis-propagated.
> 
> **Overview**
> Adds end-to-end *impersonation awareness* to backend analytics. Admin impersonation tokens now include an `impersonating` JWT claim, `JwtAuthStrategy` forwards this onto `request.user`, and a new global `ImpersonationInterceptor` propagates the flag via `AsyncLocalStorage`.
> 
> `AnalyticsService.track` now accepts an optional `isImpersonating` override and otherwise reads from the request context to append an `impersonation` property to Segment event payloads. Includes new unit tests covering the JWT claim, controller token generation, interceptor scoping, context helpers, and analytics event tagging behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 121ca4658d50d4d5ab8ecf406cff05d926524bf7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->