### PR TITLE
Remove failing prod protection.

### DIFF
--- a/src/queue/consumer/queueConsumer.service.ts
+++ b/src/queue/consumer/queueConsumer.service.ts
@@ -293,17 +293,11 @@ export class QueueConsumerService {
           pollExpansionEvent,
           message.MessageId!,
         )
-      // TODO: Remove prod guard and add prod queue URL + S3 bucket to deploy/index.ts when ready to launch in prod
       case QueueType.CAMPAIGN_PLAN_COMPLETE:
         this.logger.info(
           { data: queueMessage.data, messageId: message.MessageId },
           'received campaignPlanComplete message',
         )
-        // TODO: Remove prod guard and add prod queue URL + S3 bucket to deploy/index.ts when ready to launch in prod
-        if (process.env.NODE_ENV === 'production') {
-          this.logger.warn('campaign plan complete handler disabled in prod')
-          return true
-        }
         return await this.withLegacyErrorSwallowing(message, async () => {
           const campaignPlanData = CampaignPlanCompleteMessageSchema.parse(
             queueMessage.data,


### PR DESCRIPTION
We don't want event generation in prod yet.

The deploy/index.ts protection is enough.

`process.env.NODE_ENV` is equal to production in all environments.

There's no prod envs defined in deploy/index.ts for CAMPAIGN_PLAN_INPUT_QUEUE_URL and CAMPAIGN_PLAN_RESULTS_BUCKET.

Confirmed system fails gracefully when these variables aren't provided.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables `CAMPAIGN_PLAN_COMPLETE` messages to be processed in production, which can trigger task creation and Slack notifications if the queue is wired up incorrectly. Risk is mitigated by relying on deployment-level queue/bucket configuration, but misconfiguration could cause unexpected side effects.
> 
> **Overview**
> Removes the `NODE_ENV === 'production'` short-circuit that previously disabled handling of `QueueType.CAMPAIGN_PLAN_COMPLETE` messages.
> 
> `campaignPlanComplete` events will now always be parsed and processed via `handleCampaignPlanComplete`, including the follow-up Slack notification, under the existing `withLegacyErrorSwallowing` error-handling behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45178c4a4bb804b10bc25017ed49f5c2e49c6f58. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->