### PR TITLE
Remove incorrect readme info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,6 @@ CAMPAIGN_PLAN_LOCAL_URL=http://localhost:8089/generate
 CAMPAIGN_PLAN_RESULTS_BUCKET=campaign-plan-results-dev
 ```
 
-The local server also needs `OUTPUT_SQS_QUEUE_URL` set to your personal SQS queue (e.g. `YourName_Queue.fifo`). Each engineer should have their own dedicated queue.
-
 See `gp-ai-projects/campaign_plan_lambda/README.md` for full setup instructions including AWS credentials and SQS queue configuration.
 
 ### AWS Setup


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes an incorrect environment variable requirement; no runtime behavior is affected.
> 
> **Overview**
> Removes the README instruction that the local campaign plan server requires `OUTPUT_SQS_QUEUE_URL` to be set to a personal SQS queue, leaving setup guidance to the referenced `gp-ai-projects/campaign_plan_lambda/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ae5433bda39c4b99994c2f9b6786151e23db4f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->