### PR TITLE
ENG-7260

### DIFF
--- a/prisma/schema/migrations/20260413000000_clear_campaign_plan_and_tasks/migration.sql
+++ b/prisma/schema/migrations/20260413000000_clear_campaign_plan_and_tasks/migration.sql
@@ -1,4 +1,4 @@
 -- Clear all campaign tasks and campaign plans for a clean slate.
 -- Campaign tasks will be regenerated when users visit their dashboard.
-TRUNCATE TABLE "campaign_task" CASCADE;
-TRUNCATE TABLE "campaign_plan" CASCADE;
+TRUNCATE TABLE "campaign_task";
+TRUNCATE TABLE "campaign_plan";

--- a/prisma/schema/migrations/20260413000000_clear_campaign_plan_and_tasks/migration.sql
+++ b/prisma/schema/migrations/20260413000000_clear_campaign_plan_and_tasks/migration.sql
@@ -1,0 +1,4 @@
+-- Clear all campaign tasks and campaign plans for a clean slate.
+-- Campaign tasks will be regenerated when users visit their dashboard.
+TRUNCATE TABLE "campaign_task" CASCADE;
+TRUNCATE TABLE "campaign_plan" CASCADE;


### PR DESCRIPTION
Clear out existing campaignplan and campaigntask data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces a destructive migration that irreversibly deletes all `campaign_task` and `campaign_plan` rows (and dependent rows via `CASCADE`) when applied.
> 
> **Overview**
> Adds a new Prisma migration that **truncates** `campaign_task` and `campaign_plan` using `TRUNCATE ... CASCADE`, effectively wiping all existing campaign tasks/plans so they can be regenerated later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918d00e18cf11cac4613019337c4bcffdc1db480. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->