### PR TITLE
feat: recurring tasks

### DIFF
--- a/prisma/schema/campaignTask.prisma
+++ b/prisma/schema/campaignTask.prisma
@@ -8,6 +8,7 @@ enum CampaignTaskType {
   education
   compliance
   awareness
+  recurring
 }
 
 model CampaignTask {

--- a/prisma/schema/migrations/20260410024513_recurring_tasks/migration.sql
+++ b/prisma/schema/migrations/20260410024513_recurring_tasks/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "CampaignTaskType" ADD VALUE 'recurring';

--- a/src/campaigns/tasks/campaignTasks.types.ts
+++ b/src/campaigns/tasks/campaignTasks.types.ts
@@ -1,5 +1,5 @@
 export { CampaignTaskType } from '@prisma/client'
-import { CampaignTaskType } from '@prisma/client'
+import type { CampaignTaskType } from '@prisma/client'
 
 export type CampaignTask = {
   id: string

--- a/src/campaigns/tasks/campaignTasks.types.ts
+++ b/src/campaigns/tasks/campaignTasks.types.ts
@@ -1,14 +1,5 @@
-export enum CampaignTaskType {
-  text = 'text',
-  robocall = 'robocall',
-  doorKnocking = 'doorKnocking',
-  phoneBanking = 'phoneBanking',
-  socialMedia = 'socialMedia',
-  events = 'events',
-  education = 'education',
-  compliance = 'compliance',
-  awareness = 'awareness',
-}
+export { CampaignTaskType } from '@prisma/client'
+import { CampaignTaskType } from '@prisma/client'
 
 export type CampaignTask = {
   id: string
@@ -23,4 +14,22 @@ export type CampaignTask = {
   isDefaultTask?: boolean
   deadline?: number
   defaultAiTemplateId?: string
+}
+
+export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+export type RecurrenceRule =
+  | { type: 'weekly'; dayOfWeek: DayOfWeek }
+  | { type: 'monthlyNthDay'; dayOfWeek: DayOfWeek; occurrences: number[] }
+  | {
+      type: 'weeksBeforeElection'
+      dayOfWeek: DayOfWeek
+      weeksBefore: number
+    }
+
+export type RecurringTaskTemplate = {
+  id: string
+  title: string
+  description: string
+  recurrence: RecurrenceRule
 }

--- a/src/campaigns/tasks/fixtures/defaultRecurringTasks.ts
+++ b/src/campaigns/tasks/fixtures/defaultRecurringTasks.ts
@@ -1,0 +1,66 @@
+import { RecurringTaskTemplate } from '../campaignTasks.types'
+
+export const defaultRecurringTasks: RecurringTaskTemplate[] = [
+  {
+    id: 'rec-social-posts',
+    title: 'Plan and Schedule 2 Social Posts for the week',
+    description:
+      'Keep your campaign visible! Plan and schedule two social posts to engage supporters and reach more voters.',
+    recurrence: { type: 'weekly', dayOfWeek: 5 },
+  },
+  {
+    id: 'rec-social-update',
+    title: 'Social media update',
+    description:
+      'Post campaign activities and photos on your social media channel of choice',
+    recurrence: { type: 'weekly', dayOfWeek: 5 },
+  },
+  {
+    id: 'rec-fundraising-ask',
+    title: 'Fundraising ask',
+    description:
+      'Make a fundraising solicitation (email and/or social media) to close out the month strong',
+    recurrence: { type: 'weekly', dayOfWeek: 5 },
+  },
+  {
+    id: 'rec-email-update',
+    title: 'Email update',
+    description: 'Send a campaign progress update to your email contacts',
+    recurrence: { type: 'weekly', dayOfWeek: 5 },
+  },
+  {
+    id: 'rec-house-party',
+    title: 'Organize a House Party with Supporters',
+    description:
+      'Work with your supporters to organize an informational house party where you can talk to voters directly.',
+    recurrence: { type: 'monthlyNthDay', dayOfWeek: 3, occurrences: [1] },
+  },
+  {
+    id: 'rec-fundraiser',
+    title: 'Organize a Fundraiser',
+    description:
+      'Work with your supporters to plan and organize a fundraiser to get the financial support you need',
+    recurrence: { type: 'monthlyNthDay', dayOfWeek: 2, occurrences: [2, 4] },
+  },
+  {
+    id: 'rec-volunteer-plan',
+    title: 'Organize a Volunteer Voter Contact Event',
+    description:
+      'Give your supporters a way to give back! Plan a volunteer voter contact event',
+    recurrence: { type: 'monthlyNthDay', dayOfWeek: 2, occurrences: [2, 4] },
+  },
+  {
+    id: 'rec-volunteer-hold',
+    title: 'Hold a Volunteer Voter Contact Event',
+    description:
+      'Put your plan into action! Bring volunteers together to connect with voters and build momentum for your campaign.',
+    recurrence: { type: 'monthlyNthDay', dayOfWeek: 2, occurrences: [1, 3] },
+  },
+  {
+    id: 'rec-letters-editor',
+    title: 'Submit 2 Letters to the Editor in support of your campaign',
+    description:
+      'Have some of your supporters write some Letters to the Editor in support of your campaign to the local press.',
+    recurrence: { type: 'weeksBeforeElection', dayOfWeek: 4, weeksBefore: 4 },
+  },
+]

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -9,11 +9,10 @@ import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
 import { CampaignUpdateHistoryType, Prisma } from '@prisma/client'
 import { MessageGroup, QueueType } from 'src/queue/queue.types'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
-import { addDays, getDay, startOfDay, startOfWeek, subWeeks } from 'date-fns'
+import { startOfDay } from 'date-fns'
 import { parseIsoDateString } from '@/shared/util/date.util'
 import { CampaignTask } from '../campaignTasks.types'
 import { generalAwarenessTasks } from '../fixtures/defaultAwarenessTasks'
-import { defaultRecurringTasks } from '../fixtures/defaultRecurringTasks'
 import { generalDefaultTasks } from '../fixtures/defaultTasks'
 import { primaryDefaultTasks } from '../fixtures/defaultTasksForPrimary'
 
@@ -740,8 +739,15 @@ describe('CampaignTasksService', () => {
       const call = mockTxModel.createMany.mock.calls[0][0] as {
         data: {
           title: string
+          description: string
+          cta: string | null
           date: Date | null
           week: number
+          link: string | undefined
+          proRequired: boolean
+          deadline: number | undefined
+          defaultAiTemplateId: string | undefined
+          completed: boolean
           isDefaultTask: boolean
           campaignId: number
           flowType: CampaignTaskType | null
@@ -984,7 +990,113 @@ describe('CampaignTasksService', () => {
       })
     })
 
-    it('generates recurring tasks with correct flowType and dates', async () => {
+    it('generates weekly recurring tasks on the correct day each week', async () => {
+      const SHORT_ELECTION = '2025-06-15'
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: SHORT_ELECTION },
+        }),
+      )
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      const socialPosts = recurring.filter(
+        (t) => t.title === 'Plan and Schedule 2 Social Posts for the week',
+      )
+      expect(socialPosts).toEqual([
+        {
+          campaignId: 1,
+          title: 'Plan and Schedule 2 Social Posts for the week',
+          description:
+            'Keep your campaign visible! Plan and schedule two social posts to engage supporters and reach more voters.',
+          cta: null,
+          flowType: CampaignTaskType.recurring,
+          week: 2,
+          date: startOfDay(parseIsoDateString('2025-06-06')),
+          link: undefined,
+          proRequired: false,
+          deadline: undefined,
+          defaultAiTemplateId: undefined,
+          completed: false,
+          isDefaultTask: true,
+        },
+        {
+          campaignId: 1,
+          title: 'Plan and Schedule 2 Social Posts for the week',
+          description:
+            'Keep your campaign visible! Plan and schedule two social posts to engage supporters and reach more voters.',
+          cta: null,
+          flowType: CampaignTaskType.recurring,
+          week: 1,
+          date: startOfDay(parseIsoDateString('2025-06-13')),
+          link: undefined,
+          proRequired: false,
+          deadline: undefined,
+          defaultAiTemplateId: undefined,
+          completed: false,
+          isDefaultTask: true,
+        },
+      ])
+    })
+
+    it('generates monthlyNthDay recurring tasks on correct week-of-month occurrences', async () => {
+      const SHORT_ELECTION = '2025-06-22'
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: SHORT_ELECTION },
+        }),
+      )
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      const houseParty = recurring.filter(
+        (t) => t.title === 'Organize a House Party with Supporters',
+      )
+      expect(houseParty).toEqual([
+        {
+          campaignId: 1,
+          title: 'Organize a House Party with Supporters',
+          description:
+            'Work with your supporters to organize an informational house party where you can talk to voters directly.',
+          cta: null,
+          flowType: CampaignTaskType.recurring,
+          week: 3,
+          date: startOfDay(parseIsoDateString('2025-06-04')),
+          link: undefined,
+          proRequired: false,
+          deadline: undefined,
+          defaultAiTemplateId: undefined,
+          completed: false,
+          isDefaultTask: true,
+        },
+      ])
+
+      const fundraiser = recurring.filter(
+        (t) => t.title === 'Organize a Fundraiser',
+      )
+      expect(fundraiser).toEqual([
+        {
+          campaignId: 1,
+          title: 'Organize a Fundraiser',
+          description:
+            'Work with your supporters to plan and organize a fundraiser to get the financial support you need',
+          cta: null,
+          flowType: CampaignTaskType.recurring,
+          week: 2,
+          date: startOfDay(parseIsoDateString('2025-06-10')),
+          link: undefined,
+          proRequired: false,
+          deadline: undefined,
+          defaultAiTemplateId: undefined,
+          completed: false,
+          isDefaultTask: true,
+        },
+      ])
+    })
+
+    it('generates weeksBeforeElection recurring task at the exact computed date', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(
@@ -994,62 +1106,70 @@ describe('CampaignTasksService', () => {
       )
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
-      expect(recurring.length).toBeGreaterThan(0)
+      const lettersToEditor = recurring.filter(
+        (t) =>
+          t.title ===
+          'Submit 2 Letters to the Editor in support of your campaign',
+      )
+      expect(lettersToEditor).toEqual([
+        {
+          campaignId: 1,
+          title: 'Submit 2 Letters to the Editor in support of your campaign',
+          description:
+            'Have some of your supporters write some Letters to the Editor in support of your campaign to the local press.',
+          cta: null,
+          flowType: CampaignTaskType.recurring,
+          week: 4,
+          date: startOfDay(parseIsoDateString('2025-10-09')),
+          link: undefined,
+          proRequired: false,
+          deadline: undefined,
+          defaultAiTemplateId: undefined,
+          completed: false,
+          isDefaultTask: true,
+        },
+      ])
+    })
+
+    it('generates all recurring task templates with correct total counts', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: FUTURE_GENERAL },
+        }),
+      )
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      expect(recurring).toHaveLength(125)
+
+      const countByTitle = recurring.reduce<Record<string, number>>(
+        (acc, t) => {
+          acc[t.title] = (acc[t.title] || 0) + 1
+          return acc
+        },
+        {},
+      )
+
+      expect(countByTitle).toEqual({
+        'Plan and Schedule 2 Social Posts for the week': 22,
+        'Social media update': 22,
+        'Fundraising ask': 22,
+        'Email update': 22,
+        'Organize a House Party with Supporters': 5,
+        'Organize a Fundraiser': 10,
+        'Organize a Volunteer Voter Contact Event': 10,
+        'Hold a Volunteer Voter Contact Event': 11,
+        'Submit 2 Letters to the Editor in support of your campaign': 1,
+      })
+
       recurring.forEach((task) => {
         expect(task.flowType).toBe(CampaignTaskType.recurring)
         expect(task.date).toBeInstanceOf(Date)
         expect(task.isDefaultTask).toBe(true)
+        expect(task.campaignId).toBe(1)
+        expect(task.completed).toBe(false)
       })
