### PR TITLE
ENG-6987: final audit post-win/serve split

### DIFF
--- a/prisma/schema/campaign.prisma
+++ b/prisma/schema/campaign.prisma
@@ -42,7 +42,6 @@ model Campaign {
   freeTextsOfferRedeemedAt DateTime?               @map("free_texts_offer_redeemed_at")
   ScheduledMessage         ScheduledMessage[]
   tcrCompliance            TcrCompliance?
-  voterFileFilters         VoterFileFilter[]
   website                  Website?
   outreach                 Outreach[]
   communityIssue           CommunityIssue[]

--- a/prisma/schema/voterFileFilter.prisma
+++ b/prisma/schema/voterFileFilter.prisma
@@ -60,14 +60,10 @@ model VoterFileFilter {
   homeownerNo                Boolean?      @default(false) @map("homeowner_no")
   homeownerUnknown           Boolean?      @default(false) @map("homeowner_unknown")
   voterCount                 Int?          @map("voter_count")
-  campaign                   Campaign?     @relation(fields: [campaignId], references: [id], onDelete: Cascade)
-  campaignId                 Int?          @map("campaign_id")
   outreaches                 Outreach[]
   organizationSlug           String        @map("organization_slug")
   organization               Organization  @relation(fields: [organizationSlug], references: [slug], onDelete: Cascade)
 
-  @@index([campaignId])
-  @@index([id, campaignId])
   @@index([organizationSlug])
   @@map("voter_file_filter")
 }

--- a/src/contacts/services/contacts.service.test.ts
+++ b/src/contacts/services/contacts.service.test.ts
@@ -36,7 +36,6 @@ describe('ContactsService', () => {
       get: ReturnType<typeof vi.fn>
     }
     let mockVoterFileFilterService: {
-      findByIdAndCampaignId: ReturnType<typeof vi.fn>
       findByIdAndOrganizationSlug: ReturnType<typeof vi.fn>
     }
     let mockElectionsService: {
@@ -55,7 +54,6 @@ describe('ContactsService', () => {
         get: vi.fn(),
       }
       mockVoterFileFilterService = {
-        findByIdAndCampaignId: vi.fn().mockResolvedValue(null),
         findByIdAndOrganizationSlug: vi.fn().mockResolvedValue(null),
       }
       mockElectionsService = {

--- a/src/voters/services/voterFileFilter.service.ts
+++ b/src/voters/services/voterFileFilter.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { BadRequestException, Injectable } from '@nestjs/common'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { Prisma, VoterFileFilter } from '@prisma/client'
 import { UpdateVoterFileFilterSchema } from '../schemas/UpdateVoterFileFilterSchema'
@@ -8,7 +8,6 @@ export class VoterFileFilterService extends createPrismaBase(
   MODELS.VoterFileFilter,
 ) {
   async create(
-    campaignId: number | undefined,
     organizationSlug: string,
     data: Omit<
       Prisma.VoterFileFilterCreateInput,
@@ -17,7 +16,6 @@ export class VoterFileFilterService extends createPrismaBase(
   ) {
     return this.model.create({
       data: {
-        campaignId,
         organizationSlug,
         ...data,
       },
@@ -47,22 +45,6 @@ export class VoterFileFilterService extends createPrismaBase(
     })
   }
 
-  findByCampaignId(campaignId: number): Promise<VoterFileFilter[]> {
-    return this.model.findMany({
-      where: { campaignId },
-      orderBy: { name: 'asc' },
-    })
-  }
-
-  findByIdAndCampaignId(
-    id: number,
-    campaignId: number,
-  ): Promise<VoterFileFilter | null> {
-    return this.findFirst({
-      where: { id, campaignId },
-    })
-  }
-
   findByIdAndOrganizationSlug(
     id: number,
     organizationSlug: string,
@@ -83,32 +65,12 @@ export class VoterFileFilterService extends createPrismaBase(
     })
   }
 
-  updateByIdAndCampaignId(
-    id: number,
-    campaignId: number,
-    data: UpdateVoterFileFilterSchema,
-  ): Promise<VoterFileFilter> {
-    return this.model.update({
-      where: { id, campaignId },
-      data,
-    })
-  }
-
   deleteByIdAndOrganizationSlug(
     id: number,
     organizationSlug: string,
   ): Promise<VoterFileFilter> {
     return this.model.delete({
       where: { id, organizationSlug },
-    })
-  }
-
-  deleteByIdAndCampaignId(
-    id: number,
-    campaignId: number,
-  ): Promise<VoterFileFilter> {
-    return this.model.delete({
-      where: { id, campaignId },
     })
   }
 
@@ -166,6 +128,18 @@ export class VoterFileFilterService extends createPrismaBase(
       ...(age50Plus === true ? { age_50_plus: age50Plus } : {}),
       ...(genderMale === true ? { gender_male: genderMale } : {}),
       ...(genderFemale === true ? { gender_female: genderFemale } : {}),
+    }
+  }
+
+  async filterAccessCheck(organizationSlug: string): Promise<void> {
+    if (organizationSlug.startsWith('campaign-')) {
+      const campaign = await this._prisma.campaign.findFirst({
+        where: { organizationSlug },
+      })
+
+      if (!campaign?.isPro) {
+        throw new BadRequestException('Campaign is not pro')
+      }
     }
   }
 }

--- a/src/voters/voterFile/voterFile.controller.test.ts
+++ b/src/voters/voterFile/voterFile.controller.test.ts
@@ -12,6 +12,7 @@ describe('VoterFileController', () => {
   let mockCampaignsService: Record<string, ReturnType<typeof vi.fn>>
   let mockVoterFileFilterService: {
     create: ReturnType<typeof vi.fn>
+    filterAccessCheck: ReturnType<typeof vi.fn>
     findByIdAndCampaignId: ReturnType<typeof vi.fn>
     findByIdAndOrganizationSlug: ReturnType<typeof vi.fn>
     findByOrganizationSlug: ReturnType<typeof vi.fn>
@@ -39,7 +40,6 @@ describe('VoterFileController', () => {
 
   const mockFilter = {
     id: 1,
-    campaignId: 1,
     name: 'Test Filter',
   } as VoterFileFilter
 
@@ -50,6 +50,7 @@ describe('VoterFileController', () => {
     mockCampaignsService = {}
     mockVoterFileFilterService = {
       create: vi.fn().mockResolvedValue(mockFilter),
+      filterAccessCheck: vi.fn().mockResolvedValue(undefined),
       findByIdAndCampaignId: vi.fn().mockResolvedValue(mockFilter),
       findByIdAndOrganizationSlug: vi.fn().mockResolvedValue(mockFilter),
       findByOrganizationSlug: vi.fn().mockResolvedValue([mockFilter]),
@@ -81,60 +82,32 @@ describe('VoterFileController', () => {
   })
 
   describe('createVoterFileFilter', () => {
-    it('throws when campaign is not pro and org has no elected office', async () => {
-      mockElectedOfficeService.findFirst.mockResolvedValue(null)
+    it('throws when filterAccessCheck rejects', async () => {
+      mockVoterFileFilterService.filterAccessCheck.mockRejectedValue(
+        new BadRequestException('Campaign is not pro'),
+      )
       const body = { name: 'My Filter' } as never
 
       await expect(
-        controller.createVoterFileFilter(baseCampaign, baseOrg, body),
+        controller.createVoterFileFilter(baseOrg, body),
       ).rejects.toThrow(BadRequestException)
-      await expect(
-        controller.createVoterFileFilter(baseCampaign, baseOrg, body),
-      ).rejects.toThrow('Campaign is not pro')
 
-      expect(mockElectedOfficeService.findFirst).toHaveBeenCalledWith({
-        where: { organizationSlug: baseOrg.slug },
-      })
-    })
-
-    it('creates filter when campaign is pro', async () => {
-      const campaign = { ...baseCampaign, isPro: true }
-      const body = { name: 'My Filter' } as never
-
-      const result = await controller.createVoterFileFilter(
-        campaign,
-        baseOrg,
-        body,
-      )
-
-      expect(mockVoterFileFilterService.create).toHaveBeenCalledWith(
-        campaign.id,
+      expect(mockVoterFileFilterService.filterAccessCheck).toHaveBeenCalledWith(
         baseOrg.slug,
-        body,
       )
-      expect(result).toEqual(mockFilter)
+      expect(mockVoterFileFilterService.create).not.toHaveBeenCalled()
     })
 
-    it('creates filter when org has elected office access', async () => {
-      const org = { slug: 'eo-org-1' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue({
-        id: 'office-1',
-        organizationSlug: 'eo-org-1',
-      })
+    it('creates filter when access check passes', async () => {
       const body = { name: 'My Filter' } as never
 
-      const result = await controller.createVoterFileFilter(
-        undefined,
-        org,
-        body,
-      )
+      const result = await controller.createVoterFileFilter(baseOrg, body)
 
-      expect(mockElectedOfficeService.findFirst).toHaveBeenCalledWith({
-        where: { organizationSlug: org.slug },
-      })
+      expect(mockVoterFileFilterService.filterAccessCheck).toHaveBeenCalledWith(
+        baseOrg.slug,
+      )
       expect(mockVoterFileFilterService.create).toHaveBeenCalledWith(
-        undefined,
-        org.slug,
+        baseOrg.slug,
         body,
       )
       expect(result).toEqual(mockFilter)
@@ -174,95 +147,70 @@ describe('VoterFileController', () => {
   })
 
   describe('updateVoterFileFilter', () => {
-    it('throws when campaign is not pro and org has no elected office', async () => {
-      mockElectedOfficeService.findFirst.mockResolvedValue(null)
+    it('throws when filterAccessCheck rejects', async () => {
+      mockVoterFileFilterService.filterAccessCheck.mockRejectedValue(
+        new BadRequestException('Campaign is not pro'),
+      )
       const body = { name: 'Updated Filter' } as never
 
       await expect(
-        controller.updateVoterFileFilter(1, body, baseCampaign, baseOrg),
-      ).rejects.toThrow(BadRequestException)
-      await expect(
-        controller.updateVoterFileFilter(1, body, baseCampaign, baseOrg),
+        controller.updateVoterFileFilter(1, body, baseOrg),
       ).rejects.toThrow('Campaign is not pro')
     })
 
-    it('updates filter with organization and EO access', async () => {
-      const org = { slug: 'eo-org-1' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue({
-        id: 'office-1',
-        organizationSlug: 'eo-org-1',
-      })
+    it('updates filter when access check passes', async () => {
       const body = { name: 'Updated Filter' } as never
 
-      const result = await controller.updateVoterFileFilter(
-        1,
-        body,
-        undefined,
-        org,
-      )
+      const result = await controller.updateVoterFileFilter(1, body, baseOrg)
 
+      expect(mockVoterFileFilterService.filterAccessCheck).toHaveBeenCalledWith(
+        baseOrg.slug,
+      )
       expect(
         mockVoterFileFilterService.findByIdAndOrganizationSlug,
-      ).toHaveBeenCalledWith(1, org.slug)
+      ).toHaveBeenCalledWith(1, baseOrg.slug)
       expect(
         mockVoterFileFilterService.updateByIdAndOrganizationSlug,
-      ).toHaveBeenCalledWith(1, org.slug, body)
+      ).toHaveBeenCalledWith(1, baseOrg.slug, body)
       expect(result).toEqual(mockFilter)
     })
 
     it('throws NotFoundException when filter not found', async () => {
-      const org = { slug: 'eo-org-1' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue({
-        id: 'office-1',
-      })
       mockVoterFileFilterService.findByIdAndOrganizationSlug.mockResolvedValue(
         null,
       )
       const body = { name: 'Updated Filter' } as never
 
       await expect(
-        controller.updateVoterFileFilter(1, body, undefined, org),
+        controller.updateVoterFileFilter(1, body, baseOrg),
       ).rejects.toThrow('Voter file filter not found')
     })
   })
 
   describe('deleteVoterFileFilter', () => {
-    it('deletes filter with EO access', async () => {
-      const org = { slug: 'eo-org-1' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue({
-        id: 'office-1',
-        organizationSlug: 'eo-org-1',
-      })
+    it('deletes filter when access check passes', async () => {
+      await controller.deleteVoterFileFilter(1, baseOrg)
 
-      await controller.deleteVoterFileFilter(1, baseCampaign, org)
-
+      expect(mockVoterFileFilterService.filterAccessCheck).toHaveBeenCalledWith(
+        baseOrg.slug,
+      )
       expect(
         mockVoterFileFilterService.deleteByIdAndOrganizationSlug,
-      ).toHaveBeenCalledWith(1, org.slug)
+      ).toHaveBeenCalledWith(1, baseOrg.slug)
     })
 
-    it('throws when no EO access and not pro', async () => {
-      const org = { slug: 'some-org' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue(null)
+    it('throws when filterAccessCheck rejects', async () => {
+      mockVoterFileFilterService.filterAccessCheck.mockRejectedValue(
+        new BadRequestException('Campaign is not pro'),
+      )
 
       await expect(
-        controller.deleteVoterFileFilter(1, baseCampaign, org),
+        controller.deleteVoterFileFilter(1, baseOrg),
       ).rejects.toThrow('Campaign is not pro')
 
       expect(
         mockVoterFileFilterService.deleteByIdAndOrganizationSlug,
       ).not.toHaveBeenCalled()
-    })
-
-    it('deletes when campaign is pro', async () => {
-      const campaign = { ...baseCampaign, isPro: true }
-      mockElectedOfficeService.findFirst.mockResolvedValue(null)
-
-      await controller.deleteVoterFileFilter(1, campaign, baseOrg)
-
-      expect(
-        mockVoterFileFilterService.deleteByIdAndOrganizationSlug,
-      ).toHaveBeenCalledWith(1, baseOrg.slug)
     })
   })
 

--- a/src/voters/voterFile/voterFile.controller.test.ts
+++ b/src/voters/voterFile/voterFile.controller.test.ts
@@ -13,20 +13,13 @@ describe('VoterFileController', () => {
   let mockVoterFileFilterService: {
     create: ReturnType<typeof vi.fn>
     filterAccessCheck: ReturnType<typeof vi.fn>
-    findByIdAndCampaignId: ReturnType<typeof vi.fn>
     findByIdAndOrganizationSlug: ReturnType<typeof vi.fn>
     findByOrganizationSlug: ReturnType<typeof vi.fn>
-    findByCampaignId: ReturnType<typeof vi.fn>
-    updateByIdAndCampaignId: ReturnType<typeof vi.fn>
     updateByIdAndOrganizationSlug: ReturnType<typeof vi.fn>
-    deleteByIdAndCampaignId: ReturnType<typeof vi.fn>
     deleteByIdAndOrganizationSlug: ReturnType<typeof vi.fn>
   }
   let mockOutreachService: {
     model: { findFirst: ReturnType<typeof vi.fn> }
-  }
-  let mockElectedOfficeService: {
-    findFirst: ReturnType<typeof vi.fn>
   }
 
   const baseCampaign = {
@@ -51,20 +44,13 @@ describe('VoterFileController', () => {
     mockVoterFileFilterService = {
       create: vi.fn().mockResolvedValue(mockFilter),
       filterAccessCheck: vi.fn().mockResolvedValue(undefined),
-      findByIdAndCampaignId: vi.fn().mockResolvedValue(mockFilter),
       findByIdAndOrganizationSlug: vi.fn().mockResolvedValue(mockFilter),
       findByOrganizationSlug: vi.fn().mockResolvedValue([mockFilter]),
-      findByCampaignId: vi.fn().mockResolvedValue([mockFilter]),
-      updateByIdAndCampaignId: vi.fn().mockResolvedValue(mockFilter),
       updateByIdAndOrganizationSlug: vi.fn().mockResolvedValue(mockFilter),
-      deleteByIdAndCampaignId: vi.fn().mockResolvedValue(mockFilter),
       deleteByIdAndOrganizationSlug: vi.fn().mockResolvedValue(mockFilter),
     }
     mockOutreachService = {
       model: { findFirst: vi.fn() },
-    }
-    mockElectedOfficeService = {
-      findFirst: vi.fn().mockResolvedValue(null),
     }
 
     controller = new VoterFileController(
@@ -74,7 +60,6 @@ describe('VoterFileController', () => {
       mockCampaignsService as never,
       mockVoterFileFilterService as never,
       mockOutreachService as never,
-      mockElectedOfficeService as never,
       {} as never,
       createMockLogger(),
     )

--- a/src/voters/voterFile/voterFile.controller.ts
+++ b/src/voters/voterFile/voterFile.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -150,21 +149,13 @@ export class VoterFileController {
   }
 
   @Post('filter')
-  @UseCampaign({ continueIfNotFound: true })
   @UseOrganization()
   async createVoterFileFilter(
-    @ReqCampaign() campaign: Campaign | undefined,
     @ReqOrganization() organization: Organization,
     @Body() voterFileFilter: CreateVoterFileFilterSchema,
   ) {
-    const electedOffice = await this.electedOfficeService.findFirst({
-      where: { organizationSlug: organization.slug },
-    })
-    if (!(campaign?.isPro ?? false) && !electedOffice) {
-      throw new BadRequestException('Campaign is not pro')
-    }
+    await this.voterFileFilterService.filterAccessCheck(organization.slug)
     return this.voterFileFilterService.create(
-      campaign?.id,
       organization.slug,
       voterFileFilter,
     )
@@ -194,20 +185,13 @@ export class VoterFileController {
   }
 
   @Put('filter/:id')
-  @UseCampaign({ continueIfNotFound: true })
   @UseOrganization()
   async updateVoterFileFilter(
     @Param('id', ParseIntPipe) id: number,
     @Body() body: UpdateVoterFileFilterSchema,
-    @ReqCampaign() campaign: Campaign | undefined,
     @ReqOrganization() organization: Organization,
   ) {
-    const electedOffice = await this.electedOfficeService.findFirst({
-      where: { organizationSlug: organization.slug },
-    })
-    if (!(campaign?.isPro ?? false) && !electedOffice) {
-      throw new BadRequestException('Campaign is not pro')
-    }
+    await this.voterFileFilterService.filterAccessCheck(organization.slug)
     const filter =
       await this.voterFileFilterService.findByIdAndOrganizationSlug(
         id,
@@ -224,20 +208,13 @@ export class VoterFileController {
   }
 
   @Delete('filter/:id')
-  @UseCampaign({ continueIfNotFound: true })
   @UseOrganization()
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteVoterFileFilter(
     @Param('id', ParseIntPipe) id: number,
-    @ReqCampaign() campaign: Campaign | undefined,
     @ReqOrganization() organization: Organization,
   ) {
-    const electedOffice = await this.electedOfficeService.findFirst({
-      where: { organizationSlug: organization.slug },
-    })
-    if (!(campaign?.isPro ?? false) && !electedOffice) {
-      throw new BadRequestException('Campaign is not pro')
-    }
+    await this.voterFileFilterService.filterAccessCheck(organization.slug)
     await this.voterFileFilterService.deleteByIdAndOrganizationSlug(
       id,
       organization.slug,

--- a/src/voters/voterFile/voterFile.controller.ts
+++ b/src/voters/voterFile/voterFile.controller.ts
@@ -22,7 +22,6 @@ import { CampaignWith } from 'src/campaigns/campaigns.types'
 import { ReqCampaign } from 'src/campaigns/decorators/ReqCampaign.decorator'
 import { UseCampaign } from 'src/campaigns/decorators/UseCampaign.decorator'
 import { CampaignsService } from 'src/campaigns/services/campaigns.service'
-import { ElectedOfficeService } from 'src/electedOffice/services/electedOffice.service'
 import { ReqOrganization } from 'src/organizations/decorators/ReqOrganization.decorator'
 import { UseOrganization } from 'src/organizations/decorators/UseOrganization.decorator'
 import { OrganizationsService } from 'src/organizations/services/organizations.service'
@@ -50,7 +49,6 @@ export class VoterFileController {
     private readonly campaigns: CampaignsService,
     private readonly voterFileFilterService: VoterFileFilterService,
     private readonly outreachService: OutreachService,
-    private readonly electedOfficeService: ElectedOfficeService,
     private readonly organizationsService: OrganizationsService,
     private readonly logger: PinoLogger,
   ) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the data model and API behavior for voter file filters by removing campaign scoping and centralizing access checks; this may affect existing queries/migrations and could change who can create/update/delete filters if org slugs are misclassified.
> 
> **Overview**
> **Voter file filters are no longer campaign-scoped.** The Prisma schema removes the `Campaign`↔`VoterFileFilter` relationship and associated `campaignId` indexes/fields, making filters owned only by `organizationSlug`.
> 
> **Access gating for filter mutations is centralized.** `VoterFileController` now uses `@UseOrganization()` only for create/update/delete, and delegates pro-check enforcement to a new `VoterFileFilterService.filterAccessCheck()` (rejects non-pro `campaign-*` orgs). Tests are updated to assert this new access-check flow and the updated `create()` signature (no `campaignId`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313db2cc231ec6ac1ee048a52b214a42b677531d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->