### PR TITLE
Ravenhurst/eng 7087 get migrations to run

### DIFF
--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -42,10 +42,12 @@ while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
     if [ "$P3009_RESOLVED" = "false" ] \
       && echo "$DEPLOY_OUTPUT" | grep -q "P3009"; then
       echo "⚠️ Failed migration detected (P3009). Resolving..."
-      npx prisma migrate resolve \
+      if npx prisma migrate resolve \
         --applied 20260414144530_take_new_migration_from_dev \
-        --schema=prisma/schema 2>&1 && P3009_RESOLVED=true
-      continue
+        --schema=prisma/schema 2>&1; then
+        P3009_RESOLVED=true
+        continue
+      fi
     fi
 
     RETRY_COUNT=$((RETRY_COUNT + 1))

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -29,7 +29,11 @@ RETRY_COUNT=0
 while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
   echo "Attempting database connection (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)..."
 
-  if npx prisma migrate deploy --schema=prisma/schema 2>&1; then
+  # TODO: Remove resolve once the failed migration is marked as resolved/applied
+  if npx prisma migrate resolve \
+    --applied 20260414144530_take_new_migration_from_dev \
+    --schema=prisma/schema 2>&1 \
+  && npx prisma migrate deploy --schema=prisma/schema 2>&1; then
     echo "✅ Migrations completed successfully."
     break
   else

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -25,26 +25,38 @@ echo "Waiting for database to be ready..."
 # Retry logic for database connection (important for Aurora Serverless v2 which takes time to wake up)
 MAX_RETRIES=30
 RETRY_COUNT=0
+# TODO: Remove P3009_RESOLVED flag once the failed migration is resolved
+P3009_RESOLVED=false
 
 while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
   echo "Attempting database connection (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)..."
 
-  # TODO: Remove resolve once the failed migration is marked as resolved/applied
-  if npx prisma migrate resolve \
-    --applied 20260414144530_take_new_migration_from_dev \
-    --schema=prisma/schema 2>&1 \
-  && npx prisma migrate deploy --schema=prisma/schema 2>&1; then
+  DEPLOY_OUTPUT=$(npx prisma migrate deploy --schema=prisma/schema 2>&1)
+  DEPLOY_EXIT=$?
+  echo "$DEPLOY_OUTPUT"
+
+  if [ $DEPLOY_EXIT -eq 0 ]; then
     echo "✅ Migrations completed successfully."
     break
+  fi
+
+  # TODO: Remove this P3009 block once the failed migration is resolved
+  if [ "$P3009_RESOLVED" = "false" ] \
+    && echo "$DEPLOY_OUTPUT" | grep -q "P3009"; then
+    echo "⚠️ Failed migration detected (P3009). Resolving..."
+    npx prisma migrate resolve \
+      --applied 20260414144530_take_new_migration_from_dev \
+      --schema=prisma/schema 2>&1 && P3009_RESOLVED=true
+    continue
+  fi
+
+  RETRY_COUNT=$((RETRY_COUNT + 1))
+  if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+    echo "⏳ Database not ready yet. Retrying in 10s..."
+    sleep 10
   else
-    RETRY_COUNT=$((RETRY_COUNT + 1))
-    if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-      echo "⏳ Database not ready yet. Retrying in 10s..."
-      sleep 10
-    else
-      echo "❌ ERROR: Failed to connect to database after $MAX_RETRIES attempts."
-      exit 1
-    fi
+    echo "❌ ERROR: Failed to connect to database after $MAX_RETRIES attempts."
+    exit 1
   fi
 done
 

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -31,32 +31,31 @@ P3009_RESOLVED=false
 while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
   echo "Attempting database connection (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)..."
 
-  DEPLOY_OUTPUT=$(npx prisma migrate deploy --schema=prisma/schema 2>&1)
-  DEPLOY_EXIT=$?
-  echo "$DEPLOY_OUTPUT"
-
-  if [ $DEPLOY_EXIT -eq 0 ]; then
+  if DEPLOY_OUTPUT=$(npx prisma migrate deploy --schema=prisma/schema 2>&1); then
+    echo "$DEPLOY_OUTPUT"
     echo "✅ Migrations completed successfully."
     break
-  fi
-
-  # TODO: Remove this P3009 block once the failed migration is resolved
-  if [ "$P3009_RESOLVED" = "false" ] \
-    && echo "$DEPLOY_OUTPUT" | grep -q "P3009"; then
-    echo "⚠️ Failed migration detected (P3009). Resolving..."
-    npx prisma migrate resolve \
-      --applied 20260414144530_take_new_migration_from_dev \
-      --schema=prisma/schema 2>&1 && P3009_RESOLVED=true
-    continue
-  fi
-
-  RETRY_COUNT=$((RETRY_COUNT + 1))
-  if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-    echo "⏳ Database not ready yet. Retrying in 10s..."
-    sleep 10
   else
-    echo "❌ ERROR: Failed to connect to database after $MAX_RETRIES attempts."
-    exit 1
+    echo "$DEPLOY_OUTPUT"
+
+    # TODO: Remove this P3009 block once the failed migration is resolved
+    if [ "$P3009_RESOLVED" = "false" ] \
+      && echo "$DEPLOY_OUTPUT" | grep -q "P3009"; then
+      echo "⚠️ Failed migration detected (P3009). Resolving..."
+      npx prisma migrate resolve \
+        --applied 20260414144530_take_new_migration_from_dev \
+        --schema=prisma/schema 2>&1 && P3009_RESOLVED=true
+      continue
+    fi
+
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+      echo "⏳ Database not ready yet. Retrying in 10s..."
+      sleep 10
+    else
+      echo "❌ ERROR: Failed to connect to database after $MAX_RETRIES attempts."
+      exit 1
+    fi
   fi
 done
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches deployment-time database migration behavior; the auto-`migrate resolve` workaround could mark a migration applied in environments where it shouldn’t, impacting schema consistency if misused.
> 
> **Overview**
> Adjusts `deploy/docker-entrypoint.sh` migration startup logic to capture and print `prisma migrate deploy` output on both success and failure.
> 
> Adds a temporary workaround for Prisma error `P3009`: on first detection it runs `prisma migrate resolve --applied 20260414144530_take_new_migration_from_dev` and then retries migrations, guarded by a `P3009_RESOLVED` flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 093584934b14f7f6db537b7c94afa6d58947df39. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->