### PR TITLE
QA <- Dev

### DIFF
--- a/e2e-tests/utils/auth.util.ts
+++ b/e2e-tests/utils/auth.util.ts
@@ -151,6 +151,20 @@ export function getBearerToken(token: string): string {
   return `Bearer ${token}`
 }
 
+export function campaignOrgSlug(campaignId: number): string {
+  return `campaign-${campaignId}`
+}
+
+export function authHeaders(
+  token: string,
+  orgSlug: string,
+): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    'x-organization-slug': orgSlug,
+  }
+}
+
 export function generateRandomPassword(): string {
   const letters = faker.string.alpha({ length: 8, casing: 'mixed' })
   const numbers = faker.string.numeric({ length: 4 })

--- a/e2e-tests/utils/request.util.ts
+++ b/e2e-tests/utils/request.util.ts
@@ -51,10 +51,14 @@ export async function updateCampaignWithRetry(
   request: APIRequestContext,
   token: string,
   data: Record<string, unknown>,
+  orgSlug?: string,
 ): Promise<APIResponse> {
   return retryOnConflict(() =>
     request.put('/v1/campaigns/mine', {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(orgSlug && { 'x-organization-slug': orgSlug }),
+      },
       data,
     }),
   )

--- a/prisma/schema/campaign.jsonTypes.d.ts
+++ b/prisma/schema/campaign.jsonTypes.d.ts
@@ -61,9 +61,6 @@ declare global {
       officeTermLength?: string
       partisanType?: string | null
       priorElectionDates?: string[]
-      positionId?: string | null
-      office?: string
-      otherOffice?: string
       electionId?: string | null
       tier?: string
       einNumber?: string | null

--- a/prisma/schema/campaign.prisma
+++ b/prisma/schema/campaign.prisma
@@ -42,7 +42,6 @@ model Campaign {
   freeTextsOfferRedeemedAt DateTime?               @map("free_texts_offer_redeemed_at")
   ScheduledMessage         ScheduledMessage[]
   tcrCompliance            TcrCompliance?
-  voterFileFilters         VoterFileFilter[]
   website                  Website?
   outreach                 Outreach[]
   communityIssue           CommunityIssue[]

--- a/prisma/schema/campaignTask.prisma
+++ b/prisma/schema/campaignTask.prisma
@@ -8,6 +8,7 @@ enum CampaignTaskType {
   education
   compliance
   awareness
+  recurring
 }
 
 model CampaignTask {

--- a/prisma/schema/migrations/20260410024513_recurring_tasks/migration.sql
+++ b/prisma/schema/migrations/20260410024513_recurring_tasks/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "CampaignTaskType" ADD VALUE 'recurring';

--- a/prisma/schema/voterFileFilter.prisma
+++ b/prisma/schema/voterFileFilter.prisma
@@ -60,14 +60,10 @@ model VoterFileFilter {
   homeownerNo                Boolean?      @default(false) @map("homeowner_no")
   homeownerUnknown           Boolean?      @default(false) @map("homeowner_unknown")
   voterCount                 Int?          @map("voter_count")
-  campaign                   Campaign?     @relation(fields: [campaignId], references: [id], onDelete: Cascade)
-  campaignId                 Int?          @map("campaign_id")
   outreaches                 Outreach[]
   organizationSlug           String        @map("organization_slug")
   organization               Organization  @relation(fields: [organizationSlug], references: [slug], onDelete: Cascade)
 
-  @@index([campaignId])
-  @@index([id, campaignId])
   @@index([organizationSlug])
   @@map("voter_file_filter")
 }

--- a/src/admin/campaigns/adminCampaigns.service.ts
+++ b/src/admin/campaigns/adminCampaigns.service.ts
@@ -10,6 +10,7 @@ import { CampaignCreatedBy, OnboardingStep } from '@goodparty_org/contracts'
 import { CampaignWith } from 'src/campaigns/campaigns.types'
 import { formatDate } from 'date-fns'
 import { P2VStatus } from 'src/elections/types/pathToVictory.types'
+import { P2VSource } from 'src/pathToVictory/types/pathToVictory.types'
 import { DateFormats } from 'src/shared/util/date.util'
 import { CrmCampaignsService } from '../../campaigns/services/crmCampaigns.service'
 import { VoterFileDownloadAccessService } from '../../shared/services/voterFileDownloadAccess.service'
@@ -261,8 +262,8 @@ export class AdminCampaignsService {
           {
             pathToVictory: {
               data: {
-                path: ['electionType'],
-                not: Prisma.AnyNull,
+                path: ['source'],
+                equals: P2VSource.ElectionApi,
               },
             },
           },
@@ -272,7 +273,6 @@ export class AdminCampaignsService {
   }
 
   private async getManualP2V(electionDate: string) {
-    // TODO: switch to checking for data->>'completedBy' IS NULL (comment copied from tgp-api)
     return this.campaigns.count({
       where: {
         AND: [
@@ -299,10 +299,12 @@ export class AdminCampaignsService {
             },
           },
           {
-            pathToVictory: {
-              data: {
-                path: ['electionType'],
-                equals: Prisma.AnyNull,
+            NOT: {
+              pathToVictory: {
+                data: {
+                  path: ['source'],
+                  equals: P2VSource.ElectionApi,
+                },
               },
             },
           },

--- a/src/campaigns/campaigns.controller.test.ts
+++ b/src/campaigns/campaigns.controller.test.ts
@@ -36,8 +36,6 @@ function mockRaceTargetResult(
     winNumber: 0,
     voterContactGoal: 0,
     source: 'test',
-    electionType: 'General',
-    electionLocation: 'Test Location',
     p2vStatus: 'Complete',
     p2vCompleteDate: '2025-01-01',
     ...overrides,
@@ -536,58 +534,6 @@ describe('CampaignsController', () => {
       )
       expect(result).toEqual(mockCampaign)
     })
-
-    it('falls back to details.positionId when top-level field absent', async () => {
-      vi.spyOn(campaignsService, 'findByUserId').mockResolvedValue(null!)
-      vi.spyOn(campaignsService, 'createForUser').mockResolvedValue(
-        mockCampaign,
-      )
-
-      const legacyBody = {
-        details: {
-          state: 'CA',
-          positionId: 'legacy-pos-1',
-          office: 'Other',
-          otherOffice: 'Mayor',
-        },
-      } as CreateCampaignSchema
-
-      await controller.create(mockUser, legacyBody)
-
-      expect(campaignsService.createForUser).toHaveBeenCalledWith(
-        mockUser,
-        { details: legacyBody.details, data: undefined },
-        {
-          ballotReadyPositionId: 'legacy-pos-1',
-          customPositionName: undefined,
-        },
-      )
-    })
-
-    it('falls back to details.office for customPositionName when no positionId', async () => {
-      vi.spyOn(campaignsService, 'findByUserId').mockResolvedValue(null!)
-      vi.spyOn(campaignsService, 'createForUser').mockResolvedValue(
-        mockCampaign,
-      )
-
-      const legacyBody = {
-        details: {
-          state: 'CA',
-          office: 'City Council',
-        },
-      } as CreateCampaignSchema
-
-      await controller.create(mockUser, legacyBody)
-
-      expect(campaignsService.createForUser).toHaveBeenCalledWith(
-        mockUser,
-        { details: legacyBody.details, data: undefined },
-        {
-          ballotReadyPositionId: undefined,
-          customPositionName: 'City Council',
-        },
-      )
-    })
   })
 
   describe('update', () => {
@@ -695,7 +641,6 @@ describe('CampaignsController', () => {
 
       expect(analyticsService.identify).toHaveBeenCalledWith(5, {
         officeMunicipality: 'Springfield',
-        officeName: 'Mayor',
         officeElectionDate: '2025-11-04',
         affiliation: 'Independent',
         pledged: true,
@@ -1280,7 +1225,7 @@ describe('CampaignsController', () => {
     it('throws BadRequestException when no electionDate', async () => {
       const campaign: Campaign = {
         ...mockCampaign,
-        details: { positionId: 'pos-1' } as unknown as Campaign['details'],
+        details: {} as Campaign['details'],
       }
 
       await expect(

--- a/src/campaigns/campaigns.controller.ts
+++ b/src/campaigns/campaigns.controller.ts
@@ -185,22 +185,13 @@ export class CampaignsController {
     if (existing) {
       throw new ConflictException('User campaign already exists.')
     }
-    const ballotReadyPositionId =
-      body.ballotReadyPositionId ?? body.details?.positionId ?? undefined
-
-    const customPositionName =
-      body.customPositionName ??
-      (!ballotReadyPositionId
-        ? (OrganizationsService.resolveCustomPositionName(
-            body.details?.office,
-            body.details?.otherOffice,
-          ) ?? undefined)
-        : undefined)
-
     return this.campaigns.createForUser(
       user,
       { details: body.details, data: body.data },
-      { ballotReadyPositionId, customPositionName },
+      {
+        ballotReadyPositionId: body.ballotReadyPositionId ?? undefined,
+        customPositionName: body.customPositionName ?? undefined,
+      },
     )
   }
 
@@ -229,11 +220,10 @@ export class CampaignsController {
       })
 
       if (body?.details) {
-        const { city, office, electionDate, pledged, party } = body.details
+        const { city, electionDate, pledged, party } = body.details
 
         await this.analytics.identify(campaign.userId, {
           ...(city && { officeMunicipality: city }),
-          ...(office && { officeName: office }),
           ...(electionDate && { officeElectionDate: electionDate }),
           ...(party && { affiliation: party }),
           ...(pledged && { pledged }),
@@ -412,7 +402,7 @@ export class CampaignsController {
 
     if (!ballotreadyPositionId || !campaign.details.electionDate) {
       throw new BadRequestException(
-        `Error: The campaign has no ballotready 'positionId' or electionDate and likely hasn't selected an office yet`,
+        `Error: The campaign's organization has no BallotReady position or the campaign has no electionDate — the candidate likely hasn't selected an office yet`,
       )
     }
 
@@ -488,7 +478,7 @@ export class CampaignsController {
 
     if (!ballotreadyPositionId || !campaign.details.electionDate) {
       throw new BadRequestException(
-        `Error: The campaign has no ballotready 'positionId' or electionDate and likely hasn't selected an office yet`,
+        `Error: The campaign's organization has no BallotReady position or the campaign has no electionDate — the candidate likely hasn't selected an office yet`,
       )
     }
     const raceTargetDetails = await this.elections

--- a/src/campaigns/decorators/UseCampaign.decorator.ts
+++ b/src/campaigns/decorators/UseCampaign.decorator.ts
@@ -4,17 +4,17 @@ import { Prisma } from '@prisma/client'
 
 export const REQUIRE_CAMPAIGN_META_KEY = 'requireCampaignDecorator'
 
-export type RequireCamapaignMetadata = {
+export type RequireCampaignMetadata = {
   include?: Prisma.CampaignInclude
   continueIfNotFound?: boolean
 }
 
 /**
- * Decorator to apply UserCampaign guard and preload campaign to pull in with "@ReqCampaign" decorator
+ * Decorator to apply UseCampaign guard and preload campaign to pull in with "@ReqCampaign" decorator
  * @param continueIfNotFound Allow the handler to continue if current user doesn't have a campaign, (e.g. to deal with fallbacks in the handler)
  * @param include Object to specify what relations to load with the campaign
  * */
-export const UseCampaign = (args: RequireCamapaignMetadata = {}) => {
+export const UseCampaign = (args: RequireCampaignMetadata = {}) => {
   return applyDecorators(
     SetMetadata(REQUIRE_CAMPAIGN_META_KEY, args),
     UseGuards(UseCampaignGuard),

--- a/src/campaigns/guards/UseCampaign.guard.integration.test.ts
+++ b/src/campaigns/guards/UseCampaign.guard.integration.test.ts
@@ -29,18 +29,10 @@ describe('UseCampaign guard (integration)', () => {
     return { org, campaign }
   }
 
-  describe('legacy fallback (no header)', () => {
-    it('resolves campaign by userId', async () => {
-      const { campaign } = await createCampaignWithOrg('legacy')
+  describe('no header', () => {
+    it('returns 404 when no org header is provided (even if user has a campaign)', async () => {
+      await createCampaignWithOrg('no-header')
 
-      const result = await service.client.get('/v1/campaigns/mine')
-
-      expect(result.status).toBe(200)
-      expect(result.data.slug).toBe(campaign.slug)
-      expect(result.data.id).toBe(campaign.id)
-    })
-
-    it('returns 404 when user has no campaign', async () => {
       const result = await service.client.get('/v1/campaigns/mine')
 
       expect(result.status).toBe(404)

--- a/src/campaigns/guards/UseCampaign.guard.test.ts
+++ b/src/campaigns/guards/UseCampaign.guard.test.ts
@@ -3,7 +3,7 @@ import { ExecutionContext, NotFoundException } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { Campaign } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { RequireCamapaignMetadata } from '../decorators/UseCampaign.decorator'
+import { RequireCampaignMetadata } from '../decorators/UseCampaign.decorator'
 import { CampaignsService } from '../services/campaigns.service'
 import { UseCampaignGuard } from './UseCampaign.guard'
 
@@ -40,7 +40,7 @@ describe('UseCampaignGuard', () => {
     } as unknown as ExecutionContext
   }
 
-  function mockMetadata(meta: RequireCamapaignMetadata = {}) {
+  function mockMetadata(meta: RequireCampaignMetadata = {}) {
     vi.spyOn(reflector, 'getAllAndOverride').mockReturnValue(meta)
   }
 
@@ -49,7 +49,6 @@ describe('UseCampaignGuard', () => {
 
     campaignsService = {
       findFirst: vi.fn(),
-      findByUserId: vi.fn(),
       client: {
         organization: {
           findFirst: mockOrgFindFirst,
@@ -120,7 +119,6 @@ describe('UseCampaignGuard', () => {
       })
 
       await expect(guard.canActivate(ctx)).rejects.toThrow(NotFoundException)
-      expect(campaignsService.findByUserId).not.toHaveBeenCalled()
     })
 
     it('throws NotFoundException when org not found', async () => {
@@ -133,7 +131,6 @@ describe('UseCampaignGuard', () => {
       })
 
       await expect(guard.canActivate(ctx)).rejects.toThrow(NotFoundException)
-      expect(campaignsService.findByUserId).not.toHaveBeenCalled()
     })
 
     it('throws NotFoundException when ownerId does not match', async () => {
@@ -150,54 +147,20 @@ describe('UseCampaignGuard', () => {
       expect(mockOrgFindFirst).toHaveBeenCalledWith({
         where: { slug: 'campaign-100', ownerId: 999 },
       })
-      expect(campaignsService.findByUserId).not.toHaveBeenCalled()
-    })
-
-    it('does not call findByUserId when org header resolves campaign', async () => {
-      mockMetadata()
-      mockOrgFindFirst.mockResolvedValue({ slug: 'campaign-100', ownerId: 1 })
-      vi.spyOn(campaignsService, 'findFirst').mockResolvedValue(mockCampaign)
-
-      const ctx = buildContext({
-        headers: { 'x-organization-slug': 'campaign-100' },
-      })
-      await guard.canActivate(ctx)
-
-      expect(campaignsService.findByUserId).not.toHaveBeenCalled()
     })
   })
 
-  describe('step 2: legacy fallback (findByUserId)', () => {
-    it('resolves campaign by userId when no header', async () => {
+  describe('no header behavior', () => {
+    it('throws NotFoundException when no header and no continueIfNotFound', async () => {
       mockMetadata()
-      vi.spyOn(campaignsService, 'findByUserId').mockResolvedValue(mockCampaign)
-
-      const ctx = buildContext()
-      const result = await guard.canActivate(ctx)
-
-      expect(result).toBe(true)
-      expect(mockOrgFindFirst).not.toHaveBeenCalled()
-      expect(campaignsService.findByUserId).toHaveBeenCalledWith(1, {
-        pathToVictory: true,
-      })
-      const req = ctx.switchToHttp().getRequest() as {
-        campaign?: Campaign
-      }
-      expect(req.campaign).toEqual(mockCampaign)
-    })
-
-    it('throws NotFoundException when no campaign found', async () => {
-      mockMetadata()
-      vi.spyOn(campaignsService, 'findByUserId').mockResolvedValue(null)
 
       const ctx = buildContext()
 
       await expect(guard.canActivate(ctx)).rejects.toThrow(NotFoundException)
     })
 
-    it('returns true when continueIfNotFound and no campaign found', async () => {
+    it('returns true when continueIfNotFound and no header', async () => {
       mockMetadata({ continueIfNotFound: true })
-      vi.spyOn(campaignsService, 'findByUserId').mockResolvedValue(null)
 
       const ctx = buildContext()
       const result = await guard.canActivate(ctx)

--- a/src/campaigns/guards/UseCampaign.guard.ts
+++ b/src/campaigns/guards/UseCampaign.guard.ts
@@ -10,18 +10,15 @@ import { PinoLogger } from 'nestjs-pino'
 import { CampaignWith } from '../campaigns.types'
 import {
   REQUIRE_CAMPAIGN_META_KEY,
-  RequireCamapaignMetadata,
+  RequireCampaignMetadata,
 } from '../decorators/UseCampaign.decorator'
 import { CampaignsService } from '../services/campaigns.service'
 
 /**
  * Guard that resolves a Campaign and attaches it to the request.
  *
- * Resolution order:
- * 1. `X-Organization-Slug` header — look up Organization, get its campaign.
- * 2. Legacy fallback — find campaign by userId.
- *
- * Once all requests include the organization header, the legacy fallback can be removed.
+ * Requires the `X-Organization-Slug` header. Looks up the Organization by slug
+ * and owner, then fetches the associated campaign.
  */
 @Injectable()
 export class UseCampaignGuard implements CanActivate {
@@ -36,13 +33,12 @@ export class UseCampaignGuard implements CanActivate {
   async canActivate(context: ExecutionContext) {
     const request = context.switchToHttp().getRequest<{
       headers: Record<string, string | undefined>
-      params: { slug: string }
       campaign?: Campaign
       user: { id: number }
     }>()
 
     const { continueIfNotFound, include: campaignInclude } =
-      this.reflector.getAllAndOverride<RequireCamapaignMetadata>(
+      this.reflector.getAllAndOverride<RequireCampaignMetadata>(
         REQUIRE_CAMPAIGN_META_KEY,
         [context.getHandler(), context.getClass()],
       )
@@ -51,7 +47,6 @@ export class UseCampaignGuard implements CanActivate {
     const include = campaignInclude ?? { pathToVictory: true }
     let campaign: Campaign | null = null
 
-    // Step 1: Try x-organization-slug header
     const slug = request.headers['x-organization-slug']
     if (typeof slug === 'string') {
       const [org, cam] = await Promise.all([
@@ -66,8 +61,6 @@ export class UseCampaignGuard implements CanActivate {
       if (org && cam) {
         campaign = cam
       }
-    } else {
-      campaign = await this.campaignsService.findByUserId(userId, include)
     }
 
     if (campaign) {

--- a/src/campaigns/schemas/updateCampaign.schema.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.ts
@@ -48,8 +48,6 @@ const CampaignDetailsSchema = z
     city: z.string(),
     county: z.string(),
     normalizedOffice: z.string(),
-    office: z.string(),
-    otherOffice: z.string(),
     party: z.string(),
     otherParty: z.string(),
     district: z.string(),
@@ -73,7 +71,6 @@ const CampaignDetailsSchema = z
     officeTermLength: z.string(),
     partisanType: z.string().nullish().optional(),
     priorElectionDates: z.array(z.string()),
-    positionId: z.string().nullish(),
     electionId: z.string().nullish(),
     tier: z.string(),
   })

--- a/src/campaigns/services/campaigns.service.test.ts
+++ b/src/campaigns/services/campaigns.service.test.ts
@@ -218,29 +218,6 @@ describe('CampaignsService - Organization positionId sync', () => {
       )
     })
 
-    it('strips positionId, office, and otherOffice from persisted details', async () => {
-      const { service, mockCampaignCreate } = await buildOrgSyncModule()
-
-      vi.spyOn(service, 'findSlug').mockResolvedValue('test-slug')
-
-      const user = { id: 1, zip: '90210' } as User
-      const details = {
-        state: 'CA',
-        positionId: 'br-pos-123',
-        office: 'Other',
-        otherOffice: 'City Council',
-      } as PrismaJson.CampaignDetails
-
-      await service.createForUser(user, { details })
-
-      const created = mockCampaignCreate.mock.calls[0][0].data.details
-      expect(created.state).toBe('CA')
-      expect(created.zip).toBe('90210')
-      expect(created).not.toHaveProperty('positionId')
-      expect(created).not.toHaveProperty('office')
-      expect(created).not.toHaveProperty('otherOffice')
-    })
-
     describe('details json deep merge (same deepMerge as createForUser)', () => {
       it('keeps user zip when patch omits zip', () => {
         expect(deepMerge({ zip: '90210' } as object, {} as object)).toEqual({
@@ -387,67 +364,6 @@ describe('CampaignsService - Organization positionId sync', () => {
 
       await service.updateJsonFields(10, {
         pathToVictory: { p2vCompleteDate: '2025-01-01' },
-      })
-
-      expect(mockOrgUpdate).not.toHaveBeenCalled()
-    })
-
-    it('should sync organization when legacy positionId is in details', async () => {
-      const { service, mockOrgUpdate, mockCampaignFindFirst, mockGetPosition } =
-        await buildOrgSyncModule()
-
-      mockCampaignFindFirst.mockResolvedValue({ ...baseCampaign })
-      mockGetPosition.mockResolvedValue({
-        id: 'gp-pos-99',
-        brPositionId: 'br-legacy-1',
-        brDatabaseId: 'br-db-1',
-        state: 'CA',
-        name: 'Mayor',
-      })
-
-      await service.updateJsonFields(10, {
-        details: { positionId: 'br-legacy-1', office: 'Mayor' },
-      })
-
-      expect(mockGetPosition).toHaveBeenCalledWith('br-legacy-1')
-      expect(mockOrgUpdate).toHaveBeenCalledWith({
-        where: { slug: 'campaign-10' },
-        data: {
-          positionId: 'gp-pos-99',
-          customPositionName: null,
-          overrideDistrictId: null,
-        },
-      })
-    })
-
-    it('should sync organization with customPositionName when no positionId', async () => {
-      const { service, mockOrgUpdate, mockCampaignFindFirst } =
-        await buildOrgSyncModule()
-
-      mockCampaignFindFirst.mockResolvedValue({ ...baseCampaign })
-
-      await service.updateJsonFields(10, {
-        details: { office: 'Other', otherOffice: 'Town Clerk' },
-      })
-
-      expect(mockOrgUpdate).toHaveBeenCalledWith({
-        where: { slug: 'campaign-10' },
-        data: {
-          positionId: null,
-          customPositionName: 'Town Clerk',
-          overrideDistrictId: null,
-        },
-      })
-    })
-
-    it('should not sync organization when details lacks legacy position fields', async () => {
-      const { service, mockOrgUpdate, mockCampaignFindFirst } =
-        await buildOrgSyncModule()
-
-      mockCampaignFindFirst.mockResolvedValue({ ...baseCampaign })
-
-      await service.updateJsonFields(10, {
-        details: { city: 'Austin', state: 'TX' },
       })
 
       expect(mockOrgUpdate).not.toHaveBeenCalled()
@@ -1081,8 +997,6 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
       winNumber: 3001,
       voterContactGoal: 15005,
       source: 'test',
-      electionType: 'test',
-      electionLocation: 'test',
       p2vStatus: 'Complete',
       p2vCompleteDate: '2026-01-01',
     })
@@ -1114,8 +1028,6 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
       winNumber: 2001,
       voterContactGoal: 10005,
       source: 'test',
-      electionType: 'test',
-      electionLocation: 'test',
       p2vStatus: 'Complete',
       p2vCompleteDate: '2026-01-01',
     })

--- a/src/campaigns/services/campaigns.service.ts
+++ b/src/campaigns/services/campaigns.service.ts
@@ -193,9 +193,6 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
         { zip: user.zip } as object,
         initialData.details as object,
       ) as PrismaJson.CampaignDetails
-      delete mergedDetails.positionId
-      delete mergedDetails.office
-      delete mergedDetails.otherOffice
 
       return tx.campaign.create({
         data: {
@@ -300,15 +297,6 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
               description: string
             }>
           }
-          if (
-            'positionId' in details ||
-            'office' in details ||
-            'otherOffice' in details
-          ) {
-            delete mergedDetails.positionId
-            delete mergedDetails.office
-            delete mergedDetails.otherOffice
-          }
           campaignUpdateData.details = mergedDetails
         }
         if (objectNotEmpty(aiContent)) {
@@ -319,8 +307,6 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
             aiContent,
           ) as PrismaJson.CampaignAiContent
         }
-
-        await this.syncLegacyPositionToOrg(details, campaign, tx)
 
         if (overrideDistrictId !== undefined) {
           const orgSlug = OrganizationsService.campaignOrgSlug(campaign.id)
@@ -383,76 +369,6 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
     }
 
     return updatedCampaign ? updatedCampaign : null
-  }
-
-  private async syncLegacyPositionToOrg(
-    details: UpdateCampaignFieldsInput['details'],
-    campaign: {
-      id: number
-      details: {
-        positionId?: string | null
-        office?: string
-        otherOffice?: string
-      }
-    },
-    tx: { organization: Pick<Prisma.OrganizationDelegate, 'update'> },
-  ) {
-    if (!details || typeof details !== 'object') return
-    if (!('positionId' in details) && !('office' in details)) return
-
-    const positionIdRaw = details['positionId']
-    const incomingPositionId =
-      typeof positionIdRaw === 'string' ? positionIdRaw : null
-
-    const storedPositionIdRaw = campaign.details.positionId
-    const storedBallotReadyId =
-      typeof storedPositionIdRaw === 'string' ? storedPositionIdRaw : null
-
-    const resolvedBallotReadyId =
-      'positionId' in details ? incomingPositionId : storedBallotReadyId
-
-    let resolvedPosition: Awaited<
-      ReturnType<ElectionsService['getPositionByBallotReadyId']>
-    > = null
-    if (resolvedBallotReadyId) {
-      try {
-        resolvedPosition = await this.elections.getPositionByBallotReadyId(
-          resolvedBallotReadyId,
-        )
-      } catch (err: unknown) {
-        this.logger.warn(
-          { resolvedBallotReadyId, err },
-          'Election API position lookup failed during legacy org sync; treating as unresolved',
-        )
-        resolvedPosition = null
-      }
-    }
-
-    const officeRaw = details['office']
-    const otherOfficeRaw = details['otherOffice']
-    const mergedOffice =
-      (typeof officeRaw === 'string' ? officeRaw : undefined) ??
-      campaign.details.office
-    const mergedOtherOffice =
-      (typeof otherOfficeRaw === 'string' ? otherOfficeRaw : undefined) ??
-      campaign.details.otherOffice
-
-    const customPositionName = !resolvedPosition
-      ? OrganizationsService.resolveCustomPositionName(
-          mergedOffice,
-          mergedOtherOffice,
-        )
-      : null
-
-    const orgSlug = OrganizationsService.campaignOrgSlug(campaign.id)
-    await tx.organization.update({
-      where: { slug: orgSlug },
-      data: {
-        positionId: resolvedPosition?.id ?? null,
-        customPositionName,
-        overrideDistrictId: null,
-      },
-    })
   }
 
   async patchCampaignDetails(

--- a/src/campaigns/tasks/campaignTasks.types.ts
+++ b/src/campaigns/tasks/campaignTasks.types.ts
@@ -32,4 +32,7 @@ export type RecurringTaskTemplate = {
   title: string
   description: string
   recurrence: RecurrenceRule
+  flowType?: CampaignTaskType
+  proRequired?: boolean
+  defaultAiTemplateId?: string
 }

--- a/src/campaigns/tasks/campaignTasks.types.ts
+++ b/src/campaigns/tasks/campaignTasks.types.ts
@@ -1,5 +1,5 @@
 export { CampaignTaskType } from '@prisma/client'
-import { CampaignTaskType } from '@prisma/client'
+import type { CampaignTaskType } from '@prisma/client'
 
 export type CampaignTask = {
   id: string

--- a/src/campaigns/tasks/campaignTasks.types.ts
+++ b/src/campaigns/tasks/campaignTasks.types.ts
@@ -1,14 +1,5 @@
-export enum CampaignTaskType {
-  text = 'text',
-  robocall = 'robocall',
-  doorKnocking = 'doorKnocking',
-  phoneBanking = 'phoneBanking',
-  socialMedia = 'socialMedia',
-  events = 'events',
-  education = 'education',
-  compliance = 'compliance',
-  awareness = 'awareness',
-}
+export { CampaignTaskType } from '@prisma/client'
+import { CampaignTaskType } from '@prisma/client'
 
 export type CampaignTask = {
   id: string
@@ -23,4 +14,22 @@ export type CampaignTask = {
   isDefaultTask?: boolean
   deadline?: number
   defaultAiTemplateId?: string
+}
+
+export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+export type RecurrenceRule =
+  | { type: 'weekly'; dayOfWeek: DayOfWeek }
+  | { type: 'monthlyNthDay'; dayOfWeek: DayOfWeek; occurrences: number[] }
+  | {
+      type: 'weeksBeforeElection'
+      dayOfWeek: DayOfWeek
+      weeksBefore: number
+    }
+
+export type RecurringTaskTemplate = {
+  id: string
+  title: string
+  description: string
+  recurrence: RecurrenceRule
 }

--- a/src/campaigns/tasks/fixtures/defaultRecurringTasks.ts
+++ b/src/campaigns/tasks/fixtures/defaultRecurringTasks.ts
@@ -1,0 +1,66 @@
+import { RecurringTaskTemplate } from '../campaignTasks.types'
+
+export const defaultRecurringTasks: RecurringTaskTemplate[] = [
+  {
+    id: 'rec-social-posts',
+    title: 'Plan and Schedule 2 Social Posts for the week',
+    description:
+      'Keep your campaign visible! Plan and schedule two social posts to engage supporters and reach more voters.',
+    recurrence: { type: 'weekly', dayOfWeek: 5 },
+  },
+  {
+    id: 'rec-social-update',
+    title: 'Social media update',
+    description:
+      'Post campaign activities and photos on your social media channel of choice',
+    recurrence: { type: 'weekly', dayOfWeek: 5 },
+  },
+  {
+    id: 'rec-fundraising-ask',
+    title: 'Fundraising ask',
+    description:
+      'Make a fundraising solicitation (email and/or social media) to close out the month strong',
+    recurrence: { type: 'weekly', dayOfWeek: 5 },
+  },
+  {
+    id: 'rec-email-update',
+    title: 'Email update',
+    description: 'Send a campaign progress update to your email contacts',
+    recurrence: { type: 'weekly', dayOfWeek: 5 },
+  },
+  {
+    id: 'rec-house-party',
+    title: 'Organize a House Party with Supporters',
+    description:
+      'Work with your supporters to organize an informational house party where you can talk to voters directly.',
+    recurrence: { type: 'monthlyNthDay', dayOfWeek: 3, occurrences: [1] },
+  },
+  {
+    id: 'rec-fundraiser',
+    title: 'Organize a Fundraiser',
+    description:
+      'Work with your supporters to plan and organize a fundraiser to get the financial support you need',
+    recurrence: { type: 'monthlyNthDay', dayOfWeek: 2, occurrences: [2, 4] },
+  },
+  {
+    id: 'rec-volunteer-plan',
+    title: 'Organize a Volunteer Voter Contact Event',
+    description:
+      'Give your supporters a way to give back! Plan a volunteer voter contact event',
+    recurrence: { type: 'monthlyNthDay', dayOfWeek: 2, occurrences: [2, 4] },
+  },
+  {
+    id: 'rec-volunteer-hold',
+    title: 'Hold a Volunteer Voter Contact Event',
+    description:
+      'Put your plan into action! Bring volunteers together to connect with voters and build momentum for your campaign.',
+    recurrence: { type: 'monthlyNthDay', dayOfWeek: 2, occurrences: [1, 3] },
+  },
+  {
+    id: 'rec-letters-editor',
+    title: 'Submit 2 Letters to the Editor in support of your campaign',
+    description:
+      'Have some of your supporters write some Letters to the Editor in support of your campaign to the local press.',
+    recurrence: { type: 'weeksBeforeElection', dayOfWeek: 4, weeksBefore: 4 },
+  },
+]

--- a/src/campaigns/tasks/fixtures/defaultRecurringTasks.ts
+++ b/src/campaigns/tasks/fixtures/defaultRecurringTasks.ts
@@ -1,4 +1,4 @@
-import { RecurringTaskTemplate } from '../campaignTasks.types'
+import { CampaignTaskType, RecurringTaskTemplate } from '../campaignTasks.types'
 
 export const defaultRecurringTasks: RecurringTaskTemplate[] = [
   {
@@ -62,5 +62,25 @@ export const defaultRecurringTasks: RecurringTaskTemplate[] = [
     description:
       'Have some of your supporters write some Letters to the Editor in support of your campaign to the local press.',
     recurrence: { type: 'weeksBeforeElection', dayOfWeek: 4, weeksBefore: 4 },
+  },
+  {
+    id: 'rec-door-knocking',
+    title: 'Knock on Doors',
+    description:
+      'Keep your campaign on track to hit your voter contact goals. Knock on your target doors to connect with voters face-to-face.',
+    recurrence: { type: 'weekly', dayOfWeek: 5 },
+    flowType: CampaignTaskType.doorKnocking,
+    proRequired: true,
+    defaultAiTemplateId: 'wgbnDDTxrf8OrresVE1HU',
+  },
+  {
+    id: 'rec-phone-banking',
+    title: 'Make phone bank calls',
+    description:
+      'Keep your campaign on track to hit your voter contact goals. Complete a phone bank shift to reach voters and share your message.',
+    recurrence: { type: 'weekly', dayOfWeek: 5 },
+    flowType: CampaignTaskType.phoneBanking,
+    proRequired: true,
+    defaultAiTemplateId: '5N93cglp3cvq62EIwu1IOa',
   },
 ]

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -13,6 +13,7 @@ import { startOfDay } from 'date-fns'
 import { parseIsoDateString } from '@/shared/util/date.util'
 import { CampaignTask } from '../campaignTasks.types'
 import { generalAwarenessTasks } from '../fixtures/defaultAwarenessTasks'
+import { defaultRecurringTasks } from '../fixtures/defaultRecurringTasks'
 import { generalDefaultTasks } from '../fixtures/defaultTasks'
 import { primaryDefaultTasks } from '../fixtures/defaultTasksForPrimary'
 
@@ -747,13 +748,13 @@ describe('CampaignTasksService', () => {
       return call.data
     }
 
+    const recurringTitles = new Set(defaultRecurringTasks.map((t) => t.title))
+
     const splitByRecurring = (
       tasks: ReturnType<typeof getCreatedTaskData>,
     ) => ({
-      recurring: tasks.filter((t) => t.flowType === CampaignTaskType.recurring),
-      nonRecurring: tasks.filter(
-        (t) => t.flowType !== CampaignTaskType.recurring,
-      ),
+      recurring: tasks.filter((t) => recurringTitles.has(t.title)),
+      nonRecurring: tasks.filter((t) => !recurringTitles.has(t.title)),
     })
 
     it('uses general tasks without dates when details is empty', async () => {
@@ -782,7 +783,7 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
-      expect(recurring).toHaveLength(125)
+      expect(recurring.length).toBeGreaterThan(0)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
       expect(tasks[tasks.length - 1].date).toBeInstanceOf(Date)
@@ -802,8 +803,7 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
-      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
-      expect(recurring).toHaveLength(63)
+      expect(recurring.length).toBeGreaterThan(0)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
     })
@@ -828,7 +828,7 @@ describe('CampaignTasksService', () => {
           generalDefaultTasks.length +
           generalAwarenessTasks.length,
       )
-      expect(recurring).toHaveLength(125)
+      expect(recurring.length).toBeGreaterThan(0)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
     })
@@ -882,7 +882,7 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
-      expect(recurring).toHaveLength(125)
+      expect(recurring.length).toBeGreaterThan(0)
     })
 
     it('distributes only primary when general is past and primary is future', async () => {
@@ -901,8 +901,7 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
-      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
-      expect(recurring).toHaveLength(63)
+      expect(recurring.length).toBeGreaterThan(0)
     })
 
     it('assigns dates in chronological order', async () => {
@@ -1098,6 +1097,50 @@ describe('CampaignTasksService', () => {
       ])
     })
 
+    it('generates door-knocking recurring tasks with correct flowType and proRequired', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: '2025-06-15' },
+        }),
+        TODAY,
+      )
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      const doorKnocking = recurring.filter((t) => t.title === 'Knock on Doors')
+      expect(doorKnocking.length).toBeGreaterThan(0)
+      doorKnocking.forEach((t) => {
+        expect(t.flowType).toBe(CampaignTaskType.doorKnocking)
+        expect(t.proRequired).toBe(true)
+        expect(t.defaultAiTemplateId).toBe('wgbnDDTxrf8OrresVE1HU')
+        expect(t.isDefaultTask).toBe(true)
+      })
+    })
+
+    it('generates phone-banking recurring tasks with correct flowType and proRequired', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: '2025-06-15' },
+        }),
+        TODAY,
+      )
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      const phoneBanking = recurring.filter(
+        (t) => t.title === 'Make phone bank calls',
+      )
+      expect(phoneBanking.length).toBeGreaterThan(0)
+      phoneBanking.forEach((t) => {
+        expect(t.flowType).toBe(CampaignTaskType.phoneBanking)
+        expect(t.proRequired).toBe(true)
+        expect(t.defaultAiTemplateId).toBe('5N93cglp3cvq62EIwu1IOa')
+        expect(t.isDefaultTask).toBe(true)
+      })
+    })
+
     it('generates all recurring task templates with correct total counts', async () => {
       setupForCreation()
 
@@ -1109,7 +1152,7 @@ describe('CampaignTasksService', () => {
       )
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
-      expect(recurring).toHaveLength(125)
+      expect(recurring).toHaveLength(169)
 
       const countByTitle = recurring.reduce<Record<string, number>>(
         (acc, t) => {
@@ -1129,17 +1172,17 @@ describe('CampaignTasksService', () => {
         'Organize a Volunteer Voter Contact Event': 10,
         'Hold a Volunteer Voter Contact Event': 11,
         'Submit 2 Letters to the Editor in support of your campaign': 1,
+        'Knock on Doors': 22,
+        'Make phone bank calls': 22,
       })
 
       expect(recurring[0]).toMatchObject({
-        flowType: CampaignTaskType.recurring,
         isDefaultTask: true,
         campaignId: 1,
         completed: false,
       })
       expect(recurring[0].date).toBeInstanceOf(Date)
       expect(recurring[recurring.length - 1]).toMatchObject({
-        flowType: CampaignTaskType.recurring,
         isDefaultTask: true,
         campaignId: 1,
         completed: false,

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -9,11 +9,10 @@ import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
 import { CampaignUpdateHistoryType, Prisma } from '@prisma/client'
 import { MessageGroup, QueueType } from 'src/queue/queue.types'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
-import { addDays, getDay, startOfDay, startOfWeek, subWeeks } from 'date-fns'
+import { startOfDay } from 'date-fns'
 import { parseIsoDateString } from '@/shared/util/date.util'
 import { CampaignTask } from '../campaignTasks.types'
 import { generalAwarenessTasks } from '../fixtures/defaultAwarenessTasks'
-import { defaultRecurringTasks } from '../fixtures/defaultRecurringTasks'
 import { generalDefaultTasks } from '../fixtures/defaultTasks'
 import { primaryDefaultTasks } from '../fixtures/defaultTasksForPrimary'
 
@@ -740,8 +739,15 @@ describe('CampaignTasksService', () => {
       const call = mockTxModel.createMany.mock.calls[0][0] as {
         data: {
           title: string
+          description: string
+          cta: string | null
           date: Date | null
           week: number
+          link: string | undefined
+          proRequired: boolean
+          deadline: number | undefined
+          defaultAiTemplateId: string | undefined
+          completed: boolean
           isDefaultTask: boolean
           campaignId: number
           flowType: CampaignTaskType | null
@@ -984,7 +990,113 @@ describe('CampaignTasksService', () => {
       })
     })
 
-    it('generates recurring tasks with correct flowType and dates', async () => {
+    it('generates weekly recurring tasks on the correct day each week', async () => {
+      const SHORT_ELECTION = '2025-06-15'
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: SHORT_ELECTION },
+        }),
+      )
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      const socialPosts = recurring.filter(
+        (t) => t.title === 'Plan and Schedule 2 Social Posts for the week',
+      )
+      expect(socialPosts).toEqual([
+        {
+          campaignId: 1,
+          title: 'Plan and Schedule 2 Social Posts for the week',
+          description:
+            'Keep your campaign visible! Plan and schedule two social posts to engage supporters and reach more voters.',
+          cta: null,
+          flowType: CampaignTaskType.recurring,
+          week: 2,
+          date: startOfDay(parseIsoDateString('2025-06-06')),
+          link: undefined,
+          proRequired: false,
+          deadline: undefined,
+          defaultAiTemplateId: undefined,
+          completed: false,
+          isDefaultTask: true,
+        },
+        {
+          campaignId: 1,
+          title: 'Plan and Schedule 2 Social Posts for the week',
+          description:
+            'Keep your campaign visible! Plan and schedule two social posts to engage supporters and reach more voters.',
+          cta: null,
+          flowType: CampaignTaskType.recurring,
+          week: 1,
+          date: startOfDay(parseIsoDateString('2025-06-13')),
+          link: undefined,
+          proRequired: false,
+          deadline: undefined,
+          defaultAiTemplateId: undefined,
+          completed: false,
+          isDefaultTask: true,
+        },
+      ])
+    })
+
+    it('generates monthlyNthDay recurring tasks on correct week-of-month occurrences', async () => {
+      const SHORT_ELECTION = '2025-06-22'
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: SHORT_ELECTION },
+        }),
+      )
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      const houseParty = recurring.filter(
+        (t) => t.title === 'Organize a House Party with Supporters',
+      )
+      expect(houseParty).toEqual([
+        {
+          campaignId: 1,
+          title: 'Organize a House Party with Supporters',
+          description:
+            'Work with your supporters to organize an informational house party where you can talk to voters directly.',
+          cta: null,
+          flowType: CampaignTaskType.recurring,
+          week: 3,
+          date: startOfDay(parseIsoDateString('2025-06-04')),
+          link: undefined,
+          proRequired: false,
+          deadline: undefined,
+          defaultAiTemplateId: undefined,
+          completed: false,
+          isDefaultTask: true,
+        },
+      ])
+
+      const fundraiser = recurring.filter(
+        (t) => t.title === 'Organize a Fundraiser',
+      )
+      expect(fundraiser).toEqual([
+        {
+          campaignId: 1,
+          title: 'Organize a Fundraiser',
+          description:
+            'Work with your supporters to plan and organize a fundraiser to get the financial support you need',
+          cta: null,
+          flowType: CampaignTaskType.recurring,
+          week: 2,
+          date: startOfDay(parseIsoDateString('2025-06-10')),
+          link: undefined,
+          proRequired: false,
+          deadline: undefined,
+          defaultAiTemplateId: undefined,
+          completed: false,
+          isDefaultTask: true,
+        },
+      ])
+    })
+
+    it('generates weeksBeforeElection recurring task at the exact computed date', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(
@@ -994,62 +1106,70 @@ describe('CampaignTasksService', () => {
       )
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
-      expect(recurring.length).toBeGreaterThan(0)
+      const lettersToEditor = recurring.filter(
+        (t) =>
+          t.title ===
+          'Submit 2 Letters to the Editor in support of your campaign',
+      )
+      expect(lettersToEditor).toEqual([
+        {
+          campaignId: 1,
+          title: 'Submit 2 Letters to the Editor in support of your campaign',
+          description:
+            'Have some of your supporters write some Letters to the Editor in support of your campaign to the local press.',
+          cta: null,
+          flowType: CampaignTaskType.recurring,
+          week: 4,
+          date: startOfDay(parseIsoDateString('2025-10-09')),
+          link: undefined,
+          proRequired: false,
+          deadline: undefined,
+          defaultAiTemplateId: undefined,
+          completed: false,
+          isDefaultTask: true,
+        },
+      ])
+    })
+
+    it('generates all recurring task templates with correct total counts', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: FUTURE_GENERAL },
+        }),
+      )
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      expect(recurring).toHaveLength(125)
+
+      const countByTitle = recurring.reduce<Record<string, number>>(
+        (acc, t) => {
+          acc[t.title] = (acc[t.title] || 0) + 1
+          return acc
+        },
+        {},
+      )
+
+      expect(countByTitle).toEqual({
+        'Plan and Schedule 2 Social Posts for the week': 22,
+        'Social media update': 22,
+        'Fundraising ask': 22,
+        'Email update': 22,
+        'Organize a House Party with Supporters': 5,
+        'Organize a Fundraiser': 10,
+        'Organize a Volunteer Voter Contact Event': 10,
+        'Hold a Volunteer Voter Contact Event': 11,
+        'Submit 2 Letters to the Editor in support of your campaign': 1,
+      })
+
       recurring.forEach((task) => {
         expect(task.flowType).toBe(CampaignTaskType.recurring)
         expect(task.date).toBeInstanceOf(Date)
         expect(task.isDefaultTask).toBe(true)
+        expect(task.campaignId).toBe(1)
+        expect(task.completed).toBe(false)
       })
-
-      const recurringTitles = new Set(recurring.map((t) => t.title))
-      defaultRecurringTasks.forEach((template) => {
-        expect(recurringTitles.has(template.title)).toBe(true)
-      })
-
-      const weeklyTemplate = defaultRecurringTasks.find(
-        (t) => t.recurrence.type === 'weekly',
-      )!
-      const weeklyTasks = recurring.filter(
-        (t) => t.title === weeklyTemplate.title,
-      )
-      expect(weeklyTasks.length).toBeGreaterThan(0)
-      weeklyTasks.forEach((task) => {
-        expect(getDay(task.date!)).toBe(weeklyTemplate.recurrence.dayOfWeek)
-      })
-
-      const monthlyTemplate = defaultRecurringTasks.find(
-        (t) => t.recurrence.type === 'monthlyNthDay',
-      )!
-      const mr = monthlyTemplate.recurrence as {
-        type: 'monthlyNthDay'
-        dayOfWeek: number
-        occurrences: number[]
-      }
-      const monthlyTasks = recurring.filter(
-        (t) => t.title === monthlyTemplate.title,
-      )
-      expect(monthlyTasks.length).toBeGreaterThan(0)
-      monthlyTasks.forEach((task) => {
-        const d = task.date!
-        expect(getDay(d)).toBe(mr.dayOfWeek)
-        const weekOfMonth = Math.ceil(d.getDate() / 7)
-        expect(mr.occurrences).toContain(weekOfMonth)
-      })
-
-      const beTemplate = defaultRecurringTasks.find(
-        (t) => t.recurrence.type === 'weeksBeforeElection',
-      )!
-      const ber = beTemplate.recurrence as {
-        type: 'weeksBeforeElection'
-        dayOfWeek: number
-        weeksBefore: number
-      }
-      const beTasks = recurring.filter((t) => t.title === beTemplate.title)
-      expect(beTasks).toHaveLength(1)
-      const electionDate = startOfDay(parseIsoDateString(FUTURE_GENERAL))
-      const weekRef = subWeeks(electionDate, ber.weeksBefore)
-      const expectedDate = addDays(startOfWeek(weekRef), ber.dayOfWeek)
-      expect(beTasks[0].date!.getTime()).toBe(expectedDate.getTime())
     })
 
     it('does not generate recurring tasks when no election dates exist', async () => {

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { BadGatewayException, NotFoundException } from '@nestjs/common'
 import { CampaignWithPathToVictory } from '../../campaigns.types'
 import { CampaignTaskType } from '../campaignTasks.types'
@@ -714,20 +714,11 @@ describe('CampaignTasksService', () => {
   })
 
   describe('generateDefaultTasks - task distribution', () => {
-    const FAKE_TODAY = new Date('2025-06-01T00:00:00.000Z')
+    const TODAY = startOfDay(parseIsoDateString('2025-06-01'))
     const FUTURE_GENERAL = '2025-11-04'
     const FUTURE_PRIMARY = '2025-08-15'
     const PAST_PRIMARY = '2024-03-01'
     const PAST_GENERAL = '2024-11-04'
-
-    beforeEach(() => {
-      vi.useFakeTimers()
-      vi.setSystemTime(FAKE_TODAY)
-    })
-
-    afterEach(() => {
-      vi.useRealTimers()
-    })
 
     const setupForCreation = () => {
       mockTxModel.count.mockResolvedValueOnce(0)
@@ -768,7 +759,7 @@ describe('CampaignTasksService', () => {
     it('uses general tasks without dates when details is empty', async () => {
       setupForCreation()
 
-      await service.generateDefaultTasks(makeCampaign({ details: {} }))
+      await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
 
       const tasks = getCreatedTaskData()
       expect(tasks).toHaveLength(generalDefaultTasks.length)
@@ -783,6 +774,7 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { electionDate: FUTURE_GENERAL },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -790,11 +782,11 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
-      expect(recurring.length).toBeGreaterThan(0)
-      tasks.forEach((task) => {
-        expect(task.date).toBeInstanceOf(Date)
-        expect(task.isDefaultTask).toBe(true)
-      })
+      expect(recurring).toHaveLength(125)
+      expect(tasks[0].date).toBeInstanceOf(Date)
+      expect(tasks[0].isDefaultTask).toBe(true)
+      expect(tasks[tasks.length - 1].date).toBeInstanceOf(Date)
+      expect(tasks[tasks.length - 1].isDefaultTask).toBe(true)
     })
 
     it('distributes primary tasks when only primary date is future', async () => {
@@ -804,17 +796,16 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { primaryElectionDate: FUTURE_PRIMARY },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
       expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
-      expect(recurring.length).toBeGreaterThan(0)
-      tasks.forEach((task) => {
-        expect(task.date).toBeInstanceOf(Date)
-        expect(task.isDefaultTask).toBe(true)
-      })
+      expect(recurring).toHaveLength(63)
+      expect(tasks[0].date).toBeInstanceOf(Date)
+      expect(tasks[0].isDefaultTask).toBe(true)
     })
 
     it('distributes both sets when both dates are future', async () => {
@@ -827,6 +818,7 @@ describe('CampaignTasksService', () => {
             electionDate: FUTURE_GENERAL,
           },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -836,11 +828,9 @@ describe('CampaignTasksService', () => {
           generalDefaultTasks.length +
           generalAwarenessTasks.length,
       )
-      expect(recurring.length).toBeGreaterThan(0)
-      tasks.forEach((task) => {
-        expect(task.date).toBeInstanceOf(Date)
-        expect(task.isDefaultTask).toBe(true)
-      })
+      expect(recurring).toHaveLength(125)
+      expect(tasks[0].date).toBeInstanceOf(Date)
+      expect(tasks[0].isDefaultTask).toBe(true)
     })
 
     it('returns empty when both dates are in the past', async () => {
@@ -853,6 +843,7 @@ describe('CampaignTasksService', () => {
             electionDate: PAST_GENERAL,
           },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -866,6 +857,7 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { electionDate: PAST_GENERAL },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -882,6 +874,7 @@ describe('CampaignTasksService', () => {
             electionDate: FUTURE_GENERAL,
           },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -889,7 +882,7 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(recurring).toHaveLength(125)
     })
 
     it('distributes only primary when general is past and primary is future', async () => {
@@ -902,13 +895,14 @@ describe('CampaignTasksService', () => {
             electionDate: PAST_GENERAL,
           },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
       expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(recurring).toHaveLength(63)
     })
 
     it('assigns dates in chronological order', async () => {
@@ -918,6 +912,7 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { electionDate: FUTURE_GENERAL },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -935,6 +930,7 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { electionDate: FUTURE_GENERAL },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
@@ -943,61 +939,31 @@ describe('CampaignTasksService', () => {
       }
     })
 
-    it('produces consistent weeks regardless of server time-of-day', async () => {
-      vi.setSystemTime(new Date('2025-06-01T14:30:00.000Z'))
-      setupForCreation()
-
-      await service.generateDefaultTasks(
-        makeCampaign({
-          details: { electionDate: FUTURE_GENERAL },
-        }),
-      )
-
-      const midDayTasks = getCreatedTaskData()
-
-      vi.clearAllMocks()
-      vi.setSystemTime(new Date('2025-06-01T00:00:00.000Z'))
-      setupForCreation()
-
-      await service.generateDefaultTasks(
-        makeCampaign({
-          details: { electionDate: FUTURE_GENERAL },
-        }),
-      )
-
-      const midnightTasks = getCreatedTaskData()
-
-      expect(midDayTasks).toHaveLength(midnightTasks.length)
-      midDayTasks.forEach((task, i) => {
-        expect(task.week).toBe(midnightTasks[i].week)
-        expect(task.date!.getTime()).toBe(midnightTasks[i].date!.getTime())
-      })
-    })
-
-    it('treats election date equal to today as future with no awareness or recurring tasks', async () => {
+    it('treats election date equal to today as future with only general default tasks', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(
         makeCampaign({
           details: { electionDate: '2025-06-01' },
         }),
+        TODAY,
       )
 
       const tasks = getCreatedTaskData()
       expect(tasks).toHaveLength(generalDefaultTasks.length)
-      tasks.forEach((task) => {
-        expect(task.date).toBeInstanceOf(Date)
-      })
+      expect(tasks[0].date).toBeInstanceOf(Date)
+      expect(tasks[0].isDefaultTask).toBe(true)
+      expect(tasks[tasks.length - 1].date).toBeInstanceOf(Date)
     })
 
     it('generates weekly recurring tasks on the correct day each week', async () => {
-      const SHORT_ELECTION = '2025-06-15'
       setupForCreation()
 
       await service.generateDefaultTasks(
         makeCampaign({
-          details: { electionDate: SHORT_ELECTION },
+          details: { electionDate: '2025-06-15' },
         }),
+        TODAY,
       )
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
@@ -1041,13 +1007,13 @@ describe('CampaignTasksService', () => {
     })
 
     it('generates monthlyNthDay recurring tasks on correct week-of-month occurrences', async () => {
-      const SHORT_ELECTION = '2025-06-22'
       setupForCreation()
 
       await service.generateDefaultTasks(
         makeCampaign({
-          details: { electionDate: SHORT_ELECTION },
+          details: { electionDate: '2025-06-22' },
         }),
+        TODAY,
       )
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
@@ -1103,6 +1069,7 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { electionDate: FUTURE_GENERAL },
         }),
+        TODAY,
       )
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
@@ -1138,6 +1105,7 @@ describe('CampaignTasksService', () => {
         makeCampaign({
           details: { electionDate: FUTURE_GENERAL },
         }),
+        TODAY,
       )
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
@@ -1163,19 +1131,26 @@ describe('CampaignTasksService', () => {
         'Submit 2 Letters to the Editor in support of your campaign': 1,
       })
 
-      recurring.forEach((task) => {
-        expect(task.flowType).toBe(CampaignTaskType.recurring)
-        expect(task.date).toBeInstanceOf(Date)
-        expect(task.isDefaultTask).toBe(true)
-        expect(task.campaignId).toBe(1)
-        expect(task.completed).toBe(false)
+      expect(recurring[0]).toMatchObject({
+        flowType: CampaignTaskType.recurring,
+        isDefaultTask: true,
+        campaignId: 1,
+        completed: false,
       })
+      expect(recurring[0].date).toBeInstanceOf(Date)
+      expect(recurring[recurring.length - 1]).toMatchObject({
+        flowType: CampaignTaskType.recurring,
+        isDefaultTask: true,
+        campaignId: 1,
+        completed: false,
+      })
+      expect(recurring[recurring.length - 1].date).toBeInstanceOf(Date)
     })
 
     it('does not generate recurring tasks when no election dates exist', async () => {
       setupForCreation()
 
-      await service.generateDefaultTasks(makeCampaign({ details: {} }))
+      await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
 
       const { recurring } = splitByRecurring(getCreatedTaskData())
       expect(recurring).toHaveLength(0)

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -783,7 +783,7 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(recurring).toHaveLength(169)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
       expect(tasks[tasks.length - 1].date).toBeInstanceOf(Date)
@@ -803,7 +803,8 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
+      expect(recurring).toHaveLength(85)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
     })
@@ -828,7 +829,7 @@ describe('CampaignTasksService', () => {
           generalDefaultTasks.length +
           generalAwarenessTasks.length,
       )
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(recurring).toHaveLength(169)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
     })
@@ -882,7 +883,7 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(recurring).toHaveLength(169)
     })
 
     it('distributes only primary when general is past and primary is future', async () => {
@@ -901,7 +902,8 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
-      expect(recurring.length).toBeGreaterThan(0)
+      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
+      expect(recurring).toHaveLength(85)
     })
 
     it('assigns dates in chronological order', async () => {

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -13,6 +13,7 @@ import { startOfDay } from 'date-fns'
 import { parseIsoDateString } from '@/shared/util/date.util'
 import { CampaignTask } from '../campaignTasks.types'
 import { generalAwarenessTasks } from '../fixtures/defaultAwarenessTasks'
+import { defaultRecurringTasks } from '../fixtures/defaultRecurringTasks'
 import { generalDefaultTasks } from '../fixtures/defaultTasks'
 import { primaryDefaultTasks } from '../fixtures/defaultTasksForPrimary'
 
@@ -743,10 +744,20 @@ describe('CampaignTasksService', () => {
           week: number
           isDefaultTask: boolean
           campaignId: number
+          flowType: CampaignTaskType | null
         }[]
       }
       return call.data
     }
+
+    const splitByRecurring = (
+      tasks: ReturnType<typeof getCreatedTaskData>,
+    ) => ({
+      recurring: tasks.filter((t) => t.flowType === CampaignTaskType.recurring),
+      nonRecurring: tasks.filter(
+        (t) => t.flowType !== CampaignTaskType.recurring,
+      ),
+    })
 
     it('uses general tasks without dates when details is empty', async () => {
       setupForCreation()
@@ -769,9 +780,11 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(
+      const { nonRecurring, recurring } = splitByRecurring(tasks)
+      expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
+      expect(recurring.length).toBeGreaterThan(0)
       tasks.forEach((task) => {
         expect(task.date).toBeInstanceOf(Date)
         expect(task.isDefaultTask).toBe(true)
@@ -788,8 +801,10 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(primaryDefaultTasks.length)
-      expect(tasks[0].title).toBe(primaryDefaultTasks[0].title)
+      const { nonRecurring, recurring } = splitByRecurring(tasks)
+      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
+      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
+      expect(recurring.length).toBeGreaterThan(0)
       tasks.forEach((task) => {
         expect(task.date).toBeInstanceOf(Date)
         expect(task.isDefaultTask).toBe(true)
@@ -809,11 +824,13 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(
+      const { nonRecurring, recurring } = splitByRecurring(tasks)
+      expect(nonRecurring).toHaveLength(
         primaryDefaultTasks.length +
           generalDefaultTasks.length +
           generalAwarenessTasks.length,
       )
+      expect(recurring.length).toBeGreaterThan(0)
       tasks.forEach((task) => {
         expect(task.date).toBeInstanceOf(Date)
         expect(task.isDefaultTask).toBe(true)
@@ -862,9 +879,11 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(
+      const { nonRecurring, recurring } = splitByRecurring(tasks)
+      expect(nonRecurring).toHaveLength(
         generalDefaultTasks.length + generalAwarenessTasks.length,
       )
+      expect(recurring.length).toBeGreaterThan(0)
     })
 
     it('distributes only primary when general is past and primary is future', async () => {
@@ -880,8 +899,10 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(primaryDefaultTasks.length)
-      expect(tasks[0].title).toBe(primaryDefaultTasks[0].title)
+      const { nonRecurring, recurring } = splitByRecurring(tasks)
+      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
+      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
+      expect(recurring.length).toBeGreaterThan(0)
     })
 
     it('assigns dates in chronological order', async () => {
@@ -947,7 +968,7 @@ describe('CampaignTasksService', () => {
       })
     })
 
-    it('treats election date equal to today as future with no awareness tasks', async () => {
+    it('treats election date equal to today as future with no awareness or recurring tasks', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(
@@ -961,6 +982,38 @@ describe('CampaignTasksService', () => {
       tasks.forEach((task) => {
         expect(task.date).toBeInstanceOf(Date)
       })
+    })
+
+    it('generates recurring tasks with correct flowType and dates', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: FUTURE_GENERAL },
+        }),
+      )
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      expect(recurring.length).toBeGreaterThan(0)
+      recurring.forEach((task) => {
+        expect(task.flowType).toBe(CampaignTaskType.recurring)
+        expect(task.date).toBeInstanceOf(Date)
+        expect(task.isDefaultTask).toBe(true)
+      })
+
+      const recurringTitles = new Set(recurring.map((t) => t.title))
+      defaultRecurringTasks.forEach((template) => {
+        expect(recurringTitles.has(template.title)).toBe(true)
+      })
+    })
+
+    it('does not generate recurring tasks when no election dates exist', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(makeCampaign({ details: {} }))
+
+      const { recurring } = splitByRecurring(getCreatedTaskData())
+      expect(recurring).toHaveLength(0)
     })
   })
 

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -9,7 +9,7 @@ import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
 import { CampaignUpdateHistoryType, Prisma } from '@prisma/client'
 import { MessageGroup, QueueType } from 'src/queue/queue.types'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
-import { startOfDay } from 'date-fns'
+import { addDays, getDay, startOfDay, startOfWeek, subWeeks } from 'date-fns'
 import { parseIsoDateString } from '@/shared/util/date.util'
 import { CampaignTask } from '../campaignTasks.types'
 import { generalAwarenessTasks } from '../fixtures/defaultAwarenessTasks'
@@ -1005,6 +1005,51 @@ describe('CampaignTasksService', () => {
       defaultRecurringTasks.forEach((template) => {
         expect(recurringTitles.has(template.title)).toBe(true)
       })
+
+      const weeklyTemplate = defaultRecurringTasks.find(
+        (t) => t.recurrence.type === 'weekly',
+      )!
+      const weeklyTasks = recurring.filter(
+        (t) => t.title === weeklyTemplate.title,
+      )
+      expect(weeklyTasks.length).toBeGreaterThan(0)
+      weeklyTasks.forEach((task) => {
+        expect(getDay(task.date!)).toBe(weeklyTemplate.recurrence.dayOfWeek)
+      })
+
+      const monthlyTemplate = defaultRecurringTasks.find(
+        (t) => t.recurrence.type === 'monthlyNthDay',
+      )!
+      const mr = monthlyTemplate.recurrence as {
+        type: 'monthlyNthDay'
+        dayOfWeek: number
+        occurrences: number[]
+      }
+      const monthlyTasks = recurring.filter(
+        (t) => t.title === monthlyTemplate.title,
+      )
+      expect(monthlyTasks.length).toBeGreaterThan(0)
+      monthlyTasks.forEach((task) => {
+        const d = task.date!
+        expect(getDay(d)).toBe(mr.dayOfWeek)
+        const weekOfMonth = Math.ceil(d.getDate() / 7)
+        expect(mr.occurrences).toContain(weekOfMonth)
+      })
+
+      const beTemplate = defaultRecurringTasks.find(
+        (t) => t.recurrence.type === 'weeksBeforeElection',
+      )!
+      const ber = beTemplate.recurrence as {
+        type: 'weeksBeforeElection'
+        dayOfWeek: number
+        weeksBefore: number
+      }
+      const beTasks = recurring.filter((t) => t.title === beTemplate.title)
+      expect(beTasks).toHaveLength(1)
+      const electionDate = startOfDay(parseIsoDateString(FUTURE_GENERAL))
+      const weekRef = subWeeks(electionDate, ber.weeksBefore)
+      const expectedDate = addDays(startOfWeek(weekRef), ber.dayOfWeek)
+      expect(beTasks[0].date!.getTime()).toBe(expectedDate.getTime())
     })
 
     it('does not generate recurring tasks when no election dates exist', async () => {

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -360,8 +360,10 @@ export class CampaignTasksService extends createPrismaBase(
     })
   }
 
-  async generateDefaultTasks(campaign: Campaign) {
-    const today = startOfDay(new Date())
+  async generateDefaultTasks(
+    campaign: Campaign,
+    today = startOfDay(new Date()),
+  ) {
     await this.client.$transaction(async (tx) => {
       await tx.$executeRaw`SELECT pg_advisory_xact_lock(${CAMPAIGN_DEFAULT_TASKS_ADVISORY_LOCK_KEY}::integer, ${campaign.id}::integer)`
       const existingDefaults = await tx.campaignTask.count({

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -546,7 +546,9 @@ export class CampaignTasksService extends createPrismaBase(
         id: `${template.id}-${formatDate(date, DateFormats.isoDate)}`,
         title: template.title,
         description: template.description,
-        flowType: CampaignTaskType.recurring,
+        flowType: template.flowType ?? CampaignTaskType.recurring,
+        proRequired: template.proRequired,
+        defaultAiTemplateId: template.defaultAiTemplateId,
         week: differenceInWeeks(electionDate, date, {
           roundingMethod: 'ceil',
         }),

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -9,6 +9,8 @@ import {
   addDays,
   differenceInCalendarDays,
   differenceInWeeks,
+  getDate,
+  getDay,
   isAfter,
   isBefore,
   startOfDay,
@@ -26,8 +28,15 @@ import {
 } from 'src/shared/util/date.util'
 import { sleep } from 'src/shared/util/sleep.util'
 import { ProgressStreamData } from '../aiCampaignManager.types'
-import { CampaignTask } from '../campaignTasks.types'
+import {
+  CampaignTask,
+  CampaignTaskType,
+  DayOfWeek,
+  RecurrenceRule,
+  RecurringTaskTemplate,
+} from '../campaignTasks.types'
 import { generalAwarenessTasks } from '../fixtures/defaultAwarenessTasks'
+import { defaultRecurringTasks } from '../fixtures/defaultRecurringTasks'
 import { generalDefaultTasks } from '../fixtures/defaultTasks'
 import { primaryDefaultTasks } from '../fixtures/defaultTasksForPrimary'
 import { CampaignWithPathToVictory } from '../../campaigns.types'
@@ -401,15 +410,27 @@ export class CampaignTasksService extends createPrismaBase(
           generalDate,
           today,
         ),
+        ...this.computeRecurringTasks(
+          defaultRecurringTasks,
+          today,
+          generalDate,
+        ),
       ])
     }
 
     if (primaryDate) {
-      return this.distributeTasksOverWindow(
-        primaryDefaultTasks,
-        today,
-        primaryDate,
-      )
+      return this.sortTasksByDate([
+        ...this.distributeTasksOverWindow(
+          primaryDefaultTasks,
+          today,
+          primaryDate,
+        ),
+        ...this.computeRecurringTasks(
+          defaultRecurringTasks,
+          today,
+          primaryDate,
+        ),
+      ])
     }
 
     if (generalDate) {
@@ -423,6 +444,11 @@ export class CampaignTasksService extends createPrismaBase(
           generalAwarenessTasks,
           generalDate,
           today,
+        ),
+        ...this.computeRecurringTasks(
+          defaultRecurringTasks,
+          today,
+          generalDate,
         ),
       ])
     }
@@ -502,6 +528,106 @@ export class CampaignTasksService extends createPrismaBase(
         }
       })
       .filter((task) => !isBefore(parseIsoDateString(task.date), today))
+  }
+
+  private computeRecurringTasks(
+    templates: RecurringTaskTemplate[],
+    windowStart: Date,
+    electionDate: Date,
+  ): CampaignTask[] {
+    return templates.flatMap((template) =>
+      this.computeRecurrenceDates(
+        template.recurrence,
+        windowStart,
+        electionDate,
+      ).map((date) => ({
+        id: `${template.id}-${formatDate(date, DateFormats.isoDate)}`,
+        title: template.title,
+        description: template.description,
+        flowType: CampaignTaskType.recurring,
+        week: differenceInWeeks(electionDate, date, {
+          roundingMethod: 'ceil',
+        }),
+        date: formatDate(date, DateFormats.isoDate),
+        isDefaultTask: true,
+      })),
+    )
+  }
+
+  private computeRecurrenceDates(
+    recurrence: RecurrenceRule,
+    windowStart: Date,
+    electionDate: Date,
+  ): Date[] {
+    switch (recurrence.type) {
+      case 'weekly':
+        return this.getWeeklyDates(
+          recurrence.dayOfWeek,
+          windowStart,
+          electionDate,
+        )
+      case 'monthlyNthDay':
+        return this.getMonthlyNthDayDates(
+          recurrence.dayOfWeek,
+          recurrence.occurrences,
+          windowStart,
+          electionDate,
+        )
+      case 'weeksBeforeElection':
+        return this.getSingleOccurrenceDate(
+          recurrence.dayOfWeek,
+          recurrence.weeksBefore,
+          electionDate,
+          windowStart,
+        )
+    }
+  }
+
+  private getWeeklyDates(dayOfWeek: DayOfWeek, start: Date, end: Date): Date[] {
+    const dates: Date[] = []
+    let current = this.nextOrSameDayOfWeek(start, dayOfWeek)
+    while (!isAfter(current, end)) {
+      dates.push(current)
+      current = addDays(current, 7)
+    }
+    return dates
+  }
+
+  private getMonthlyNthDayDates(
+    dayOfWeek: DayOfWeek,
+    occurrences: number[],
+    start: Date,
+    end: Date,
+  ): Date[] {
+    const dates: Date[] = []
+    let current = this.nextOrSameDayOfWeek(start, dayOfWeek)
+    while (!isAfter(current, end)) {
+      const weekOfMonth = Math.ceil(getDate(current) / 7)
+      if (occurrences.includes(weekOfMonth)) {
+        dates.push(current)
+      }
+      current = addDays(current, 7)
+    }
+    return dates
+  }
+
+  private getSingleOccurrenceDate(
+    dayOfWeek: DayOfWeek,
+    weeksBefore: number,
+    electionDate: Date,
+    windowStart: Date,
+  ): Date[] {
+    const weekRef = subWeeks(electionDate, weeksBefore)
+    const date = addDays(startOfWeek(weekRef), dayOfWeek)
+    return !isBefore(date, windowStart) && !isAfter(date, electionDate)
+      ? [date]
+      : []
+  }
+
+  private nextOrSameDayOfWeek(date: Date, dayOfWeek: DayOfWeek): Date {
+    const currentDay = getDay(date)
+    const daysUntil = (dayOfWeek - currentDay + 7) % 7
+    return daysUntil === 0 ? date : addDays(date, daysUntil)
   }
 
   private mapTasksToCreateData(

--- a/src/campaigns/tasks/tests/complete-tasks.e2e.ts
+++ b/src/campaigns/tasks/tests/complete-tasks.e2e.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test'
 import { HttpStatus } from '@nestjs/common'
 import {
+  authHeaders,
+  campaignOrgSlug,
   deleteUser,
   generateRandomEmail,
   generateRandomName,
@@ -16,6 +18,7 @@ type CampaignTaskWithCompletion = CampaignTask & { completed: boolean }
 
 test.describe('Campaigns Tasks - Complete Tasks', () => {
   let reg: RegisterResponse
+  let orgSlug: string
   let testTaskId: string
 
   test.beforeAll(async ({ request }) => {
@@ -29,11 +32,10 @@ test.describe('Campaigns Tasks - Complete Tasks', () => {
       zip: '12345-1234',
       signUpMode: 'candidate',
     })
+    orgSlug = campaignOrgSlug(reg.campaign.id)
 
     const generateResponse = await request.post(`${TASKS_BASE_PATH}/generate`, {
-      headers: {
-        Authorization: `Bearer ${reg.token}`,
-      },
+      headers: authHeaders(reg.token, orgSlug),
     })
     expect(generateResponse.status()).toBe(HttpStatus.ACCEPTED)
 
@@ -41,9 +43,7 @@ test.describe('Campaigns Tasks - Complete Tasks', () => {
       .poll(
         async () => {
           const response = await request.get(TASKS_BASE_PATH, {
-            headers: {
-              Authorization: `Bearer ${reg.token}`,
-            },
+            headers: authHeaders(reg.token, orgSlug),
           })
           expect(response.status()).toBe(HttpStatus.OK)
           const tasks = (await response.json()) as CampaignTask[]
@@ -68,9 +68,7 @@ test.describe('Campaigns Tasks - Complete Tasks', () => {
     const listResponse = await request.get(
       `${TASKS_BASE_PATH}?date=${date}&endDate=${endDate}`,
       {
-        headers: {
-          Authorization: `Bearer ${reg.token}`,
-        },
+        headers: authHeaders(reg.token, orgSlug),
       },
     )
 
@@ -80,9 +78,7 @@ test.describe('Campaigns Tasks - Complete Tasks', () => {
     const response = await request.put(
       `${TASKS_BASE_PATH}/complete/${testTaskId}`,
       {
-        headers: {
-          Authorization: `Bearer ${reg.token}`,
-        },
+        headers: authHeaders(reg.token, orgSlug),
       },
     )
 
@@ -101,9 +97,7 @@ test.describe('Campaigns Tasks - Complete Tasks', () => {
     const listResponse = await request.get(
       `${TASKS_BASE_PATH}?date=${date}&endDate=${endDate}`,
       {
-        headers: {
-          Authorization: `Bearer ${reg.token}`,
-        },
+        headers: authHeaders(reg.token, orgSlug),
       },
     )
 
@@ -111,17 +105,13 @@ test.describe('Campaigns Tasks - Complete Tasks', () => {
     testTaskId = tasks[0].id
 
     await request.put(`${TASKS_BASE_PATH}/complete/${testTaskId}`, {
-      headers: {
-        Authorization: `Bearer ${reg.token}`,
-      },
+      headers: authHeaders(reg.token, orgSlug),
     })
 
     const response = await request.delete(
       `${TASKS_BASE_PATH}/complete/${testTaskId}`,
       {
-        headers: {
-          Authorization: `Bearer ${reg.token}`,
-        },
+        headers: authHeaders(reg.token, orgSlug),
       },
     )
 

--- a/src/campaigns/tasks/tests/list-tasks.test.ts
+++ b/src/campaigns/tasks/tests/list-tasks.test.ts
@@ -7,11 +7,15 @@ import { CampaignTaskType } from '../campaignTasks.types'
 const service = useTestService()
 
 const TASKS_BASE_PATH = '/v1/campaigns/tasks'
+const ORG_SLUG = 'campaign-org-tasks-test'
+const orgHeaders = {
+  headers: { 'x-organization-slug': ORG_SLUG },
+}
 
 async function createCampaignWithTasks() {
   const org = await service.prisma.organization.create({
     data: {
-      slug: 'campaign-org-tasks-test',
+      slug: ORG_SLUG,
       ownerId: service.user.id,
     },
   })
@@ -70,8 +74,10 @@ describe('Campaigns Tasks - List Tasks', () => {
   it('lists all tasks', async () => {
     await createCampaignWithTasks()
 
-    const result =
-      await service.client.get<PrismaCampaignTask[]>(TASKS_BASE_PATH)
+    const result = await service.client.get<PrismaCampaignTask[]>(
+      TASKS_BASE_PATH,
+      orgHeaders,
+    )
 
     expect(result.status).toBe(HttpStatus.OK)
     expect(Array.isArray(result.data)).toBe(true)
@@ -84,8 +90,10 @@ describe('Campaigns Tasks - List Tasks', () => {
   it('returns tasks ordered by week descending', async () => {
     await createCampaignWithTasks()
 
-    const result =
-      await service.client.get<PrismaCampaignTask[]>(TASKS_BASE_PATH)
+    const result = await service.client.get<PrismaCampaignTask[]>(
+      TASKS_BASE_PATH,
+      orgHeaders,
+    )
 
     expect(result.status).toBe(HttpStatus.OK)
     expect(result.data.length).toBeGreaterThan(0)
@@ -104,9 +112,10 @@ describe('Campaigns Tasks - List Tasks', () => {
     const endDate = '2025-04-01T21:17:31.648Z'
 
     const [allResult, filteredResult] = await Promise.all([
-      service.client.get<PrismaCampaignTask[]>(TASKS_BASE_PATH),
+      service.client.get<PrismaCampaignTask[]>(TASKS_BASE_PATH, orgHeaders),
       service.client.get<PrismaCampaignTask[]>(
         `${TASKS_BASE_PATH}?date=${date}&endDate=${endDate}`,
+        orgHeaders,
       ),
     ])
 

--- a/src/campaigns/tests/race-target-details.e2e.ts
+++ b/src/campaigns/tests/race-target-details.e2e.ts
@@ -6,9 +6,16 @@ import {
   generateRandomName,
   generateRandomPassword,
   loginUser,
+  authHeaders,
+  campaignOrgSlug,
 } from '../../../e2e-tests/utils/auth.util'
-import { updateCampaignWithRetry } from '../../../e2e-tests/utils/request.util'
+import {
+  assertResponseOk,
+  updateCampaignWithRetry,
+} from '../../../e2e-tests/utils/request.util'
 import { CampaignWithPathToVictory } from '../campaigns.types'
+
+const E2E_POSITION_ID = 'Z2lkOi8vYmFsbG90LWZhY3RvcnkvUG9zaXRpb24vNDYyMTM='
 
 test.describe('Campaigns - Race Target Details', () => {
   const testUsers: Array<{ id: number; token: string }> = []
@@ -42,18 +49,25 @@ test.describe('Campaigns - Race Target Details', () => {
       token: registerResponse.token,
     })
 
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
+    const headers = authHeaders(registerResponse.token, orgSlug)
+
+    const patchOrgRes = await request.patch(`/v1/organizations/${orgSlug}`, {
+      headers,
+      data: { ballotReadyPositionId: E2E_POSITION_ID },
+    })
+    await assertResponseOk(patchOrgRes, 'Org position update failed')
+
     const updateResponse = await updateCampaignWithRetry(
       request,
       registerResponse.token,
       {
         details: {
-          office: 'Other',
-          otherOffice: 'Creola City Mayor',
           state: 'GA',
           electionDate: '2025-11-03',
-          positionId: 'Z2lkOi8vYmFsbG90LWZhY3RvcnkvUG9zaXRpb24vNDYyMTM=',
         },
       },
+      orgSlug,
     )
 
     expect(updateResponse.status()).toBe(200)
@@ -82,23 +96,30 @@ test.describe('Campaigns - Race Target Details', () => {
       token: registerResponse.token,
     })
 
-    await updateCampaignWithRetry(request, registerResponse.token, {
-      details: {
-        office: 'Other',
-        otherOffice: 'Creola City Mayor',
-        state: 'GA',
-        electionDate: '2025-11-03',
-        positionId: 'Z2lkOi8vYmFsbG90LWZhY3RvcnkvUG9zaXRpb24vNDYyMTM=',
-      },
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
+    const headers = authHeaders(registerResponse.token, orgSlug)
+
+    const patchOrgRes = await request.patch(`/v1/organizations/${orgSlug}`, {
+      headers,
+      data: { ballotReadyPositionId: E2E_POSITION_ID },
     })
+    await assertResponseOk(patchOrgRes, 'Org position update failed')
+
+    await updateCampaignWithRetry(
+      request,
+      registerResponse.token,
+      {
+        details: {
+          state: 'GA',
+          electionDate: '2025-11-03',
+        },
+      },
+      orgSlug,
+    )
 
     const response = await request.put(
       '/v1/campaigns/mine/race-target-details',
-      {
-        headers: {
-          Authorization: `Bearer ${registerResponse.token}`,
-        },
-      },
+      { headers },
     )
 
     expect([200, 404, 502]).toContain(response.status())
@@ -141,20 +162,29 @@ test.describe('Campaigns - Race Target Details', () => {
       token: registerResponse.token,
     })
 
-    await updateCampaignWithRetry(request, registerResponse.token, {
-      details: {
-        office: 'Other',
-        otherOffice: 'Creola City Mayor',
-        state: 'GA',
-        electionDate: '2025-11-03',
-        positionId: 'Z2lkOi8vYmFsbG90LWZhY3RvcnkvUG9zaXRpb24vNDYyMTM=',
-      },
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
+    const headers = authHeaders(registerResponse.token, orgSlug)
+
+    const patchOrgRes = await request.patch(`/v1/organizations/${orgSlug}`, {
+      headers,
+      data: { ballotReadyPositionId: E2E_POSITION_ID },
     })
+    await assertResponseOk(patchOrgRes, 'Org position update failed')
+
+    await updateCampaignWithRetry(
+      request,
+      registerResponse.token,
+      {
+        details: {
+          state: 'GA',
+          electionDate: '2025-11-03',
+        },
+      },
+      orgSlug,
+    )
 
     const response = await request.put('/v1/campaigns/mine/district', {
-      headers: {
-        Authorization: `Bearer ${registerResponse.token}`,
-      },
+      headers: authHeaders(registerResponse.token, orgSlug),
       data: {
         L2DistrictType: 'Town_District',
         L2DistrictName: 'CREOLOA TOWN',
@@ -217,15 +247,26 @@ test.describe('Campaigns - Race Target Details (Admin)', () => {
     })
     testSlug = registerResponse.campaign.slug
 
-    await updateCampaignWithRetry(request, registerResponse.token, {
-      details: {
-        office: 'Other',
-        otherOffice: 'Creola City Mayor',
-        state: 'GA',
-        electionDate: '2025-11-03',
-        positionId: 'Z2lkOi8vYmFsbG90LWZhY3RvcnkvUG9zaXRpb24vNDYyMTM=',
-      },
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
+    const headers = authHeaders(registerResponse.token, orgSlug)
+
+    const patchOrgRes = await request.patch(`/v1/organizations/${orgSlug}`, {
+      headers,
+      data: { ballotReadyPositionId: E2E_POSITION_ID },
     })
+    await assertResponseOk(patchOrgRes, 'Org position update failed')
+
+    await updateCampaignWithRetry(
+      request,
+      registerResponse.token,
+      {
+        details: {
+          state: 'GA',
+          electionDate: '2025-11-03',
+        },
+      },
+      orgSlug,
+    )
 
     const response = await request.put(
       `/v1/campaigns/admin/${testSlug}/race-target-details`,
@@ -275,15 +316,26 @@ test.describe('Campaigns - Race Target Details (Admin)', () => {
     })
     testSlug = registerResponse.campaign.slug
 
-    await updateCampaignWithRetry(request, registerResponse.token, {
-      details: {
-        office: 'Other',
-        otherOffice: 'Creola City Mayor',
-        state: 'GA',
-        electionDate: '2025-11-03',
-        positionId: 'Z2lkOi8vYmFsbG90LWZhY3RvcnkvUG9zaXRpb24vNDYyMTM=',
-      },
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
+    const headers = authHeaders(registerResponse.token, orgSlug)
+
+    const patchOrgRes = await request.patch(`/v1/organizations/${orgSlug}`, {
+      headers,
+      data: { ballotReadyPositionId: E2E_POSITION_ID },
     })
+    await assertResponseOk(patchOrgRes, 'Org position update failed')
+
+    await updateCampaignWithRetry(
+      request,
+      registerResponse.token,
+      {
+        details: {
+          state: 'GA',
+          electionDate: '2025-11-03',
+        },
+      },
+      orgSlug,
+    )
 
     const { token: adminToken } = await loginUser(
       request,

--- a/src/campaigns/tests/user-campaigns.e2e.ts
+++ b/src/campaigns/tests/user-campaigns.e2e.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test'
 import {
+  authHeaders,
+  campaignOrgSlug,
   deleteUser,
   generateRandomEmail,
   generateRandomName,
@@ -8,6 +10,7 @@ import {
   RegisterResponse,
 } from '../../../e2e-tests/utils/auth.util'
 import {
+  assertResponseOk,
   retryOnConflict,
   updateCampaignWithRetry,
 } from '../../../e2e-tests/utils/request.util'
@@ -18,6 +21,7 @@ const E2E_BALLOT_READY_POSITION_ID =
 
 test.describe('Campaigns - User Campaign Operations', () => {
   let reg: RegisterResponse
+  let orgSlug: string
 
   test.beforeAll(async ({ request }) => {
     reg = await registerUser(request, {
@@ -29,6 +33,7 @@ test.describe('Campaigns - User Campaign Operations', () => {
       zip: '12345-1234',
       signUpMode: 'candidate',
     })
+    orgSlug = campaignOrgSlug(reg.campaign.id)
   })
 
   test.afterAll(async ({ request }) => {
@@ -39,9 +44,7 @@ test.describe('Campaigns - User Campaign Operations', () => {
 
   test('should get campaign status for logged in user', async ({ request }) => {
     const response = await request.get('/v1/campaigns/mine/status', {
-      headers: {
-        Authorization: `Bearer ${reg.token}`,
-      },
+      headers: authHeaders(reg.token, orgSlug),
     })
 
     expect(response.status()).toBe(200)
@@ -55,9 +58,7 @@ test.describe('Campaigns - User Campaign Operations', () => {
 
   test('should get logged in user campaign', async ({ request }) => {
     const response = await request.get('/v1/campaigns/mine', {
-      headers: {
-        Authorization: `Bearer ${reg.token}`,
-      },
+      headers: authHeaders(reg.token, orgSlug),
     })
 
     expect(response.status()).toBe(200)
@@ -78,9 +79,7 @@ test.describe('Campaigns - User Campaign Operations', () => {
     request,
   }) => {
     const response = await request.get('/v1/campaigns/mine/plan-version', {
-      headers: {
-        Authorization: `Bearer ${reg.token}`,
-      },
+      headers: authHeaders(reg.token, orgSlug),
     })
 
     expect([200, 404]).toContain(response.status())
@@ -90,14 +89,19 @@ test.describe('Campaigns - User Campaign Operations', () => {
     const randomName = generateRandomName()
     const randomWebsite = `https://${Math.random().toString(36).substring(7)}.com`
 
-    const response = await updateCampaignWithRetry(request, reg.token, {
-      data: {
-        name: randomName,
+    const response = await updateCampaignWithRetry(
+      request,
+      reg.token,
+      {
+        data: {
+          name: randomName,
+        },
+        details: {
+          website: randomWebsite,
+        },
       },
-      details: {
-        website: randomWebsite,
-      },
-    })
+      orgSlug,
+    )
 
     expect(response.status()).toBe(200)
 
@@ -113,9 +117,7 @@ test.describe('Campaigns - User Campaign Operations', () => {
     request,
   }) => {
     const response = await request.put('/v1/campaigns/mine', {
-      headers: {
-        Authorization: `Bearer ${reg.token}`,
-      },
+      headers: authHeaders(reg.token, orgSlug),
       data: {
         details: {
           website: ['array'],
@@ -133,31 +135,16 @@ test.describe('Campaigns - User Campaign Operations', () => {
     expect(body.errors[0].message).toBe('Expected string, received array')
   })
 
-  test('should strip org-managed fields from persisted details', async ({
-    request,
-  }) => {
-    const response = await updateCampaignWithRetry(request, reg.token, {
-      details: {
-        office: 'Other',
-        otherOffice: 'State Representative',
-        positionId: E2E_BALLOT_READY_POSITION_ID,
-      },
-    })
-
-    expect(response.status()).toBe(200)
-
-    const campaign = (await response.json()) as {
-      details: Record<string, unknown>
-    }
-    expect(campaign.details).not.toHaveProperty('office')
-    expect(campaign.details).not.toHaveProperty('otherOffice')
-    expect(campaign.details).not.toHaveProperty('positionId')
-  })
-
   test('should launch campaign', async ({ request }) => {
+    const patchOrgRes = await request.patch(`/v1/organizations/${orgSlug}`, {
+      headers: authHeaders(reg.token, orgSlug),
+      data: { ballotReadyPositionId: E2E_BALLOT_READY_POSITION_ID },
+    })
+    await assertResponseOk(patchOrgRes, 'Org position update failed')
+
     const response = await retryOnConflict(() =>
       request.post('/v1/campaigns/launch', {
-        headers: { Authorization: `Bearer ${reg.token}` },
+        headers: authHeaders(reg.token, orgSlug),
       }),
     )
 

--- a/src/campaigns/updateHistory/tests/update-history.e2e.ts
+++ b/src/campaigns/updateHistory/tests/update-history.e2e.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test'
 import {
+  authHeaders,
+  campaignOrgSlug,
   deleteUser,
   generateRandomEmail,
   generateRandomName,
@@ -12,6 +14,7 @@ import { CampaignUpdateHistory } from '@prisma/client'
 
 test.describe('Campaigns - Update History', () => {
   let reg: RegisterResponse
+  let orgSlug: string
 
   test.beforeAll(async ({ request }) => {
     reg = await registerUser(request, {
@@ -23,6 +26,7 @@ test.describe('Campaigns - Update History', () => {
       zip: '12345-1234',
       signUpMode: 'candidate',
     })
+    orgSlug = campaignOrgSlug(reg.campaign.id)
   })
 
   test.afterAll(async ({ request }) => {
@@ -33,9 +37,7 @@ test.describe('Campaigns - Update History', () => {
 
   test('should get current user update history', async ({ request }) => {
     const response = await request.get('/v1/campaigns/mine/update-history', {
-      headers: {
-        Authorization: `Bearer ${reg.token}`,
-      },
+      headers: authHeaders(reg.token, orgSlug),
     })
 
     expect(response.status()).toBe(200)
@@ -50,9 +52,7 @@ test.describe('Campaigns - Update History', () => {
     const quantity = Math.floor(Math.random() * 100) + 1
 
     const response = await request.post('/v1/campaigns/mine/update-history', {
-      headers: {
-        Authorization: `Bearer ${reg.token}`,
-      },
+      headers: authHeaders(reg.token, orgSlug),
       data: {
         type: 'doorKnocking',
         quantity,
@@ -72,9 +72,7 @@ test.describe('Campaigns - Update History', () => {
     const createResponse = await request.post(
       '/v1/campaigns/mine/update-history',
       {
-        headers: {
-          Authorization: `Bearer ${reg.token}`,
-        },
+        headers: authHeaders(reg.token, orgSlug),
         data: {
           type: 'doorKnocking',
           quantity,
@@ -87,9 +85,7 @@ test.describe('Campaigns - Update History', () => {
     const response = await request.delete(
       `/v1/campaigns/mine/update-history/${created.id}`,
       {
-        headers: {
-          Authorization: `Bearer ${reg.token}`,
-        },
+        headers: authHeaders(reg.token, orgSlug),
       },
     )
 
@@ -100,18 +96,14 @@ test.describe('Campaigns - Update History', () => {
     request,
   }) => {
     const slugResponse = await request.get('/v1/campaigns/mine/status', {
-      headers: {
-        Authorization: `Bearer ${reg.token}`,
-      },
+      headers: authHeaders(reg.token, orgSlug),
     })
     const { slug } = (await slugResponse.json()) as { slug: string }
 
     const response = await request.get(
       `/v1/campaigns/mine/update-history?slug=${slug}`,
       {
-        headers: {
-          Authorization: `Bearer ${reg.token}`,
-        },
+        headers: authHeaders(reg.token, orgSlug),
       },
     )
 
@@ -123,6 +115,7 @@ test.describe('Campaigns - Update History (Admin Access)', () => {
   const adminEmail = process.env.ADMIN_EMAIL
   const adminPassword = process.env.ADMIN_PASSWORD
   let candidateReg: RegisterResponse
+  let candidateOrgSlug: string
 
   test.beforeAll(async ({ request }) => {
     test.skip(!adminEmail || !adminPassword, 'Admin credentials not configured')
@@ -136,11 +129,10 @@ test.describe('Campaigns - Update History (Admin Access)', () => {
       zip: '12345-1234',
       signUpMode: 'candidate',
     })
+    candidateOrgSlug = campaignOrgSlug(candidateReg.campaign.id)
 
     await request.post('/v1/campaigns/mine/update-history', {
-      headers: {
-        Authorization: `Bearer ${candidateReg.token}`,
-      },
+      headers: authHeaders(candidateReg.token, candidateOrgSlug),
       data: {
         type: 'doorKnocking',
         quantity: 5,
@@ -158,9 +150,7 @@ test.describe('Campaigns - Update History (Admin Access)', () => {
     request,
   }) => {
     const slugResponse = await request.get('/v1/campaigns/mine/status', {
-      headers: {
-        Authorization: `Bearer ${candidateReg.token}`,
-      },
+      headers: authHeaders(candidateReg.token, candidateOrgSlug),
     })
     const { slug } = (await slugResponse.json()) as { slug: string }
 
@@ -173,9 +163,7 @@ test.describe('Campaigns - Update History (Admin Access)', () => {
     const response = await request.get(
       `/v1/campaigns/mine/update-history?slug=${slug}`,
       {
-        headers: {
-          Authorization: `Bearer ${adminToken}`,
-        },
+        headers: authHeaders(adminToken, candidateOrgSlug),
       },
     )
 

--- a/src/contacts/contacts.controller.ts
+++ b/src/contacts/contacts.controller.ts
@@ -2,11 +2,8 @@ import { Controller, Get, Param, Query, Res, UsePipes } from '@nestjs/common'
 import { Organization } from '@prisma/client'
 import { FastifyReply } from 'fastify'
 import { ZodValidationPipe } from 'nestjs-zod'
-import { ReqCampaign } from 'src/campaigns/decorators/ReqCampaign.decorator'
-import { UseCampaign } from 'src/campaigns/decorators/UseCampaign.decorator'
 import { ReqOrganization } from 'src/organizations/decorators/ReqOrganization.decorator'
 import { UseOrganization } from 'src/organizations/decorators/UseOrganization.decorator'
-import { CampaignWithPathToVictory } from './contacts.types'
 import { GetPersonParamsDTO } from './schemas/getPerson.schema'
 import {
   DownloadContactsDTO,
@@ -15,11 +12,7 @@ import {
 import { ContactsService } from './services/contacts.service'
 
 @Controller('contacts')
-// LEGACY: Remove @UseCampaign and @ReqCampaign from all endpoints when org migration is complete.
-//         @UseOrganization becomes required (remove continueIfNotFound).
-//         campaign parameter removed from all service calls.
-@UseCampaign({ continueIfNotFound: true })
-@UseOrganization({ continueIfNotFound: true })
+@UseOrganization()
 @UsePipes(ZodValidationPipe)
 export class ContactsController {
   constructor(private readonly contactsService: ContactsService) {}
@@ -27,43 +20,32 @@ export class ContactsController {
   @Get()
   async listContacts(
     @Query() filterDto: ListContactsDTO,
-    @ReqCampaign() campaign: CampaignWithPathToVictory | undefined,
-    @ReqOrganization() organization: Organization | undefined,
+    @ReqOrganization() organization: Organization,
   ) {
-    return this.contactsService.findContacts(filterDto, campaign, organization)
+    return this.contactsService.findContacts(filterDto, organization)
   }
 
   @Get('download')
   async downloadContacts(
     @Query() dto: DownloadContactsDTO,
-    @ReqCampaign() campaign: CampaignWithPathToVictory | undefined,
-    @ReqOrganization() organization: Organization | undefined,
+    @ReqOrganization() organization: Organization,
     @Res() res: FastifyReply,
   ) {
     res.header('Content-Type', 'text/csv')
     res.header('Content-Disposition', 'attachment; filename="contacts.csv"')
-    await this.contactsService.downloadContacts(
-      dto,
-      campaign,
-      res,
-      organization,
-    )
+    await this.contactsService.downloadContacts(dto, res, organization)
   }
 
   @Get('stats')
-  getContactsStats(
-    @ReqCampaign() campaign: CampaignWithPathToVictory | undefined,
-    @ReqOrganization() organization: Organization | undefined,
-  ) {
-    return this.contactsService.getDistrictStats(campaign, organization)
+  getContactsStats(@ReqOrganization() organization: Organization) {
+    return this.contactsService.getDistrictStats(organization)
   }
 
   @Get(':id')
   async getContact(
     @Param() params: GetPersonParamsDTO,
-    @ReqCampaign() campaign: CampaignWithPathToVictory | undefined,
-    @ReqOrganization() organization: Organization | undefined,
+    @ReqOrganization() organization: Organization,
   ) {
-    return this.contactsService.findPerson(params.id, campaign, organization)
+    return this.contactsService.findPerson(params.id, organization)
   }
 }

--- a/src/contacts/contacts.module.ts
+++ b/src/contacts/contacts.module.ts
@@ -1,4 +1,3 @@
-import { ElectedOfficeModule } from '@/electedOffice/electedOffice.module'
 import { HttpModule } from '@nestjs/axios'
 import { Module } from '@nestjs/common'
 import { CampaignsModule } from 'src/campaigns/campaigns.module'
@@ -14,7 +13,6 @@ import { ContactsService } from './services/contacts.service'
     CampaignsModule,
     VotersModule,
     ElectionsModule,
-    ElectedOfficeModule,
     OrganizationsModule,
   ],
   controllers: [ContactsController],

--- a/src/contacts/services/contacts.service.test.ts
+++ b/src/contacts/services/contacts.service.test.ts
@@ -36,7 +36,6 @@ describe('ContactsService', () => {
       get: ReturnType<typeof vi.fn>
     }
     let mockVoterFileFilterService: {
-      findByIdAndCampaignId: ReturnType<typeof vi.fn>
       findByIdAndOrganizationSlug: ReturnType<typeof vi.fn>
     }
     let mockElectionsService: {
@@ -55,7 +54,6 @@ describe('ContactsService', () => {
         get: vi.fn(),
       }
       mockVoterFileFilterService = {
-        findByIdAndCampaignId: vi.fn().mockResolvedValue(null),
         findByIdAndOrganizationSlug: vi.fn().mockResolvedValue(null),
       }
       mockElectionsService = {

--- a/src/contacts/services/contacts.service.test.ts
+++ b/src/contacts/services/contacts.service.test.ts
@@ -3,7 +3,6 @@ import { BadRequestException } from '@nestjs/common'
 import { Organization } from '@prisma/client'
 import { of } from 'rxjs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { CampaignWithPathToVictory } from '../contacts.types'
 import { ContactsService } from './contacts.service'
 
 vi.mock('@nestjs/axios', () => ({
@@ -11,7 +10,6 @@ vi.mock('@nestjs/axios', () => ({
 }))
 
 const SEARCH_REQUIRES_PRO_MSG = 'Search is only available for pro campaigns'
-const TEST_ELECTION_DISTRICT_NAME = 'District 1'
 const OVERRIDE_DISTRICT_ID = 'override-district-uuid'
 const POSITION_ID_FIXTURE = 'position-uuid'
 const PEOPLE_V1_PATH = '/v1/people'
@@ -45,24 +43,9 @@ describe('ContactsService', () => {
       cleanDistrictName: ReturnType<typeof vi.fn>
       getPositionById: ReturnType<typeof vi.fn>
     }
-    let mockCampaignsService: { updateJsonFields: ReturnType<typeof vi.fn> }
-    let mockElectedOfficeService: {
-      getCurrentElectedOffice: ReturnType<typeof vi.fn>
+    let mockCampaignsService: {
       findFirst: ReturnType<typeof vi.fn>
     }
-
-    const baseCampaign = {
-      id: 1,
-      userId: 100,
-      isPro: false,
-      details: { state: 'NC' },
-      pathToVictory: {
-        data: {
-          electionType: 'district',
-          electionLocation: TEST_ELECTION_DISTRICT_NAME,
-        },
-      },
-    } as unknown as CampaignWithPathToVictory
 
     beforeEach(() => {
       mockHttpService = {
@@ -80,10 +63,6 @@ describe('ContactsService', () => {
         getPositionById: vi.fn().mockResolvedValue(null),
       }
       mockCampaignsService = {
-        updateJsonFields: vi.fn().mockResolvedValue(undefined),
-      }
-      mockElectedOfficeService = {
-        getCurrentElectedOffice: vi.fn().mockResolvedValue(null),
         findFirst: vi.fn().mockResolvedValue(null),
       }
 
@@ -92,195 +71,135 @@ describe('ContactsService', () => {
         mockVoterFileFilterService as never,
         mockElectionsService as never,
         mockCampaignsService as never,
-        mockElectedOfficeService as never,
         createMockLogger(),
       )
       vi.clearAllMocks()
     })
 
     describe('findContacts (search)', () => {
-      it('throws BadRequestException when search is used and campaign is not pro and user has no elected office', async () => {
-        mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue(null)
-        const campaign = { ...baseCampaign, isPro: false }
+      it('throws when search is used and organization is not pro', async () => {
+        const org = makeOrganization({
+          slug: 'campaign-1',
+          overrideDistrictId: OVERRIDE_DISTRICT_ID,
+        })
+        mockCampaignsService.findFirst.mockResolvedValue({ isPro: false })
 
         await expect(
           service.findContacts(
             { resultsPerPage: 10, page: 1, search: 'smith', segment: 'all' },
-            campaign,
+            org,
           ),
         ).rejects.toThrow(BadRequestException)
         await expect(
           service.findContacts(
             { resultsPerPage: 10, page: 1, search: 'smith', segment: 'all' },
-            campaign,
-          ),
-        ).rejects.toThrow(SEARCH_REQUIRES_PRO_MSG)
-
-        expect(
-          mockElectedOfficeService.getCurrentElectedOffice,
-        ).toHaveBeenCalledWith(campaign.userId)
-      })
-
-      it('does not throw when search is used and campaign is pro', async () => {
-        mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue(null)
-        const campaign = { ...baseCampaign, isPro: true }
-
-        await expect(
-          service.findContacts(
-            { resultsPerPage: 10, page: 1, search: 'smith', segment: 'all' },
-            campaign,
-          ),
-        ).resolves.toBeDefined()
-
-        expect(
-          mockElectedOfficeService.getCurrentElectedOffice,
-        ).toHaveBeenCalledWith(campaign.userId)
-      })
-
-      it('does not throw when search is used and user has elected office', async () => {
-        mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue({
-          id: 'office-1',
-          userId: 100,
-          isActive: true,
-        })
-        const campaign = { ...baseCampaign, isPro: false }
-
-        await expect(
-          service.findContacts(
-            { resultsPerPage: 10, page: 1, search: 'smith', segment: 'all' },
-            campaign,
-          ),
-        ).resolves.toBeDefined()
-
-        expect(
-          mockElectedOfficeService.getCurrentElectedOffice,
-        ).toHaveBeenCalledWith(campaign.userId)
-      })
-
-      it('uses findFirst with organizationSlug check when organization is provided', async () => {
-        mockElectedOfficeService.findFirst.mockResolvedValue({
-          id: 'office-1',
-          userId: 100,
-          organizationSlug: 'eo-office-1',
-        })
-        const campaign = { ...baseCampaign, isPro: false }
-        const org = makeOrganization({
-          overrideDistrictId: OVERRIDE_DISTRICT_ID,
-        })
-
-        await expect(
-          service.findContacts(
-            { resultsPerPage: 10, page: 1, search: 'smith', segment: 'all' },
-            campaign,
-            org,
-          ),
-        ).resolves.toBeDefined()
-
-        expect(mockElectedOfficeService.findFirst).toHaveBeenCalledWith({
-          where: { campaignId: 1, userId: org.ownerId },
-        })
-        expect(
-          mockElectedOfficeService.getCurrentElectedOffice,
-        ).not.toHaveBeenCalled()
-      })
-
-      it('throws when search is used with organization and user has no org-linked elected office', async () => {
-        mockElectedOfficeService.findFirst.mockResolvedValue(null)
-        const campaign = { ...baseCampaign, isPro: false }
-        const org = makeOrganization({
-          overrideDistrictId: OVERRIDE_DISTRICT_ID,
-        })
-
-        await expect(
-          service.findContacts(
-            { resultsPerPage: 10, page: 1, search: 'smith', segment: 'all' },
-            campaign,
             org,
           ),
         ).rejects.toThrow(SEARCH_REQUIRES_PRO_MSG)
+      })
 
-        expect(mockElectedOfficeService.findFirst).toHaveBeenCalledWith({
-          where: { campaignId: 1, userId: org.ownerId },
+      it('allows search when organization is an elected office (eo- slug)', async () => {
+        const org = makeOrganization({
+          slug: 'eo-office-1',
+          overrideDistrictId: OVERRIDE_DISTRICT_ID,
         })
-        // Does NOT fall through to userId — org header represents the user's chosen context
-        expect(
-          mockElectedOfficeService.getCurrentElectedOffice,
-        ).not.toHaveBeenCalled()
+
+        mockHttpService.post.mockReturnValue(
+          of({ data: { people: [], pagination: {} } }),
+        )
+
+        await expect(
+          service.findContacts(
+            { resultsPerPage: 10, page: 1, search: 'smith', segment: 'all' },
+            org,
+          ),
+        ).resolves.toBeDefined()
+      })
+
+      it('allows search when campaign is pro (isPro) even with a non-EO org', async () => {
+        const org = makeOrganization({
+          slug: 'campaign-1',
+          overrideDistrictId: OVERRIDE_DISTRICT_ID,
+        })
+        mockCampaignsService.findFirst.mockResolvedValue({ isPro: true })
+
+        mockHttpService.post.mockReturnValue(
+          of({ data: { people: [], pagination: {} } }),
+        )
+
+        await expect(
+          service.findContacts(
+            { resultsPerPage: 10, page: 1, search: 'smith', segment: 'all' },
+            org,
+          ),
+        ).resolves.toBeDefined()
+      })
+
+      it('does not check access when search is not provided', async () => {
+        const org = makeOrganization({
+          slug: 'campaign-1',
+          overrideDistrictId: OVERRIDE_DISTRICT_ID,
+        })
+
+        mockHttpService.post.mockReturnValue(
+          of({ data: { people: [], pagination: {} } }),
+        )
+
+        await expect(
+          service.findContacts(
+            {
+              resultsPerPage: 10,
+              page: 1,
+              search: undefined,
+              segment: 'all',
+            },
+            org,
+          ),
+        ).resolves.toBeDefined()
       })
     })
 
     describe('downloadContacts', () => {
-      it('throws BadRequestException when campaign is not pro and user has no elected office', async () => {
-        mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue(null)
-        const campaign = { ...baseCampaign, isPro: false }
+      it('throws when organization is not pro', async () => {
+        const org = makeOrganization({
+          slug: 'campaign-1',
+          overrideDistrictId: OVERRIDE_DISTRICT_ID,
+        })
+        mockCampaignsService.findFirst.mockResolvedValue({ isPro: false })
         const res = { raw: {} } as never
 
         await expect(
-          service.downloadContacts({ segment: 'all' }, campaign, res),
+          service.downloadContacts({ segment: 'all' }, res, org),
         ).rejects.toThrow(BadRequestException)
         await expect(
-          service.downloadContacts({ segment: 'all' }, campaign, res),
+          service.downloadContacts({ segment: 'all' }, res, org),
         ).rejects.toThrow('Campaign is not pro')
-
-        expect(
-          mockElectedOfficeService.getCurrentElectedOffice,
-        ).toHaveBeenCalledWith(campaign.userId)
       })
 
-      it('does not throw when campaign is pro', async () => {
-        mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue(null)
-        const campaign = { ...baseCampaign, isPro: true }
-        const mockStream = {
-          pipe: vi.fn(),
-          on: vi.fn((event: string, cb: () => void) => {
-            if (event === 'end') setImmediate(cb)
-          }),
-        }
-        mockHttpService.post.mockReturnValue(of({ data: mockStream }))
-        const res = { raw: {} } as never
-
-        await expect(
-          service.downloadContacts({ segment: 'all' }, campaign, res),
-        ).resolves.toBeUndefined()
-
-        expect(
-          mockElectedOfficeService.getCurrentElectedOffice,
-        ).toHaveBeenCalledWith(campaign.userId)
-      })
-
-      it('does not throw when user has elected office', async () => {
-        mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue({
-          id: 'office-1',
-          userId: 100,
-          isActive: true,
-        })
-        const campaign = { ...baseCampaign, isPro: false }
-        const mockStream = {
-          pipe: vi.fn(),
-          on: vi.fn((event: string, cb: () => void) => {
-            if (event === 'end') setImmediate(cb)
-          }),
-        }
-        mockHttpService.post.mockReturnValue(of({ data: mockStream }))
-        const res = { raw: {} } as never
-
-        await expect(
-          service.downloadContacts({ segment: 'all' }, campaign, res),
-        ).resolves.toBeUndefined()
-
-        expect(
-          mockElectedOfficeService.getCurrentElectedOffice,
-        ).toHaveBeenCalledWith(campaign.userId)
-      })
-
-      it('uses findFirst with organizationSlug check when organization is provided', async () => {
-        mockElectedOfficeService.findFirst.mockResolvedValue({
-          id: 'office-1',
-          userId: 100,
-          organizationSlug: 'eo-office-1',
-        })
-        const campaign = { ...baseCampaign, isPro: false }
+      it('allows download when campaign is pro (isPro) even with a non-EO org', async () => {
         const org = makeOrganization({
+          slug: 'campaign-1',
+          overrideDistrictId: OVERRIDE_DISTRICT_ID,
+        })
+        mockCampaignsService.findFirst.mockResolvedValue({ isPro: true })
+
+        const mockStream = {
+          pipe: vi.fn(),
+          on: vi.fn((event: string, cb: () => void) => {
+            if (event === 'end') setImmediate(cb)
+          }),
+        }
+        mockHttpService.post.mockReturnValue(of({ data: mockStream }))
+        const res = { raw: {} } as never
+
+        await expect(
+          service.downloadContacts({ segment: 'all' }, res, org),
+        ).resolves.toBeUndefined()
+      })
+
+      it('allows download when organization is an elected office', async () => {
+        const org = makeOrganization({
+          slug: 'eo-office-1',
           overrideDistrictId: OVERRIDE_DISTRICT_ID,
         })
         const mockStream = {
@@ -293,67 +212,8 @@ describe('ContactsService', () => {
         const res = { raw: {} } as never
 
         await expect(
-          service.downloadContacts({ segment: 'all' }, campaign, res, org),
+          service.downloadContacts({ segment: 'all' }, res, org),
         ).resolves.toBeUndefined()
-
-        expect(mockElectedOfficeService.findFirst).toHaveBeenCalledWith({
-          where: { campaignId: 1, userId: org.ownerId },
-        })
-        expect(
-          mockElectedOfficeService.getCurrentElectedOffice,
-        ).not.toHaveBeenCalled()
-      })
-
-      it('throws when organization is provided but user has no org-linked elected office', async () => {
-        mockElectedOfficeService.findFirst.mockResolvedValue(null)
-        const campaign = { ...baseCampaign, isPro: false }
-        const org = makeOrganization({
-          overrideDistrictId: OVERRIDE_DISTRICT_ID,
-        })
-        const res = { raw: {} } as never
-
-        await expect(
-          service.downloadContacts({ segment: 'all' }, campaign, res, org),
-        ).rejects.toThrow('Campaign is not pro')
-
-        expect(mockElectedOfficeService.findFirst).toHaveBeenCalledWith({
-          where: { campaignId: 1, userId: org.ownerId },
-        })
-        // Does NOT fall through to userId — org header represents the user's chosen context
-        expect(
-          mockElectedOfficeService.getCurrentElectedOffice,
-        ).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('getDistrictStats', () => {
-      it('allows statewide fallback (state only) when campaign is approved for statewide contacts', async () => {
-        const campaign = {
-          ...baseCampaign,
-          canDownloadFederal: true,
-          details: { state: 'WY', ballotLevel: 'STATE' },
-          pathToVictory: {
-            data: { electionType: 'State', electionLocation: 'WY' },
-          },
-        } as unknown as CampaignWithPathToVictory
-
-        mockHttpService.get.mockReturnValue(
-          of({
-            data: {
-              districtId: 'statewide-wy',
-              totalConstituents: 1000,
-              buckets: {},
-            },
-          }),
-        )
-
-        await expect(service.getDistrictStats(campaign)).resolves.toBeDefined()
-        expect(mockHttpService.get).toHaveBeenCalledWith(
-          expect.stringContaining(`${PEOPLE_V1_PATH}/stats`),
-          expect.objectContaining({
-            params: { state: 'WY' },
-          }),
-        )
       })
     })
 
@@ -370,7 +230,6 @@ describe('ContactsService', () => {
 
         await service.findContacts(
           { resultsPerPage: 10, page: 1, search: undefined, segment: 'all' },
-          baseCampaign,
           org,
         )
 
@@ -381,7 +240,6 @@ describe('ContactsService', () => {
           }),
           expect.any(Object),
         )
-        // Should not call getPositionById since overrideDistrictId takes priority
         expect(mockElectionsService.getPositionById).not.toHaveBeenCalled()
       })
 
@@ -395,7 +253,7 @@ describe('ContactsService', () => {
           district: {
             id: 'position-district-uuid',
             L2DistrictType: 'State_Senate',
-            L2DistrictName: TEST_ELECTION_DISTRICT_NAME,
+            L2DistrictName: 'District 1',
           },
         })
         mockHttpService.post.mockReturnValue(
@@ -404,7 +262,6 @@ describe('ContactsService', () => {
 
         await service.findContacts(
           { resultsPerPage: 10, page: 1, search: undefined, segment: 'all' },
-          baseCampaign,
           org,
         )
 
@@ -421,45 +278,7 @@ describe('ContactsService', () => {
         )
       })
 
-      it('falls back to state-only when position has no district and campaign is approved for statewide', async () => {
-        const org = makeOrganization({ positionId: POSITION_ID_FIXTURE })
-        mockElectionsService.getPositionById.mockResolvedValue({
-          id: POSITION_ID_FIXTURE,
-          state: 'WY',
-          district: null,
-        })
-        const statewideCampaign = {
-          ...baseCampaign,
-          canDownloadFederal: true,
-        } as unknown as CampaignWithPathToVictory
-
-        mockHttpService.post.mockReturnValue(
-          of({ data: { people: [], pagination: {} } }),
-        )
-
-        await service.findContacts(
-          { resultsPerPage: 10, page: 1, search: undefined, segment: 'all' },
-          statewideCampaign,
-          org,
-        )
-
-        expect(mockElectionsService.getPositionById).toHaveBeenCalledWith(
-          POSITION_ID_FIXTURE,
-          { includeDistrict: true },
-        )
-        expect(mockHttpService.post).toHaveBeenCalledWith(
-          expect.stringContaining(PEOPLE_V1_PATH),
-          expect.objectContaining({ state: 'WY' }),
-          expect.any(Object),
-        )
-        const callBody = mockHttpService.post.mock.calls[0][1] as Record<
-          string,
-          unknown
-        >
-        expect(callBody.districtId).toBeUndefined()
-      })
-
-      it('throws when position has no district and campaign is not approved for statewide', async () => {
+      it('throws when position has no district', async () => {
         const org = makeOrganization({ positionId: POSITION_ID_FIXTURE })
         mockElectionsService.getPositionById.mockResolvedValue({
           id: POSITION_ID_FIXTURE,
@@ -475,11 +294,10 @@ describe('ContactsService', () => {
               search: undefined,
               segment: 'all',
             },
-            baseCampaign,
             org,
           ),
         ).rejects.toThrow(
-          'Statewide or federal contacts require admin approval',
+          'Organization does not have sufficient data to resolve district',
         )
       })
 
@@ -494,7 +312,6 @@ describe('ContactsService', () => {
               search: undefined,
               segment: 'all',
             },
-            baseCampaign,
             org,
           ),
         ).rejects.toThrow(
@@ -502,30 +319,7 @@ describe('ContactsService', () => {
         )
       })
 
-      it('uses legacy campaign path when organization is undefined', async () => {
-        mockHttpService.post.mockReturnValue(
-          of({ data: { people: [], pagination: {} } }),
-        )
-
-        await service.findContacts(
-          { resultsPerPage: 10, page: 1, search: undefined, segment: 'all' },
-          baseCampaign,
-          undefined,
-        )
-
-        // Legacy path uses state + districtType + districtName from campaign
-        expect(mockHttpService.post).toHaveBeenCalledWith(
-          expect.stringContaining(PEOPLE_V1_PATH),
-          expect.objectContaining({
-            state: 'NC',
-            districtType: 'district',
-            districtName: TEST_ELECTION_DISTRICT_NAME,
-          }),
-          expect.any(Object),
-        )
-      })
-
-      it('uses overrideDistrictId for getDistrictStats with organization', async () => {
+      it('uses overrideDistrictId for getDistrictStats', async () => {
         const org = makeOrganization({
           overrideDistrictId: OVERRIDE_DISTRICT_ID,
         })
@@ -540,7 +334,7 @@ describe('ContactsService', () => {
           }),
         )
 
-        await service.getDistrictStats(baseCampaign, org)
+        await service.getDistrictStats(org)
 
         expect(mockHttpService.get).toHaveBeenCalledWith(
           expect.stringContaining(`${PEOPLE_V1_PATH}/stats`),
@@ -550,7 +344,7 @@ describe('ContactsService', () => {
         )
       })
 
-      it('uses overrideDistrictId for findPerson with organization', async () => {
+      it('uses overrideDistrictId for findPerson', async () => {
         const org = makeOrganization({
           overrideDistrictId: OVERRIDE_DISTRICT_ID,
         })
@@ -561,7 +355,7 @@ describe('ContactsService', () => {
           }),
         )
 
-        await service.findPerson('person-1', baseCampaign, org)
+        await service.findPerson('person-1', org)
 
         expect(mockHttpService.get).toHaveBeenCalledWith(
           expect.stringContaining(`${PEOPLE_V1_PATH}/person-1`),
@@ -571,11 +365,11 @@ describe('ContactsService', () => {
         )
       })
 
-      it('uses overrideDistrictId for downloadContacts with organization', async () => {
+      it('uses overrideDistrictId for downloadContacts', async () => {
         const org = makeOrganization({
+          slug: 'eo-office-1',
           overrideDistrictId: OVERRIDE_DISTRICT_ID,
         })
-        const campaign = { ...baseCampaign, isPro: true }
 
         const mockStream = {
           pipe: vi.fn(),
@@ -586,7 +380,7 @@ describe('ContactsService', () => {
         mockHttpService.post.mockReturnValue(of({ data: mockStream }))
         const res = { raw: {} } as never
 
-        await service.downloadContacts({ segment: 'all' }, campaign, res, org)
+        await service.downloadContacts({ segment: 'all' }, res, org)
 
         expect(mockHttpService.post).toHaveBeenCalledWith(
           expect.stringContaining(`${PEOPLE_V1_PATH}/download`),
@@ -598,11 +392,12 @@ describe('ContactsService', () => {
       })
     })
 
-    describe('org-only path (no campaign)', () => {
-      it('findContacts succeeds with org and no campaign', async () => {
+    describe('org-only path (no campaign in org)', () => {
+      it('findContacts succeeds with org that has no linked campaign', async () => {
         const org = makeOrganization({
           overrideDistrictId: OVERRIDE_DISTRICT_ID,
         })
+        mockCampaignsService.findFirst.mockResolvedValue(null)
 
         mockHttpService.post.mockReturnValue(
           of({ data: { people: [], pagination: {} } }),
@@ -610,7 +405,6 @@ describe('ContactsService', () => {
 
         await service.findContacts(
           { resultsPerPage: 10, page: 1, search: undefined, segment: 'all' },
-          undefined,
           org,
         )
 
@@ -620,106 +414,6 @@ describe('ContactsService', () => {
             districtId: OVERRIDE_DISTRICT_ID,
           }),
           expect.any(Object),
-        )
-      })
-
-      it('findContacts search succeeds with org + EO access and no campaign', async () => {
-        const org = makeOrganization({
-          overrideDistrictId: OVERRIDE_DISTRICT_ID,
-        })
-        mockElectedOfficeService.findFirst.mockResolvedValue({
-          id: 'office-1',
-          organizationSlug: org.slug,
-        })
-
-        mockHttpService.post.mockReturnValue(
-          of({ data: { people: [], pagination: {} } }),
-        )
-
-        await expect(
-          service.findContacts(
-            { resultsPerPage: 10, page: 1, search: 'smith', segment: 'all' },
-            undefined,
-            org,
-          ),
-        ).resolves.toBeDefined()
-      })
-
-      it('findContacts search throws with org + no EO access and no campaign', async () => {
-        const org = makeOrganization({
-          overrideDistrictId: OVERRIDE_DISTRICT_ID,
-        })
-        mockElectedOfficeService.findFirst.mockResolvedValue(null)
-
-        await expect(
-          service.findContacts(
-            { resultsPerPage: 10, page: 1, search: 'smith', segment: 'all' },
-            undefined,
-            org,
-          ),
-        ).rejects.toThrow(SEARCH_REQUIRES_PRO_MSG)
-      })
-
-      it('downloadContacts succeeds with org + EO access and no campaign', async () => {
-        const org = makeOrganization({
-          overrideDistrictId: OVERRIDE_DISTRICT_ID,
-        })
-        mockElectedOfficeService.findFirst.mockResolvedValue({
-          id: 'office-1',
-          organizationSlug: org.slug,
-        })
-
-        const mockStream = {
-          pipe: vi.fn(),
-          on: vi.fn((event: string, cb: () => void) => {
-            if (event === 'end') setImmediate(cb)
-          }),
-        }
-        mockHttpService.post.mockReturnValue(of({ data: mockStream }))
-        const res = { raw: {} } as never
-
-        await expect(
-          service.downloadContacts({ segment: 'all' }, undefined, res, org),
-        ).resolves.toBeUndefined()
-      })
-
-      it('throws when neither campaign nor organization is provided', async () => {
-        await expect(
-          service.findContacts(
-            { resultsPerPage: 10, page: 1, search: undefined, segment: 'all' },
-            undefined,
-            undefined,
-          ),
-        ).rejects.toThrow('Campaign or organization is required')
-      })
-
-      it('getDistrictStats throws when neither campaign nor organization is provided', async () => {
-        await expect(
-          service.getDistrictStats(undefined, undefined),
-        ).rejects.toThrow('Campaign or organization is required')
-      })
-
-      it('statewide org with no campaign throws (canDownloadFederal defaults to false)', async () => {
-        const org = makeOrganization({ positionId: POSITION_ID_FIXTURE })
-        mockElectionsService.getPositionById.mockResolvedValue({
-          id: POSITION_ID_FIXTURE,
-          state: 'WY',
-          district: null,
-        })
-
-        await expect(
-          service.findContacts(
-            {
-              resultsPerPage: 10,
-              page: 1,
-              search: undefined,
-              segment: 'all',
-            },
-            undefined,
-            org,
-          ),
-        ).rejects.toThrow(
-          'Statewide or federal contacts require admin approval',
         )
       })
     })

--- a/src/contacts/services/contacts.service.ts
+++ b/src/contacts/services/contacts.service.ts
@@ -1,5 +1,3 @@
-// LEGACY: Remove when org migration is complete (only used by canUseStatewideFallback).
-import { BallotReadyPositionLevel } from '@goodparty_org/contracts'
 import { HttpService } from '@nestjs/axios'
 import {
   BadGatewayException,
@@ -16,12 +14,9 @@ import { PinoLogger } from 'nestjs-pino'
 import { Readable } from 'node:stream'
 import { lastValueFrom } from 'rxjs'
 import { CampaignsService } from 'src/campaigns/services/campaigns.service'
-import { ElectedOfficeService } from 'src/electedOffice/services/electedOffice.service'
 import { ElectionsService } from 'src/elections/services/elections.service'
-// LEGACY: Remove when org migration is complete (only used by isStatewideSelection).
-import { SHORT_TO_LONG_STATE } from 'src/shared/constants/states'
 import { VoterFileFilterService } from 'src/voters/services/voterFileFilter.service'
-import { CampaignWithPathToVictory, StatsResponse } from '../contacts.types'
+import { StatsResponse } from '../contacts.types'
 import {
   DownloadContactsDTO,
   ListContactsDTO,
@@ -33,11 +28,6 @@ import {
   convertVoterFileFilterToFilters,
   type FilterObject,
 } from '../utils/voterFileFilter.utils'
-
-const P2V_ELECTION_INFO_MISSING_MESSAGE =
-  'Campaign path to victory data is missing required election information'
-
-const CAMPAIGN_OR_ORGANIZATION_REQUIRED = 'Campaign or organization is required'
 
 const { PEOPLE_API_URL, PEOPLE_API_S2S_SECRET } = process.env
 
@@ -57,161 +47,68 @@ export class ContactsService {
     private readonly voterFileFilterService: VoterFileFilterService,
     private readonly elections: ElectionsService,
     private readonly campaigns: CampaignsService,
-    private readonly electedOfficeService: ElectedOfficeService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(ContactsService.name)
   }
 
-  // LEGACY: Remove when org migration is complete.
-  //         Replaced by withOrgDistrictResolution which uses org.overrideDistrictId / position.district.id.
-  async withFallbackDistrictName<Result>(
-    campaign: CampaignWithPathToVictory,
-    fn: (params: {
-      state: string
-      districtType?: string
-      districtName?: string
-    }) => Promise<Result>,
-  ): Promise<Result> {
-    const { state, districtType, districtName, alternativeDistrictName } =
-      this.resolveLocationForRequest(campaign)
-
-    try {
-      return await fn({ state, districtType, districtName })
-    } catch (error) {
-      const is404 = isAxiosError(error) && error.response?.status === 404
-      if (!alternativeDistrictName || !is404) {
-        throw error
-      }
-      return fn({
-        state,
-        districtType,
-        districtName: alternativeDistrictName,
-      })
-    }
+  private hasElectedOfficeAccess(organization: Organization): boolean {
+    return organization.slug.startsWith('eo-')
   }
 
-  private async hasElectedOfficeAccess(
-    userId: number,
-    organization?: Organization,
-  ): Promise<boolean> {
-    if (organization) {
-      if (organization.slug.startsWith('eo-')) return true
-
-      // LEGACY: campaign-* slug fallback for backwards compatibility.
-      const campaignOrg = /^campaign-(\d+)$/.exec(organization.slug)
-      if (campaignOrg) {
-        const campaignId = Number(campaignOrg[1])
-        const eoForCampaign = await this.electedOfficeService.findFirst({
-          where: { campaignId, userId },
-        })
-        return eoForCampaign !== null
-      }
-
-      return false
-    }
-    // LEGACY: Remove this branch when org migration is complete.
-    //         The userId param and getCurrentElectedOffice call become unnecessary.
-    const eo = await this.electedOfficeService.getCurrentElectedOffice(userId)
-    return eo !== null
+  private async isProAccess(organization: Organization): Promise<boolean> {
+    if (this.hasElectedOfficeAccess(organization)) return true
+    const campaign = await this.campaigns.findFirst({
+      where: { organizationSlug: organization.slug },
+      select: { isPro: true },
+    })
+    return campaign?.isPro ?? false
   }
 
   private async resolveDistrictInfoFromOrg(
     org: Organization,
-  ): Promise<{ districtId: string | null; state: string | null }> {
+  ): Promise<{ districtId: string | null }> {
     if (org.overrideDistrictId) {
-      return { districtId: org.overrideDistrictId, state: null }
+      return { districtId: org.overrideDistrictId }
     }
 
     if (org.positionId) {
       const position = await this.elections.getPositionById(org.positionId, {
         includeDistrict: true,
       })
-      return {
-        districtId: position?.district?.id ?? null,
-        state: position?.state ?? null,
-      }
+      return { districtId: position?.district?.id ?? null }
     }
 
-    return { districtId: null, state: null }
+    return { districtId: null }
   }
 
   private async withOrgDistrictResolution<Result>(
     org: Organization,
-    campaign: CampaignWithPathToVictory | undefined,
-    fn: (params: { districtId?: string; state?: string }) => Promise<Result>,
+    fn: (params: { districtId: string }) => Promise<Result>,
   ): Promise<Result> {
-    const resolved = await this.resolveDistrictInfoFromOrg(org)
-    const districtId = resolved.districtId
-    let state = resolved.state
-    const canDownloadFederal = Boolean(campaign?.canDownloadFederal)
+    const { districtId } = await this.resolveDistrictInfoFromOrg(org)
 
-    // Custom office / statewide: org may have only customPositionName; use campaign state + approval.
-    if (!districtId && !state && campaign?.details) {
-      const details = campaign.details as {
-        state?: string
-        ballotLevel?: BallotReadyPositionLevel
-      }
-      const level = details.ballotLevel
-      if (
-        details.state &&
-        typeof details.state === 'string' &&
-        details.state.length === 2 &&
-        (level === BallotReadyPositionLevel.STATE ||
-          level === BallotReadyPositionLevel.FEDERAL) &&
-        canDownloadFederal
-      ) {
-        state = details.state.toUpperCase()
-      }
-    }
-
-    if (districtId) {
-      return fn({ districtId })
-    }
-
-    // No district on the org (statewide/federal case).
-    // Position having no district already proves it's statewide — only check admin approval.
-    if (!state) {
+    if (!districtId) {
       throw new BadRequestException(
         'Organization does not have sufficient data to resolve district',
       )
     }
-    // LEGACY: Replace with org-based approval when org migration is complete.
-    if (!canDownloadFederal) {
-      throw new BadRequestException(
-        'Statewide or federal contacts require admin approval',
-      )
-    }
-    return fn({ state })
+
+    return fn({ districtId })
   }
 
-  // LEGACY: Remove campaign param when org migration is complete.
-  //         organization becomes required, remove legacy branch.
   async findContacts(
     { resultsPerPage, page, search, segment }: ListContactsDTO,
-    campaign: CampaignWithPathToVictory | undefined,
-    organization?: Organization,
+    organization: Organization,
   ) {
-    if (search) {
-      const hasElectedOffice = await this.hasElectedOfficeAccess(
-        campaign?.userId ?? 0, // userId unused on org path (checks organizationSlug)
-        organization,
+    if (search && !(await this.isProAccess(organization))) {
+      throw new BadRequestException(
+        'Search is only available for pro campaigns',
       )
-      // LEGACY: Remove campaign.isPro check when org migration is complete.
-      if (!(campaign?.isPro ?? false) && !hasElectedOffice) {
-        throw new BadRequestException(
-          'Search is only available for pro campaigns',
-        )
-      }
     }
 
     const fetchPeople = async (
-      districtParams: {
-        districtId?: string
-        state?: string
-        districtType?: string
-        districtName?: string
-      },
+      districtParams: { districtId: string },
       filters: FilterObject,
     ) => {
       try {
@@ -234,43 +131,19 @@ export class ContactsService {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         return response.data as PeopleListResponse
       } catch (error) {
-        this.logger.error(
-          {
-            error,
-          },
-          `Failed to fetch from people API`,
-        )
+        this.logger.error({ error }, `Failed to fetch from people API`)
         throw new BadGatewayException(`Failed to fetch from people API`)
       }
     }
 
-    if (organization) {
-      const filters = await this.segmentToFilters(segment, organization)
-      return this.withOrgDistrictResolution(organization, campaign, (params) =>
-        fetchPeople(params, filters),
-      )
-    }
-
-    // LEGACY: Remove when org migration is complete.
-    if (!campaign) {
-      throw new BadRequestException(CAMPAIGN_OR_ORGANIZATION_REQUIRED)
-    }
-    const filters = await this.legacySegmentToFilters(segment, campaign)
-    return this.withFallbackDistrictName(campaign, (params) =>
+    const filters = await this.segmentToFilters(segment, organization)
+    return this.withOrgDistrictResolution(organization, (params) =>
       fetchPeople(params, filters),
     )
   }
 
-  // LEGACY: Remove campaign param when org migration is complete.
-  async sampleContacts(
-    dto: SampleContacts,
-    campaign: CampaignWithPathToVictory,
-    organization: Organization,
-  ) {
-    const fetchSample = async (districtParams: {
-      districtId?: string
-      state?: string
-    }) => {
+  async sampleContacts(dto: SampleContacts, organization: Organization) {
+    const fetchSample = async (districtParams: { districtId: string }) => {
       const body = {
         ...districtParams,
         size: String(dto.size ?? 500),
@@ -303,22 +176,14 @@ export class ContactsService {
       }
     }
 
-    return this.withOrgDistrictResolution(organization, campaign, fetchSample)
+    return this.withOrgDistrictResolution(organization, fetchSample)
   }
 
-  // LEGACY: Remove campaign param when org migration is complete.
-  //         organization becomes required, remove withFallbackDistrictName branch.
   async findPerson(
     id: string,
-    campaign: CampaignWithPathToVictory | undefined,
-    organization?: Organization,
+    organization: Organization,
   ): Promise<PersonOutput> {
-    const fetchPerson = async (districtParams: {
-      districtId?: string
-      state?: string
-      districtType?: string
-      districtName?: string
-    }) => {
+    const fetchPerson = async (districtParams: { districtId: string }) => {
       try {
         const response = await lastValueFrom(
           this.httpService.get<PersonOutput>(
@@ -350,51 +215,20 @@ export class ContactsService {
       }
     }
 
-    if (organization) {
-      return this.withOrgDistrictResolution(organization, campaign, fetchPerson)
-    }
-
-    // LEGACY: Remove when org migration is complete.
-    if (!campaign) {
-      throw new BadRequestException(CAMPAIGN_OR_ORGANIZATION_REQUIRED)
-    }
-    return this.withFallbackDistrictName(
-      campaign,
-      async ({ state, districtType, districtName }) => {
-        const params: Record<string, string> = { state }
-        if (districtType && districtName) {
-          params.districtType = districtType
-          params.districtName = districtName
-        }
-        return fetchPerson(params)
-      },
-    )
+    return this.withOrgDistrictResolution(organization, fetchPerson)
   }
 
-  // LEGACY: Remove campaign param when org migration is complete.
-  //         organization becomes required, remove legacy branch.
   async downloadContacts(
     { segment }: DownloadContactsDTO,
-    campaign: CampaignWithPathToVictory | undefined,
     res: FastifyReply,
-    organization?: Organization,
+    organization: Organization,
   ) {
-    const hasElectedOffice = await this.hasElectedOfficeAccess(
-      campaign?.userId ?? 0, // userId unused on org path (checks organizationSlug)
-      organization,
-    )
-    // LEGACY: Remove campaign.isPro check when org migration is complete.
-    if (!(campaign?.isPro ?? false) && !hasElectedOffice) {
+    if (!(await this.isProAccess(organization))) {
       throw new BadRequestException('Campaign is not pro')
     }
 
     const downloadPeople = async (
-      districtParams: {
-        districtId?: string
-        state?: string
-        districtType?: string
-        districtName?: string
-      },
+      districtParams: { districtId: string },
       filters: FilterObject,
     ) => {
       try {
@@ -418,9 +252,7 @@ export class ContactsService {
         })
       } catch (error) {
         this.logger.error(
-          {
-            error,
-          },
+          { error },
           'Failed to download contacts from people API',
         )
 
@@ -430,35 +262,14 @@ export class ContactsService {
       }
     }
 
-    if (organization) {
-      const filters = await this.segmentToFilters(segment, organization)
-      return this.withOrgDistrictResolution(organization, campaign, (params) =>
-        downloadPeople(params, filters),
-      )
-    }
-
-    // LEGACY: Remove when org migration is complete.
-    if (!campaign) {
-      throw new BadRequestException(CAMPAIGN_OR_ORGANIZATION_REQUIRED)
-    }
-    const filters = await this.legacySegmentToFilters(segment, campaign)
-    return this.withFallbackDistrictName(campaign, (params) =>
+    const filters = await this.segmentToFilters(segment, organization)
+    return this.withOrgDistrictResolution(organization, (params) =>
       downloadPeople(params, filters),
     )
   }
 
-  // LEGACY: Remove campaign param when org migration is complete.
-  //         organization becomes required, remove withFallbackDistrictName branch.
-  async getDistrictStats(
-    campaign: CampaignWithPathToVictory | undefined,
-    organization?: Organization,
-  ) {
-    const fetchStats = async (districtParams: {
-      districtId?: string
-      state?: string
-      districtType?: string
-      districtName?: string
-    }) => {
+  async getDistrictStats(organization: Organization) {
+    const fetchStats = async (districtParams: { districtId: string }) => {
       const token = this.getValidS2SToken()
 
       const response = await lastValueFrom(
@@ -474,37 +285,7 @@ export class ContactsService {
       return response.data
     }
 
-    if (organization) {
-      return this.withOrgDistrictResolution(organization, campaign, fetchStats)
-    }
-
-    // LEGACY: Remove when org migration is complete.
-    if (!campaign) {
-      throw new BadRequestException(CAMPAIGN_OR_ORGANIZATION_REQUIRED)
-    }
-    return this.withFallbackDistrictName(
-      campaign,
-      async ({ state, districtType, districtName }) => {
-        if (!state) {
-          const msg = 'Could not resolve state for contacts stats'
-          this.logger.error({
-            campaign,
-            msg,
-            state,
-            districtType,
-            districtName,
-          })
-          throw new BadRequestException(msg)
-        }
-
-        const params: Record<string, string> = { state }
-        if (districtType && districtName) {
-          params.districtType = districtType
-          params.districtName = districtName
-        }
-        return fetchStats(params)
-      },
-    )
+    return this.withOrgDistrictResolution(organization, fetchStats)
   }
 
   private getValidS2SToken(): string {
@@ -547,114 +328,6 @@ export class ContactsService {
     return this.cachedToken
   }
 
-  // LEGACY: Remove when org migration is complete.
-  //         Replaced by the simpler canDownloadFederal check in withOrgDistrictResolution.
-  private canUseStatewideFallback(
-    campaign: CampaignWithPathToVictory,
-  ): boolean {
-    const ballotLevel = (
-      campaign.details as { ballotLevel?: BallotReadyPositionLevel } | null
-    )?.ballotLevel
-    const canDownloadFederal = campaign.canDownloadFederal
-    return (
-      (ballotLevel === BallotReadyPositionLevel.FEDERAL ||
-        ballotLevel === BallotReadyPositionLevel.STATE) &&
-      Boolean(canDownloadFederal)
-    )
-  }
-
-  // LEGACY: Remove when org migration is complete.
-  //         Org path gets state from position via election API instead.
-  private getCampaignState(campaign: CampaignWithPathToVictory): string {
-    if (!campaign.details) {
-      throw new BadRequestException({
-        message: 'Campaign details are missing',
-        errorCode: 'DATA_INTEGRITY_CAMPAIGN_DETAILS_MISSING',
-      })
-    }
-    const { state } = campaign.details as { state?: string }
-    if (!state || state.length !== 2) {
-      throw new BadRequestException({
-        message: 'Invalid state code in campaign data',
-        errorCode: 'DATA_INTEGRITY_CAMPAIGN_STATE_INVALID',
-      })
-    }
-    return state.toUpperCase()
-  }
-
-  // LEGACY: Remove when org migration is complete.
-  //         Replaced by resolveDistrictInfoFromOrg which uses org.overrideDistrictId / position.district.id.
-  private resolveLocationForRequest(campaign: CampaignWithPathToVictory): {
-    state: string
-    districtType?: string
-    districtName?: string
-    alternativeDistrictName?: string
-  } {
-    const state = this.getCampaignState(campaign)
-
-    // LEGACY: These fields still exist in old DB rows until the cleanup migration runs.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const ptv = campaign.pathToVictory?.data as
-      | { electionType?: string; electionLocation?: string }
-      | undefined
-    const electionType = ptv?.electionType
-    const electionLocation = ptv?.electionLocation
-
-    if (electionType && electionLocation) {
-      const cleanedName = this.elections.cleanDistrictName(electionLocation) // removes ##
-      const alternativeCleanedName = cleanedName.replace(/^0/, '') // Delete 1 leading zero
-      const isStatewide = this.isStatewideSelection(
-        state,
-        electionType,
-        cleanedName,
-      )
-
-      if (isStatewide) {
-        if (!this.canUseStatewideFallback(campaign)) {
-          throw new BadRequestException(
-            'Statewide or federal contacts require admin approval',
-          )
-        }
-        return { state }
-      }
-
-      return {
-        state,
-        districtType: electionType,
-        districtName: cleanedName,
-        alternativeDistrictName: alternativeCleanedName,
-      }
-    }
-
-    if (this.canUseStatewideFallback(campaign)) {
-      return { state }
-    }
-
-    throw new BadRequestException({
-      message: P2V_ELECTION_INFO_MISSING_MESSAGE,
-      errorCode: 'DATA_INTEGRITY_P2V_ELECTION_INFO_MISSING',
-    })
-  }
-
-  // LEGACY: Remove when org migration is complete.
-  //         Org path infers statewide from absence of district on the position.
-  private isStatewideSelection(
-    stateCode: string,
-    electionType: string,
-    districtName: string,
-  ): boolean {
-    const type = electionType.toLowerCase()
-    const stateLong =
-      // Dynamic key lookup into const object — TypeScript cannot narrow string to known keys
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      SHORT_TO_LONG_STATE[stateCode as keyof typeof SHORT_TO_LONG_STATE]
-    const matchesCode = districtName.toUpperCase() === stateCode.toUpperCase()
-    const matchesLong =
-      typeof stateLong === 'string' &&
-      districtName.toLowerCase() === stateLong.toLowerCase()
-    return type === 'state' ? matchesCode || matchesLong : false
-  }
-
   private async segmentToFilters(
     segment: string | undefined,
     organization: Organization,
@@ -667,25 +340,6 @@ export class ContactsService {
       await this.voterFileFilterService.findByIdAndOrganizationSlug(
         parseInt(resolvedSegment),
         organization.slug,
-      )
-
-    return customSegment ? convertVoterFileFilterToFilters(customSegment) : {}
-  }
-
-  // LEGACY: Remove when org migration is complete.
-  //         Replaced by segmentToFilters which uses organization.slug.
-  private async legacySegmentToFilters(
-    segment: string | undefined,
-    campaign: CampaignWithPathToVictory,
-  ): Promise<FilterObject> {
-    const resolvedSegment = segment || 'all'
-    const builtInFilters = this.resolveBuiltInSegment(resolvedSegment)
-    if (builtInFilters) return builtInFilters
-
-    const customSegment =
-      await this.voterFileFilterService.findByIdAndCampaignId(
-        parseInt(resolvedSegment),
-        campaign.id,
       )
 
     return customSegment ? convertVoterFileFilterToFilters(customSegment) : {}

--- a/src/contacts/tests/contacts.e2e.ts
+++ b/src/contacts/tests/contacts.e2e.ts
@@ -6,7 +6,6 @@ import {
   deleteUser,
   generateRandomEmail,
   generateRandomName,
-  loginUser,
   registerUser,
 } from '../../../e2e-tests/utils/auth.util'
 import { updateCampaignWithRetry } from '../../../e2e-tests/utils/request.util'
@@ -22,9 +21,7 @@ const CONTACTS_TEST_POSITION_ID =
 
 /**
  * Campaign org slug (`campaign-${id}`) must be sent so contacts use
- * `resolveDistrictInfoFromOrg` (position / overrideDistrict). Without it, the
- * legacy path requires pathToVictory electionType/electionLocation, which this
- * suite does not set.
+ * `resolveDistrictInfoFromOrg` (position / overrideDistrict).
  */
 let campaignOrgSlug = ''
 
@@ -51,7 +48,12 @@ async function updateCampaignMine(params: {
 }) {
   const { request, authToken, data } = params
 
-  const response = await updateCampaignWithRetry(request, authToken, data)
+  const response = await updateCampaignWithRetry(
+    request,
+    authToken,
+    data,
+    campaignOrgSlug,
+  )
   await assertOk(response, 'Campaign update failed')
 }
 
@@ -72,11 +74,24 @@ async function createElectedOffice(params: {
   return payload.id
 }
 
+async function setOrganizationPosition(params: {
+  request: APIRequestContext
+  authToken: string
+}) {
+  const { request, authToken } = params
+  const response = await request.patch(`/v1/organizations/${campaignOrgSlug}`, {
+    headers: AUTH_HEADER(authToken),
+    data: { ballotReadyPositionId: CONTACTS_TEST_POSITION_ID },
+  })
+  await assertOk(response, 'Organization position update failed')
+}
+
 async function prepareCampaignAndOffice(params: {
   request: APIRequestContext
   authToken: string
 }) {
   const { request, authToken } = params
+  await setOrganizationPosition({ request, authToken })
   await updateCampaignMine({
     request,
     authToken,
@@ -84,9 +99,6 @@ async function prepareCampaignAndOffice(params: {
       details: {
         state: CONTACTS_TEST_DISTRICT.state,
         zip: '82001',
-        office: 'Other',
-        otherOffice: 'Cheyenne City Council Ward 1',
-        positionId: CONTACTS_TEST_POSITION_ID,
         electionDate: '2026-11-03',
         ballotLevel: 'CITY',
       },
@@ -103,34 +115,16 @@ async function prepareCampaignAndOffice(params: {
   return createElectedOffice({ request, authToken })
 }
 
-async function approveCampaignForStatewideDownload(params: {
-  request: APIRequestContext
-  campaignSlug: string
-}) {
-  const { request, campaignSlug } = params
-  const adminEmail = process.env.ADMIN_EMAIL
-  const adminPassword = process.env.ADMIN_PASSWORD
-
-  if (!adminEmail || !adminPassword) {
-    throw new Error(
-      'ADMIN_EMAIL and ADMIN_PASSWORD are required for statewide contacts e2e setup',
-    )
-  }
-
-  const admin = await loginUser(request, adminEmail, adminPassword)
-  const response = await updateCampaignWithRetry(request, admin.token, {
-    slug: campaignSlug,
-    canDownloadFederal: true,
-  })
-
-  await assertOk(response, 'Admin campaign approval failed')
-}
+const EO_AUTH_HEADER = (token: string, eoSlug: string) => ({
+  Authorization: `Bearer ${token}`,
+  'x-organization-slug': eoSlug,
+})
 
 test.describe('Contacts and Segments', () => {
   let authToken: string
-  let campaignSlug: string
   let testUserId: number
   let testAuthToken: string
+  let eoOrgSlug: string
 
   test.beforeEach(async ({ request }) => {
     const registerResponse = await registerUser(request, {
@@ -144,15 +138,15 @@ test.describe('Contacts and Segments', () => {
     })
 
     authToken = registerResponse.token
-    campaignSlug = registerResponse.campaign.slug
     testUserId = registerResponse.user.id
     testAuthToken = registerResponse.token
     campaignOrgSlug = `campaign-${registerResponse.campaign.id}`
 
-    await prepareCampaignAndOffice({
+    const electedOfficeId = await prepareCampaignAndOffice({
       request,
       authToken,
     })
+    eoOrgSlug = `eo-${electedOfficeId}`
   })
 
   test.afterEach(async ({ request }) => {
@@ -238,59 +232,11 @@ test.describe('Contacts and Segments', () => {
     }
   })
 
-  test('should return statewide stats when district picker is set to State and campaign is approved', async ({
-    request,
-  }) => {
-    test.skip(
-      !process.env.ADMIN_EMAIL || !process.env.ADMIN_PASSWORD,
-      'Requires ADMIN_EMAIL and ADMIN_PASSWORD for admin-only campaign approval',
-    )
-
-    await approveCampaignForStatewideDownload({
-      request,
-      campaignSlug,
-    })
-
-    await updateCampaignMine({
-      request,
-      authToken,
-      data: {
-        details: {
-          state: 'AL',
-          ballotLevel: 'STATE',
-          office: 'Other',
-          otherOffice: 'Alabama Governor',
-          positionId: null,
-          electionDate: '2026-11-03',
-        },
-        pathToVictory: {
-          source: P2VSource.ElectionApi,
-          p2vStatus: P2VStatus.complete,
-          p2vCompleteDate: '2025-09-25',
-        },
-      },
-    })
-
-    const response = await request.get(`/v1/contacts/stats`, {
-      headers: AUTH_HEADER(authToken),
-    })
-
-    expect(response.status()).toBe(HttpStatus.OK)
-    const stats = (await response.json()) as {
-      districtId: string
-      totalConstituents: number
-      buckets: Record<string, unknown>
-    }
-    expect(typeof stats.districtId).toBe('string')
-    expect(stats.totalConstituents).toBeGreaterThan(0)
-    expect(stats).toHaveProperty('buckets')
-  })
-
   test('should download non-empty contacts CSV for seeded district', async ({
     request,
   }) => {
     const response = await request.get(`/v1/contacts/download`, {
-      headers: AUTH_HEADER(authToken),
+      headers: EO_AUTH_HEADER(authToken, eoOrgSlug),
     })
 
     expect(response.status()).toBe(HttpStatus.OK)

--- a/src/electedOffice/electedOffice.controller.test.ts
+++ b/src/electedOffice/electedOffice.controller.test.ts
@@ -6,13 +6,14 @@ const service = useTestService()
 
 describe('ElectedOfficeController', () => {
   let campaign: Campaign
+  let orgSlug: string
 
   beforeEach(async () => {
     const suffix = Date.now()
-    const organizationSlug = `campaign-${suffix}`
+    orgSlug = `campaign-${suffix}`
     await service.prisma.organization.create({
       data: {
-        slug: organizationSlug,
+        slug: orgSlug,
         ownerId: service.user.id,
         positionId: '2875e5f3-ecf0-6fae-f270-6951f85e8468',
       },
@@ -21,13 +22,15 @@ describe('ElectedOfficeController', () => {
       data: {
         userId: service.user.id,
         slug: `test-campaign-${suffix}`,
-        organizationSlug,
+        organizationSlug: orgSlug,
       },
     })
   })
 
   const createElectedOffice = (body: Record<string, unknown> = {}) =>
-    service.client.post('/v1/elected-office', body)
+    service.client.post('/v1/elected-office', body, {
+      headers: { 'x-organization-slug': orgSlug },
+    })
 
   describe('GET /elected-office/current', () => {
     it('returns current elected office', async () => {
@@ -36,7 +39,10 @@ describe('ElectedOfficeController', () => {
       })
       expect(created.status).toBe(201)
 
-      const result = await service.client.get('/v1/elected-office/current')
+      const eoOrgSlug = `eo-${created.data.id}`
+      const result = await service.client.get('/v1/elected-office/current', {
+        headers: { 'x-organization-slug': eoOrgSlug },
+      })
 
       expect(result.status).toBe(200)
       expect(result.data).toEqual({
@@ -46,7 +52,9 @@ describe('ElectedOfficeController', () => {
     })
 
     it('returns 404 when no elected office exists', async () => {
-      const result = await service.client.get('/v1/elected-office/current')
+      const result = await service.client.get('/v1/elected-office/current', {
+        headers: { 'x-organization-slug': orgSlug },
+      })
 
       expect(result.status).toBe(404)
     })

--- a/src/electedOffice/electedOffice.controller.ts
+++ b/src/electedOffice/electedOffice.controller.ts
@@ -67,45 +67,18 @@ export class ElectedOfficeController {
     return req.m2mToken ? record : this.toApi(record)
   }
 
-  // LEGACY: When org migration is complete:
-  //         - @UseOrganization becomes required (remove continueIfNotFound)
-  //         - Remove the entire legacy branch (findFirst by userId, campaign.organization/details fallback)
-  //         - organization param becomes non-optional
   @Post('/')
-  @UseOrganization({ continueIfNotFound: true })
+  @UseOrganization()
   async create(
     @ReqUser() user: User,
     @Body() body: CreateElectedOfficeDto,
-    @ReqOrganization() organization: Organization | undefined,
+    @ReqOrganization() organization: Organization,
   ) {
-    if (organization) {
-      // Org path: get campaign from the organization
-      const campaign =
-        await this.electedOfficeService.client.campaign.findUnique({
-          where: { organizationSlug: organization.slug },
-        })
-      if (!campaign) {
-        throw new ForbiddenException('Not allowed to link campaign')
-      }
-
-      const created = await this.electedOfficeService.create({
-        ...body,
-        userId: user.id,
-        campaignId: campaign.id,
-        orgData: {
-          positionId: organization.positionId,
-          customPositionName: organization.customPositionName,
-          overrideDistrictId: organization.overrideDistrictId,
-        },
-      })
-      return this.toApi(created)
-    }
-
-    // LEGACY: Remove this entire branch when org migration is complete.
-    const campaign = await this.electedOfficeService.client.campaign.findFirst({
-      where: { userId: user.id },
-      include: { organization: true },
-    })
+    const campaign = await this.electedOfficeService.client.campaign.findUnique(
+      {
+        where: { organizationSlug: organization.slug },
+      },
+    )
     if (!campaign) {
       throw new ForbiddenException('Not allowed to link campaign')
     }
@@ -114,15 +87,11 @@ export class ElectedOfficeController {
       ...body,
       userId: user.id,
       campaignId: campaign.id,
-      ...(campaign.organization
-        ? {
-            orgData: {
-              positionId: campaign.organization.positionId,
-              customPositionName: campaign.organization.customPositionName,
-              overrideDistrictId: campaign.organization.overrideDistrictId,
-            },
-          }
-        : {}),
+      orgData: {
+        positionId: organization.positionId,
+        customPositionName: organization.customPositionName,
+        overrideDistrictId: organization.overrideDistrictId,
+      },
     })
     return this.toApi(created)
   }

--- a/src/electedOffice/guards/UseElectedOffice.guard.integration.test.ts
+++ b/src/electedOffice/guards/UseElectedOffice.guard.integration.test.ts
@@ -50,16 +50,9 @@ describe('UseElectedOffice guard (integration)', () => {
     return { org, eo }
   }
 
-  describe('legacy fallback (no header)', () => {
-    it('resolves elected office by userId', async () => {
+  describe('no header', () => {
+    it('returns 404 when no org header is provided (even if user has an elected office)', async () => {
       await createElectedOfficeWithOrg()
-      const result = await service.client.get('/v1/polls/has-polls')
-
-      expect(result.status).toBe(200)
-      expect(result.data).toEqual({ hasPolls: false })
-    })
-
-    it('returns 404 when user has no active elected office', async () => {
       const result = await service.client.get('/v1/polls/has-polls')
 
       expect(result.status).toBe(404)

--- a/src/electedOffice/guards/UseElectedOffice.guard.test.ts
+++ b/src/electedOffice/guards/UseElectedOffice.guard.test.ts
@@ -157,38 +157,17 @@ describe('UseElectedOfficeGuard', () => {
     })
   })
 
-  describe('step 2: legacy fallback (userId)', () => {
-    it('resolves EO by userId when no header', async () => {
+  describe('no header behavior', () => {
+    it('throws NotFoundException when no header and no continueIfNotFound', async () => {
       mockMetadata()
-      vi.spyOn(electedOfficeService, 'findFirst').mockResolvedValue(mockEO)
-
-      const ctx = buildContext()
-      const result = await guard.canActivate(ctx)
-
-      expect(result).toBe(true)
-      expect(mockOrgFindFirst).not.toHaveBeenCalled()
-      expect(electedOfficeService.findFirst).toHaveBeenCalledWith({
-        where: { userId: 1 },
-        include: undefined,
-      })
-      const req = ctx.switchToHttp().getRequest() as {
-        electedOffice?: ElectedOffice
-      }
-      expect(req.electedOffice).toEqual(mockEO)
-    })
-
-    it('throws NotFoundException when no EO found at all', async () => {
-      mockMetadata()
-      vi.spyOn(electedOfficeService, 'findFirst').mockResolvedValue(null)
 
       const ctx = buildContext()
 
       await expect(guard.canActivate(ctx)).rejects.toThrow(NotFoundException)
     })
 
-    it('returns true when continueIfNotFound and no EO found', async () => {
+    it('returns true when continueIfNotFound and no header', async () => {
       mockMetadata({ continueIfNotFound: true })
-      vi.spyOn(electedOfficeService, 'findFirst').mockResolvedValue(null)
 
       const ctx = buildContext()
       const result = await guard.canActivate(ctx)

--- a/src/electedOffice/guards/UseElectedOffice.guard.ts
+++ b/src/electedOffice/guards/UseElectedOffice.guard.ts
@@ -16,11 +16,8 @@ import { ElectedOfficeService } from '../services/electedOffice.service'
 /**
  * Guard that resolves an ElectedOffice and attaches it to the request.
  *
- * Resolution order:
- * 1. `X-Organization-Slug` header — look up Organization, get its electedOffice.
- * 2. Legacy fallback — user's active elected office (userId + isActive).
- *
- * Once all requests include the organization header, the legacy fallback can be removed.
+ * Requires the `X-Organization-Slug` header. Looks up the Organization by slug
+ * and owner, then fetches the associated elected office.
  */
 @Injectable()
 export class UseElectedOfficeGuard implements CanActivate {
@@ -48,7 +45,6 @@ export class UseElectedOfficeGuard implements CanActivate {
     const userId = request.user.id
     let electedOffice: ElectedOffice | null = null
 
-    // Step 1: Try x-organization-slug header
     const slug = request.headers['x-organization-slug']
     if (typeof slug === 'string') {
       const [org, eo] = await Promise.all([
@@ -63,11 +59,6 @@ export class UseElectedOfficeGuard implements CanActivate {
       if (org && eo) {
         electedOffice = eo
       }
-    } else {
-      electedOffice = await this.electedOfficeService.findFirst({
-        where: { userId },
-        include,
-      })
     }
 
     if (electedOffice) {

--- a/src/electedOffice/services/electedOffice.service.test.ts
+++ b/src/electedOffice/services/electedOffice.service.test.ts
@@ -190,26 +190,4 @@ describe('ElectedOfficeService', () => {
       expect(result).toEqual(mockElectedOffice)
     })
   })
-
-  describe('getCurrentElectedOffice', () => {
-    it('returns elected office for user', async () => {
-      const mockElectedOffice = {
-        id: 'office-1',
-        userId: 1,
-        campaignId: 1,
-        swornInDate: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      }
-
-      mockModel.findFirst.mockResolvedValue(mockElectedOffice)
-
-      const result = await service.getCurrentElectedOffice(1)
-
-      expect(mockModel.findFirst).toHaveBeenCalledWith({
-        where: { userId: 1 },
-      })
-      expect(result).toEqual(mockElectedOffice)
-    })
-  })
 })

--- a/src/electedOffice/services/electedOffice.service.ts
+++ b/src/electedOffice/services/electedOffice.service.ts
@@ -72,14 +72,6 @@ export class ElectedOfficeService extends createPrismaBase(
     return this.model.delete(args)
   }
 
-  // LEGACY: Remove when org migration is complete.
-  //         Callers should use findFirst({ where: { organizationSlug } }) instead.
-  getCurrentElectedOffice(userId: number) {
-    return this.model.findFirst({
-      where: { userId },
-    })
-  }
-
   async listElectedOffices({
     offset: skip = DEFAULT_PAGINATION_OFFSET,
     limit = DEFAULT_PAGINATION_LIMIT,

--- a/src/elections/services/elections.service.ts
+++ b/src/elections/services/elections.service.ts
@@ -25,9 +25,6 @@ import {
 } from '../types/elections.types'
 import { P2VStatus } from '../types/pathToVictory.types'
 
-// TODO: Revisit this file after the stakeholders decide on the direction we're going...
-// ...for the win number / p2v solution. Remove any unneeded code at that time.
-
 @Injectable()
 export class ElectionsService {
   private static readonly BASE_URL = process.env.ELECTION_API_URL
@@ -337,17 +334,11 @@ export class ElectionsService {
         throw new NotFoundException('No projectedTurnout found')
       }
 
-      const {
-        projectedTurnout: turnout,
-        L2DistrictType,
-        L2DistrictName,
-      } = projectedTurnout
+      const { projectedTurnout: turnout } = projectedTurnout
 
       return {
         ...this.calculateRaceTargetMetrics(turnout),
         source: P2VSource.ElectionApi,
-        electionType: L2DistrictType,
-        electionLocation: L2DistrictName,
         p2vStatus: P2VStatus.complete,
         p2vCompleteDate: formatDate(new Date(), DateFormats.isoDate),
       }

--- a/src/elections/types/elections.types.ts
+++ b/src/elections/types/elections.types.ts
@@ -68,8 +68,6 @@ export type RaceTargetMetrics = {
 
 export type RaceTargetDetailsResult = RaceTargetMetrics & {
   source: string
-  electionType: string
-  electionLocation: string
   p2vStatus: string
   p2vCompleteDate: string
 }

--- a/src/organizations/decorators/UseOrganization.decorator.ts
+++ b/src/organizations/decorators/UseOrganization.decorator.ts
@@ -15,7 +15,7 @@ export type RequireOrganizationMetadata = {
  * Used when you need Organization data directly (positionId, overrideDistrictId, etc.).
  *
  * For ElectedOffice or Campaign resolution, use @UseElectedOffice() or @UseCampaign()
- * instead — those guards also resolve via the organization header with userId fallback.
+ * instead — those guards also resolve via the `X-Organization-Slug` header.
  */
 export const UseOrganization = (args: RequireOrganizationMetadata = {}) => {
   return applyDecorators(

--- a/src/organizations/guards/UseOrganization.guard.ts
+++ b/src/organizations/guards/UseOrganization.guard.ts
@@ -18,8 +18,7 @@ import { OrganizationsService } from '../services/organizations.service'
  *
  * Used when you need Organization data directly (positionId, overrideDistrictId, etc.).
  * For ElectedOffice or Campaign context, use @UseElectedOffice() or @UseCampaign()
- * instead — those guards also try the organization header before falling back to
- * userId-based lookups.
+ * instead — those guards also resolve via the `X-Organization-Slug` header.
  *
  * Resolution:
  * 1. Read `X-Organization-Slug` header.

--- a/src/organizations/schemas/organization.schema.ts
+++ b/src/organizations/schemas/organization.schema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 
 export class PatchOrganizationDto extends createZodDto(
   z.object({
-    ballotReadyPositionId: z.string().optional(),
+    ballotReadyPositionId: z.string().nullable().optional(),
     overrideDistrictId: z.string().nullable().optional(),
     customPositionName: z.string().nullable().optional(),
   }),

--- a/src/organizations/services/organizations.service.ts
+++ b/src/organizations/services/organizations.service.ts
@@ -105,14 +105,18 @@ export class OrganizationsService extends createPrismaBase(
 
     let position: { id: string } | null = org.position
 
-    if (updates.ballotReadyPositionId) {
-      position = await this.electionsService.getPositionByBallotReadyId(
-        updates.ballotReadyPositionId,
-        { includeDistrict: true },
-      )
+    if ('ballotReadyPositionId' in updates) {
+      if (updates.ballotReadyPositionId === null) {
+        position = null
+      } else if (updates.ballotReadyPositionId) {
+        position = await this.electionsService.getPositionByBallotReadyId(
+          updates.ballotReadyPositionId,
+          { includeDistrict: true },
+        )
 
-      if (!position) {
-        throw new BadRequestException('Position not found')
+        if (!position) {
+          throw new BadRequestException('Position not found')
+        }
       }
     }
 

--- a/src/outreach/tests/outreach.e2e.ts
+++ b/src/outreach/tests/outreach.e2e.ts
@@ -2,6 +2,8 @@ import { test, expect } from '@playwright/test'
 import { HttpStatus } from '@nestjs/common'
 import { OutreachType } from '@prisma/client'
 import {
+  authHeaders,
+  campaignOrgSlug,
   deleteUser,
   generateRandomEmail,
   generateRandomName,
@@ -22,6 +24,7 @@ interface Outreach {
 
 test.describe('Outreach', () => {
   let reg: RegisterResponse
+  let orgSlug: string
 
   test.beforeAll(async ({ request }) => {
     reg = await registerUser(request, {
@@ -33,6 +36,7 @@ test.describe('Outreach', () => {
       zip: '12345-1234',
       signUpMode: 'candidate',
     })
+    orgSlug = campaignOrgSlug(reg.campaign.id)
   })
 
   test.afterAll(async ({ request }) => {
@@ -45,9 +49,7 @@ test.describe('Outreach', () => {
     request,
   }) => {
     const response = await request.get('/v1/outreach', {
-      headers: {
-        Authorization: `Bearer ${reg.token}`,
-      },
+      headers: authHeaders(reg.token, orgSlug),
     })
 
     expect([HttpStatus.OK, HttpStatus.NOT_FOUND]).toContain(response.status())
@@ -88,6 +90,7 @@ test.describe('Outreach', () => {
 
 test.describe('Outreach - Validation', () => {
   let reg: RegisterResponse
+  let orgSlug: string
 
   test.beforeAll(async ({ request }) => {
     reg = await registerUser(request, {
@@ -99,6 +102,7 @@ test.describe('Outreach - Validation', () => {
       zip: '12345-1234',
       signUpMode: 'candidate',
     })
+    orgSlug = campaignOrgSlug(reg.campaign.id)
   })
 
   test.afterAll(async ({ request }) => {
@@ -109,9 +113,7 @@ test.describe('Outreach - Validation', () => {
 
   test('should reject POST without required fields', async ({ request }) => {
     const response = await request.post('/v1/outreach', {
-      headers: {
-        Authorization: `Bearer ${reg.token}`,
-      },
+      headers: authHeaders(reg.token, orgSlug),
       data: {},
     })
 
@@ -122,9 +124,7 @@ test.describe('Outreach - Validation', () => {
     request,
   }) => {
     const response = await request.post('/v1/outreach', {
-      headers: {
-        Authorization: `Bearer ${reg.token}`,
-      },
+      headers: authHeaders(reg.token, orgSlug),
       data: {
         campaignId: reg.campaign.id,
         outreachType: OutreachType.p2p,

--- a/src/pathToVictory/types/pathToVictory.types.ts
+++ b/src/pathToVictory/types/pathToVictory.types.ts
@@ -11,6 +11,5 @@ export interface ViabilityScore {
 }
 
 export enum P2VSource {
-  GpApi = 'GpApi',
   ElectionApi = 'ElectionApi',
 }

--- a/src/polls/polls.controller.ts
+++ b/src/polls/polls.controller.ts
@@ -1,6 +1,3 @@
-import { CampaignWithPathToVictory } from '@/campaigns/campaigns.types'
-import { ReqCampaign } from '@/campaigns/decorators/ReqCampaign.decorator'
-import { UseCampaign } from '@/campaigns/decorators/UseCampaign.decorator'
 import { ContactsService } from '@/contacts/services/contacts.service'
 import {
   BadRequestException,
@@ -135,20 +132,14 @@ export class PollsController {
     return { hasPolls: userHasPolls }
   }
 
-  // LEGACY: When org migration is complete:
-  //         - Remove @UseCampaign and @ReqCampaign (campaign param)
-  //         - @UseOrganization becomes required (remove continueIfNotFound)
-  //         - organization becomes non-optional, campaign no longer passed to getDistrictStats
   @Post('initial-poll')
   @UseElectedOffice()
-  @UseCampaign({ continueIfNotFound: true })
-  @UseOrganization({ continueIfNotFound: true })
+  @UseOrganization()
   async createInitialPoll(
     @ReqElectedOffice() electedOffice: ElectedOffice,
     @Body()
     { message, imageUrl, swornInDate, scheduledDate }: CreatePollDto,
-    @ReqCampaign() campaign: CampaignWithPathToVictory | undefined,
-    @ReqOrganization() organization: Organization | undefined,
+    @ReqOrganization() organization: Organization,
   ) {
     electedOffice = await this.electedOfficeService.update({
       where: { id: electedOffice.id },
@@ -159,7 +150,7 @@ export class PollsController {
 
     const [userHasPolls, districtStats] = await Promise.all([
       this.pollsService.hasPolls(electedOffice.id),
-      this.contactService.getDistrictStats(campaign, organization),
+      this.contactService.getDistrictStats(organization),
     ])
     if (userHasPolls) {
       throw new ConflictException(

--- a/src/polls/polls.test.ts
+++ b/src/polls/polls.test.ts
@@ -10,6 +10,8 @@ const service = useTestService()
 
 const getStats = vi.fn(ContactsService.prototype.getDistrictStats)
 
+let eoOrgSlug: string
+
 beforeEach(async () => {
   const campaignId = 8888
   const organizationSlug = `campaign-${campaignId}`
@@ -42,7 +44,7 @@ beforeEach(async () => {
   })
 
   const electedOfficeId = uuidv7()
-  const eoOrgSlug = `eo-${electedOfficeId}`
+  eoOrgSlug = `eo-${electedOfficeId}`
   await service.prisma.organization.create({
     data: { slug: eoOrgSlug, ownerId: service.user.id },
   })
@@ -64,12 +66,17 @@ beforeEach(async () => {
 })
 
 describe('POST /polls/initial-poll', () => {
+  const eoHeaders = () => ({
+    headers: { 'x-organization-slug': eoOrgSlug },
+  })
+
   it.each([{ message: '', swornInDate: '2025-01-01' }])(
     'blocks bad input',
     async (payload) => {
       const result = await service.client.post(
         '/v1/polls/initial-poll',
         payload,
+        eoHeaders(),
       )
       expect(result).toMatchObject({
         status: 400,
@@ -83,10 +90,14 @@ describe('POST /polls/initial-poll', () => {
       totalConstituents: 499,
       totalConstituentsWithCellPhone: 499,
     } as StatsResponse)
-    const result = await service.client.post('/v1/polls/initial-poll', {
-      message: 'This is a test message',
-      swornInDate: '2025-01-01',
-    })
+    const result = await service.client.post(
+      '/v1/polls/initial-poll',
+      {
+        message: 'This is a test message',
+        swornInDate: '2025-01-01',
+      },
+      eoHeaders(),
+    )
     expect(result).toMatchObject({
       status: 400,
       data: {
@@ -102,10 +113,14 @@ describe('POST /polls/initial-poll', () => {
       data: { details: {} },
     })
 
-    const result = await service.client.post('/v1/polls/initial-poll', {
-      message: 'This is a test message',
-      swornInDate: '2025-01-01',
-    })
+    const result = await service.client.post(
+      '/v1/polls/initial-poll',
+      {
+        message: 'This is a test message',
+        swornInDate: '2025-01-01',
+      },
+      eoHeaders(),
+    )
 
     expect(result).toMatchObject({
       status: 201,
@@ -116,10 +131,14 @@ describe('POST /polls/initial-poll', () => {
   })
 
   it('creates a poll', async () => {
-    const result = await service.client.post('/v1/polls/initial-poll', {
-      message: 'This is a test message',
-      swornInDate: '2025-01-01',
-    })
+    const result = await service.client.post(
+      '/v1/polls/initial-poll',
+      {
+        message: 'This is a test message',
+        swornInDate: '2025-01-01',
+      },
+      eoHeaders(),
+    )
 
     expect(result).toMatchObject({
       status: 201,
@@ -129,13 +148,19 @@ describe('POST /polls/initial-poll', () => {
     })
 
     // Appears in list
-    const fetched = await service.client.get<{ results: Poll[] }>(`/v1/polls`)
+    const fetched = await service.client.get<{ results: Poll[] }>(
+      `/v1/polls`,
+      eoHeaders(),
+    )
     expect(fetched.data.results).toContainEqual(
       expect.objectContaining({ id: result.data.id }),
     )
 
     // Can be fetched by ID
-    const fetchedById = await service.client.get(`/v1/polls/${result.data.id}`)
+    const fetchedById = await service.client.get(
+      `/v1/polls/${result.data.id}`,
+      eoHeaders(),
+    )
     expect(fetchedById).toMatchObject({
       status: 200,
       data: result.data,

--- a/src/queue/consumer/queueConsumer.service.test.ts
+++ b/src/queue/consumer/queueConsumer.service.test.ts
@@ -931,7 +931,6 @@ describe('QueueConsumerService - triggerPollExecution', () => {
         size: 1000 - existingRecords.length,
         excludeIds: ['person-existing-1', 'person-existing-2'],
       },
-      expect.anything(),
       expect.objectContaining({ slug: 'eo-office-1' }),
     )
   })

--- a/src/queue/consumer/queueConsumer.service.ts
+++ b/src/queue/consumer/queueConsumer.service.ts
@@ -507,7 +507,6 @@ export class QueueConsumerService {
 
     const constituency = await this.contactsService.findContacts(
       { segment: 'all', resultsPerPage: 5, page: 1 },
-      campaign,
       organization,
     )
 
@@ -800,7 +799,6 @@ export class QueueConsumerService {
       )
       const sample = await this.contactsService.sampleContacts(
         sampleParams,
-        campaign,
         organization,
       )
       if (sample.length === 0) {

--- a/src/voters/services/voterFileFilter.service.ts
+++ b/src/voters/services/voterFileFilter.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { BadRequestException, Injectable } from '@nestjs/common'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { Prisma, VoterFileFilter } from '@prisma/client'
 import { UpdateVoterFileFilterSchema } from '../schemas/UpdateVoterFileFilterSchema'
@@ -8,7 +8,6 @@ export class VoterFileFilterService extends createPrismaBase(
   MODELS.VoterFileFilter,
 ) {
   async create(
-    campaignId: number | undefined,
     organizationSlug: string,
     data: Omit<
       Prisma.VoterFileFilterCreateInput,
@@ -17,7 +16,6 @@ export class VoterFileFilterService extends createPrismaBase(
   ) {
     return this.model.create({
       data: {
-        campaignId,
         organizationSlug,
         ...data,
       },
@@ -47,22 +45,6 @@ export class VoterFileFilterService extends createPrismaBase(
     })
   }
 
-  findByCampaignId(campaignId: number): Promise<VoterFileFilter[]> {
-    return this.model.findMany({
-      where: { campaignId },
-      orderBy: { name: 'asc' },
-    })
-  }
-
-  findByIdAndCampaignId(
-    id: number,
-    campaignId: number,
-  ): Promise<VoterFileFilter | null> {
-    return this.findFirst({
-      where: { id, campaignId },
-    })
-  }
-
   findByIdAndOrganizationSlug(
     id: number,
     organizationSlug: string,
@@ -83,32 +65,12 @@ export class VoterFileFilterService extends createPrismaBase(
     })
   }
 
-  updateByIdAndCampaignId(
-    id: number,
-    campaignId: number,
-    data: UpdateVoterFileFilterSchema,
-  ): Promise<VoterFileFilter> {
-    return this.model.update({
-      where: { id, campaignId },
-      data,
-    })
-  }
-
   deleteByIdAndOrganizationSlug(
     id: number,
     organizationSlug: string,
   ): Promise<VoterFileFilter> {
     return this.model.delete({
       where: { id, organizationSlug },
-    })
-  }
-
-  deleteByIdAndCampaignId(
-    id: number,
-    campaignId: number,
-  ): Promise<VoterFileFilter> {
-    return this.model.delete({
-      where: { id, campaignId },
     })
   }
 
@@ -166,6 +128,18 @@ export class VoterFileFilterService extends createPrismaBase(
       ...(age50Plus === true ? { age_50_plus: age50Plus } : {}),
       ...(genderMale === true ? { gender_male: genderMale } : {}),
       ...(genderFemale === true ? { gender_female: genderFemale } : {}),
+    }
+  }
+
+  async filterAccessCheck(organizationSlug: string): Promise<void> {
+    if (organizationSlug.startsWith('campaign-')) {
+      const campaign = await this._prisma.campaign.findFirst({
+        where: { organizationSlug },
+      })
+
+      if (!campaign?.isPro) {
+        throw new BadRequestException('Campaign is not pro')
+      }
     }
   }
 }

--- a/src/voters/voterFile/voterFile.controller.test.ts
+++ b/src/voters/voterFile/voterFile.controller.test.ts
@@ -12,6 +12,7 @@ describe('VoterFileController', () => {
   let mockCampaignsService: Record<string, ReturnType<typeof vi.fn>>
   let mockVoterFileFilterService: {
     create: ReturnType<typeof vi.fn>
+    filterAccessCheck: ReturnType<typeof vi.fn>
     findByIdAndCampaignId: ReturnType<typeof vi.fn>
     findByIdAndOrganizationSlug: ReturnType<typeof vi.fn>
     findByOrganizationSlug: ReturnType<typeof vi.fn>
@@ -39,7 +40,6 @@ describe('VoterFileController', () => {
 
   const mockFilter = {
     id: 1,
-    campaignId: 1,
     name: 'Test Filter',
   } as VoterFileFilter
 
@@ -50,6 +50,7 @@ describe('VoterFileController', () => {
     mockCampaignsService = {}
     mockVoterFileFilterService = {
       create: vi.fn().mockResolvedValue(mockFilter),
+      filterAccessCheck: vi.fn().mockResolvedValue(undefined),
       findByIdAndCampaignId: vi.fn().mockResolvedValue(mockFilter),
       findByIdAndOrganizationSlug: vi.fn().mockResolvedValue(mockFilter),
       findByOrganizationSlug: vi.fn().mockResolvedValue([mockFilter]),
@@ -81,60 +82,32 @@ describe('VoterFileController', () => {
   })
 
   describe('createVoterFileFilter', () => {
-    it('throws when campaign is not pro and org has no elected office', async () => {
-      mockElectedOfficeService.findFirst.mockResolvedValue(null)
+    it('throws when filterAccessCheck rejects', async () => {
+      mockVoterFileFilterService.filterAccessCheck.mockRejectedValue(
+        new BadRequestException('Campaign is not pro'),
+      )
       const body = { name: 'My Filter' } as never
 
       await expect(
-        controller.createVoterFileFilter(baseCampaign, baseOrg, body),
+        controller.createVoterFileFilter(baseOrg, body),
       ).rejects.toThrow(BadRequestException)
-      await expect(
-        controller.createVoterFileFilter(baseCampaign, baseOrg, body),
-      ).rejects.toThrow('Campaign is not pro')
 
-      expect(mockElectedOfficeService.findFirst).toHaveBeenCalledWith({
-        where: { organizationSlug: baseOrg.slug },
-      })
-    })
-
-    it('creates filter when campaign is pro', async () => {
-      const campaign = { ...baseCampaign, isPro: true }
-      const body = { name: 'My Filter' } as never
-
-      const result = await controller.createVoterFileFilter(
-        campaign,
-        baseOrg,
-        body,
-      )
-
-      expect(mockVoterFileFilterService.create).toHaveBeenCalledWith(
-        campaign.id,
+      expect(mockVoterFileFilterService.filterAccessCheck).toHaveBeenCalledWith(
         baseOrg.slug,
-        body,
       )
-      expect(result).toEqual(mockFilter)
+      expect(mockVoterFileFilterService.create).not.toHaveBeenCalled()
     })
 
-    it('creates filter when org has elected office access', async () => {
-      const org = { slug: 'eo-org-1' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue({
-        id: 'office-1',
-        organizationSlug: 'eo-org-1',
-      })
+    it('creates filter when access check passes', async () => {
       const body = { name: 'My Filter' } as never
 
-      const result = await controller.createVoterFileFilter(
-        undefined,
-        org,
-        body,
-      )
+      const result = await controller.createVoterFileFilter(baseOrg, body)
 
-      expect(mockElectedOfficeService.findFirst).toHaveBeenCalledWith({
-        where: { organizationSlug: org.slug },
-      })
+      expect(mockVoterFileFilterService.filterAccessCheck).toHaveBeenCalledWith(
+        baseOrg.slug,
+      )
       expect(mockVoterFileFilterService.create).toHaveBeenCalledWith(
-        undefined,
-        org.slug,
+        baseOrg.slug,
         body,
       )
       expect(result).toEqual(mockFilter)
@@ -174,95 +147,70 @@ describe('VoterFileController', () => {
   })
 
   describe('updateVoterFileFilter', () => {
-    it('throws when campaign is not pro and org has no elected office', async () => {
-      mockElectedOfficeService.findFirst.mockResolvedValue(null)
+    it('throws when filterAccessCheck rejects', async () => {
+      mockVoterFileFilterService.filterAccessCheck.mockRejectedValue(
+        new BadRequestException('Campaign is not pro'),
+      )
       const body = { name: 'Updated Filter' } as never
 
       await expect(
-        controller.updateVoterFileFilter(1, body, baseCampaign, baseOrg),
-      ).rejects.toThrow(BadRequestException)
-      await expect(
-        controller.updateVoterFileFilter(1, body, baseCampaign, baseOrg),
+        controller.updateVoterFileFilter(1, body, baseOrg),
       ).rejects.toThrow('Campaign is not pro')
     })
 
-    it('updates filter with organization and EO access', async () => {
-      const org = { slug: 'eo-org-1' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue({
-        id: 'office-1',
-        organizationSlug: 'eo-org-1',
-      })
+    it('updates filter when access check passes', async () => {
       const body = { name: 'Updated Filter' } as never
 
-      const result = await controller.updateVoterFileFilter(
-        1,
-        body,
-        undefined,
-        org,
-      )
+      const result = await controller.updateVoterFileFilter(1, body, baseOrg)
 
+      expect(mockVoterFileFilterService.filterAccessCheck).toHaveBeenCalledWith(
+        baseOrg.slug,
+      )
       expect(
         mockVoterFileFilterService.findByIdAndOrganizationSlug,
-      ).toHaveBeenCalledWith(1, org.slug)
+      ).toHaveBeenCalledWith(1, baseOrg.slug)
       expect(
         mockVoterFileFilterService.updateByIdAndOrganizationSlug,
-      ).toHaveBeenCalledWith(1, org.slug, body)
+      ).toHaveBeenCalledWith(1, baseOrg.slug, body)
       expect(result).toEqual(mockFilter)
     })
 
     it('throws NotFoundException when filter not found', async () => {
-      const org = { slug: 'eo-org-1' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue({
-        id: 'office-1',
-      })
       mockVoterFileFilterService.findByIdAndOrganizationSlug.mockResolvedValue(
         null,
       )
       const body = { name: 'Updated Filter' } as never
 
       await expect(
-        controller.updateVoterFileFilter(1, body, undefined, org),
+        controller.updateVoterFileFilter(1, body, baseOrg),
       ).rejects.toThrow('Voter file filter not found')
     })
   })
 
   describe('deleteVoterFileFilter', () => {
-    it('deletes filter with EO access', async () => {
-      const org = { slug: 'eo-org-1' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue({
-        id: 'office-1',
-        organizationSlug: 'eo-org-1',
-      })
+    it('deletes filter when access check passes', async () => {
+      await controller.deleteVoterFileFilter(1, baseOrg)
 
-      await controller.deleteVoterFileFilter(1, baseCampaign, org)
-
+      expect(mockVoterFileFilterService.filterAccessCheck).toHaveBeenCalledWith(
+        baseOrg.slug,
+      )
       expect(
         mockVoterFileFilterService.deleteByIdAndOrganizationSlug,
-      ).toHaveBeenCalledWith(1, org.slug)
+      ).toHaveBeenCalledWith(1, baseOrg.slug)
     })
 
-    it('throws when no EO access and not pro', async () => {
-      const org = { slug: 'some-org' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue(null)
+    it('throws when filterAccessCheck rejects', async () => {
+      mockVoterFileFilterService.filterAccessCheck.mockRejectedValue(
+        new BadRequestException('Campaign is not pro'),
+      )
 
       await expect(
-        controller.deleteVoterFileFilter(1, baseCampaign, org),
+        controller.deleteVoterFileFilter(1, baseOrg),
       ).rejects.toThrow('Campaign is not pro')
 
       expect(
         mockVoterFileFilterService.deleteByIdAndOrganizationSlug,
       ).not.toHaveBeenCalled()
-    })
-
-    it('deletes when campaign is pro', async () => {
-      const campaign = { ...baseCampaign, isPro: true }
-      mockElectedOfficeService.findFirst.mockResolvedValue(null)
-
-      await controller.deleteVoterFileFilter(1, campaign, baseOrg)
-
-      expect(
-        mockVoterFileFilterService.deleteByIdAndOrganizationSlug,
-      ).toHaveBeenCalledWith(1, baseOrg.slug)
     })
   })
 

--- a/src/voters/voterFile/voterFile.controller.test.ts
+++ b/src/voters/voterFile/voterFile.controller.test.ts
@@ -13,20 +13,13 @@ describe('VoterFileController', () => {
   let mockVoterFileFilterService: {
     create: ReturnType<typeof vi.fn>
     filterAccessCheck: ReturnType<typeof vi.fn>
-    findByIdAndCampaignId: ReturnType<typeof vi.fn>
     findByIdAndOrganizationSlug: ReturnType<typeof vi.fn>
     findByOrganizationSlug: ReturnType<typeof vi.fn>
-    findByCampaignId: ReturnType<typeof vi.fn>
-    updateByIdAndCampaignId: ReturnType<typeof vi.fn>
     updateByIdAndOrganizationSlug: ReturnType<typeof vi.fn>
-    deleteByIdAndCampaignId: ReturnType<typeof vi.fn>
     deleteByIdAndOrganizationSlug: ReturnType<typeof vi.fn>
   }
   let mockOutreachService: {
     model: { findFirst: ReturnType<typeof vi.fn> }
-  }
-  let mockElectedOfficeService: {
-    findFirst: ReturnType<typeof vi.fn>
   }
 
   const baseCampaign = {
@@ -51,20 +44,13 @@ describe('VoterFileController', () => {
     mockVoterFileFilterService = {
       create: vi.fn().mockResolvedValue(mockFilter),
       filterAccessCheck: vi.fn().mockResolvedValue(undefined),
-      findByIdAndCampaignId: vi.fn().mockResolvedValue(mockFilter),
       findByIdAndOrganizationSlug: vi.fn().mockResolvedValue(mockFilter),
       findByOrganizationSlug: vi.fn().mockResolvedValue([mockFilter]),
-      findByCampaignId: vi.fn().mockResolvedValue([mockFilter]),
-      updateByIdAndCampaignId: vi.fn().mockResolvedValue(mockFilter),
       updateByIdAndOrganizationSlug: vi.fn().mockResolvedValue(mockFilter),
-      deleteByIdAndCampaignId: vi.fn().mockResolvedValue(mockFilter),
       deleteByIdAndOrganizationSlug: vi.fn().mockResolvedValue(mockFilter),
     }
     mockOutreachService = {
       model: { findFirst: vi.fn() },
-    }
-    mockElectedOfficeService = {
-      findFirst: vi.fn().mockResolvedValue(null),
     }
 
     controller = new VoterFileController(
@@ -74,7 +60,6 @@ describe('VoterFileController', () => {
       mockCampaignsService as never,
       mockVoterFileFilterService as never,
       mockOutreachService as never,
-      mockElectedOfficeService as never,
       {} as never,
       createMockLogger(),
     )

--- a/src/voters/voterFile/voterFile.controller.test.ts
+++ b/src/voters/voterFile/voterFile.controller.test.ts
@@ -25,7 +25,6 @@ describe('VoterFileController', () => {
     model: { findFirst: ReturnType<typeof vi.fn> }
   }
   let mockElectedOfficeService: {
-    getCurrentElectedOffice: ReturnType<typeof vi.fn>
     findFirst: ReturnType<typeof vi.fn>
   }
 
@@ -35,6 +34,8 @@ describe('VoterFileController', () => {
     isPro: false,
     organizationSlug: 'campaign-1',
   } as Campaign
+
+  const baseOrg = { slug: 'campaign-1' } as Organization
 
   const mockFilter = {
     id: 1,
@@ -62,7 +63,6 @@ describe('VoterFileController', () => {
       model: { findFirst: vi.fn() },
     }
     mockElectedOfficeService = {
-      getCurrentElectedOffice: vi.fn().mockResolvedValue(null),
       findFirst: vi.fn().mockResolvedValue(null),
     }
 
@@ -81,95 +81,46 @@ describe('VoterFileController', () => {
   })
 
   describe('createVoterFileFilter', () => {
-    it('throws BadRequestException when campaign is not pro and user has no elected office', async () => {
-      mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue(null)
-      const campaign = { ...baseCampaign, isPro: false }
+    it('throws when campaign is not pro and org has no elected office', async () => {
+      mockElectedOfficeService.findFirst.mockResolvedValue(null)
       const body = { name: 'My Filter' } as never
 
       await expect(
-        controller.createVoterFileFilter(campaign, undefined, body),
+        controller.createVoterFileFilter(baseCampaign, baseOrg, body),
       ).rejects.toThrow(BadRequestException)
       await expect(
-        controller.createVoterFileFilter(campaign, undefined, body),
+        controller.createVoterFileFilter(baseCampaign, baseOrg, body),
       ).rejects.toThrow('Campaign is not pro')
 
-      expect(
-        mockElectedOfficeService.getCurrentElectedOffice,
-      ).toHaveBeenCalledWith(campaign.userId)
-      expect(mockVoterFileFilterService.create).not.toHaveBeenCalled()
+      expect(mockElectedOfficeService.findFirst).toHaveBeenCalledWith({
+        where: { organizationSlug: baseOrg.slug },
+      })
     })
 
     it('creates filter when campaign is pro', async () => {
-      mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue(null)
       const campaign = { ...baseCampaign, isPro: true }
       const body = { name: 'My Filter' } as never
 
       const result = await controller.createVoterFileFilter(
         campaign,
-        undefined,
+        baseOrg,
         body,
       )
 
-      expect(
-        mockElectedOfficeService.getCurrentElectedOffice,
-      ).toHaveBeenCalledWith(campaign.userId)
       expect(mockVoterFileFilterService.create).toHaveBeenCalledWith(
         campaign.id,
-        campaign.organizationSlug,
+        baseOrg.slug,
         body,
       )
       expect(result).toEqual(mockFilter)
     })
 
-    it('creates filter when user has elected office', async () => {
-      const mockEO = {
-        id: 'office-1',
-        userId: 100,
-        isActive: true,
-        organizationSlug: 'eo-office-1',
-      }
-      mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue(mockEO)
-      const campaign = { ...baseCampaign, isPro: false }
-      const body = { name: 'My Filter' } as never
-
-      const result = await controller.createVoterFileFilter(
-        campaign,
-        undefined,
-        body,
-      )
-
-      expect(
-        mockElectedOfficeService.getCurrentElectedOffice,
-      ).toHaveBeenCalledWith(campaign.userId)
-      expect(mockVoterFileFilterService.create).toHaveBeenCalledWith(
-        campaign.id,
-        campaign.organizationSlug,
-        body,
-      )
-      expect(mockVoterFileFilterService.create).toHaveBeenCalledWith(
-        campaign.id,
-        mockEO.organizationSlug,
-        body,
-      )
-      expect(mockVoterFileFilterService.create).toHaveBeenCalledTimes(2)
-      expect(result).toEqual(mockFilter)
-    })
-
-    it('throws when neither campaign nor organization is provided', async () => {
-      const body = { name: 'My Filter' } as never
-
-      await expect(
-        controller.createVoterFileFilter(undefined, undefined, body),
-      ).rejects.toThrow('Campaign or organization is required')
-    })
-
-    it('creates filter with organization and EO access (no campaign)', async () => {
+    it('creates filter when org has elected office access', async () => {
       const org = { slug: 'eo-org-1' } as Organization
-      const mockEO = {
+      mockElectedOfficeService.findFirst.mockResolvedValue({
         id: 'office-1',
         organizationSlug: 'eo-org-1',
-      }
-      mockElectedOfficeService.findFirst.mockResolvedValue(mockEO)
+      })
       const body = { name: 'My Filter' } as never
 
       const result = await controller.createVoterFileFilter(
@@ -188,115 +139,54 @@ describe('VoterFileController', () => {
       )
       expect(result).toEqual(mockFilter)
     })
+  })
 
-    it('throws with organization but no EO access and no campaign pro', async () => {
-      const org = { slug: 'some-org' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue(null)
-      const body = { name: 'My Filter' } as never
+  describe('listVoterFileFilters', () => {
+    it('lists filters by organization slug', async () => {
+      const result = controller.listVoterFileFilters(baseOrg)
 
-      await expect(
-        controller.createVoterFileFilter(undefined, org, body),
-      ).rejects.toThrow('Campaign is not pro')
+      expect(
+        mockVoterFileFilterService.findByOrganizationSlug,
+      ).toHaveBeenCalledWith(baseOrg.slug)
+      await expect(result).resolves.toEqual([mockFilter])
+    })
+  })
+
+  describe('getVoterFileFilter', () => {
+    it('gets filter by organization slug', async () => {
+      const result = await controller.getVoterFileFilter(1, baseOrg)
+
+      expect(
+        mockVoterFileFilterService.findByIdAndOrganizationSlug,
+      ).toHaveBeenCalledWith(1, baseOrg.slug)
+      expect(result).toEqual(mockFilter)
+    })
+
+    it('throws NotFoundException when filter not found', async () => {
+      mockVoterFileFilterService.findByIdAndOrganizationSlug.mockResolvedValue(
+        null,
+      )
+
+      await expect(controller.getVoterFileFilter(1, baseOrg)).rejects.toThrow(
+        'Voter file filter not found',
+      )
     })
   })
 
   describe('updateVoterFileFilter', () => {
-    it('throws BadRequestException when campaign is not pro and user has no elected office', async () => {
-      mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue(null)
-      const campaign = { ...baseCampaign, isPro: false }
+    it('throws when campaign is not pro and org has no elected office', async () => {
+      mockElectedOfficeService.findFirst.mockResolvedValue(null)
       const body = { name: 'Updated Filter' } as never
 
       await expect(
-        controller.updateVoterFileFilter(1, body, campaign, undefined),
+        controller.updateVoterFileFilter(1, body, baseCampaign, baseOrg),
       ).rejects.toThrow(BadRequestException)
       await expect(
-        controller.updateVoterFileFilter(1, body, campaign, undefined),
+        controller.updateVoterFileFilter(1, body, baseCampaign, baseOrg),
       ).rejects.toThrow('Campaign is not pro')
-
-      expect(
-        mockElectedOfficeService.getCurrentElectedOffice,
-      ).toHaveBeenCalledWith(campaign.userId)
-      expect(
-        mockVoterFileFilterService.updateByIdAndCampaignId,
-      ).not.toHaveBeenCalled()
     })
 
-    it('updates filter when campaign is pro', async () => {
-      mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue(null)
-      const campaign = { ...baseCampaign, isPro: true }
-      const body = { name: 'Updated Filter' } as never
-
-      const result = await controller.updateVoterFileFilter(
-        1,
-        body,
-        campaign,
-        undefined,
-      )
-
-      expect(
-        mockElectedOfficeService.getCurrentElectedOffice,
-      ).toHaveBeenCalledWith(campaign.userId)
-      expect(
-        mockVoterFileFilterService.findByIdAndCampaignId,
-      ).toHaveBeenCalledWith(1, campaign.id)
-      expect(
-        mockVoterFileFilterService.updateByIdAndCampaignId,
-      ).toHaveBeenCalledWith(1, campaign.id, body)
-      expect(result).toEqual(mockFilter)
-    })
-
-    it('updates filter when user has elected office', async () => {
-      mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue({
-        id: 'office-1',
-        userId: 100,
-        isActive: true,
-      })
-      const campaign = { ...baseCampaign, isPro: false }
-      const body = { name: 'Updated Filter' } as never
-
-      const result = await controller.updateVoterFileFilter(
-        1,
-        body,
-        campaign,
-        undefined,
-      )
-
-      expect(
-        mockElectedOfficeService.getCurrentElectedOffice,
-      ).toHaveBeenCalledWith(campaign.userId)
-      expect(
-        mockVoterFileFilterService.updateByIdAndCampaignId,
-      ).toHaveBeenCalledWith(1, campaign.id, body)
-      expect(result).toEqual(mockFilter)
-    })
-
-    it('throws NotFoundException when filter does not exist for campaign', async () => {
-      mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue(null)
-      mockVoterFileFilterService.findByIdAndCampaignId.mockResolvedValue(null)
-      const campaign = { ...baseCampaign, isPro: true }
-      const body = { name: 'Updated Filter' } as never
-
-      await expect(
-        controller.updateVoterFileFilter(1, body, campaign, undefined),
-      ).rejects.toThrow(NotFoundException)
-      await expect(
-        controller.updateVoterFileFilter(1, body, campaign, undefined),
-      ).rejects.toThrow('Voter file filter not found')
-
-      expect(
-        mockVoterFileFilterService.updateByIdAndCampaignId,
-      ).not.toHaveBeenCalled()
-    })
-
-    it('throws when neither campaign nor organization is provided', async () => {
-      const body = { name: 'Updated Filter' } as never
-
-      await expect(
-        controller.updateVoterFileFilter(1, body, undefined, undefined),
-      ).rejects.toThrow('Campaign or organization is required')
-    })
-
-    it('updates filter with organization and EO access (no campaign)', async () => {
+    it('updates filter with organization and EO access', async () => {
       const org = { slug: 'eo-org-1' } as Organization
       mockElectedOfficeService.findFirst.mockResolvedValue({
         id: 'office-1',
@@ -320,174 +210,24 @@ describe('VoterFileController', () => {
       expect(result).toEqual(mockFilter)
     })
 
-    it('throws with organization but no EO access and no campaign pro', async () => {
-      const org = { slug: 'some-org' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue(null)
+    it('throws NotFoundException when filter not found', async () => {
+      const org = { slug: 'eo-org-1' } as Organization
+      mockElectedOfficeService.findFirst.mockResolvedValue({
+        id: 'office-1',
+      })
+      mockVoterFileFilterService.findByIdAndOrganizationSlug.mockResolvedValue(
+        null,
+      )
       const body = { name: 'Updated Filter' } as never
 
       await expect(
         controller.updateVoterFileFilter(1, body, undefined, org),
-      ).rejects.toThrow('Campaign is not pro')
-    })
-  })
-
-  describe('listVoterFileFilters', () => {
-    it('lists filters by campaign when no organization', async () => {
-      const result = controller.listVoterFileFilters(baseCampaign, undefined)
-
-      expect(mockVoterFileFilterService.findByCampaignId).toHaveBeenCalledWith(
-        baseCampaign.id,
-      )
-      await expect(result).resolves.toEqual([mockFilter])
-    })
-
-    it('lists filters by organization when present', async () => {
-      const org = { slug: 'my-org' } as Organization
-
-      const result = controller.listVoterFileFilters(undefined, org)
-
-      expect(
-        mockVoterFileFilterService.findByOrganizationSlug,
-      ).toHaveBeenCalledWith(org.slug)
-      await expect(result).resolves.toEqual([mockFilter])
-    })
-
-    it('prefers organization over campaign', () => {
-      const org = { slug: 'my-org' } as Organization
-
-      controller.listVoterFileFilters(baseCampaign, org)
-
-      expect(
-        mockVoterFileFilterService.findByOrganizationSlug,
-      ).toHaveBeenCalledWith(org.slug)
-      expect(mockVoterFileFilterService.findByCampaignId).not.toHaveBeenCalled()
-    })
-
-    it('throws when neither campaign nor organization is provided', () => {
-      expect(() =>
-        controller.listVoterFileFilters(undefined, undefined),
-      ).toThrow('Campaign or organization is required')
-    })
-  })
-
-  describe('getVoterFileFilter', () => {
-    it('gets filter by campaign when no organization', async () => {
-      const result = await controller.getVoterFileFilter(
-        1,
-        baseCampaign,
-        undefined,
-      )
-
-      expect(
-        mockVoterFileFilterService.findByIdAndCampaignId,
-      ).toHaveBeenCalledWith(1, baseCampaign.id)
-      expect(result).toEqual(mockFilter)
-    })
-
-    it('gets filter by organization when present', async () => {
-      const org = { slug: 'my-org' } as Organization
-
-      const result = await controller.getVoterFileFilter(1, undefined, org)
-
-      expect(
-        mockVoterFileFilterService.findByIdAndOrganizationSlug,
-      ).toHaveBeenCalledWith(1, org.slug)
-      expect(result).toEqual(mockFilter)
-    })
-
-    it('prefers organization over campaign', async () => {
-      const org = { slug: 'my-org' } as Organization
-
-      await controller.getVoterFileFilter(1, baseCampaign, org)
-
-      expect(
-        mockVoterFileFilterService.findByIdAndOrganizationSlug,
-      ).toHaveBeenCalledWith(1, org.slug)
-      expect(
-        mockVoterFileFilterService.findByIdAndCampaignId,
-      ).not.toHaveBeenCalled()
-    })
-
-    it('throws NotFoundException when filter not found', async () => {
-      mockVoterFileFilterService.findByIdAndCampaignId.mockResolvedValue(null)
-
-      await expect(
-        controller.getVoterFileFilter(1, baseCampaign, undefined),
-      ).rejects.toThrow('Voter file filter not found')
-    })
-
-    it('throws NotFoundException when neither campaign nor organization', async () => {
-      await expect(
-        controller.getVoterFileFilter(1, undefined, undefined),
       ).rejects.toThrow('Voter file filter not found')
     })
   })
 
   describe('deleteVoterFileFilter', () => {
-    it('deletes filter by campaign when pro', async () => {
-      const campaign = { ...baseCampaign, isPro: true }
-
-      await controller.deleteVoterFileFilter(1, campaign, undefined)
-
-      expect(
-        mockVoterFileFilterService.deleteByIdAndCampaignId,
-      ).toHaveBeenCalledWith(1, campaign.id)
-    })
-
-    it('deletes filter by campaign when user has elected office', async () => {
-      mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue({
-        id: 'office-1',
-        userId: 100,
-        isActive: true,
-      })
-
-      await controller.deleteVoterFileFilter(1, baseCampaign, undefined)
-
-      expect(
-        mockVoterFileFilterService.deleteByIdAndCampaignId,
-      ).toHaveBeenCalledWith(1, baseCampaign.id)
-    })
-
-    it('throws when campaign is not pro and no elected office', async () => {
-      mockElectedOfficeService.getCurrentElectedOffice.mockResolvedValue(null)
-
-      await expect(
-        controller.deleteVoterFileFilter(1, baseCampaign, undefined),
-      ).rejects.toThrow('Campaign is not pro')
-
-      expect(
-        mockVoterFileFilterService.deleteByIdAndCampaignId,
-      ).not.toHaveBeenCalled()
-    })
-
-    it('deletes filter by organization with EO access', async () => {
-      const org = { slug: 'eo-org-1' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue({
-        id: 'office-1',
-        organizationSlug: 'eo-org-1',
-      })
-
-      await controller.deleteVoterFileFilter(1, undefined, org)
-
-      expect(
-        mockVoterFileFilterService.deleteByIdAndOrganizationSlug,
-      ).toHaveBeenCalledWith(1, org.slug)
-    })
-
-    it('throws with organization but no EO access and no campaign pro', async () => {
-      const org = { slug: 'some-org' } as Organization
-      mockElectedOfficeService.findFirst.mockResolvedValue(null)
-
-      await expect(
-        controller.deleteVoterFileFilter(1, undefined, org),
-      ).rejects.toThrow('Campaign is not pro')
-
-      expect(
-        mockVoterFileFilterService.deleteByIdAndOrganizationSlug,
-      ).not.toHaveBeenCalled()
-    })
-
-    it('prefers organization over campaign', async () => {
+    it('deletes filter with EO access', async () => {
       const org = { slug: 'eo-org-1' } as Organization
       mockElectedOfficeService.findFirst.mockResolvedValue({
         id: 'office-1',
@@ -499,15 +239,30 @@ describe('VoterFileController', () => {
       expect(
         mockVoterFileFilterService.deleteByIdAndOrganizationSlug,
       ).toHaveBeenCalledWith(1, org.slug)
+    })
+
+    it('throws when no EO access and not pro', async () => {
+      const org = { slug: 'some-org' } as Organization
+      mockElectedOfficeService.findFirst.mockResolvedValue(null)
+
+      await expect(
+        controller.deleteVoterFileFilter(1, baseCampaign, org),
+      ).rejects.toThrow('Campaign is not pro')
+
       expect(
-        mockVoterFileFilterService.deleteByIdAndCampaignId,
+        mockVoterFileFilterService.deleteByIdAndOrganizationSlug,
       ).not.toHaveBeenCalled()
     })
 
-    it('throws when neither campaign nor organization is provided', async () => {
-      await expect(
-        controller.deleteVoterFileFilter(1, undefined, undefined),
-      ).rejects.toThrow('Campaign or organization is required')
+    it('deletes when campaign is pro', async () => {
+      const campaign = { ...baseCampaign, isPro: true }
+      mockElectedOfficeService.findFirst.mockResolvedValue(null)
+
+      await controller.deleteVoterFileFilter(1, campaign, baseOrg)
+
+      expect(
+        mockVoterFileFilterService.deleteByIdAndOrganizationSlug,
+      ).toHaveBeenCalledWith(1, baseOrg.slug)
     })
   })
 
@@ -554,22 +309,6 @@ describe('VoterFileController', () => {
           outreachId: 999,
         }),
       ).rejects.toThrow('Outreach not found')
-    })
-
-    it('prevents accessing outreach from a different campaign (scoping)', async () => {
-      mockOutreachService.model.findFirst.mockResolvedValue(null)
-      const differentCampaign = { ...baseCampaign, id: 999 }
-
-      await expect(
-        controller.scheduleOutreachCampaign(mockUser, differentCampaign, {
-          outreachId: 10,
-        }),
-      ).rejects.toThrow(NotFoundException)
-
-      expect(mockOutreachService.model.findFirst).toHaveBeenCalledWith({
-        where: { id: 10, campaignId: 999 },
-        include: { voterFileFilter: true },
-      })
     })
   })
 })

--- a/src/voters/voterFile/voterFile.controller.ts
+++ b/src/voters/voterFile/voterFile.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -150,21 +149,13 @@ export class VoterFileController {
   }
 
   @Post('filter')
-  @UseCampaign({ continueIfNotFound: true })
   @UseOrganization()
   async createVoterFileFilter(
-    @ReqCampaign() campaign: Campaign | undefined,
     @ReqOrganization() organization: Organization,
     @Body() voterFileFilter: CreateVoterFileFilterSchema,
   ) {
-    const electedOffice = await this.electedOfficeService.findFirst({
-      where: { organizationSlug: organization.slug },
-    })
-    if (!(campaign?.isPro ?? false) && !electedOffice) {
-      throw new BadRequestException('Campaign is not pro')
-    }
+    await this.voterFileFilterService.filterAccessCheck(organization.slug)
     return this.voterFileFilterService.create(
-      campaign?.id,
       organization.slug,
       voterFileFilter,
     )
@@ -194,20 +185,13 @@ export class VoterFileController {
   }
 
   @Put('filter/:id')
-  @UseCampaign({ continueIfNotFound: true })
   @UseOrganization()
   async updateVoterFileFilter(
     @Param('id', ParseIntPipe) id: number,
     @Body() body: UpdateVoterFileFilterSchema,
-    @ReqCampaign() campaign: Campaign | undefined,
     @ReqOrganization() organization: Organization,
   ) {
-    const electedOffice = await this.electedOfficeService.findFirst({
-      where: { organizationSlug: organization.slug },
-    })
-    if (!(campaign?.isPro ?? false) && !electedOffice) {
-      throw new BadRequestException('Campaign is not pro')
-    }
+    await this.voterFileFilterService.filterAccessCheck(organization.slug)
     const filter =
       await this.voterFileFilterService.findByIdAndOrganizationSlug(
         id,
@@ -224,20 +208,13 @@ export class VoterFileController {
   }
 
   @Delete('filter/:id')
-  @UseCampaign({ continueIfNotFound: true })
   @UseOrganization()
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteVoterFileFilter(
     @Param('id', ParseIntPipe) id: number,
-    @ReqCampaign() campaign: Campaign | undefined,
     @ReqOrganization() organization: Organization,
   ) {
-    const electedOffice = await this.electedOfficeService.findFirst({
-      where: { organizationSlug: organization.slug },
-    })
-    if (!(campaign?.isPro ?? false) && !electedOffice) {
-      throw new BadRequestException('Campaign is not pro')
-    }
+    await this.voterFileFilterService.filterAccessCheck(organization.slug)
     await this.voterFileFilterService.deleteByIdAndOrganizationSlug(
       id,
       organization.slug,

--- a/src/voters/voterFile/voterFile.controller.ts
+++ b/src/voters/voterFile/voterFile.controller.ts
@@ -16,13 +16,7 @@ import {
   UseGuards,
   UsePipes,
 } from '@nestjs/common'
-import {
-  Campaign,
-  Organization,
-  User,
-  UserRole,
-  VoterFileFilter,
-} from '@prisma/client'
+import { Campaign, Organization, User, UserRole } from '@prisma/client'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { ReqUser } from 'src/authentication/decorators/ReqUser.decorator'
 import { CampaignWith } from 'src/campaigns/campaigns.types'
@@ -157,87 +151,42 @@ export class VoterFileController {
 
   @Post('filter')
   @UseCampaign({ continueIfNotFound: true })
-  @UseOrganization({ continueIfNotFound: true })
+  @UseOrganization()
   async createVoterFileFilter(
     @ReqCampaign() campaign: Campaign | undefined,
-    @ReqOrganization() organization: Organization | undefined,
+    @ReqOrganization() organization: Organization,
     @Body() voterFileFilter: CreateVoterFileFilterSchema,
   ) {
-    if (organization) {
-      const electedOffice = await this.electedOfficeService.findFirst({
-        where: { organizationSlug: organization.slug },
-      })
-      if (!(campaign?.isPro ?? false) && !electedOffice) {
-        throw new BadRequestException('Campaign is not pro')
-      }
-      return this.voterFileFilterService.create(
-        campaign?.id,
-        organization.slug,
-        voterFileFilter,
-      )
-    }
-
-    if (!campaign) {
-      throw new BadRequestException('Campaign or organization is required')
-    }
-
-    const electedOffice =
-      await this.electedOfficeService.getCurrentElectedOffice(campaign.userId)
-    if (!campaign.isPro && !electedOffice) {
+    const electedOffice = await this.electedOfficeService.findFirst({
+      where: { organizationSlug: organization.slug },
+    })
+    if (!(campaign?.isPro ?? false) && !electedOffice) {
       throw new BadRequestException('Campaign is not pro')
     }
-    const campaignFilter = await this.voterFileFilterService.create(
-      campaign.id,
-      campaign.organizationSlug,
+    return this.voterFileFilterService.create(
+      campaign?.id,
+      organization.slug,
       voterFileFilter,
     )
-    if (electedOffice) {
-      await this.voterFileFilterService.create(
-        campaign.id,
-        electedOffice.organizationSlug,
-        voterFileFilter,
-      )
-    }
-    return campaignFilter
   }
 
   @Get('filters')
-  @UseCampaign({ continueIfNotFound: true })
-  @UseOrganization({ continueIfNotFound: true })
-  listVoterFileFilters(
-    @ReqCampaign() campaign: Campaign | undefined,
-    @ReqOrganization() organization: Organization | undefined,
-  ) {
-    if (organization) {
-      return this.voterFileFilterService.findByOrganizationSlug(
-        organization.slug,
-      )
-    }
-    if (!campaign) {
-      throw new BadRequestException('Campaign or organization is required')
-    }
-    return this.voterFileFilterService.findByCampaignId(campaign.id)
+  @UseOrganization()
+  listVoterFileFilters(@ReqOrganization() organization: Organization) {
+    return this.voterFileFilterService.findByOrganizationSlug(organization.slug)
   }
 
   @Get('filter/:id')
-  @UseCampaign({ continueIfNotFound: true })
-  @UseOrganization({ continueIfNotFound: true })
+  @UseOrganization()
   async getVoterFileFilter(
     @Param('id', ParseIntPipe) id: number,
-    @ReqCampaign() campaign: Campaign | undefined,
-    @ReqOrganization() organization: Organization | undefined,
+    @ReqOrganization() organization: Organization,
   ) {
-    const filter: VoterFileFilter | null = organization
-      ? await this.voterFileFilterService.findByIdAndOrganizationSlug(
-          id,
-          organization.slug,
-        )
-      : campaign
-        ? await this.voterFileFilterService.findByIdAndCampaignId(
-            id,
-            campaign.id,
-          )
-        : null
+    const filter =
+      await this.voterFileFilterService.findByIdAndOrganizationSlug(
+        id,
+        organization.slug,
+      )
     if (!filter) {
       throw new NotFoundException('Voter file filter not found')
     }
@@ -246,88 +195,52 @@ export class VoterFileController {
 
   @Put('filter/:id')
   @UseCampaign({ continueIfNotFound: true })
-  @UseOrganization({ continueIfNotFound: true })
+  @UseOrganization()
   async updateVoterFileFilter(
     @Param('id', ParseIntPipe) id: number,
     @Body() body: UpdateVoterFileFilterSchema,
     @ReqCampaign() campaign: Campaign | undefined,
-    @ReqOrganization() organization: Organization | undefined,
+    @ReqOrganization() organization: Organization,
   ) {
-    if (organization) {
-      const electedOffice = await this.electedOfficeService.findFirst({
-        where: { organizationSlug: organization.slug },
-      })
-      if (!(campaign?.isPro ?? false) && !electedOffice) {
-        throw new BadRequestException('Campaign is not pro')
-      }
-      const filter =
-        await this.voterFileFilterService.findByIdAndOrganizationSlug(
-          id,
-          organization.slug,
-        )
-      if (!filter) {
-        throw new NotFoundException('Voter file filter not found')
-      }
-      return this.voterFileFilterService.updateByIdAndOrganizationSlug(
-        id,
-        organization.slug,
-        body,
-      )
-    }
-
-    if (!campaign) {
-      throw new BadRequestException('Campaign or organization is required')
-    }
-
-    const electedOffice =
-      await this.electedOfficeService.getCurrentElectedOffice(campaign.userId)
-    if (!campaign.isPro && !electedOffice) {
+    const electedOffice = await this.electedOfficeService.findFirst({
+      where: { organizationSlug: organization.slug },
+    })
+    if (!(campaign?.isPro ?? false) && !electedOffice) {
       throw new BadRequestException('Campaign is not pro')
     }
-    const filter: VoterFileFilter | null =
-      await this.voterFileFilterService.findByIdAndCampaignId(id, campaign.id)
+    const filter =
+      await this.voterFileFilterService.findByIdAndOrganizationSlug(
+        id,
+        organization.slug,
+      )
     if (!filter) {
       throw new NotFoundException('Voter file filter not found')
     }
-    return this.voterFileFilterService.updateByIdAndCampaignId(
+    return this.voterFileFilterService.updateByIdAndOrganizationSlug(
       id,
-      campaign.id,
+      organization.slug,
       body,
     )
   }
 
   @Delete('filter/:id')
   @UseCampaign({ continueIfNotFound: true })
-  @UseOrganization({ continueIfNotFound: true })
+  @UseOrganization()
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteVoterFileFilter(
     @Param('id', ParseIntPipe) id: number,
     @ReqCampaign() campaign: Campaign | undefined,
-    @ReqOrganization() organization: Organization | undefined,
+    @ReqOrganization() organization: Organization,
   ) {
-    if (organization) {
-      const electedOffice = await this.electedOfficeService.findFirst({
-        where: { organizationSlug: organization.slug },
-      })
-      if (!(campaign?.isPro ?? false) && !electedOffice) {
-        throw new BadRequestException('Campaign is not pro')
-      }
-      await this.voterFileFilterService.deleteByIdAndOrganizationSlug(
-        id,
-        organization.slug,
-      )
-      return
-    }
-
-    if (!campaign) {
-      throw new BadRequestException('Campaign or organization is required')
-    }
-
-    const electedOffice =
-      await this.electedOfficeService.getCurrentElectedOffice(campaign.userId)
-    if (!campaign.isPro && !electedOffice) {
+    const electedOffice = await this.electedOfficeService.findFirst({
+      where: { organizationSlug: organization.slug },
+    })
+    if (!(campaign?.isPro ?? false) && !electedOffice) {
       throw new BadRequestException('Campaign is not pro')
     }
-    await this.voterFileFilterService.deleteByIdAndCampaignId(id, campaign.id)
+    await this.voterFileFilterService.deleteByIdAndOrganizationSlug(
+      id,
+      organization.slug,
+    )
   }
 }

--- a/src/voters/voterFile/voterFile.controller.ts
+++ b/src/voters/voterFile/voterFile.controller.ts
@@ -22,7 +22,6 @@ import { CampaignWith } from 'src/campaigns/campaigns.types'
 import { ReqCampaign } from 'src/campaigns/decorators/ReqCampaign.decorator'
 import { UseCampaign } from 'src/campaigns/decorators/UseCampaign.decorator'
 import { CampaignsService } from 'src/campaigns/services/campaigns.service'
-import { ElectedOfficeService } from 'src/electedOffice/services/electedOffice.service'
 import { ReqOrganization } from 'src/organizations/decorators/ReqOrganization.decorator'
 import { UseOrganization } from 'src/organizations/decorators/UseOrganization.decorator'
 import { OrganizationsService } from 'src/organizations/services/organizations.service'
@@ -50,7 +49,6 @@ export class VoterFileController {
     private readonly campaigns: CampaignsService,
     private readonly voterFileFilterService: VoterFileFilterService,
     private readonly outreachService: OutreachService,
-    private readonly electedOfficeService: ElectedOfficeService,
     private readonly organizationsService: OrganizationsService,
     private readonly logger: PinoLogger,
   ) {

--- a/src/voters/voterFile/voterFile.types.ts
+++ b/src/voters/voterFile/voterFile.types.ts
@@ -8,7 +8,7 @@ export enum VoterFileType {
   directMail = 'directMail',
   telemarketing = 'telemarketing',
   custom = 'custom',
-  robocall = CampaignTaskType.robocall,
+  robocall = 'robocall',
 }
 
 // TODO: these should be cleaned up to only be what is currently used
@@ -57,6 +57,7 @@ export const TASK_TO_TYPE_MAP: {
   [CampaignTaskType.education]: VoterFileType.full,
   [CampaignTaskType.compliance]: VoterFileType.full,
   [CampaignTaskType.awareness]: VoterFileType.full,
+  [CampaignTaskType.recurring]: VoterFileType.full,
 }
 
 // TODO: store this in DB table? (currently in campaign.data)

--- a/src/websites/tests/website-contacts.e2e.ts
+++ b/src/websites/tests/website-contacts.e2e.ts
@@ -5,6 +5,8 @@ import {
   generateRandomEmail,
   generateRandomName,
   generateRandomPassword,
+  authHeaders,
+  campaignOrgSlug,
 } from '../../../e2e-tests/utils/auth.util'
 import { faker } from '@faker-js/faker'
 import { WebsiteContact } from '@prisma/client'
@@ -41,19 +43,16 @@ test.describe('Websites - Contacts', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const vanityPath = `contact-path-${Date.now()}`
 
     await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         vanityPath,
         status: 'published',
@@ -105,19 +104,16 @@ test.describe('Websites - Contacts', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const vanityPath = `unpublished-contact-${Date.now()}`
 
     await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         vanityPath,
         status: 'unpublished',
@@ -158,19 +154,16 @@ test.describe('Websites - Contacts', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const vanityPath = `get-contacts-${Date.now()}`
 
     await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         vanityPath,
         status: 'published',
@@ -188,9 +181,7 @@ test.describe('Websites - Contacts', () => {
     })
 
     const response = await request.get('/v1/websites/mine/contacts', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     expect(response.status()).toBe(200)
@@ -228,19 +219,16 @@ test.describe('Websites - Contacts', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const vanityPath = `pagination-contacts-${Date.now()}`
 
     await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         vanityPath,
         status: 'published',
@@ -262,9 +250,7 @@ test.describe('Websites - Contacts', () => {
     const response = await request.get(
       '/v1/websites/mine/contacts?limit=2&page=1',
       {
-        headers: {
-          Authorization: `Bearer ${authToken}`,
-        },
+        headers: authHeaders(authToken, orgSlug),
       },
     )
 

--- a/src/websites/tests/website-crud.e2e.ts
+++ b/src/websites/tests/website-crud.e2e.ts
@@ -5,6 +5,8 @@ import {
   generateRandomEmail,
   generateRandomName,
   generateRandomPassword,
+  authHeaders,
+  campaignOrgSlug,
 } from '../../../e2e-tests/utils/auth.util'
 import { Prisma } from '@prisma/client'
 
@@ -44,11 +46,10 @@ test.describe('Websites - CRUD Operations', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     const response = await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     expect(response.status()).toBe(201)
@@ -76,17 +77,14 @@ test.describe('Websites - CRUD Operations', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const response = await request.get('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     expect(response.status()).toBe(200)
@@ -116,11 +114,10 @@ test.describe('Websites - CRUD Operations', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const mainTitle = 'Test Campaign Title'
@@ -130,9 +127,7 @@ test.describe('Websites - CRUD Operations', () => {
     const vanityPath = `test-path-${Date.now()}`
 
     const updateResponse = await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         'main[title]': mainTitle,
         'about[issues][0][title]': issueTitle,
@@ -185,17 +180,14 @@ test.describe('Websites - CRUD Operations', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         'main[title]': 'Original Title',
         'main[tagline]': 'Original Tagline',
@@ -203,9 +195,7 @@ test.describe('Websites - CRUD Operations', () => {
     })
 
     const updateResponse = await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         'main[title]': 'Updated Title',
       },

--- a/src/websites/tests/website-vanity-path.e2e.ts
+++ b/src/websites/tests/website-vanity-path.e2e.ts
@@ -5,6 +5,8 @@ import {
   generateRandomEmail,
   generateRandomName,
   generateRandomPassword,
+  authHeaders,
+  campaignOrgSlug,
 } from '../../../e2e-tests/utils/auth.util'
 import { Prisma } from '@prisma/client'
 
@@ -54,19 +56,16 @@ test.describe('Websites - Vanity Path', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const vanityPath = `unique-path-${Date.now()}`
 
     const response = await request.post('/v1/websites/validate-vanity-path', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       data: {
         vanityPath,
       },
@@ -95,18 +94,16 @@ test.describe('Websites - Vanity Path', () => {
       signUpMode: 'candidate',
     })
 
+    const orgSlug1 = campaignOrgSlug(registerResponse1.campaign.id)
+
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${registerResponse1.token}`,
-      },
+      headers: authHeaders(registerResponse1.token, orgSlug1),
     })
 
     const vanityPath = `shared-path-${Date.now()}`
 
     await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${registerResponse1.token}`,
-      },
+      headers: authHeaders(registerResponse1.token, orgSlug1),
       multipart: {
         vanityPath,
       },
@@ -124,17 +121,14 @@ test.describe('Websites - Vanity Path', () => {
 
     testUserId = registerResponse2.user.id
     authToken = registerResponse2.token
+    const orgSlug2 = campaignOrgSlug(registerResponse2.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug2),
     })
 
     const response = await request.post('/v1/websites/validate-vanity-path', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug2),
       data: {
         vanityPath,
       },
@@ -170,19 +164,16 @@ test.describe('Websites - Vanity Path', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const vanityPath = `view-path-${Date.now()}`
 
     await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         vanityPath,
         status: 'published',
@@ -221,19 +212,16 @@ test.describe('Websites - Vanity Path', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const vanityPath = `unpublished-path-${Date.now()}`
 
     await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         vanityPath,
         status: 'unpublished',

--- a/src/websites/tests/website-views.e2e.ts
+++ b/src/websites/tests/website-views.e2e.ts
@@ -5,6 +5,8 @@ import {
   generateRandomEmail,
   generateRandomName,
   generateRandomPassword,
+  authHeaders,
+  campaignOrgSlug,
 } from '../../../e2e-tests/utils/auth.util'
 import { faker } from '@faker-js/faker'
 import { WebsiteView } from '@prisma/client'
@@ -39,19 +41,16 @@ test.describe('Websites - Views', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const vanityPath = `track-view-${Date.now()}`
 
     await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         vanityPath,
         status: 'published',
@@ -96,19 +95,16 @@ test.describe('Websites - Views', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const vanityPath = `multi-views-${Date.now()}`
 
     await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         vanityPath,
         status: 'published',
@@ -134,9 +130,7 @@ test.describe('Websites - Views', () => {
     }
 
     const viewsResponse = await request.get('/v1/websites/mine/views', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     expect(viewsResponse.status()).toBe(200)
@@ -163,19 +157,16 @@ test.describe('Websites - Views', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const vanityPath = `date-range-views-${Date.now()}`
 
     await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         vanityPath,
         status: 'published',
@@ -196,9 +187,7 @@ test.describe('Websites - Views', () => {
     const response = await request.get(
       `/v1/websites/mine/views?startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}`,
       {
-        headers: {
-          Authorization: `Bearer ${authToken}`,
-        },
+        headers: authHeaders(authToken, orgSlug),
       },
     )
 
@@ -234,19 +223,16 @@ test.describe('Websites - Views', () => {
 
     testUserId = registerResponse.user.id
     authToken = registerResponse.token
+    const orgSlug = campaignOrgSlug(registerResponse.campaign.id)
 
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const vanityPath = `empty-views-${Date.now()}`
 
     await request.put('/v1/websites/mine', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       multipart: {
         vanityPath,
         status: 'published',
@@ -261,9 +247,7 @@ test.describe('Websites - Views', () => {
     const response = await request.get(
       `/v1/websites/mine/views?startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}`,
       {
-        headers: {
-          Authorization: `Bearer ${authToken}`,
-        },
+        headers: authHeaders(authToken, orgSlug),
       },
     )
 

--- a/src/websites/tests/websites.e2e.ts
+++ b/src/websites/tests/websites.e2e.ts
@@ -5,11 +5,14 @@ import {
   deleteUser,
   generateRandomEmail,
   generateRandomName,
+  authHeaders,
+  campaignOrgSlug,
 } from '../../../e2e-tests/utils/auth.util'
 import { faker } from '@faker-js/faker'
 
 test.describe('Candidate Website', () => {
   let authToken: string
+  let orgSlug: string
   let testUserId: number
   let testAuthToken: string
 
@@ -25,6 +28,7 @@ test.describe('Candidate Website', () => {
     })
 
     authToken = registerResponse.token
+    orgSlug = campaignOrgSlug(registerResponse.campaign.id)
     testUserId = registerResponse.user.id
     testAuthToken = registerResponse.token
   })
@@ -37,9 +41,7 @@ test.describe('Candidate Website', () => {
 
   test('should create a website', async ({ request }) => {
     const response = await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     expect(response.status()).toBe(HttpStatus.CREATED)
@@ -54,14 +56,12 @@ test.describe('Candidate Website', () => {
 
   test('should update website content', async ({ request }) => {
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const updateResponse = await request.put('/v1/websites/mine', {
       headers: {
-        Authorization: `Bearer ${authToken}`,
+        ...authHeaders(authToken, orgSlug),
         'Content-Type': 'application/json',
       },
       data: {
@@ -77,17 +77,13 @@ test.describe('Candidate Website', () => {
 
   test('should validate vanity path', async ({ request }) => {
     await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const vanityPath = `test-${Date.now()}`
 
     const response = await request.post('/v1/websites/validate-vanity-path', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
       data: {
         vanityPath,
       },
@@ -101,16 +97,14 @@ test.describe('Candidate Website', () => {
 
   test('should get website by vanity path', async ({ request }) => {
     const createResponse = await request.post('/v1/websites', {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
+      headers: authHeaders(authToken, orgSlug),
     })
 
     const website = (await createResponse.json()) as { vanityPath: string }
 
     await request.put('/v1/websites/mine', {
       headers: {
-        Authorization: `Bearer ${authToken}`,
+        ...authHeaders(authToken, orgSlug),
         'Content-Type': 'application/json',
       },
       data: {


### PR DESCRIPTION
This PR releases gp-api to QA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to stricter request context requirements (now requiring `x-organization-slug`) and data-model changes (Prisma enum + relation removals) that can break existing clients/tests if headers or migrations aren’t applied correctly.
> 
> **Overview**
> **Organization header is now required** for campaign and elected-office context: `UseCampaignGuard`/`UseElectedOfficeGuard` drop the userId fallback, and controllers like `ContactsController` and `PollsController` now require `@UseOrganization()` with org-only service calls.
> 
> **Contacts and segments fully migrate to org-based resolution**: `ContactsService` no longer accepts campaign-based district/state fallbacks or admin-approved statewide logic; district resolution now depends solely on `Organization.overrideDistrictId` or `Organization.positionId`, and pro/search access is determined by the org’s linked campaign `isPro` (or `eo-*` orgs).
> 
> **Recurring default campaign tasks added**: introduces `CampaignTaskType.recurring`, new recurring task templates, and generation logic that expands templates into dated tasks between today and the election date (with updated tests and deterministic `today` injection).
> 
> **Legacy campaign detail fields removed/ignored**: campaign create/update no longer falls back to `details.positionId/office/otherOffice`, analytics no longer identifies `officeName`, and Prisma JSON types/schemas drop those fields; organization patching now supports explicitly clearing `ballotReadyPositionId` via `null`.
> 
> **Data model cleanup**: removes `VoterFileFilter`’s campaign relationship and adds `VoterFileFilterService.filterAccessCheck` for pro-gating campaign orgs; also updates P2V/manual counts to use `pathToVictory.data.source` and removes unused `RaceTargetDetailsResult` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6770e916852cd1cf2ecfc4e16ead6ca5747650b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->