### PR TITLE
ENG-7199 Create custom schedule for each p2p job.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,6 @@ WINNERS_ELECTION_YEAR='2024'
 PEERLY_MD5_EMAIL=MD5(email@domain.io)
 PEERLY_MD5_PASSWORD=MD5(password)
 PEERLY_ACCOUNT_NUMBER=12345678
-PEERLY_SCHEDULE_ID=1058113 # Default schedule ID for P2P jobs in Peerly DEV account, change for Peerly PROD account
 PEERLY_API_BASE_URL=https://app.peerly.com/api
 PEERLY_HTTP_TIMEOUT=10000 # 10 seconds
 EXPLICITLY_LOG_PEERLY_TOKEN=false # Set to true to log Peerly token in the logs (useful for debugging, but sensitive information)

--- a/.env.test
+++ b/.env.test
@@ -71,7 +71,6 @@ WINNERS_ELECTION_YEAR='2024'
 PEERLY_MD5_EMAIL=dummy-value
 PEERLY_MD5_PASSWORD=dummy-value
 PEERLY_ACCOUNT_NUMBER=12345678
-PEERLY_SCHEDULE_ID=1058113 # Default schedule ID for P2P jobs in Peerly DEV account, change for Peerly PROD account
 PEERLY_API_BASE_URL=https://app.peerly.com/api
 PEERLY_HTTP_TIMEOUT=10000 # 10 seconds
 EXPLICITLY_LOG_PEERLY_TOKEN=false # Set to true to log Peerly token in the logs (useful for debugging, but sensitive information)

