### PR TITLE
Remove our coding style that says no comments in code.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,6 @@ npm run prisma-format      # Format Prisma schema files
 ## Code Style
 
 - **No semicolons**, single quotes, trailing commas everywhere (`.prettierrc`)
-- **No comments** in code
 - `@typescript-eslint/no-explicit-any` is an **error** — never use `any`
 - `unused-imports/no-unused-imports` is an **error**
 - Path alias: `@/*` → `src/*` (e.g., `import { Foo } from '@/shared/util/foo'`)


### PR DESCRIPTION
It's great when code is self documenting, but the occational comment can be valuable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that does not affect runtime behavior, APIs, or data handling.
> 
> **Overview**
> Updates `CLAUDE.md` coding standards by removing the guideline that forbade comments in code, while keeping the rest of the formatting and linting rules unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9e262780871598386ad4d8dbf1e610cc886fbb2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->