### PR TITLE
feat: add new recurring tasks for door knocking and phone banking wit…

### DIFF
--- a/src/campaigns/tasks/campaignTasks.types.ts
+++ b/src/campaigns/tasks/campaignTasks.types.ts
@@ -32,4 +32,7 @@ export type RecurringTaskTemplate = {
   title: string
   description: string
   recurrence: RecurrenceRule
+  flowType?: CampaignTaskType
+  proRequired?: boolean
+  defaultAiTemplateId?: string
 }

--- a/src/campaigns/tasks/fixtures/defaultRecurringTasks.ts
+++ b/src/campaigns/tasks/fixtures/defaultRecurringTasks.ts
@@ -1,4 +1,4 @@
-import { RecurringTaskTemplate } from '../campaignTasks.types'
+import { CampaignTaskType, RecurringTaskTemplate } from '../campaignTasks.types'
 
 export const defaultRecurringTasks: RecurringTaskTemplate[] = [
   {
@@ -62,5 +62,25 @@ export const defaultRecurringTasks: RecurringTaskTemplate[] = [
     description:
       'Have some of your supporters write some Letters to the Editor in support of your campaign to the local press.',
     recurrence: { type: 'weeksBeforeElection', dayOfWeek: 4, weeksBefore: 4 },
+  },
+  {
+    id: 'rec-door-knocking',
+    title: 'Knock on Doors',
+    description:
+      'Keep your campaign on track to hit your voter contact goals. Knock on your target doors to connect with voters face-to-face.',
+    recurrence: { type: 'weekly', dayOfWeek: 5 },
+    flowType: CampaignTaskType.doorKnocking,
+    proRequired: true,
+    defaultAiTemplateId: 'wgbnDDTxrf8OrresVE1HU',
+  },
+  {
+    id: 'rec-phone-banking',
+    title: 'Make phone bank calls',
+    description:
+      'Keep your campaign on track to hit your voter contact goals. Complete a phone bank shift to reach voters and share your message.',
+    recurrence: { type: 'weekly', dayOfWeek: 5 },
+    flowType: CampaignTaskType.phoneBanking,
+    proRequired: true,
+    defaultAiTemplateId: '5N93cglp3cvq62EIwu1IOa',
   },
 ]

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -13,6 +13,7 @@ import { startOfDay } from 'date-fns'
 import { parseIsoDateString } from '@/shared/util/date.util'
 import { CampaignTask } from '../campaignTasks.types'
 import { generalAwarenessTasks } from '../fixtures/defaultAwarenessTasks'
+import { defaultRecurringTasks } from '../fixtures/defaultRecurringTasks'
 import { generalDefaultTasks } from '../fixtures/defaultTasks'
 import { primaryDefaultTasks } from '../fixtures/defaultTasksForPrimary'
 
@@ -747,13 +748,13 @@ describe('CampaignTasksService', () => {
       return call.data
     }
 
+    const recurringTitles = new Set(defaultRecurringTasks.map((t) => t.title))
+
     const splitByRecurring = (
       tasks: ReturnType<typeof getCreatedTaskData>,
     ) => ({
-      recurring: tasks.filter((t) => t.flowType === CampaignTaskType.recurring),
-      nonRecurring: tasks.filter(
-        (t) => t.flowType !== CampaignTaskType.recurring,
-      ),
+      recurring: tasks.filter((t) => recurringTitles.has(t.title)),
+      nonRecurring: tasks.filter((t) => !recurringTitles.has(t.title)),
     })
 
     it('uses general tasks without dates when details is empty', async () => {
@@ -782,7 +783,7 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
-      expect(recurring).toHaveLength(125)
+      expect(recurring.length).toBeGreaterThan(0)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
       expect(tasks[tasks.length - 1].date).toBeInstanceOf(Date)
@@ -802,8 +803,7 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
-      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
-      expect(recurring).toHaveLength(63)
+      expect(recurring.length).toBeGreaterThan(0)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
     })
@@ -828,7 +828,7 @@ describe('CampaignTasksService', () => {
           generalDefaultTasks.length +
           generalAwarenessTasks.length,
       )
-      expect(recurring).toHaveLength(125)
+      expect(recurring.length).toBeGreaterThan(0)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
     })
@@ -882,7 +882,7 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
-      expect(recurring).toHaveLength(125)
+      expect(recurring.length).toBeGreaterThan(0)
     })
 
     it('distributes only primary when general is past and primary is future', async () => {
@@ -901,8 +901,7 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
-      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
-      expect(recurring).toHaveLength(63)
+      expect(recurring.length).toBeGreaterThan(0)
     })
 
     it('assigns dates in chronological order', async () => {
@@ -1098,6 +1097,50 @@ describe('CampaignTasksService', () => {
       ])
     })
 
