### PR TITLE
Add migrate diff to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,20 @@ jobs:
     concurrency:
       group: deploy-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || github.ref_name }}
       cancel-in-progress: false
+    services:
+      shadow-db:
+        image: postgres:16
+        env:
+          POSTGRES_USER: prisma
+          POSTGRES_PASSWORD: prisma
+          POSTGRES_DB: shadow
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U prisma"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=5
     outputs:
       environment: ${{ steps.context.outputs.environment }}
       service_url: ${{ steps.pulumi.outputs.service_url }}
@@ -51,6 +65,14 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
+
+      - name: Check Prisma schema is in sync with migrations
+        run: |
+          npx prisma migrate diff \
+            --from-migrations ./prisma/schema/migrations \
+            --to-schema-datamodel ./prisma/schema \
+            --shadow-database-url "postgresql://prisma:prisma@localhost:5432/shadow" \
+            --exit-code
 
       # Validation
       - run: npm run generate


### PR DESCRIPTION
Why: Detects if there's drift between the Prisma schema and the migrations generated. Or in other words, if someone forgot to run `npm run migrate:dev`
Approach: Migrate diff is the standard Prisma provided way to do this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it may introduce new pipeline failures if migrations/schema are out of sync or if the Postgres service is flaky.
> 
> **Overview**
> Adds a Postgres `shadow-db` service to the GitHub Actions `main` job and runs `npx prisma migrate diff` with `--exit-code` to ensure the Prisma schema stays in sync with checked-in migrations, failing CI on drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ad4f222c4a6fd26d88457c44febf4a3a508f362. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->