-
-      const recurringTitles = new Set(recurring.map((t) => t.title))
-      defaultRecurringTasks.forEach((template) => {
-        expect(recurringTitles.has(template.title)).toBe(true)
-      })
-
-      const weeklyTemplate = defaultRecurringTasks.find(
-        (t) => t.recurrence.type === 'weekly',
-      )!
-      const weeklyTasks = recurring.filter(
-        (t) => t.title === weeklyTemplate.title,
-      )
-      expect(weeklyTasks.length).toBeGreaterThan(0)
-      weeklyTasks.forEach((task) => {
-        expect(getDay(task.date!)).toBe(weeklyTemplate.recurrence.dayOfWeek)
-      })
-
-      const monthlyTemplate = defaultRecurringTasks.find(
-        (t) => t.recurrence.type === 'monthlyNthDay',
-      )!
-      const mr = monthlyTemplate.recurrence as {
-        type: 'monthlyNthDay'
-        dayOfWeek: number
-        occurrences: number[]
-      }
-      const monthlyTasks = recurring.filter(
-        (t) => t.title === monthlyTemplate.title,
-      )
-      expect(monthlyTasks.length).toBeGreaterThan(0)
-      monthlyTasks.forEach((task) => {
-        const d = task.date!
-        expect(getDay(d)).toBe(mr.dayOfWeek)
-        const weekOfMonth = Math.ceil(d.getDate() / 7)
-        expect(mr.occurrences).toContain(weekOfMonth)
-      })
-
-      const beTemplate = defaultRecurringTasks.find(
-        (t) => t.recurrence.type === 'weeksBeforeElection',
-      )!
-      const ber = beTemplate.recurrence as {
-        type: 'weeksBeforeElection'
-        dayOfWeek: number
-        weeksBefore: number
-      }
-      const beTasks = recurring.filter((t) => t.title === beTemplate.title)
-      expect(beTasks).toHaveLength(1)
-      const electionDate = startOfDay(parseIsoDateString(FUTURE_GENERAL))
-      const weekRef = subWeeks(electionDate, ber.weeksBefore)
-      const expectedDate = addDays(startOfWeek(weekRef), ber.dayOfWeek)
-      expect(beTasks[0].date!.getTime()).toBe(expectedDate.getTime())
     })
 
     it('does not generate recurring tasks when no election dates exist', async () => {

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { BadGatewayException, NotFoundException } from '@nestjs/common'
 import { CampaignWithPathToVictory } from '../../campaigns.types'
 import { CampaignTaskType } from '../campaignTasks.types'
@@ -714,20 +714,11 @@ describe('CampaignTasksService', () => {
   })
 
   describe('generateDefaultTasks - task distribution', () => {
-    const FAKE_TODAY = new Date('2025-06-01T00:00:00.000Z')
+    const TODAY = startOfDay(parseIsoDateString('2025-06-01'))
     const FUTURE_GENERAL = '2025-11-04'
     const FUTURE_PRIMARY = '2025-08-15'
     const PAST_PRIMARY = '2024-03-01'
     const PAST_GENERAL = '2024-11-04'
-
-    beforeEach(() => {
-      vi.useFakeTimers()
-      vi.setSystemTime(FAKE_TODAY)
-    })
-
-    afterEach(() => {
-      vi.useRealTimers()
-    })
 
     const setupForCreation = () => {
       mockTxModel.count.mockResolvedValueOnce(0)
@@ -768,7 +759,7 @@ describe('CampaignTasksService', () => {
     it('uses general tasks without dates when details is empty', async () => {
       setupForCreation()
 
-      await service.generateDefaultTasks(makeCampaign({ details: {} }))
+      await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
 
       const tasks = getCreatedTaskData()
       expect(tasks).toHaveLength(generalDefaultTasks.length)
@@ -783,6 +774,7 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { electionDate: FUTURE_GENERAL },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -790,11 +782,11 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
-      expect(recurring.length).toBeGreaterThan(0)
-      tasks.forEach((task) => {
-        expect(task.date).toBeInstanceOf(Date)
-        expect(task.isDefaultTask).toBe(true)
-      })
+      expect(recurring).toHaveLength(125)
+      expect(tasks[0].date).toBeInstanceOf(Date)
+      expect(tasks[0].isDefaultTask).toBe(true)
+      expect(tasks[tasks.length - 1].date).toBeInstanceOf(Date)
+      expect(tasks[tasks.length - 1].isDefaultTask).toBe(true)
     })
 
     it('distributes primary tasks when only primary date is future', async () => {
@@ -804,17 +796,16 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { primaryElectionDate: FUTURE_PRIMARY },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
       expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
-      expect(recurring.length).toBeGreaterThan(0)
-      tasks.forEach((task) => {
-        expect(task.date).toBeInstanceOf(Date)
-        expect(task.isDefaultTask).toBe(true)
-      })
+      expect(recurring).toHaveLength(63)
+      expect(tasks[0].date).toBeInstanceOf(Date)
+      expect(tasks[0].isDefaultTask).toBe(true)
     })
 
     it('distributes both sets when both dates are future', async () => {
@@ -827,6 +818,7 @@ describe('CampaignTasksService', () => {
             electionDate: FUTURE_GENERAL,
           },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -836,11 +828,9 @@ describe('CampaignTasksService', () => {
           generalDefaultTasks.length +
           generalAwarenessTasks.length,
       )
-      expect(recurring.length).toBeGreaterThan(0)
-      tasks.forEach((task) => {
-        expect(task.date).toBeInstanceOf(Date)
-        expect(task.isDefaultTask).toBe(true)
-      })
+      expect(recurring).toHaveLength(125)
+      expect(tasks[0].date).toBeInstanceOf(Date)
+      expect(tasks[0].isDefaultTask).toBe(true)
     })
 
     it('returns empty when both dates are in the past', async () => {
@@ -853,6 +843,7 @@ describe('CampaignTasksService', () => {
             electionDate: PAST_GENERAL,
           },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -866,6 +857,7 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { electionDate: PAST_GENERAL },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -882,6 +874,7 @@ describe('CampaignTasksService', () => {
             electionDate: FUTURE_GENERAL,
           },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -889,7 +882,7 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(recurring).toHaveLength(125)
     })
 
     it('distributes only primary when general is past and primary is future', async () => {
@@ -902,13 +895,14 @@ describe('CampaignTasksService', () => {
             electionDate: PAST_GENERAL,
           },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
       expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(recurring).toHaveLength(63)
     })
 
     it('assigns dates in chronological order', async () => {
@@ -918,6 +912,7 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { electionDate: FUTURE_GENERAL },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -935,6 +930,7 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { electionDate: FUTURE_GENERAL },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -943,61 +939,31 @@ describe('CampaignTasksService', () => {
       }
     })
 
-    it('produces consistent weeks regardless of server time-of-day', async () => {
-      vi.setSystemTime(new Date('2025-06-01T14:30:00.000Z'))
-      setupForCreation()
-
-      await service.generateDefaultTasks(
-        makeCampaign({
-          details: { electionDate: FUTURE_GENERAL },
-        }),
-      )
-
-      const midDayTasks = getCreatedTaskData()
-
-      vi.clearAllMocks()
-      vi.setSystemTime(new Date('2025-06-01T00:00:00.000Z'))
-      setupForCreation()
-
-      await service.generateDefaultTasks(
-        makeCampaign({
-          details: { electionDate: FUTURE_GENERAL },
-        }),
-      )
-
-      const midnightTasks = getCreatedTaskData()
-
-      expect(midDayTasks).toHaveLength(midnightTasks.length)
-      midDayTasks.forEach((task, i) => {
-        expect(task.week).toBe(midnightTasks[i].week)
-        expect(task.date!.getTime()).toBe(midnightTasks[i].date!.getTime())
-      })
-    })
-
-    it('treats election date equal to today as future with no awareness or recurring tasks', async () => {
+    it('treats election date equal to today as future with only general default tasks', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(
         makeCampaign({
           details: { electionDate: '2025-06-01' },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
       expect(tasks).toHaveLength(generalDefaultTasks.length)
-      tasks.forEach((task) => {
-        expect(task.date).toBeInstanceOf(Date)
-      })
+      expect(tasks[0].date).toBeInstanceOf(Date)
+      expect(tasks[0].isDefaultTask).toBe(true)
+      expect(tasks[tasks.length - 1].date).toBeInstanceOf(Date)
     })
 
     it('generates weekly recurring tasks on the correct day each week', async () => {
-      const SHORT_ELECTION = '2025-06-15'
       setupForCreation()
 
       await service.generateDefaultTasks(
         makeCampaign({
-          details: { electionDate: SHORT_ELECTION },
+          details: { electionDate: '2025-06-15' },
         }),
+        TODAY,
       )
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
@@ -1041,13 +1007,13 @@ describe('CampaignTasksService', () => {
     })
 
     it('generates monthlyNthDay recurring tasks on correct week-of-month occurrences', async () => {
-      const SHORT_ELECTION = '2025-06-22'
       setupForCreation()
 
       await service.generateDefaultTasks(
         makeCampaign({
-          details: { electionDate: SHORT_ELECTION },
+          details: { electionDate: '2025-06-22' },
         }),
+        TODAY,
       )
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
@@ -1103,6 +1069,7 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { electionDate: FUTURE_GENERAL },
         }),
+        TODAY,
       )
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
@@ -1138,6 +1105,7 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { electionDate: FUTURE_GENERAL },
         }),
+        TODAY,
       )
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
@@ -1163,19 +1131,26 @@ describe('CampaignTasksService', () => {
         'Submit 2 Letters to the Editor in support of your campaign': 1,
       })
 
-      recurring.forEach((task) => {
-        expect(task.flowType).toBe(CampaignTaskType.recurring)
-        expect(task.date).toBeInstanceOf(Date)
-        expect(task.isDefaultTask).toBe(true)
-        expect(task.campaignId).toBe(1)
-        expect(task.completed).toBe(false)
+      expect(recurring[0]).toMatchObject({
+        flowType: CampaignTaskType.recurring,
+        isDefaultTask: true,
+        campaignId: 1,
+        completed: false,
       })
+      expect(recurring[0].date).toBeInstanceOf(Date)
+      expect(recurring[recurring.length - 1]).toMatchObject({
+        flowType: CampaignTaskType.recurring,
+        isDefaultTask: true,
+        campaignId: 1,
+        completed: false,
+      })
+      expect(recurring[recurring.length - 1].date).toBeInstanceOf(Date)
     })
 
     it('does not generate recurring tasks when no election dates exist', async () => {
       setupForCreation()
 
-      await service.generateDefaultTasks(makeCampaign({ details: {} }))
+      await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
       expect(recurring).toHaveLength(0)

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -13,6 +13,7 @@ import { startOfDay } from 'date-fns'
 import { parseIsoDateString } from '@/shared/util/date.util'
 import { CampaignTask } from '../campaignTasks.types'
 import { generalAwarenessTasks } from '../fixtures/defaultAwarenessTasks'
+import { defaultRecurringTasks } from '../fixtures/defaultRecurringTasks'
 import { generalDefaultTasks } from '../fixtures/defaultTasks'
 import { primaryDefaultTasks } from '../fixtures/defaultTasksForPrimary'
 
@@ -743,10 +744,20 @@ describe('CampaignTasksService', () => {
           week: number
           isDefaultTask: boolean
           campaignId: number
+          flowType: CampaignTaskType | null
         }[]
       }
       return call.data
     }
+
+    const splitByRecurring = (
+      tasks: ReturnType<typeof getCreatedTaskData>,
+    ) => ({
+      recurring: tasks.filter((t) => t.flowType === CampaignTaskType.recurring),
+      nonRecurring: tasks.filter(
+        (t) => t.flowType !== CampaignTaskType.recurring,
+      ),
+    })
 
     it('uses general tasks without dates when details is empty', async () => {
       setupForCreation()
@@ -769,9 +780,11 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(
+      const { nonRecurring, recurring } = splitByRecurring(tasks)
+      expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
+      expect(recurring.length).toBeGreaterThan(0)
       tasks.forEach((task) => {
         expect(task.date).toBeInstanceOf(Date)
         expect(task.isDefaultTask).toBe(true)
@@ -788,8 +801,10 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(primaryDefaultTasks.length)
-      expect(tasks[0].title).toBe(primaryDefaultTasks[0].title)
+      const { nonRecurring, recurring } = splitByRecurring(tasks)
+      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
+      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
+      expect(recurring.length).toBeGreaterThan(0)
       tasks.forEach((task) => {
         expect(task.date).toBeInstanceOf(Date)
         expect(task.isDefaultTask).toBe(true)
@@ -809,11 +824,13 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(
+      const { nonRecurring, recurring } = splitByRecurring(tasks)
+      expect(nonRecurring).toHaveLength(
         primaryDefaultTasks.length +
           generalDefaultTasks.length +
           generalAwarenessTasks.length,
       )
+      expect(recurring.length).toBeGreaterThan(0)
       tasks.forEach((task) => {
         expect(task.date).toBeInstanceOf(Date)
         expect(task.isDefaultTask).toBe(true)
@@ -862,9 +879,11 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(
+      const { nonRecurring, recurring } = splitByRecurring(tasks)
+      expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
+      expect(recurring.length).toBeGreaterThan(0)
     })
 
     it('distributes only primary when general is past and primary is future', async () => {
@@ -880,8 +899,10 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(primaryDefaultTasks.length)
-      expect(tasks[0].title).toBe(primaryDefaultTasks[0].title)
+      const { nonRecurring, recurring } = splitByRecurring(tasks)
+      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
+      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
+      expect(recurring.length).toBeGreaterThan(0)
     })
 
     it('assigns dates in chronological order', async () => {
@@ -947,7 +968,7 @@ describe('CampaignTasksService', () => {
       })
     })
 
-    it('treats election date equal to today as future with no awareness tasks', async () => {
+    it('treats election date equal to today as future with no awareness or recurring tasks', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(
@@ -961,6 +982,38 @@ describe('CampaignTasksService', () => {
       tasks.forEach((task) => {
         expect(task.date).toBeInstanceOf(Date)
       })
+    })
+
+    it('generates recurring tasks with correct flowType and dates', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: FUTURE_GENERAL },
+        }),
+      )
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      expect(recurring.length).toBeGreaterThan(0)
+      recurring.forEach((task) => {
+        expect(task.flowType).toBe(CampaignTaskType.recurring)
+        expect(task.date).toBeInstanceOf(Date)
+        expect(task.isDefaultTask).toBe(true)
+      })
+
+      const recurringTitles = new Set(recurring.map((t) => t.title))
+      defaultRecurringTasks.forEach((template) => {
+        expect(recurringTitles.has(template.title)).toBe(true)
+      })
+    })
+
+    it('does not generate recurring tasks when no election dates exist', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(makeCampaign({ details: {} }))
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      expect(recurring).toHaveLength(0)
     })
   })
 

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -9,7 +9,7 @@ import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
 import { CampaignUpdateHistoryType, Prisma } from '@prisma/client'
 import { MessageGroup, QueueType } from 'src/queue/queue.types'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
-import { startOfDay } from 'date-fns'
+import { addDays, getDay, startOfDay, startOfWeek, subWeeks } from 'date-fns'
 import { parseIsoDateString } from '@/shared/util/date.util'
 import { CampaignTask } from '../campaignTasks.types'
 import { generalAwarenessTasks } from '../fixtures/defaultAwarenessTasks'
@@ -1005,6 +1005,51 @@ describe('CampaignTasksService', () => {
       defaultRecurringTasks.forEach((template) => {
         expect(recurringTitles.has(template.title)).toBe(true)
       })
+
+      const weeklyTemplate = defaultRecurringTasks.find(
+        (t) => t.recurrence.type === 'weekly',
+      )!
+      const weeklyTasks = recurring.filter(
+        (t) => t.title === weeklyTemplate.title,
+      )
+      expect(weeklyTasks.length).toBeGreaterThan(0)
+      weeklyTasks.forEach((task) => {
+        expect(getDay(task.date!)).toBe(weeklyTemplate.recurrence.dayOfWeek)
+      })
+
+      const monthlyTemplate = defaultRecurringTasks.find(
+        (t) => t.recurrence.type === 'monthlyNthDay',
+      )!
+      const mr = monthlyTemplate.recurrence as {
+        type: 'monthlyNthDay'
+        dayOfWeek: number
+        occurrences: number[]
+      }
+      const monthlyTasks = recurring.filter(
+        (t) => t.title === monthlyTemplate.title,
+      )
+      expect(monthlyTasks.length).toBeGreaterThan(0)
+      monthlyTasks.forEach((task) => {
+        const d = task.date!
+        expect(getDay(d)).toBe(mr.dayOfWeek)
+        const weekOfMonth = Math.ceil(d.getDate() / 7)
+        expect(mr.occurrences).toContain(weekOfMonth)
+      })
+
+      const beTemplate = defaultRecurringTasks.find(
+        (t) => t.recurrence.type === 'weeksBeforeElection',
+      )!
+      const ber = beTemplate.recurrence as {
+        type: 'weeksBeforeElection'
+        dayOfWeek: number
+        weeksBefore: number
+      }
+      const beTasks = recurring.filter((t) => t.title === beTemplate.title)
+      expect(beTasks).toHaveLength(1)
+      const electionDate = startOfDay(parseIsoDateString(FUTURE_GENERAL))
+      const weekRef = subWeeks(electionDate, ber.weeksBefore)
+      const expectedDate = addDays(startOfWeek(weekRef), ber.dayOfWeek)
+      expect(beTasks[0].date!.getTime()).toBe(expectedDate.getTime())
     })
 
     it('does not generate recurring tasks when no election dates exist', async () => {

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -360,8 +360,10 @@ export class CampaignTasksService extends createPrismaBase(
     })
   }
 
-  async generateDefaultTasks(campaign: Campaign) {
-    const today = startOfDay(new Date())
+  async generateDefaultTasks(
+    campaign: Campaign,
+    today = startOfDay(new Date()),
+  ) {
     await this.client.$transaction(async (tx) => {
       await tx.$executeRaw`SELECT pg_advisory_xact_lock(${CAMPAIGN_DEFAULT_TASKS_ADVISORY_LOCK_KEY}::integer, ${campaign.id}::integer)`
       const existingDefaults = await tx.campaignTask.count({

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -9,6 +9,8 @@ import {
   addDays,
   differenceInCalendarDays,
   differenceInWeeks,
+  getDate,
+  getDay,
   isAfter,
   isBefore,
   startOfDay,
@@ -26,8 +28,15 @@ import {
 } from 'src/shared/util/date.util'
 import { sleep } from 'src/shared/util/sleep.util'
 import { ProgressStreamData } from '../aiCampaignManager.types'
-import { CampaignTask } from '../campaignTasks.types'
+import {
+  CampaignTask,
+  CampaignTaskType,
+  DayOfWeek,
+  RecurrenceRule,
+  RecurringTaskTemplate,
+} from '../campaignTasks.types'
 import { generalAwarenessTasks } from '../fixtures/defaultAwarenessTasks'
+import { defaultRecurringTasks } from '../fixtures/defaultRecurringTasks'
 import { generalDefaultTasks } from '../fixtures/defaultTasks'
 import { primaryDefaultTasks } from '../fixtures/defaultTasksForPrimary'
 import { CampaignWithPathToVictory } from '../../campaigns.types'
@@ -401,15 +410,27 @@ export class CampaignTasksService extends createPrismaBase(
           generalDate,
           today,
         ),
+        ...this.computeRecurringTasks(
+          defaultRecurringTasks,
+          today,
+          generalDate,
+        ),
       ])
     }
 
     if (primaryDate) {
-      return this.distributeTasksOverWindow(
-        primaryDefaultTasks,
-        today,
-        primaryDate,
-      )
+      return this.sortTasksByDate([
+        ...this.distributeTasksOverWindow(
+          primaryDefaultTasks,
+          today,
+          primaryDate,
+        ),
+        ...this.computeRecurringTasks(
+          defaultRecurringTasks,
+          today,
+          primaryDate,
+        ),
+      ])
     }
 
     if (generalDate) {
@@ -423,6 +444,11 @@ export class CampaignTasksService extends createPrismaBase(
           generalAwarenessTasks,
           generalDate,
           today,
+        ),
+        ...this.computeRecurringTasks(
+          defaultRecurringTasks,
+          today,
+          generalDate,
         ),
       ])
     }
@@ -502,6 +528,106 @@ export class CampaignTasksService extends createPrismaBase(
         }
       })
       .filter((task) => !isBefore(parseIsoDateString(task.date), today))
+  }
+
+  private computeRecurringTasks(
+    templates: RecurringTaskTemplate[],
+    windowStart: Date,
+    electionDate: Date,
+  ): CampaignTask[] {
+    return templates.flatMap((template) =>
+      this.computeRecurrenceDates(
+        template.recurrence,
+        windowStart,
+        electionDate,
+      ).map((date) => ({
+        id: `${template.id}-${formatDate(date, DateFormats.isoDate)}`,
+        title: template.title,
+        description: template.description,
+        flowType: CampaignTaskType.recurring,
+        week: differenceInWeeks(electionDate, date, {
+          roundingMethod: 'ceil',
+        }),
+        date: formatDate(date, DateFormats.isoDate),
+        isDefaultTask: true,
+      })),
+    )
+  }
+
+  private computeRecurrenceDates(
+    recurrence: RecurrenceRule,
+    windowStart: Date,
+    electionDate: Date,
+  ): Date[] {
+    switch (recurrence.type) {
+      case 'weekly':
+        return this.getWeeklyDates(
+          recurrence.dayOfWeek,
+          windowStart,
+          electionDate,
+        )
+      case 'monthlyNthDay':
+        return this.getMonthlyNthDayDates(
+          recurrence.dayOfWeek,
+          recurrence.occurrences,
+          windowStart,
+          electionDate,
+        )
+      case 'weeksBeforeElection':
+        return this.getSingleOccurrenceDate(
+          recurrence.dayOfWeek,
+          recurrence.weeksBefore,
+          electionDate,
+          windowStart,
+        )
+    }
+  }
+
+  private getWeeklyDates(dayOfWeek: DayOfWeek, start: Date, end: Date): Date[] {
+    const dates: Date[] = []
+    let current = this.nextOrSameDayOfWeek(start, dayOfWeek)
+    while (!isAfter(current, end)) {
+      dates.push(current)
+      current = addDays(current, 7)
+    }
+    return dates
+  }
+
+  private getMonthlyNthDayDates(
+    dayOfWeek: DayOfWeek,
+    occurrences: number[],
+    start: Date,
+    end: Date,
+  ): Date[] {
+    const dates: Date[] = []
+    let current = this.nextOrSameDayOfWeek(start, dayOfWeek)
+    while (!isAfter(current, end)) {
+      const weekOfMonth = Math.ceil(getDate(current) / 7)
+      if (occurrences.includes(weekOfMonth)) {
+        dates.push(current)
+      }
+      current = addDays(current, 7)
+    }
+    return dates
+  }
+
+  private getSingleOccurrenceDate(
+    dayOfWeek: DayOfWeek,
+    weeksBefore: number,
+    electionDate: Date,
+    windowStart: Date,
+  ): Date[] {
+    const weekRef = subWeeks(electionDate, weeksBefore)
+    const date = addDays(startOfWeek(weekRef), dayOfWeek)
+    return !isBefore(date, windowStart) && !isAfter(date, electionDate)
+      ? [date]
+      : []
+  }
+
+  private nextOrSameDayOfWeek(date: Date, dayOfWeek: DayOfWeek): Date {
+    const currentDay = getDay(date)
+    const daysUntil = (dayOfWeek - currentDay + 7) % 7
+    return daysUntil === 0 ? date : addDays(date, daysUntil)
   }
 
   private mapTasksToCreateData(

--- a/src/voters/voterFile/voterFile.types.ts
+++ b/src/voters/voterFile/voterFile.types.ts
@@ -8,7 +8,7 @@ export enum VoterFileType {
   directMail = 'directMail',
   telemarketing = 'telemarketing',
   custom = 'custom',
-  robocall = CampaignTaskType.robocall,
+  robocall = 'robocall',
 }
 
 // TODO: these should be cleaned up to only be what is currently used
@@ -57,6 +57,7 @@ export const TASK_TO_TYPE_MAP: {
   [CampaignTaskType.education]: VoterFileType.full,
   [CampaignTaskType.compliance]: VoterFileType.full,
   [CampaignTaskType.awareness]: VoterFileType.full,
+  [CampaignTaskType.recurring]: VoterFileType.full,
 }
 
 // TODO: store this in DB table? (currently in campaign.data)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `CampaignTaskType` enum value via a DB migration and changes default-task generation to create dated recurring tasks, which could affect task counts/order and downstream consumers. Risk is moderate due to new date/recurrence logic and new enum usage across services.
> 
> **Overview**
> Adds a new `CampaignTaskType.recurring` (Prisma schema + migration) and switches TS task typing to re-export `CampaignTaskType` from `@prisma/client`.
> 
> Updates `CampaignTasksService.orderDefaultTasksForCampaign` to append **recurring default tasks** when an election date exists, generating instances from `defaultRecurringTasks` via new recurrence helpers (weekly, monthly Nth weekday, and a single “weeks before election” occurrence) and setting `flowType` to `recurring`.
> 
> Adjusts tests to validate recurring task creation/omission and updates voter-file mapping to handle the new task type, while also decoupling `VoterFileType.robocall` from the task enum to avoid dependency issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d20c498dcf88cac6a92549e60a09775ad193d8eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->