### PR TITLE
QA <- Dev

### DIFF
--- a/prisma/schema/migrations/20260415192216_remove_campaign_voterfile_relation/migration.sql
+++ b/prisma/schema/migrations/20260415192216_remove_campaign_voterfile_relation/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `campaign_id` on the `voter_file_filter` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "voter_file_filter" DROP CONSTRAINT "voter_file_filter_campaign_id_fkey";
+
+-- DropIndex
+DROP INDEX "voter_file_filter_campaign_id_idx";
+
+-- DropIndex
+DROP INDEX "voter_file_filter_id_campaign_id_idx";
+
+-- AlterTable
+ALTER TABLE "voter_file_filter" DROP COLUMN "campaign_id";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema migration drops `voter_file_filter.campaign_id` (and its FK/indexes), which is destructive and will permanently remove existing linkage data and may break any remaining code or queries expecting the column.
> 
> **Overview**
> Removes the database-level relationship between campaigns and voter file filters by dropping the `voter_file_filter_campaign_id_fkey` constraint and related indexes.
> 
> Applies a destructive schema change to the `voter_file_filter` table by dropping the `campaign_id` column (and all data stored in it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 839d5178c2b1d46c9ec4d4d83f508abc96806d3d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->