### PR TITLE
Run migrate dev

### DIFF
--- a/prisma/schema/migrations/20260415192216_remove_campaign_voterfile_relation/migration.sql
+++ b/prisma/schema/migrations/20260415192216_remove_campaign_voterfile_relation/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `campaign_id` on the `voter_file_filter` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "voter_file_filter" DROP CONSTRAINT "voter_file_filter_campaign_id_fkey";
+
+-- DropIndex
+DROP INDEX "voter_file_filter_campaign_id_idx";
+
+-- DropIndex
+DROP INDEX "voter_file_filter_id_campaign_id_idx";
+
+-- AlterTable
+ALTER TABLE "voter_file_filter" DROP COLUMN "campaign_id";


### PR DESCRIPTION
There's currently some drift between our Prisma files and the migrations. This corrects that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema migration drops `voter_file_filter.campaign_id` (and related FK/indexes), which is a destructive change that can permanently remove existing data and may break any code/queries expecting that relation.
> 
> **Overview**
> Removes the `campaign` relationship from `voter_file_filter` at the database level by dropping the `campaign_id` column.
> 
> The migration also removes the associated foreign key constraint and indexes (including `voter_file_filter_campaign_id_idx` and the composite `voter_file_filter_id_campaign_id_idx`) to resolve Prisma/migration drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1958c414425980f99d074ff603b6c0940f8d85f6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->