### PR TITLE
Prod <- QA

### DIFF
--- a/prisma/schema/electedOffice.prisma
+++ b/prisma/schema/electedOffice.prisma
@@ -11,10 +11,8 @@ model ElectedOffice {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  // temporary relationship to campaign
-  // goal would be to move away from the hard link to campaign, but is necessary for now
-  campaign   Campaign @relation(fields: [campaignId], references: [id], onDelete: NoAction)
-  campaignId Int      @map("campaign_id")
+  campaign   Campaign? @relation(fields: [campaignId], references: [id], onDelete: NoAction)
+  campaignId Int?      @map("campaign_id")
 
   polls                  Poll[]
   pollIndividualMessages PollIndividualMessage[]

--- a/prisma/schema/migrations/20260410160410_make_elected_office_campaign_id_optional/migration.sql
+++ b/prisma/schema/migrations/20260410160410_make_elected_office_campaign_id_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "elected_office" ALTER COLUMN "campaign_id" DROP NOT NULL;

--- a/src/electedOffice/services/electedOffice.service.ts
+++ b/src/electedOffice/services/electedOffice.service.ts
@@ -15,7 +15,7 @@ import { ListElectedOfficePaginationSchema } from '../schemas/ListElectedOfficeP
 export type CreateElectedOfficeArgs = {
   swornInDate?: Date | null
   userId: number
-  campaignId: number
+  campaignId?: number
   orgData?: {
     positionId: string | null
     customPositionName: string | null

--- a/src/organizations/services/organizations-backfill.service.ts
+++ b/src/organizations/services/organizations-backfill.service.ts
@@ -32,7 +32,7 @@ export type BackfillDryRunRecord = {
     L2DistrictName: string
     office: string
     otherOffice: string
-  }
+  } | null
   error?: string
 }
 
@@ -175,7 +175,25 @@ export class OrganizationsBackfillService extends createPrismaBase(
       if (electedOffices.length === 0) break
 
       for (const eo of electedOffices) {
-        const record = await this.dryRunElectedOffice(eo)
+        const { campaign } = eo
+        if (!campaign) {
+          eoStats['error']++
+          onRecord({
+            type: 'elected-office',
+            id: eo.id,
+            slug: OrganizationsService.electedOfficeOrgSlug(eo.id),
+            userId: eo.userId,
+            existingOrg: null,
+            resolved: null,
+            wouldWrite: false,
+            wouldCreate: false,
+            wouldLinkRecord: false,
+            inputFields: null,
+            error: 'Elected office has no linked campaign',
+          })
+          continue
+        }
+        const record = await this.dryRunElectedOffice({ ...eo, campaign })
         eoStats[record.resolved?.category ?? 'error']++
         onRecord(record)
       }
@@ -473,7 +491,19 @@ export class OrganizationsBackfillService extends createPrismaBase(
       if (electedOffices.length === 0) break
 
       for (const eo of electedOffices) {
-        const category = await this.backfillElectedOfficeOrganization(eo)
+        const { campaign } = eo
+        if (!campaign) {
+          this.logger.info(
+            { electedOfficeId: eo.id },
+            '[organization backfill] Elected office has no linked campaign, skipping',
+          )
+          categoryCounts['error']++
+          continue
+        }
+        const category = await this.backfillElectedOfficeOrganization({
+          ...eo,
+          campaign,
+        })
         categoryCounts[category]++
       }
 

--- a/src/polls/polls.controller.ts
+++ b/src/polls/polls.controller.ts
@@ -23,7 +23,6 @@ import { orderBy } from 'lodash'
 import { PinoLogger } from 'nestjs-pino'
 import { createZodDto, ZodValidationPipe } from 'nestjs-zod'
 import { ReqUser } from 'src/authentication/decorators/ReqUser.decorator'
-import { CampaignsService } from 'src/campaigns/services/campaigns.service'
 import { ReqElectedOffice } from 'src/electedOffice/decorators/ReqElectedOffice.decorator'
 import { UseElectedOffice } from 'src/electedOffice/decorators/UseElectedOffice.decorator'
 import { ReqOrganization } from 'src/organizations/decorators/ReqOrganization.decorator'
@@ -94,7 +93,6 @@ export class PollsController {
     private readonly pollsService: PollsService,
     private readonly pollIssuesService: PollIssuesService,
     private readonly pollBiasAnalysisService: PollBiasAnalysisService,
-    private readonly campaignService: CampaignsService,
     private readonly electedOfficeService: ElectedOfficeService,
     private readonly s3Service: S3Service,
     private readonly contactService: ContactsService,
@@ -246,17 +244,13 @@ export class PollsController {
     @ReqElectedOffice() electedOffice: ElectedOffice,
     @Body() dto: PollImageUploadUrlDto,
   ) {
-    const campaign = await this.campaignService.findUnique({
-      where: { id: electedOffice.campaignId },
-    })
-
-    if (!campaign || campaign.userId !== user.id) {
+    if (electedOffice.userId !== user.id) {
       throw new ForbiddenException(
         'You do not have permission to upload images for this poll',
       )
     }
 
-    const folderPath = `poll-text-images/${campaign.id}-${campaign.slug}`
+    const folderPath = `poll-text-images/${electedOffice.id}-${electedOffice.organizationSlug}`
     const key = this.s3Service.buildKey(folderPath, dto.fileName)
     const signedUrl = await this.s3Service.getSignedUrlForUpload(
       ASSET_DOMAIN,

--- a/src/polls/polls.module.ts
+++ b/src/polls/polls.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common'
-import { CampaignsModule } from 'src/campaigns/campaigns.module'
 import { ElectedOfficeModule } from 'src/electedOffice/electedOffice.module'
 import { LlmModule } from 'src/llm/llm.module'
 import { PaymentsModule } from 'src/payments/payments.module'
@@ -24,7 +23,6 @@ import { OrganizationsModule } from '@/organizations/organizations.module'
     PaymentsModule,
     QueueProducerModule,
     UsersModule,
-    CampaignsModule,
     AwsModule,
     LlmModule,
     ContactsModule,

--- a/src/queue/consumer/queueConsumer.service.test.ts
+++ b/src/queue/consumer/queueConsumer.service.test.ts
@@ -123,8 +123,7 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
 
   const pollId = 'poll-123'
   const electedOfficeId = 'office-1'
-  const campaignId = 1
-  const campaignUserId = 'user-1'
+  const officeUserId = 1
   const personId = 'person-1'
   const phoneNumber = '+15551234567'
 
@@ -145,12 +144,12 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
     electedOfficeService = {
       findUnique: vi
         .fn()
-        .mockResolvedValue({ id: electedOfficeId, campaignId }),
+        .mockResolvedValue({ id: electedOfficeId, userId: officeUserId }),
       client: {
         electedOffice: {
           findUnique: vi.fn().mockResolvedValue({
             id: electedOfficeId,
-            campaignId,
+            userId: officeUserId,
             organizationSlug: 'eo-office-1',
             organization: {
               slug: 'eo-office-1',
@@ -163,11 +162,7 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
       },
     }
     campaignsService = {
-      findUnique: vi.fn().mockResolvedValue({
-        id: campaignId,
-        userId: campaignUserId,
-        pathToVictory: { data: {} },
-      }),
+      findUnique: vi.fn(),
     }
     contactsService = {
       findContacts: vi
@@ -432,11 +427,11 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
       confidence: expect.any(String),
     })
     expect(analytics.identify).toHaveBeenCalledWith(
-      campaignUserId,
+      officeUserId,
       expect.objectContaining({ pollcount: expect.any(Number) }),
     )
     expect(analytics.track).toHaveBeenCalledWith(
-      campaignUserId,
+      officeUserId,
       expect.any(String),
       expect.objectContaining({
         pollId,
@@ -485,7 +480,7 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
     await service.processMessage(message)
 
     expect(analytics.track).toHaveBeenCalledWith(
-      campaignUserId,
+      officeUserId,
       expect.any(String),
       expect.objectContaining({
         pollResponses: 0,
@@ -760,7 +755,7 @@ describe('QueueConsumerService - triggerPollExecution', () => {
 
   const pollId = 'poll-456'
   const electedOfficeId = 'office-1'
-  const campaignId = 1
+  const officeUserId = 1
 
   const makePoll = (overrides: Record<string, unknown> = {}) => ({
     id: pollId,
@@ -789,12 +784,12 @@ describe('QueueConsumerService - triggerPollExecution', () => {
     electedOfficeService = {
       findUnique: vi
         .fn()
-        .mockResolvedValue({ id: electedOfficeId, campaignId }),
+        .mockResolvedValue({ id: electedOfficeId, userId: officeUserId }),
       client: {
         electedOffice: {
           findUnique: vi.fn().mockResolvedValue({
             id: electedOfficeId,
-            campaignId,
+            userId: officeUserId,
             organizationSlug: 'eo-office-1',
             organization: {
               slug: 'eo-office-1',
@@ -807,11 +802,7 @@ describe('QueueConsumerService - triggerPollExecution', () => {
       },
     }
     campaignsService = {
-      findUnique: vi.fn().mockResolvedValue({
-        id: campaignId,
-        userId: 'user-1',
-        pathToVictory: { data: {} },
-      }),
+      findUnique: vi.fn(),
     }
     contactsService = {
       sampleContacts: vi.fn().mockResolvedValue([

--- a/src/queue/consumer/queueConsumer.service.ts
+++ b/src/queue/consumer/queueConsumer.service.ts
@@ -479,9 +479,8 @@ export class QueueConsumerService {
       this.logger.info('Poll not found, ignoring event')
       return
     }
-    const { poll, organization, campaign } = data
+    const { poll, office, organization } = data
     const { electedOfficeId } = poll
-    const { userId: campaignUserId } = campaign
 
     if (!electedOfficeId) {
       throw new InternalServerErrorException(
@@ -668,23 +667,21 @@ export class QueueConsumerService {
     })
 
     let district: OrgDistrict | null = null
-    if (campaign.organizationSlug) {
-      try {
-        district = await this.organizationsService.getDistrictForOrgSlug(
-          campaign.organizationSlug,
-        )
-      } catch (e) {
-        this.logger.warn(
-          { e },
-          'Failed to fetch district for analytics, defaulting to null',
-        )
-      }
+    try {
+      district = await this.organizationsService.getDistrictForOrgSlug(
+        organization.slug,
+      )
+    } catch (e) {
+      this.logger.warn(
+        { e },
+        'Failed to fetch district for analytics, defaulting to null',
+      )
     }
 
     await Promise.all([
-      this.analytics.identify(campaignUserId, { pollcount: pollCount }),
+      this.analytics.identify(office.userId, { pollcount: pollCount }),
       this.analytics.track(
-        campaignUserId,
+        office.userId,
         EVENTS.Polls.ResultsSynthesisCompleted,
         {
           pollId,
@@ -759,10 +756,10 @@ export class QueueConsumerService {
       this.logger.info(`${params.pollId} Poll not found, ignoring event`)
       return
     }
-    const { poll, organization, campaign } = data
+    const { poll, office, organization } = data
 
     const user = await this.usersService.findUnique({
-      where: { id: campaign.userId },
+      where: { id: office.userId },
     })
     this.logger.info(`${params.pollId} Fetched sample and user`)
 
@@ -892,16 +889,7 @@ export class QueueConsumerService {
       return
     }
 
-    const campaign = await this.campaignsService.findUnique({
-      where: { id: office.campaignId },
-      include: { pathToVictory: true },
-    })
-
-    if (!campaign) {
-      this.logger.info('No campaign found, ignoring event')
-      return
-    }
-    return { poll, office, organization, campaign }
+    return { poll, office, organization }
   }
 
   async findMappedPersonIdsForCellPhones(params: {


### PR DESCRIPTION
This PR releases gp-api to Prod.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Includes a Prisma schema + migration making `ElectedOffice.campaignId` nullable and updates poll/queue flows to rely on `ElectedOffice.userId`/`organizationSlug` instead of campaign lookups, which can affect authorization, analytics attribution, and backfill behavior if assumptions are wrong.
> 
> **Overview**
> **Makes `ElectedOffice`→`Campaign` optional.** Updates Prisma model and adds a migration to drop the NOT NULL constraint on `elected_office.campaign_id`.
> 
> **Removes poll features’ dependency on campaigns.** `PollsController` no longer loads a campaign to authorize image uploads and now builds S3 upload paths from `electedOffice.id`/`organizationSlug`; `PollsModule` drops `CampaignsModule`. `QueueConsumerService` stops fetching campaigns in `getPollAndOrganization`, attributes analytics/user lookups to `office.userId`, and fetches district info via the elected office’s `organization.slug`.
> 
> **Hardens org backfill for missing campaigns.** `OrganizationsBackfillService` now explicitly skips/records elected offices that have no linked campaign during dry-run and real backfill, and allows `inputFields` to be `null` in those error records.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7202f0a8950a59b2f1a939d5b4e7db8ee4e910e1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->