--- a/src/vendors/peerly/config/peerlyBaseConfig.ts
+++ b/src/vendors/peerly/config/peerlyBaseConfig.ts
@@ -8,7 +8,6 @@ const {
   PEERLY_HTTP_TIMEOUT = '60000', // 60 seconds default
   PEERLY_UPLOAD_TIMEOUT_MS = '60000', // 60 seconds for uploads
   PEERLY_TEST_ENVIRONMENT,
-  PEERLY_SCHEDULE_ID, // Default schedule ID for P2P jobs
 } = process.env
 
 if (!PEERLY_API_BASE_URL) {
@@ -23,9 +22,6 @@ if (!PEERLY_ACCOUNT_NUMBER) {
   throw new Error('Missing PEERLY_ACCOUNT_NUMBER config')
 }
 
-if (!PEERLY_SCHEDULE_ID) {
-  throw new Error('Missing PEERLY_SCHEDULE_ID config')
-}
 export class PeerlyBaseConfig {
   readonly baseUrl = PEERLY_API_BASE_URL
   readonly email = PEERLY_MD5_EMAIL
@@ -34,7 +30,6 @@ export class PeerlyBaseConfig {
   readonly httpTimeoutMs = parseInt(PEERLY_HTTP_TIMEOUT!, 10)
   readonly uploadTimeoutMs = parseInt(PEERLY_UPLOAD_TIMEOUT_MS!, 10)
   readonly isTestEnvironment = Boolean(PEERLY_TEST_ENVIRONMENT === 'true')
-  readonly scheduleId = parseInt(PEERLY_SCHEDULE_ID!, 10)
 
   constructor(protected readonly logger: PinoLogger) {
     this.logger.setContext(this.constructor.name)

--- a/src/vendors/peerly/constants/p2pJob.constants.ts
+++ b/src/vendors/peerly/constants/p2pJob.constants.ts
@@ -23,5 +23,12 @@ export const P2P_PHONE_LIST_MAP = {
   zip: 6,
 } as const
 
+export const P2P_SCHEDULE_DEFAULTS = {
+  START_TIME: '09:00:00',
+  END_TIME: '21:00:00',
+  TIMEZONE: 'LOCAL',
+  IS_GLOBAL: 1,
+} as const
+
 export const P2P_DNC_SCRUBBING = 0
 export const P2P_DNC_SUPPRESS_INITIALS = 'GE' // GoodParty Engineering Peerly user

--- a/src/vendors/peerly/peerly.module.ts
+++ b/src/vendors/peerly/peerly.module.ts
@@ -17,6 +17,7 @@ import { PeerlyIdentityService } from './services/peerlyIdentity.service'
 import { PeerlyMediaService } from './services/peerlyMedia.service'
 import { PeerlyP2pJobService } from './services/peerlyP2pJob.service'
 import { PeerlyPhoneListService } from './services/peerlyPhoneList.service'
+import { PeerlyScheduleService } from './services/peerlySchedule.service'
 
 @Module({
   imports: [
@@ -38,6 +39,7 @@ import { PeerlyPhoneListService } from './services/peerlyPhoneList.service'
     PeerlyIdentityService,
     PeerlyPhoneListService,
     PeerlyMediaService,
+    PeerlyScheduleService,
     P2pPhoneListUploadService,
     PeerlyP2pJobService,
   ],

--- a/src/vendors/peerly/peerly.types.ts
+++ b/src/vendors/peerly/peerly.types.ts
@@ -412,6 +412,7 @@ export interface CreateJobParams {
   didNpaSubset?: string[]
   identityId?: string
   scheduledDate?: string
+  scheduleId: number
 }
 
 export type PeerlyRecoveryInfo = Record<string, string | number | undefined>

--- a/src/vendors/peerly/schemas/peerlySchedule.schema.ts
+++ b/src/vendors/peerly/schemas/peerlySchedule.schema.ts
@@ -1,0 +1,14 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+const createScheduleResponseSchema = z.object({
+  Data: z.object({
+    schedule_id: z.number(),
+    schedule_name: z.string(),
+    account: z.string(),
+  }),
+})
+
+export class CreateScheduleResponseDto extends createZodDto(
+  createScheduleResponseSchema,
+) {}

--- a/src/vendors/peerly/services/peerlyP2pJob.service.test.ts
+++ b/src/vendors/peerly/services/peerlyP2pJob.service.test.ts
@@ -6,12 +6,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { P2P_JOB_DEFAULTS } from '../constants/p2pJob.constants'
 import { PeerlyMediaService } from './peerlyMedia.service'
 import { PeerlyP2pJobService } from './peerlyP2pJob.service'
+import { PeerlyScheduleService } from './peerlySchedule.service'
 import { PeerlyErrorHandlingService } from './peerlyErrorHandling.service'
 import { PeerlyHttpService } from './peerlyHttp.service'
 
 describe('PeerlyP2pJobService', () => {
   let service: PeerlyP2pJobService
   let mockMediaService: { createMedia: ReturnType<typeof vi.fn> }
+  let mockScheduleService: { createSchedule: ReturnType<typeof vi.fn> }
   let mockHttpService: {
     post: ReturnType<typeof vi.fn>
     get: ReturnType<typeof vi.fn>
@@ -38,6 +40,9 @@ describe('PeerlyP2pJobService', () => {
   beforeEach(async () => {
     mockMediaService = {
       createMedia: vi.fn().mockResolvedValue('media-456'),
+    }
+    mockScheduleService = {
+      createSchedule: vi.fn().mockResolvedValue(99999),
     }
     mockHttpService = {
       post: vi.fn(),
@@ -69,6 +74,7 @@ describe('PeerlyP2pJobService', () => {
         PeerlyP2pJobService,
         { provide: PinoLogger, useValue: createMockLogger() },
         { provide: PeerlyMediaService, useValue: mockMediaService },
+        { provide: PeerlyScheduleService, useValue: mockScheduleService },
         { provide: PeerlyHttpService, useValue: mockHttpService },
         {
           provide: PeerlyErrorHandlingService,
@@ -129,11 +135,15 @@ describe('PeerlyP2pJobService', () => {
       expect(jobPostCall![1]).not.toHaveProperty('did_npa_subset')
     })
 
-    it('calls media, createJob, assignList in order', async () => {
+    it('calls media, createSchedule, createJob, assignList in order', async () => {
       const callOrder: string[] = []
       mockMediaService.createMedia.mockImplementation(async () => {
         callOrder.push('createMedia')
         return 'media-456'
+      })
+      mockScheduleService.createSchedule.mockImplementation(async () => {
+        callOrder.push('createSchedule')
+        return 99999
       })
       mockHttpService.post.mockImplementation(async (path: string) => {
         if (
@@ -148,10 +158,6 @@ describe('PeerlyP2pJobService', () => {
           callOrder.push('assignListToJob')
           return { data: {} }
         }
-        if (path.includes('request_canvassers')) {
-          callOrder.push('requestCanvassers')
-          return { data: {} }
-        }
         return { data: {} }
       })
 
@@ -161,7 +167,41 @@ describe('PeerlyP2pJobService', () => {
         didNpaSubset: ['212'],
       })
 
-      expect(callOrder).toEqual(['createMedia', 'createJob', 'assignListToJob'])
+      expect(callOrder).toEqual([
+        'createMedia',
+        'createSchedule',
+        'createJob',
+        'assignListToJob',
+      ])
+    })
+
+    it('uses dynamic schedule_id from createSchedule in job creation', async () => {
+      mockScheduleService.createSchedule.mockResolvedValue(77777)
+
+      await service.createPeerlyP2pJob(baseJobParams)
+
+      const jobPostCall = mockHttpService.post.mock.calls.find(
+        (c) => c[0] === '/1to1/jobs',
+      )
+      expect(jobPostCall).toBeDefined()
+      expect(jobPostCall![1]).toEqual(
+        expect.objectContaining({ schedule_id: 77777 }),
+      )
+    })
+
+    it('fails job creation when createSchedule rejects', async () => {
+      mockScheduleService.createSchedule.mockRejectedValue(
+        new BadGatewayException('Schedule API down'),
+      )
+
+      await expect(service.createPeerlyP2pJob(baseJobParams)).rejects.toThrow(
+        BadGatewayException,
+      )
+
+      expect(mockMediaService.createMedia).toHaveBeenCalled()
+      expect(
+        mockHttpService.post.mock.calls.some((c) => c[0] === '/1to1/jobs'),
+      ).toBe(false)
     })
 
     it('passes media ID from createMedia to createJob templates', async () => {

--- a/src/vendors/peerly/services/peerlyP2pJob.service.ts
+++ b/src/vendors/peerly/services/peerlyP2pJob.service.ts
@@ -1,4 +1,5 @@
 import { BadGatewayException, Injectable } from '@nestjs/common'
+import { formatISO } from 'date-fns'
 import { Headers } from 'http-constants-ts'
 import { Readable } from 'stream'
 import { PinoLogger } from 'nestjs-pino'
@@ -74,7 +75,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
       const dateOnly = scheduledDate?.slice(0, 10)
 
       const targetDate = dateOnly || 'no-date'
-      const createdAt = new Date().toISOString()
+      const createdAt = formatISO(new Date())
       const scheduleName = `GP P2P - Campaign ${campaignId} - ${targetDate} - ${createdAt}`
       scheduleId =
         await this.peerlyScheduleService.createSchedule(scheduleName)

--- a/src/vendors/peerly/services/peerlyP2pJob.service.ts
+++ b/src/vendors/peerly/services/peerlyP2pJob.service.ts
@@ -77,8 +77,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
       const targetDate = dateOnly || 'no-date'
       const createdAt = formatISO(new Date())
       const scheduleName = `GP P2P - Campaign ${campaignId} - ${targetDate} - ${createdAt}`
-      scheduleId =
-        await this.peerlyScheduleService.createSchedule(scheduleName)
+      scheduleId = await this.peerlyScheduleService.createSchedule(scheduleName)
 
       this.logger.info('Creating P2P job')
       jobId = await this.createJob({

--- a/src/vendors/peerly/services/peerlyP2pJob.service.ts
+++ b/src/vendors/peerly/services/peerlyP2pJob.service.ts
@@ -10,6 +10,7 @@ import { PeerlyBaseConfig } from '../config/peerlyBaseConfig'
 import { PeerlyErrorHandlingService } from './peerlyErrorHandling.service'
 import { PeerlyHttpService } from './peerlyHttp.service'
 import { PeerlyMediaService } from './peerlyMedia.service'
+import { PeerlyScheduleService } from './peerlySchedule.service'
 import { CreateJobResponseDto } from '../schemas/peerlyP2pSms.schema'
 import { CreateJobParams, PeerlyJob } from '../peerly.types'
 
@@ -36,6 +37,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
   constructor(
     protected readonly logger: PinoLogger,
     private readonly peerlyMediaService: PeerlyMediaService,
+    private readonly peerlyScheduleService: PeerlyScheduleService,
     private readonly peerlyHttpService: PeerlyHttpService,
     private readonly peerlyErrorHandling: PeerlyErrorHandlingService,
   ) {
@@ -70,6 +72,14 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
       // extract date portion directly from ISO string to preserve the user's intended date
       const dateOnly = scheduledDate?.slice(0, 10)
 
+      this.logger.info('Creating schedule for P2P job')
+      const targetDate = dateOnly || 'no-date'
+      const createdAt = new Date().toISOString()
+      const scheduleName = `GP P2P - Campaign ${campaignId} - ${targetDate} - ${createdAt}`
+      const scheduleId =
+        await this.peerlyScheduleService.createSchedule(scheduleName)
+      this.logger.info(`Schedule created with ID: ${scheduleId}`)
+
       this.logger.info('Creating P2P job')
       jobId = await this.createJob({
         name,
@@ -89,6 +99,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
         didNpaSubset,
         identityId,
         scheduledDate: dateOnly,
+        scheduleId,
       })
       this.logger.info(`Job created with ID: ${jobId}`)
 
@@ -150,6 +161,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
     didNpaSubset = [],
     identityId,
     scheduledDate,
+    scheduleId,
   }: CreateJobParams): Promise<string> {
     const hasMms = templates.some((t) => !!t.media)
 
@@ -160,7 +172,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
       did_state: didState,
       ...(didNpaSubset.length > 0 && { did_npa_subset: didNpaSubset }),
       can_use_mms: hasMms,
-      schedule_id: this.scheduleId,
+      schedule_id: scheduleId,
       ...(identityId && { identity_id: identityId }),
       ...(scheduledDate && {
         start_date: scheduledDate,

--- a/src/vendors/peerly/services/peerlyP2pJob.service.ts
+++ b/src/vendors/peerly/services/peerlyP2pJob.service.ts
@@ -56,6 +56,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
     scheduledDate,
   }: CreateP2pJobParams): Promise<string> {
     let jobId: string | undefined
+    let scheduleId: number | undefined
 
     try {
       this.logger.info('Creating media for P2P job')
@@ -72,13 +73,11 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
       // extract date portion directly from ISO string to preserve the user's intended date
       const dateOnly = scheduledDate?.slice(0, 10)
 
-      this.logger.info('Creating schedule for P2P job')
       const targetDate = dateOnly || 'no-date'
       const createdAt = new Date().toISOString()
       const scheduleName = `GP P2P - Campaign ${campaignId} - ${targetDate} - ${createdAt}`
-      const scheduleId =
+      scheduleId =
         await this.peerlyScheduleService.createSchedule(scheduleName)
-      this.logger.info(`Schedule created with ID: ${scheduleId}`)
 
       this.logger.info('Creating P2P job')
       jobId = await this.createJob({
@@ -104,7 +103,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
       this.logger.info(`Job created with ID: ${jobId}`)
 
       this.logger.info(`Assigning list ${listId} to job ${jobId}`)
-      await this.assignListToJob(jobId, listId, { campaignId })
+      await this.assignListToJob(jobId, listId, { campaignId, scheduleId })
       this.logger.info('List assigned successfully')
 
       this.logger.info(
@@ -119,7 +118,10 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
       if (isListAssignmentFailure) {
         throw error
       }
-      this.logger.error({ error }, P2P_ERROR_MESSAGES.JOB_CREATION_FAILED)
+      this.logger.error(
+        { error, scheduleId },
+        P2P_ERROR_MESSAGES.JOB_CREATION_FAILED,
+      )
       throw new BadGatewayException(P2P_ERROR_MESSAGES.JOB_CREATION_FAILED)
     }
   }
@@ -225,7 +227,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
   private async assignListToJob(
     jobId: string,
     listId: number,
-    context?: { campaignId?: number },
+    context?: { campaignId?: number; scheduleId?: number },
   ): Promise<void> {
     try {
       await this.peerlyHttpService.post(`/1to1/jobs/${jobId}/assignlist`, {
@@ -241,6 +243,9 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
             listId,
             ...(context?.campaignId != null && {
               campaignId: context.campaignId,
+            }),
+            ...(context?.scheduleId != null && {
+              scheduleId: context.scheduleId,
             }),
           },
         },

--- a/src/vendors/peerly/services/peerlySchedule.service.test.ts
+++ b/src/vendors/peerly/services/peerlySchedule.service.test.ts
@@ -29,9 +29,7 @@ describe('PeerlyScheduleService', () => {
   beforeEach(async () => {
     mockHttpService = {
       post: vi.fn().mockResolvedValue({ data: mockScheduleResponse }),
-      validateResponse: vi
-        .fn()
-        .mockImplementation((_data, _dto, _ctx) => _data),
+      validateResponse: vi.fn().mockImplementation((_data) => _data),
     }
     mockErrorHandling = {
       handleApiError: vi.fn().mockImplementation(() => {

--- a/src/vendors/peerly/services/peerlySchedule.service.test.ts
+++ b/src/vendors/peerly/services/peerlySchedule.service.test.ts
@@ -1,0 +1,110 @@
+import { BadGatewayException } from '@nestjs/common'
+import { Test, TestingModule } from '@nestjs/testing'
+import { createMockLogger } from 'src/shared/test-utils/mockLogger.util'
+import { PinoLogger } from 'nestjs-pino'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { P2P_SCHEDULE_DEFAULTS } from '../constants/p2pJob.constants'
+import { PeerlyScheduleService } from './peerlySchedule.service'
+import { PeerlyErrorHandlingService } from './peerlyErrorHandling.service'
+import { PeerlyHttpService } from './peerlyHttp.service'
+
+describe('PeerlyScheduleService', () => {
+  let service: PeerlyScheduleService
+  let mockHttpService: {
+    post: ReturnType<typeof vi.fn>
+    validateResponse: ReturnType<typeof vi.fn>
+  }
+  let mockErrorHandling: {
+    handleApiError: ReturnType<typeof vi.fn>
+  }
+
+  const mockScheduleResponse = {
+    Data: {
+      schedule_id: 12345,
+      schedule_name: 'GP P2P - Campaign 1 - 2026-04-15 - Test',
+      account: '88889754',
+    },
+  }
+
+  beforeEach(async () => {
+    mockHttpService = {
+      post: vi.fn().mockResolvedValue({ data: mockScheduleResponse }),
+      validateResponse: vi
+        .fn()
+        .mockImplementation((_data, _dto, _ctx) => _data),
+    }
+    mockErrorHandling = {
+      handleApiError: vi.fn().mockImplementation(() => {
+        throw new BadGatewayException('mock error')
+      }),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PeerlyScheduleService,
+        { provide: PinoLogger, useValue: createMockLogger() },
+        { provide: PeerlyHttpService, useValue: mockHttpService },
+        {
+          provide: PeerlyErrorHandlingService,
+          useValue: mockErrorHandling,
+        },
+      ],
+    }).compile()
+
+    service = module.get(PeerlyScheduleService)
+    Object.defineProperty(service, 'logger', {
+      get: () => createMockLogger(),
+      configurable: true,
+    })
+  })
+
+  describe('createSchedule', () => {
+    it('returns schedule_id from validated response', async () => {
+      const result = await service.createSchedule('Test Schedule')
+
+      expect(result).toBe(12345)
+    })
+
+    it('posts to /schedule with correct body structure', async () => {
+      await service.createSchedule('My Schedule')
+
+      expect(mockHttpService.post).toHaveBeenCalledWith(
+        '/schedule',
+        expect.objectContaining({
+          schedule_name: 'My Schedule',
+          schedule_timezone: P2P_SCHEDULE_DEFAULTS.TIMEZONE,
+          is_global: P2P_SCHEDULE_DEFAULTS.IS_GLOBAL,
+          mon_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          mon_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+          tue_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          tue_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+          wed_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          wed_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+          thu_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          thu_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+          fri_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          fri_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+          sat_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          sat_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+          sun_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          sun_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+        }),
+      )
+    })
+
+    it('includes account number in request body', async () => {
+      await service.createSchedule('Test')
+
+      const postCall = mockHttpService.post.mock.calls[0]
+      expect(postCall[1].account).toBe(service.accountNumber)
+    })
+
+    it('throws BadGatewayException on API failure', async () => {
+      mockHttpService.post.mockRejectedValue(new Error('API down'))
+
+      await expect(service.createSchedule('Fail')).rejects.toThrow(
+        BadGatewayException,
+      )
+    })
+  })
+})

--- a/src/vendors/peerly/services/peerlySchedule.service.ts
+++ b/src/vendors/peerly/services/peerlySchedule.service.ts
@@ -6,7 +6,7 @@ import { PeerlyErrorHandlingService } from './peerlyErrorHandling.service'
 import { PeerlyHttpService } from './peerlyHttp.service'
 import { CreateScheduleResponseDto } from '../schemas/peerlySchedule.schema'
 
-const SCHEDULE_DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
+const SCHEDULE_DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const
 
 @Injectable()
 export class PeerlyScheduleService extends PeerlyBaseConfig {

--- a/src/vendors/peerly/services/peerlySchedule.service.ts
+++ b/src/vendors/peerly/services/peerlySchedule.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common'
+import { PinoLogger } from 'nestjs-pino'
+import { P2P_SCHEDULE_DEFAULTS } from '../constants/p2pJob.constants'
+import { PeerlyBaseConfig } from '../config/peerlyBaseConfig'
+import { PeerlyErrorHandlingService } from './peerlyErrorHandling.service'
+import { PeerlyHttpService } from './peerlyHttp.service'
+import { CreateScheduleResponseDto } from '../schemas/peerlySchedule.schema'
+
+const SCHEDULE_DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
+
+@Injectable()
+export class PeerlyScheduleService extends PeerlyBaseConfig {
+  constructor(
+    protected readonly logger: PinoLogger,
+    private readonly peerlyHttpService: PeerlyHttpService,
+    private readonly peerlyErrorHandling: PeerlyErrorHandlingService,
+  ) {
+    super(logger)
+  }
+
+  async createSchedule(scheduleName: string): Promise<number> {
+    const body = this.buildScheduleBody(scheduleName)
+
+    try {
+      this.logger.info(`Creating Peerly schedule: ${scheduleName}`)
+      const response = await this.peerlyHttpService.post('/schedule', body)
+
+      const { data } = response
+      const validated = this.peerlyHttpService.validateResponse(
+        data,
+        CreateScheduleResponseDto,
+        'create schedule',
+      )
+
+      const scheduleId = validated.Data.schedule_id
+      this.logger.info(`Schedule created with ID: ${scheduleId}`)
+      return scheduleId
+    } catch (error) {
+      return this.peerlyErrorHandling.handleApiError({
+        error,
+        logger: this.logger,
+      })
+    }
+  }
+
+  private buildScheduleBody(scheduleName: string) {
+    const dayFields = Object.fromEntries(
+      SCHEDULE_DAYS.flatMap((day) => [
+        [`${day}_start`, P2P_SCHEDULE_DEFAULTS.START_TIME],
+        [`${day}_end`, P2P_SCHEDULE_DEFAULTS.END_TIME],
+      ]),
+    )
+
+    return {
+      schedule_name: scheduleName,
+      account: this.accountNumber,
+      schedule_timezone: P2P_SCHEDULE_DEFAULTS.TIMEZONE,
+      is_global: P2P_SCHEDULE_DEFAULTS.IS_GLOBAL,
+      ...dayFields,
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the Peerly P2P job creation flow to create and depend on a new remote schedule before job creation, adding an extra external API call and new failure mode. There’s also potential config drift since `PeerlyBaseConfig` still requires `PEERLY_SCHEDULE_ID` even though jobs now use a dynamically created `schedule_id`.
> 
> **Overview**
> **Peerly P2P jobs now create a dedicated schedule per job.** `PeerlyP2pJobService` creates a schedule via a new `PeerlyScheduleService` and uses the returned `schedule_id` when creating the job, replacing the previous fixed `this.scheduleId`.
> 
> Adds schedule defaults (`P2P_SCHEDULE_DEFAULTS`), a Zod DTO for schedule creation responses, wires `PeerlyScheduleService` into `PeerlyModule`, and expands tests to cover call ordering, propagation of the dynamic `schedule_id`, and schedule-creation failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31a8d1818fb203f813d653f36b7ee9a78793a4bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->