+    it('generates door-knocking recurring tasks with correct flowType and proRequired', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: '2025-06-15' },
+        }),
+        TODAY,
+      )
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      const doorKnocking = recurring.filter((t) => t.title === 'Knock on Doors')
+      expect(doorKnocking.length).toBeGreaterThan(0)
+      doorKnocking.forEach((t) => {
+        expect(t.flowType).toBe(CampaignTaskType.doorKnocking)
+        expect(t.proRequired).toBe(true)
+        expect(t.defaultAiTemplateId).toBe('wgbnDDTxrf8OrresVE1HU')
+        expect(t.isDefaultTask).toBe(true)
+      })
+    })
+
+    it('generates phone-banking recurring tasks with correct flowType and proRequired', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: '2025-06-15' },
+        }),
+        TODAY,
+      )
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      const phoneBanking = recurring.filter(
+        (t) => t.title === 'Make phone bank calls',
+      )
+      expect(phoneBanking.length).toBeGreaterThan(0)
+      phoneBanking.forEach((t) => {
+        expect(t.flowType).toBe(CampaignTaskType.phoneBanking)
+        expect(t.proRequired).toBe(true)
+        expect(t.defaultAiTemplateId).toBe('5N93cglp3cvq62EIwu1IOa')
+        expect(t.isDefaultTask).toBe(true)
+      })
+    })
+
     it('generates all recurring task templates with correct total counts', async () => {
       setupForCreation()
 
@@ -1109,7 +1152,7 @@ describe('CampaignTasksService', () => {
       )
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
-      expect(recurring).toHaveLength(125)
+      expect(recurring).toHaveLength(169)
 
       const countByTitle = recurring.reduce<Record<string, number>>(
         (acc, t) => {
@@ -1129,17 +1172,17 @@ describe('CampaignTasksService', () => {
         'Organize a Volunteer Voter Contact Event': 10,
         'Hold a Volunteer Voter Contact Event': 11,
         'Submit 2 Letters to the Editor in support of your campaign': 1,
+        'Knock on Doors': 22,
+        'Make phone bank calls': 22,
       })
 
       expect(recurring[0]).toMatchObject({
-        flowType: CampaignTaskType.recurring,
         isDefaultTask: true,
         campaignId: 1,
         completed: false,
       })
       expect(recurring[0].date).toBeInstanceOf(Date)
       expect(recurring[recurring.length - 1]).toMatchObject({
-        flowType: CampaignTaskType.recurring,
         isDefaultTask: true,
         campaignId: 1,
         completed: false,

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -783,7 +783,7 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(recurring).toHaveLength(169)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
       expect(tasks[tasks.length - 1].date).toBeInstanceOf(Date)
@@ -803,7 +803,8 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
+      expect(recurring).toHaveLength(85)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
     })
@@ -828,7 +829,7 @@ describe('CampaignTasksService', () => {
           generalDefaultTasks.length +
           generalAwarenessTasks.length,
       )
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(recurring).toHaveLength(169)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
     })
@@ -882,7 +883,7 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(recurring).toHaveLength(169)
     })
 
     it('distributes only primary when general is past and primary is future', async () => {
@@ -901,7 +902,8 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
+      expect(recurring).toHaveLength(85)
     })
 
     it('assigns dates in chronological order', async () => {

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -546,7 +546,9 @@ export class CampaignTasksService extends createPrismaBase(
         id: `${template.id}-${formatDate(date, DateFormats.isoDate)}`,
         title: template.title,
         description: template.description,
-        flowType: CampaignTaskType.recurring,
+        flowType: template.flowType ?? CampaignTaskType.recurring,
+        proRequired: template.proRequired,
+        defaultAiTemplateId: template.defaultAiTemplateId,
         week: differenceInWeeks(electionDate, date, {
           roundingMethod: 'ceil',
         }),


### PR DESCRIPTION
…h updated properties

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recurring default-task generation to allow per-template `flowType`/`proRequired`/`defaultAiTemplateId`, which affects downstream task routing and increases the number of generated defaults; risk is moderate due to behavior changes in task creation.
> 
> **Overview**
> Adds new recurring default tasks for **door knocking** and **phone banking**, marked *pro-required* and wired to specific `CampaignTaskType` values plus `defaultAiTemplateId`.
> 
> Extends `RecurringTaskTemplate` to carry optional `flowType`, `proRequired`, and `defaultAiTemplateId`, and updates recurring task generation to copy these fields (defaulting `flowType` to `CampaignTaskType.recurring`). Tests are updated to reflect higher recurring task counts and to assert the new templates’ metadata, with recurring/non-recurring splitting now based on `defaultRecurringTasks` titles rather than `flowType`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b819538c3c7b21a2acec86e4c5a1a41daee01c37. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->