### PR TITLE
We don't want to generate default tasks if nondefault tasks already exist.

### DIFF
--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -114,6 +114,7 @@ describe('CampaignTasksService', () => {
   let service: CampaignTasksService
 
   beforeEach(() => {
+    vi.clearAllMocks()
     service = new CampaignTasksService(
       mockAiGeneration as AiGenerationService,
       mockSlackService as SlackService,
@@ -479,11 +480,36 @@ describe('CampaignTasksService', () => {
   })
 
   describe('generateTasksStream', () => {
+    it('skips default task generation and AI trigger when any tasks exist', async () => {
+      const existingTasks = [
+        makeDbTask({ id: 'default-1', isDefaultTask: true }),
+      ]
+
+      mockModel.findMany.mockResolvedValueOnce(existingTasks)
+
+      const observable = service.generateTasksStream(makeCampaign())
+      const events = await firstValueFrom(observable.pipe(toArray()))
+
+      const completeEvent = events.find(
+        (e) => (e.data as { type: string }).type === 'complete',
+      )
+      expect(completeEvent).toBeDefined()
+      expect((completeEvent!.data as { tasks: unknown[] }).tasks).toEqual(
+        existingTasks,
+      )
+      // generateDefaultTasks should not have been called (no transaction)
+      expect(mockTransaction).not.toHaveBeenCalled()
+      // triggerEventGeneration should not have been called
+      expect(mockAiGeneration.triggerEventGeneration).not.toHaveBeenCalled()
+    })
+
     it('returns existing tasks immediately when not triggered', async () => {
       const existingTasks = [makeDbTask({ id: 'existing-1' })]
 
+      mockModel.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(existingTasks)
       mockTxModel.count.mockResolvedValueOnce(1)
-      mockModel.findMany.mockResolvedValueOnce(existingTasks)
       vi.mocked(mockAiGeneration.triggerEventGeneration!).mockResolvedValue(
         false,
       )
@@ -503,6 +529,9 @@ describe('CampaignTasksService', () => {
     it('polls DB for plan completion and returns tasks when plan exists', async () => {
       const savedTasks = [makeDbTask()]
 
+      mockModel.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(savedTasks)
       mockTxModel.count.mockResolvedValueOnce(1)
       mockTxModel.deleteMany.mockResolvedValue({ count: 0 })
       mockTxModel.createMany.mockResolvedValue({ count: 1 })
@@ -513,7 +542,6 @@ describe('CampaignTasksService', () => {
       vi.mocked(mockAiGeneration.triggerEventGeneration!).mockResolvedValue(
         true,
       )
-      mockModel.findMany.mockResolvedValue(savedTasks)
 
       const observable = service.generateTasksStream(makeCampaign())
       const events = await firstValueFrom(observable.pipe(toArray()))
@@ -530,8 +558,10 @@ describe('CampaignTasksService', () => {
     it('handles error during stream and returns existing tasks', async () => {
       const existingTasks = [makeDbTask({ isDefaultTask: true })]
 
+      mockModel.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(existingTasks)
       mockTxModel.count.mockResolvedValueOnce(1)
-      mockModel.findMany.mockResolvedValue(existingTasks)
       vi.mocked(mockAiGeneration.triggerEventGeneration!).mockRejectedValue(
         new Error('Lambda trigger failed'),
       )

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -60,7 +60,7 @@ export class CampaignTasksService extends createPrismaBase(
 
   async nonDefaultTasksExist(campaignId: number): Promise<boolean> {
     const count = await this.model.count({
-      where: { campaignId, isDefaultTask: false },
+      where: { campaignId, NOT: { isDefaultTask: true } },
     })
     return count > 0
   }
@@ -226,8 +226,6 @@ export class CampaignTasksService extends createPrismaBase(
     subscriber: Subscriber<MessageEvent>,
   ): Promise<void> {
     try {
-      await this.generateDefaultTasks(campaign)
-
       subscriber.next({
         data: {
           type: 'progress',
@@ -235,15 +233,16 @@ export class CampaignTasksService extends createPrismaBase(
           message: 'Starting task generation...',
         },
       })
-      const hasEventTasks = await this.nonDefaultTasksExist(campaign.id)
-      if (hasEventTasks) {
-        const tasks = await this.listCampaignTasks(campaign)
+      const existingTasks = await this.listCampaignTasks(campaign)
+      if (existingTasks.length > 0) {
         subscriber.next({
-          data: { type: 'complete', tasks },
+          data: { type: 'complete', tasks: existingTasks },
         })
         subscriber.complete()
         return
       }
+
+      await this.generateDefaultTasks(campaign)
 
       const triggered =
         await this.aiGenerationService.triggerEventGeneration(campaign)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change that only reorders task-generation steps to avoid creating default tasks when non-default tasks already exist; behavior is limited to the generation stream flow.
> 
> **Overview**
> Adjusts `runGenerationStream` to **only** call `generateDefaultTasks` after confirming no non-default (event) tasks already exist for the campaign.
> 
> This prevents default tasks from being created in campaigns that already have custom/AI-generated tasks, and returns the existing task list immediately in that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d126a0f20e583700803598ac8659401dd68e5899. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->