### PR TITLE
Revert "[ENG-7087] - Attempting to resolve failing duplicate migration"

### DIFF
--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -25,38 +25,22 @@ echo "Waiting for database to be ready..."
 # Retry logic for database connection (important for Aurora Serverless v2 which takes time to wake up)
 MAX_RETRIES=30
 RETRY_COUNT=0
-# TODO: Remove P3009_RESOLVED flag once the failed migration is resolved
-P3009_RESOLVED=false
 
 while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
   echo "Attempting database connection (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)..."
 
-  DEPLOY_OUTPUT=$(npx prisma migrate deploy --schema=prisma/schema 2>&1)
-  DEPLOY_EXIT=$?
-  echo "$DEPLOY_OUTPUT"
-
-  if [ $DEPLOY_EXIT -eq 0 ]; then
+  if npx prisma migrate deploy --schema=prisma/schema 2>&1; then
     echo "✅ Migrations completed successfully."
     break
-  fi
-
-  # TODO: Remove this P3009 block once the failed migration is resolved
-  if [ "$P3009_RESOLVED" = "false" ] \
-    && echo "$DEPLOY_OUTPUT" | grep -q "P3009"; then
-    echo "⚠️ Failed migration detected (P3009). Resolving..."
-    npx prisma migrate resolve \
-      --applied 20260414144530_take_new_migration_from_dev \
-      --schema=prisma/schema 2>&1 && P3009_RESOLVED=true
-    continue
-  fi
-
-  RETRY_COUNT=$((RETRY_COUNT + 1))
-  if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-    echo "⏳ Database not ready yet. Retrying in 10s..."
-    sleep 10
   else
-    echo "❌ ERROR: Failed to connect to database after $MAX_RETRIES attempts."
-    exit 1
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+      echo "⏳ Database not ready yet. Retrying in 10s..."
+      sleep 10
+    else
+      echo "❌ ERROR: Failed to connect to database after $MAX_RETRIES attempts."
+      exit 1
+    fi
   fi
 done
 


### PR DESCRIPTION
Reverts thegoodparty/gp-api#1462

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deployment startup/migration behavior; if the previously-worked-around failed migration still exists, containers may now fail to start instead of auto-resolving it.
> 
> **Overview**
> Simplifies `deploy/docker-entrypoint.sh` database-migration startup logic by removing the temporary Prisma `P3009` failed-migration auto-resolve workaround and its output-parsing flow.
> 
> The retry loop now just attempts `npx prisma migrate deploy` until success or max retries, failing fast if migrations continue to error after the retry window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa456c40d29e82a501265c95a900a323d15ba112. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->