### PR TITLE
ENG 7208

### DIFF
--- a/prisma/schema/campaignTask.prisma
+++ b/prisma/schema/campaignTask.prisma
@@ -34,5 +34,6 @@ model CampaignTask {
 
   @@index([campaignId])
   @@index([campaignId, completed])
+  @@index([date])
   @@map("campaign_task")
 }

--- a/prisma/schema/migrations/20260420233738_add_campaign_task_date_index/migration.sql
+++ b/prisma/schema/migrations/20260420233738_add_campaign_task_date_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "campaign_task_date_idx" ON "campaign_task"("date");

--- a/scripts/test-weekly-tasks-digest-event.ts
+++ b/scripts/test-weekly-tasks-digest-event.ts
@@ -1,0 +1,190 @@
+/**
+ * Test script: Campaign Plan - Weekly Tasks Digest (Segment event)
+ *
+ * Picks a single campaign, finds its incomplete tasks due in the next
+ * Monday-to-Monday window, and fires the "Campaign Plan - Weekly Tasks Digest"
+ * Segment event so you can verify the pipeline in Segment Debugger → HubSpot.
+ *
+ * Usage:
+ *   npx tsx scripts/test-weekly-tasks-digest-event.ts --campaign=<ID> [--dry-run]
+ *
+ * Options:
+ *   --campaign=<ID>  Required. The campaign ID to fire the event for.
+ *   --dry-run        Print the event payload without sending to Segment.
+ *
+ * Requires DATABASE_URL and SEGMENT_WRITE_KEY in .env.
+ * ONLY reads from the database — never writes.
+ */
+import 'dotenv/config'
+import pg from 'pg'
+import Analytics from '@segment/analytics-node'
+import { addDays, format, nextMonday, startOfDay } from 'date-fns'
+
+const OUTREACH_FLOW_TYPES = ['text', 'robocall', 'doorKnocking', 'phoneBanking']
+const MAX_TASKS = 5
+
+const campaignArg = process.argv.find((a) => a.startsWith('--campaign='))
+if (!campaignArg) {
+  console.error('Usage: npx tsx scripts/test-weekly-tasks-digest-event.ts --campaign=<ID> [--dry-run]')
+  process.exit(1)
+}
+const CAMPAIGN_ID = parseInt(campaignArg.split('=')[1], 10)
+if (isNaN(CAMPAIGN_ID)) {
+  throw new Error('--campaign must be a number')
+}
+const DRY_RUN = process.argv.includes('--dry-run')
+
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) throw new Error('DATABASE_URL is not set.')
+if (!DRY_RUN && !process.env.SEGMENT_WRITE_KEY) {
+  throw new Error('SEGMENT_WRITE_KEY is not set (required unless --dry-run).')
+}
+
+interface CampaignRow {
+  campaign_id: number
+  user_id: number
+  email: string
+  hubspot_id: string | null
+  election_date: string | null
+}
+
+interface TaskRow {
+  id: string
+  title: string
+  description: string
+  flow_type: string | null
+  week: number
+  date: string | null
+  completed: boolean
+}
+
+async function main() {
+  const db = new pg.Client({ connectionString: databaseUrl })
+  await db.connect()
+
+  try {
+    const { rows: campaigns } = await db.query<CampaignRow>(`
+      SELECT
+        c.id AS campaign_id,
+        c.user_id,
+        u.email,
+        u.meta_data->>'hubspotId' AS hubspot_id,
+        c.details->>'electionDate' AS election_date
+      FROM campaign c
+      JOIN "user" u ON u.id = c.user_id
+      WHERE c.id = $1
+    `, [CAMPAIGN_ID])
+
+    if (campaigns.length === 0) {
+      console.error(`Campaign ${CAMPAIGN_ID} not found.`)
+      process.exit(1)
+    }
+
+    const campaign = campaigns[0]
+    console.log(`\nCampaign: ${campaign.campaign_id}`)
+    console.log(`User:     ${campaign.email} (id: ${campaign.user_id})`)
+    console.log(`HubSpot:  ${campaign.hubspot_id ?? '(none)'}`)
+    console.log(`Election: ${campaign.election_date ?? '(none)'}`)
+
+    if (campaign.election_date) {
+      const electionDate = new Date(campaign.election_date)
+      if (electionDate <= new Date()) {
+        console.error(`\nElection date ${campaign.election_date} is in the past — would skip in production.`)
+        if (!DRY_RUN) process.exit(1)
+        console.log('Continuing anyway because --dry-run...')
+      }
+    }
+
+    const windowStart = startOfDay(nextMonday(new Date()))
+    const windowEnd = addDays(windowStart, 7)
+
+    console.log(`\nTask window: ${windowStart.toISOString().split('T')[0]} → ${windowEnd.toISOString().split('T')[0]}`)
+
+    const { rows: allWindowTasks } = await db.query<TaskRow>(`
+      SELECT id, title, description, flow_type, week, date, completed
+      FROM campaign_task
+      WHERE campaign_id = $1
+        AND date >= $2
+        AND date < $3
+      ORDER BY date ASC
+    `, [CAMPAIGN_ID, windowStart, windowEnd])
+
+    const completedCount = allWindowTasks.filter((t) => t.completed).length
+    const tasks = allWindowTasks.filter((t) => !t.completed)
+
+    console.log(`Found ${allWindowTasks.length} task(s) in window (${completedCount} completed, ${tasks.length} incomplete)`)
+
+    if (tasks.length < 3) {
+      console.log(`\nOnly ${tasks.length} incomplete task(s) — in production, no event would be sent (minimum 3).`)
+      process.exit(0)
+    }
+
+    for (const t of tasks) {
+      console.log(`  [${t.flow_type ?? 'none'}] ${t.title} (week ${t.week}, due ${t.date})`)
+    }
+
+    const sorted = [...tasks].sort((a, b) => {
+      const aIsOutreach = OUTREACH_FLOW_TYPES.includes(a.flow_type ?? '')
+      const bIsOutreach = OUTREACH_FLOW_TYPES.includes(b.flow_type ?? '')
+      if (aIsOutreach && !bIsOutreach) return -1
+      if (!aIsOutreach && bIsOutreach) return 1
+      return 0
+    })
+
+    const selected = sorted.slice(0, MAX_TASKS)
+    console.log(`\nSelected ${selected.length} task(s) (outreach prioritized):`)
+    for (const t of selected) {
+      console.log(`  [${t.flow_type ?? 'none'}] ${t.title}`)
+    }
+
+    const properties: Record<string, unknown> = {
+      email: campaign.email,
+      plan_tasks_completed: completedCount,
+      plan_total_tasks: allWindowTasks.length,
+    }
+
+    // Always emit all 5 slots so HubSpot clears any stale values from prior weeks.
+    for (let i = 0; i < MAX_TASKS; i++) {
+      const n = i + 1
+      const task = selected[i]
+      properties[`task_name_${n}`] = task?.title ?? ''
+      properties[`task_description_${n}`] = task?.description ?? ''
+      properties[`task_type_${n}`] = task?.flow_type ?? ''
+      properties[`task_due_date_${n}`] = task?.date ? format(new Date(task.date), 'yyyy-MM-dd') : ''
+      properties[`task_week_number_${n}`] = task?.week ?? null
+    }
+
+    const eventName = 'Campaign Plan - Weekly Tasks Digest'
+
+    console.log(`\nEvent: "${eventName}"`)
+    console.log('Properties:', JSON.stringify(properties, null, 2))
+
+    if (DRY_RUN) {
+      console.log('\n--dry-run: Segment event NOT sent.')
+      return
+    }
+
+    const analytics = new Analytics({ writeKey: process.env.SEGMENT_WRITE_KEY! })
+
+    const traits: Record<string, string> = {}
+    if (campaign.email) traits.email = campaign.email
+    if (campaign.hubspot_id) traits.hubspotId = campaign.hubspot_id
+
+    analytics.track({
+      event: eventName,
+      userId: String(campaign.user_id),
+      properties,
+      context: { traits },
+    })
+
+    await analytics.closeAndFlush()
+    console.log('\nSegment event sent. Check the Segment Debugger to verify.')
+  } finally {
+    await db.end()
+  }
+}
+
+main().catch((error) => {
+  console.error('Error:', error)
+  process.exit(1)
+})

--- a/scripts/test-weekly-tasks-digest-event.ts
+++ b/scripts/test-weekly-tasks-digest-event.ts
@@ -54,7 +54,7 @@ interface TaskRow {
   description: string
   flow_type: string | null
   week: number
-  date: string | null
+  date: string
   completed: boolean
 }
 

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -30,6 +30,8 @@ import { CampaignTasksService } from './tasks/services/campaignTasks.service'
 import { AiGenerationService } from './tasks/services/aiGeneration.service'
 import { CampaignTcrComplianceController } from './tcrCompliance/campaignTcrCompliance.controller'
 import { CampaignTcrComplianceService } from './tcrCompliance/services/campaignTcrCompliance.service'
+import { WeeklyTasksDigestService } from './tasks/services/weeklyTasksDigest.service'
+import { WeeklyTasksDigestHandlerService } from './tasks/services/weeklyTasksDigestHandler.service'
 import { CampaignUpdateHistoryController } from './updateHistory/campaignUpdateHistory.controller'
 import { CampaignUpdateHistoryService } from './updateHistory/campaignUpdateHistory.service'
 
@@ -73,6 +75,8 @@ import { CampaignUpdateHistoryService } from './updateHistory/campaignUpdateHist
     LegacyCampaignTasksService,
     AiGenerationService,
     CampaignTcrComplianceService,
+    WeeklyTasksDigestService,
+    WeeklyTasksDigestHandlerService,
   ],
   exports: [
     CampaignsService,
@@ -81,6 +85,7 @@ import { CampaignUpdateHistoryService } from './updateHistory/campaignUpdateHist
     CampaignTcrComplianceService,
     CampaignTasksService,
     AiGenerationService,
+    WeeklyTasksDigestHandlerService,
   ],
 })
 export class CampaignsModule {}

--- a/src/campaigns/tasks/services/weeklyTasksDigest.service.test.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigest.service.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
+import { MessageGroup, QueueType } from 'src/queue/queue.types'
+import { WeeklyTasksDigestService } from './weeklyTasksDigest.service'
+
+describe('WeeklyTasksDigestService', () => {
+  let service: WeeklyTasksDigestService
+  let sendMessage: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    sendMessage = vi.fn().mockResolvedValue(undefined)
+    const queueService = {
+      sendMessage,
+    } as unknown as QueueProducerService
+
+    service = new WeeklyTasksDigestService(queueService, createMockLogger())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('window calculation', () => {
+    it('sends a window covering Monday Apr 20 through Sunday Apr 26 when today is Sunday Apr 19 Central', async () => {
+      // Sunday April 19, 2026 at 11:00 PM Central Daylight Time = 04:00 UTC Monday April 20
+      vi.setSystemTime(new Date('2026-04-20T04:00:00.000Z'))
+
+      await service.triggerWeeklyDigest()
+
+      expect(sendMessage).toHaveBeenCalledOnce()
+      const [message] = sendMessage.mock.calls[0]
+      expect(message.type).toBe(QueueType.WEEKLY_TASKS_DIGEST)
+      expect(message.data.windowStart).toBe('2026-04-20T00:00:00.000Z')
+      expect(message.data.windowEnd).toBe('2026-04-27T00:00:00.000Z')
+    })
+
+    it('still targets the same Monday when the cron fires later Sunday night (11:59 PM Central)', async () => {
+      // Sunday April 19, 2026 at 11:59 PM CDT = 04:59 UTC Monday April 20
+      vi.setSystemTime(new Date('2026-04-20T04:59:00.000Z'))
+
+      await service.triggerWeeklyDigest()
+
+      const [message] = sendMessage.mock.calls[0]
+      expect(message.data.windowStart).toBe('2026-04-20T00:00:00.000Z')
+      expect(message.data.windowEnd).toBe('2026-04-27T00:00:00.000Z')
+    })
+
+    it('uses the upcoming Monday when fired on Saturday night Central', async () => {
+      // Saturday April 18, 2026 at 11:00 PM CDT = 04:00 UTC Sunday April 19
+      vi.setSystemTime(new Date('2026-04-19T04:00:00.000Z'))
+
+      await service.triggerWeeklyDigest()
+
+      const [message] = sendMessage.mock.calls[0]
+      expect(message.data.windowStart).toBe('2026-04-20T00:00:00.000Z')
+      expect(message.data.windowEnd).toBe('2026-04-27T00:00:00.000Z')
+    })
+
+    it('handles standard time (non-DST) correctly', async () => {
+      // Sunday January 4, 2026 at 11:00 PM CST = 05:00 UTC Monday January 5
+      vi.setSystemTime(new Date('2026-01-05T05:00:00.000Z'))
+
+      await service.triggerWeeklyDigest()
+
+      const [message] = sendMessage.mock.calls[0]
+      expect(message.data.windowStart).toBe('2026-01-05T00:00:00.000Z')
+      expect(message.data.windowEnd).toBe('2026-01-12T00:00:00.000Z')
+    })
+  })
+
+  describe('queue message', () => {
+    it('sends to the weeklyTasksDigest message group', async () => {
+      vi.setSystemTime(new Date('2026-04-20T04:00:00.000Z'))
+
+      await service.triggerWeeklyDigest()
+
+      const [, group] = sendMessage.mock.calls[0]
+      expect(group).toBe(MessageGroup.weeklyTasksDigest)
+    })
+
+    it('uses a deterministic deduplicationId derived from windowStart so multiple ECS instances collapse to a single SQS message', async () => {
+      vi.setSystemTime(new Date('2026-04-20T04:00:00.000Z'))
+
+      await service.triggerWeeklyDigest()
+      await service.triggerWeeklyDigest()
+
+      const [, , optionsA] = sendMessage.mock.calls[0]
+      const [, , optionsB] = sendMessage.mock.calls[1]
+      expect(optionsA.deduplicationId).toBe(
+        'weeklyTasksDigest-2026-04-20T00:00:00.000Z',
+      )
+      expect(optionsB.deduplicationId).toBe(optionsA.deduplicationId)
+    })
+  })
+})

--- a/src/campaigns/tasks/services/weeklyTasksDigest.service.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigest.service.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common'
+import { Cron } from '@nestjs/schedule'
+import { PinoLogger } from 'nestjs-pino'
+import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
+import { MessageGroup, QueueType } from 'src/queue/queue.types'
+
+const CENTRAL_TIMEZONE = 'America/Chicago'
+
+// Task dates are stored as calendar dates (e.g. "2026-04-20 00:00:00"). To
+// filter Monday-through-Sunday of the upcoming week, we need windowStart and
+// windowEnd to be UTC midnight of the calendar date, regardless of DST.
+function nextMondayUtcMidnight(now: Date, timeZone: string): Date {
+  // Format the current instant in the target timezone as parts — this gives us
+  // the calendar day the user is currently in.
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(now)
+
+  const year = Number(parts.find((p) => p.type === 'year')?.value)
+  const month = Number(parts.find((p) => p.type === 'month')?.value)
+  const day = Number(parts.find((p) => p.type === 'day')?.value)
+
+  // Use the Central calendar day/month/year to find the weekday, regardless of
+  // server timezone. getUTCDay() returns 0=Sun..6=Sat from pure date math,
+  // no locale parsing.
+  const weekdayIndex = new Date(Date.UTC(year, month - 1, day)).getUTCDay()
+
+  const daysUntilMonday = (1 - weekdayIndex + 7) % 7 || 7
+
+  return new Date(Date.UTC(year, month - 1, day + daysUntilMonday))
+}
+
+@Injectable()
+export class WeeklyTasksDigestService {
+  constructor(
+    private readonly queueService: QueueProducerService,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(WeeklyTasksDigestService.name)
+  }
+
+  // Every Sunday at 11 PM Central Time
+  @Cron('0 23 * * 0', {
+    name: 'weeklyTasksDigest',
+    timeZone: CENTRAL_TIMEZONE,
+  })
+  async triggerWeeklyDigest() {
+    const windowStart = nextMondayUtcMidnight(new Date(), CENTRAL_TIMEZONE)
+    const windowEnd = new Date(windowStart)
+    windowEnd.setUTCDate(windowEnd.getUTCDate() + 7)
+
+    this.logger.info(
+      { windowStart, windowEnd },
+      'Triggering weekly tasks digest',
+    )
+
+    // Every ECS instance runs its own @Cron, so all of them enqueue a message
+    // when this fires. We use a deterministic deduplicationId derived from
+    // windowStart so SQS FIFO collapses them into a single message (within
+    // the 5-minute dedup window), ensuring the handler runs once per week.
+    await this.queueService.sendMessage(
+      {
+        type: QueueType.WEEKLY_TASKS_DIGEST,
+        data: {
+          windowStart: windowStart.toISOString(),
+          windowEnd: windowEnd.toISOString(),
+        },
+      },
+      MessageGroup.weeklyTasksDigest,
+      {
+        deduplicationId: `weeklyTasksDigest-${windowStart.toISOString()}`,
+      },
+    )
+  }
+}

--- a/src/campaigns/tasks/services/weeklyTasksDigest.service.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigest.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common'
 import { Cron } from '@nestjs/schedule'
+import { addDays, nextMonday } from 'date-fns'
+import { toZonedTime } from 'date-fns-tz'
 import { PinoLogger } from 'nestjs-pino'
 import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
 import { MessageGroup, QueueType } from 'src/queue/queue.types'
@@ -10,28 +12,18 @@ const CENTRAL_TIMEZONE = 'America/Chicago'
 // filter Monday-through-Sunday of the upcoming week, we need windowStart and
 // windowEnd to be UTC midnight of the calendar date, regardless of DST.
 function nextMondayUtcMidnight(now: Date, timeZone: string): Date {
-  // Format the current instant in the target timezone as parts — this gives us
-  // the calendar day the user is currently in.
-  const parts = new Intl.DateTimeFormat('en-CA', {
-    timeZone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(now)
-
-  const year = Number(parts.find((p) => p.type === 'year')?.value)
-  const month = Number(parts.find((p) => p.type === 'month')?.value)
-  const day = Number(parts.find((p) => p.type === 'day')?.value)
-
-  // Use the Central calendar day/month/year to find the weekday, regardless of
-  // server timezone. getUTCDay() returns 0=Sun..6=Sat from pure date math,
-  // no locale parsing.
-  const weekdayIndex = new Date(Date.UTC(year, month - 1, day)).getUTCDay()
-
-  const daysUntilMonday = (1 - weekdayIndex + 7) % 7 || 7
-
-  return new Date(Date.UTC(year, month - 1, day + daysUntilMonday))
+  // Shift the current instant into the target timezone so nextMonday() picks
+  // the right calendar Monday (e.g. Sunday 11pm Central is still "Sunday" in
+  // Central, but "Monday" in UTC — we want Central's view).
+  const nowInZone = toZonedTime(now, timeZone)
+  const monday = nextMonday(nowInZone)
+  // Reconstruct as UTC midnight of that calendar date so the window aligns
+  // with how tasks are stored (naive timestamps at midnight UTC).
+  return new Date(
+    Date.UTC(monday.getFullYear(), monday.getMonth(), monday.getDate()),
+  )
 }
+
 
 @Injectable()
 export class WeeklyTasksDigestService {
@@ -49,8 +41,7 @@ export class WeeklyTasksDigestService {
   })
   async triggerWeeklyDigest() {
     const windowStart = nextMondayUtcMidnight(new Date(), CENTRAL_TIMEZONE)
-    const windowEnd = new Date(windowStart)
-    windowEnd.setUTCDate(windowEnd.getUTCDate() + 7)
+    const windowEnd = addDays(windowStart, 7)
 
     this.logger.info(
       { windowStart, windowEnd },

--- a/src/campaigns/tasks/services/weeklyTasksDigest.service.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigest.service.ts
@@ -24,7 +24,6 @@ function nextMondayUtcMidnight(now: Date, timeZone: string): Date {
   )
 }
 
-
 @Injectable()
 export class WeeklyTasksDigestService {
   constructor(

--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.integration.test.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.integration.test.ts
@@ -1,0 +1,528 @@
+import { useTestService } from '@/test-service'
+import { CampaignTaskType } from '@prisma/client'
+import { describe, expect, it, vi } from 'vitest'
+import { AnalyticsService } from '@/analytics/analytics.service'
+import { EVENTS } from '@/vendors/segment/segment.types'
+import { WeeklyTasksDigestHandlerService } from './weeklyTasksDigestHandler.service'
+
+const service = useTestService()
+
+const WINDOW_START = '2026-04-20T00:00:00.000Z' // Monday
+const WINDOW_END = '2026-04-27T00:00:00.000Z' // Following Monday (exclusive)
+const FUTURE_ELECTION = '2027-11-03'
+const PAST_ELECTION = '2020-01-01'
+
+type TrackSpy = ReturnType<typeof vi.spyOn>
+
+function getTrackSpy(): TrackSpy {
+  const analytics = service.app.get(AnalyticsService)
+  return vi.spyOn(analytics, 'track').mockResolvedValue({} as never)
+}
+
+async function makeCampaign(opts: {
+  electionDate?: string | null
+  userIdOffset?: number
+} = {}) {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const user = await service.prisma.user.create({
+    data: {
+      email: `digest-${unique}@test.goodparty.org`,
+      firstName: 'Test',
+      lastName: 'User',
+    },
+  })
+  const org = await service.prisma.organization.create({
+    data: {
+      slug: `digest-org-${unique}`,
+      ownerId: user.id,
+    },
+  })
+  const details = opts.electionDate
+    ? { electionDate: opts.electionDate }
+    : opts.electionDate === null
+      ? {}
+      : { electionDate: FUTURE_ELECTION }
+  return service.prisma.campaign.create({
+    data: {
+      userId: user.id,
+      slug: `digest-${unique}`,
+      details,
+      organizationSlug: org.slug,
+    },
+  })
+}
+
+async function makeTask(
+  campaignId: number,
+  overrides: {
+    date?: Date
+    completed?: boolean
+    flowType?: CampaignTaskType
+    title?: string
+    description?: string
+    week?: number
+  } = {},
+) {
+  return service.prisma.campaignTask.create({
+    data: {
+      campaignId,
+      title: overrides.title ?? 'Task',
+      description: overrides.description ?? 'A task',
+      flowType: overrides.flowType ?? CampaignTaskType.education,
+      week: overrides.week ?? 10,
+      date: overrides.date ?? new Date('2026-04-22T00:00:00.000Z'),
+      completed: overrides.completed ?? false,
+    },
+  })
+}
+
+describe('WeeklyTasksDigestHandlerService integration', () => {
+  describe('campaign eligibility', () => {
+    it('excludes campaigns with a past election date', async () => {
+      const campaign = await makeCampaign({ electionDate: PAST_ELECTION })
+      for (let i = 0; i < 5; i++) await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).not.toHaveBeenCalled()
+    })
+
+    it('excludes campaigns with no electionDate in details', async () => {
+      const campaign = await makeCampaign({ electionDate: null })
+      for (let i = 0; i < 5; i++) await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).not.toHaveBeenCalled()
+    })
+
+    it('excludes campaigns with fewer than 3 incomplete tasks in window', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).not.toHaveBeenCalled()
+    })
+
+    it('includes campaigns with exactly 3 incomplete tasks', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).toHaveBeenCalledOnce()
+    })
+
+    it('does not count completed tasks toward the MIN_TASKS threshold', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, { completed: true })
+      await makeTask(campaign.id, { completed: true })
+      await makeTask(campaign.id) // only 1 incomplete
+      await makeTask(campaign.id) // 2 incomplete
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('task selection', () => {
+    it('returns exactly 5 tasks when a campaign has more than 5 incomplete', async () => {
+      const campaign = await makeCampaign()
+      for (let i = 0; i < 8; i++) {
+        await makeTask(campaign.id, { title: `Task ${i}` })
+      }
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      expect(properties.task_name_5).not.toBe('')
+      // Since we always send 5 slots, check that plan_total_tasks reflects the real count
+      expect(properties.plan_total_tasks).toBe(8)
+    })
+
+    it('prioritizes outreach task types (text, robocall, doorKnocking, phoneBanking) over others', async () => {
+      const campaign = await makeCampaign()
+      // 2 non-outreach + 2 outreach, all same date so only outreach priority matters
+      const sameDate = new Date('2026-04-22T00:00:00.000Z')
+      await makeTask(campaign.id, {
+        title: 'Education Task',
+        flowType: CampaignTaskType.education,
+        date: sameDate,
+      })
+      await makeTask(campaign.id, {
+        title: 'Social Media Task',
+        flowType: CampaignTaskType.socialMedia,
+        date: sameDate,
+      })
+      await makeTask(campaign.id, {
+        title: 'Text Task',
+        flowType: CampaignTaskType.text,
+        date: sameDate,
+      })
+      await makeTask(campaign.id, {
+        title: 'Door Knocking Task',
+        flowType: CampaignTaskType.doorKnocking,
+        date: sameDate,
+      })
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      // First two slots should be the outreach tasks
+      const slot1And2 = [properties.task_name_1, properties.task_name_2]
+      expect(slot1And2).toContain('Text Task')
+      expect(slot1And2).toContain('Door Knocking Task')
+    })
+
+    it('prioritizes robocall and phoneBanking as outreach types', async () => {
+      const campaign = await makeCampaign()
+      const sameDate = new Date('2026-04-22T00:00:00.000Z')
+      await makeTask(campaign.id, {
+        title: 'Education Task',
+        flowType: CampaignTaskType.education,
+        date: sameDate,
+      })
+      await makeTask(campaign.id, {
+        title: 'Events Task',
+        flowType: CampaignTaskType.events,
+        date: sameDate,
+      })
+      await makeTask(campaign.id, {
+        title: 'Robocall Task',
+        flowType: CampaignTaskType.robocall,
+        date: sameDate,
+      })
+      await makeTask(campaign.id, {
+        title: 'Phone Banking Task',
+        flowType: CampaignTaskType.phoneBanking,
+        date: sameDate,
+      })
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      const slot1And2 = [properties.task_name_1, properties.task_name_2]
+      expect(slot1And2).toContain('Robocall Task')
+      expect(slot1And2).toContain('Phone Banking Task')
+    })
+
+    it('orders tasks by date within the same priority category', async () => {
+      const campaign = await makeCampaign()
+      // All outreach, different dates
+      await makeTask(campaign.id, {
+        title: 'Friday Task',
+        flowType: CampaignTaskType.text,
+        date: new Date('2026-04-24T00:00:00.000Z'),
+      })
+      await makeTask(campaign.id, {
+        title: 'Monday Task',
+        flowType: CampaignTaskType.text,
+        date: new Date('2026-04-20T00:00:00.000Z'),
+      })
+      await makeTask(campaign.id, {
+        title: 'Wednesday Task',
+        flowType: CampaignTaskType.text,
+        date: new Date('2026-04-22T00:00:00.000Z'),
+      })
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      expect(properties.task_name_1).toBe('Monday Task')
+      expect(properties.task_name_2).toBe('Wednesday Task')
+      expect(properties.task_name_3).toBe('Friday Task')
+    })
+
+    it('does not include completed tasks in the slots', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, { title: 'Completed', completed: true })
+      await makeTask(campaign.id, { title: 'Incomplete 1' })
+      await makeTask(campaign.id, { title: 'Incomplete 2' })
+      await makeTask(campaign.id, { title: 'Incomplete 3' })
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      const taskNames = [
+        properties.task_name_1,
+        properties.task_name_2,
+        properties.task_name_3,
+      ]
+      expect(taskNames).not.toContain('Completed')
+    })
+  })
+
+  describe('date window bounds', () => {
+    it('includes tasks dated exactly at windowStart (Monday 00:00)', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, {
+        title: 'Monday 00:00 Task',
+        date: new Date('2026-04-20T00:00:00.000Z'),
+      })
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).toHaveBeenCalledOnce()
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      const titles = [
+        properties.task_name_1,
+        properties.task_name_2,
+        properties.task_name_3,
+      ]
+      expect(titles).toContain('Monday 00:00 Task')
+    })
+
+    it('includes tasks dated Sunday 23:59:59.999', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, {
+        title: 'Sunday Late Task',
+        date: new Date('2026-04-26T23:59:59.999Z'),
+      })
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).toHaveBeenCalledOnce()
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      const titles = [
+        properties.task_name_1,
+        properties.task_name_2,
+        properties.task_name_3,
+      ]
+      expect(titles).toContain('Sunday Late Task')
+    })
+
+    it('excludes tasks dated exactly at windowEnd (next Monday 00:00)', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, {
+        title: 'Next Monday Task',
+        date: new Date('2026-04-27T00:00:00.000Z'),
+      })
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      // Only 2 tasks in window (the 3rd is outside), below MIN_TASKS → not eligible
+      expect(trackSpy).not.toHaveBeenCalled()
+    })
+
+    it('excludes tasks dated before windowStart (Sunday before)', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, {
+        title: 'Sunday Before',
+        date: new Date('2026-04-19T23:59:59.999Z'),
+      })
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      // Only 2 tasks in window → not eligible
+      expect(trackSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('event payload', () => {
+    it('reports completed and total task counts correctly', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, { completed: true })
+      await makeTask(campaign.id, { completed: true })
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      expect(properties.plan_tasks_completed).toBe(2)
+      expect(properties.plan_total_tasks).toBe(5)
+    })
+
+    it('emits all 5 task slots with blank values when fewer than 5 tasks exist', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, { title: 'T1' })
+      await makeTask(campaign.id, { title: 'T2' })
+      await makeTask(campaign.id, { title: 'T3' })
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      expect(properties.task_name_4).toBe('')
+      expect(properties.task_description_4).toBe('')
+      expect(properties.task_type_4).toBe('')
+      expect(properties.task_due_date_4).toBe('')
+      expect(properties.task_week_number_4).toBe(null)
+      expect(properties.task_name_5).toBe('')
+      expect(properties.task_week_number_5).toBe(null)
+    })
+
+    it('uses the correct event name', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).toHaveBeenCalledWith(
+        campaign.userId,
+        EVENTS.CampaignPlan.WeeklyTasksDigest,
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe('multiple campaigns', () => {
+    it('fires one event per eligible campaign', async () => {
+      const c1 = await makeCampaign()
+      const c2 = await makeCampaign()
+      const c3Ineligible = await makeCampaign({ electionDate: PAST_ELECTION })
+
+      for (let i = 0; i < 3; i++) await makeTask(c1.id)
+      for (let i = 0; i < 3; i++) await makeTask(c2.id)
+      for (let i = 0; i < 5; i++) await makeTask(c3Ineligible.id)
+
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).toHaveBeenCalledTimes(2)
+      const userIds = trackSpy.mock.calls.map((call) => call[0]).sort()
+      expect(userIds).toEqual([c1.userId, c2.userId].sort())
+    })
+  })
+})

--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.integration.test.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.integration.test.ts
@@ -21,7 +21,6 @@ function getTrackSpy(): TrackSpy {
 
 async function makeCampaign(opts: {
   electionDate?: string | null
-  userIdOffset?: number
 } = {}) {
   const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`
   const user = await service.prisma.user.create({
@@ -37,11 +36,14 @@ async function makeCampaign(opts: {
       ownerId: user.id,
     },
   })
-  const details = opts.electionDate
-    ? { electionDate: opts.electionDate }
-    : opts.electionDate === null
+  // `null` = omit the key entirely; any string (including '') = use as-is;
+  // `undefined` (not provided) = use the default future election date.
+  const details =
+    opts.electionDate === null
       ? {}
-      : { electionDate: FUTURE_ELECTION }
+      : opts.electionDate !== undefined
+        ? { electionDate: opts.electionDate }
+        : { electionDate: FUTURE_ELECTION }
   return service.prisma.campaign.create({
     data: {
       userId: user.id,
@@ -104,6 +106,31 @@ describe('WeeklyTasksDigestHandlerService integration', () => {
       })
 
       expect(trackSpy).not.toHaveBeenCalled()
+    })
+
+    it('skips (does not crash) when electionDate is an empty string or malformed', async () => {
+      const emptyCampaign = await makeCampaign({ electionDate: '' })
+      const malformedCampaign = await makeCampaign({ electionDate: 'TBD' })
+      const validCampaign = await makeCampaign()
+      for (let i = 0; i < 5; i++) await makeTask(emptyCampaign.id)
+      for (let i = 0; i < 5; i++) await makeTask(malformedCampaign.id)
+      for (let i = 0; i < 3; i++) await makeTask(validCampaign.id)
+
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      // The valid campaign still fires; the bad rows are silently filtered by the SQL regex.
+      expect(trackSpy).toHaveBeenCalledOnce()
+      expect(trackSpy).toHaveBeenCalledWith(
+        validCampaign.userId,
+        expect.any(String),
+        expect.any(Object),
+      )
     })
 
     it('excludes campaigns with fewer than 3 incomplete tasks in window', async () => {

--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.integration.test.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.integration.test.ts
@@ -19,9 +19,11 @@ function getTrackSpy(): TrackSpy {
   return vi.spyOn(analytics, 'track').mockResolvedValue({} as never)
 }
 
-async function makeCampaign(opts: {
-  electionDate?: string | null
-} = {}) {
+async function makeCampaign(
+  opts: {
+    electionDate?: string | null
+  } = {},
+) {
   const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`
   const user = await service.prisma.user.create({
     data: {

--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.test.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CampaignTaskType } from '@prisma/client'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { AnalyticsService } from 'src/analytics/analytics.service'
+import { EVENTS } from 'src/vendors/segment/segment.types'
+import { WeeklyTasksDigestHandlerService } from './weeklyTasksDigestHandler.service'
+
+const mockAnalytics: Partial<AnalyticsService> = {
+  track: vi.fn().mockResolvedValue(undefined),
+}
+
+const mockQueryRaw = vi.fn()
+
+const WINDOW_START = '2026-04-20T00:00:00.000Z'
+const WINDOW_END = '2026-04-27T00:00:00.000Z'
+
+const makeDigestRow = (overrides = {}) => ({
+  campaign_id: 1,
+  user_id: 100,
+  completed_count: 0,
+  incomplete_count: 3,
+  slot: 1,
+  title: 'Task',
+  description: 'Description',
+  flow_type: CampaignTaskType.education,
+  date: new Date('2026-04-21T00:00:00.000Z'),
+  week: 10,
+  ...overrides,
+})
+
+describe('WeeklyTasksDigestHandlerService', () => {
+  let service: WeeklyTasksDigestHandlerService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    service = new WeeklyTasksDigestHandlerService(
+      mockAnalytics as AnalyticsService,
+    )
+
+    Object.defineProperty(service, '_prisma', {
+      get: () => ({
+        $queryRaw: mockQueryRaw,
+      }),
+    })
+    Object.defineProperty(service, 'logger', {
+      get: () => createMockLogger(),
+    })
+  })
+
+  it('does not track when no eligible campaigns', async () => {
+    mockQueryRaw.mockResolvedValueOnce([])
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    expect(mockAnalytics.track).not.toHaveBeenCalled()
+  })
+
+  it('sends event with 3 tasks populated and slots 4/5 blank to clear stale HubSpot data', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeDigestRow({
+        slot: 1,
+        title: 'Task A',
+        flow_type: CampaignTaskType.text,
+        completed_count: 1,
+        incomplete_count: 3,
+      }),
+      makeDigestRow({
+        slot: 2,
+        title: 'Task B',
+        flow_type: CampaignTaskType.doorKnocking,
+        completed_count: 1,
+        incomplete_count: 3,
+      }),
+      makeDigestRow({
+        slot: 3,
+        title: 'Task C',
+        flow_type: CampaignTaskType.education,
+        completed_count: 1,
+        incomplete_count: 3,
+      }),
+    ])
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    expect(mockAnalytics.track).toHaveBeenCalledOnce()
+    const [, , properties] = (mockAnalytics.track as ReturnType<typeof vi.fn>)
+      .mock.calls[0]
+
+    expect(properties.plan_tasks_completed).toBe(1)
+    expect(properties.plan_total_tasks).toBe(4)
+
+    expect(properties.task_name_1).toBe('Task A')
+    expect(properties.task_name_2).toBe('Task B')
+    expect(properties.task_name_3).toBe('Task C')
+
+    expect(properties.task_due_date_1).toBe('2026-04-21')
+    expect(properties.task_due_date_1).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+
+    // Slots 4 and 5 are still sent, but blank/null, so HubSpot clears any
+    // stale values left over from prior weeks' digests.
+    expect(properties.task_name_4).toBe('')
+    expect(properties.task_description_4).toBe('')
+    expect(properties.task_type_4).toBe('')
+    expect(properties.task_due_date_4).toBe('')
+    expect(properties.task_week_number_4).toBe(null)
+    expect(properties.task_name_5).toBe('')
+    expect(properties.task_description_5).toBe('')
+    expect(properties.task_type_5).toBe('')
+    expect(properties.task_due_date_5).toBe('')
+    expect(properties.task_week_number_5).toBe(null)
+  })
+
+  it('sends event with all 5 task slots when 5 tasks exist', async () => {
+    mockQueryRaw.mockResolvedValueOnce(
+      [1, 2, 3, 4, 5].map((slot) =>
+        makeDigestRow({
+          slot,
+          title: `T${slot}`,
+          completed_count: 0,
+          incomplete_count: 7,
+        }),
+      ),
+    )
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    const [, , properties] = (mockAnalytics.track as ReturnType<typeof vi.fn>)
+      .mock.calls[0]
+
+    expect(properties.task_name_1).toBe('T1')
+    expect(properties.task_name_5).toBe('T5')
+    expect(properties.plan_total_tasks).toBe(7)
+  })
+
+  it('tracks the correct event name and user id', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeDigestRow({ user_id: 100, slot: 1 }),
+      makeDigestRow({ user_id: 100, slot: 2 }),
+      makeDigestRow({ user_id: 100, slot: 3 }),
+    ])
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    expect(mockAnalytics.track).toHaveBeenCalledWith(
+      100,
+      EVENTS.CampaignPlan.WeeklyTasksDigest,
+      expect.any(Object),
+    )
+  })
+
+  it('fires one event per campaign when multiple campaigns are eligible', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeDigestRow({ campaign_id: 1, user_id: 100, slot: 1 }),
+      makeDigestRow({ campaign_id: 1, user_id: 100, slot: 2 }),
+      makeDigestRow({ campaign_id: 1, user_id: 100, slot: 3 }),
+      makeDigestRow({ campaign_id: 2, user_id: 200, slot: 1 }),
+      makeDigestRow({ campaign_id: 2, user_id: 200, slot: 2 }),
+      makeDigestRow({ campaign_id: 2, user_id: 200, slot: 3 }),
+    ])
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    expect(mockAnalytics.track).toHaveBeenCalledTimes(2)
+    const userIds = (mockAnalytics.track as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c[0])
+      .sort()
+    expect(userIds).toEqual([100, 200])
+  })
+
+  it('continues processing remaining campaigns when analytics fails for one', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeDigestRow({ campaign_id: 1, user_id: 100, slot: 1 }),
+      makeDigestRow({ campaign_id: 1, user_id: 100, slot: 2 }),
+      makeDigestRow({ campaign_id: 1, user_id: 100, slot: 3 }),
+      makeDigestRow({ campaign_id: 2, user_id: 200, slot: 1 }),
+      makeDigestRow({ campaign_id: 2, user_id: 200, slot: 2 }),
+      makeDigestRow({ campaign_id: 2, user_id: 200, slot: 3 }),
+    ])
+    ;(mockAnalytics.track as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('Segment down'))
+      .mockResolvedValueOnce(undefined)
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    expect(mockAnalytics.track).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.ts
@@ -1,0 +1,279 @@
+import { Injectable } from '@nestjs/common'
+import { CampaignTaskType, Prisma } from '@prisma/client'
+import { AnalyticsService } from 'src/analytics/analytics.service'
+import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
+import { toDateOnlyString } from 'src/shared/util/date.util'
+import { EVENTS } from 'src/vendors/segment/segment.types'
+import { WeeklyTasksDigestMessage } from 'src/queue/queue.types'
+
+const OUTREACH_FLOW_TYPES: CampaignTaskType[] = [
+  CampaignTaskType.text,
+  CampaignTaskType.robocall,
+  CampaignTaskType.doorKnocking,
+  CampaignTaskType.phoneBanking,
+]
+const MAX_TASKS = 5
+const MIN_TASKS = 3
+
+interface DigestRow {
+  campaign_id: number
+  user_id: number
+  completed_count: number
+  incomplete_count: number
+  slot: number
+  title: string
+  description: string
+  flow_type: CampaignTaskType | null
+  date: Date | null
+  week: number
+}
+
+interface TopTaskRow {
+  title: string
+  description: string
+  flow_type: CampaignTaskType | null
+  date: Date | null
+  week: number
+}
+
+interface WeeklyDigestProperties {
+  plan_tasks_completed: number
+  plan_total_tasks: number
+  task_name_1: string
+  task_description_1: string
+  task_type_1: string
+  task_due_date_1: string
+  task_week_number_1: number | null
+  task_name_2: string
+  task_description_2: string
+  task_type_2: string
+  task_due_date_2: string
+  task_week_number_2: number | null
+  task_name_3: string
+  task_description_3: string
+  task_type_3: string
+  task_due_date_3: string
+  task_week_number_3: number | null
+  task_name_4: string
+  task_description_4: string
+  task_type_4: string
+  task_due_date_4: string
+  task_week_number_4: number | null
+  task_name_5: string
+  task_description_5: string
+  task_type_5: string
+  task_due_date_5: string
+  task_week_number_5: number | null
+}
+
+type TaskSlotProperties = Pick<
+  WeeklyDigestProperties,
+  | 'task_name_1'
+  | 'task_description_1'
+  | 'task_type_1'
+  | 'task_due_date_1'
+  | 'task_week_number_1'
+  | 'task_name_2'
+  | 'task_description_2'
+  | 'task_type_2'
+  | 'task_due_date_2'
+  | 'task_week_number_2'
+  | 'task_name_3'
+  | 'task_description_3'
+  | 'task_type_3'
+  | 'task_due_date_3'
+  | 'task_week_number_3'
+  | 'task_name_4'
+  | 'task_description_4'
+  | 'task_type_4'
+  | 'task_due_date_4'
+  | 'task_week_number_4'
+  | 'task_name_5'
+  | 'task_description_5'
+  | 'task_type_5'
+  | 'task_due_date_5'
+  | 'task_week_number_5'
+>
+
+// Always emits all 5 task slots. Empty slots send blank/null values so HubSpot
+// clears stale data from the previous week's digest.
+function buildTaskProperties(tasks: TopTaskRow[]): TaskSlotProperties {
+  const [t1, t2, t3, t4, t5] = tasks
+  return {
+    task_name_1: t1?.title ?? '',
+    task_description_1: t1?.description ?? '',
+    task_type_1: t1?.flow_type ?? '',
+    task_due_date_1: toDateOnlyString(t1?.date) ?? '',
+    task_week_number_1: t1?.week ?? null,
+    task_name_2: t2?.title ?? '',
+    task_description_2: t2?.description ?? '',
+    task_type_2: t2?.flow_type ?? '',
+    task_due_date_2: toDateOnlyString(t2?.date) ?? '',
+    task_week_number_2: t2?.week ?? null,
+    task_name_3: t3?.title ?? '',
+    task_description_3: t3?.description ?? '',
+    task_type_3: t3?.flow_type ?? '',
+    task_due_date_3: toDateOnlyString(t3?.date) ?? '',
+    task_week_number_3: t3?.week ?? null,
+    task_name_4: t4?.title ?? '',
+    task_description_4: t4?.description ?? '',
+    task_type_4: t4?.flow_type ?? '',
+    task_due_date_4: toDateOnlyString(t4?.date) ?? '',
+    task_week_number_4: t4?.week ?? null,
+    task_name_5: t5?.title ?? '',
+    task_description_5: t5?.description ?? '',
+    task_type_5: t5?.flow_type ?? '',
+    task_due_date_5: toDateOnlyString(t5?.date) ?? '',
+    task_week_number_5: t5?.week ?? null,
+  }
+}
+
+interface CampaignDigestGroup {
+  userId: number
+  completedCount: number
+  incompleteCount: number
+  tasks: TopTaskRow[]
+}
+
+function groupByCampaign(rows: DigestRow[]): Map<number, CampaignDigestGroup> {
+  const groups = new Map<number, CampaignDigestGroup>()
+  for (const row of rows) {
+    let group = groups.get(row.campaign_id)
+    if (!group) {
+      group = {
+        userId: row.user_id,
+        completedCount: row.completed_count,
+        incompleteCount: row.incomplete_count,
+        tasks: [],
+      }
+      groups.set(row.campaign_id, group)
+    }
+    group.tasks.push({
+      title: row.title,
+      description: row.description,
+      flow_type: row.flow_type,
+      date: row.date,
+      week: row.week,
+    })
+  }
+  return groups
+}
+
+@Injectable()
+export class WeeklyTasksDigestHandlerService extends createPrismaBase(
+  MODELS.CampaignTask,
+) {
+  constructor(private readonly analytics: AnalyticsService) {
+    super()
+  }
+
+  async handleWeeklyTasksDigest(data: WeeklyTasksDigestMessage) {
+    const windowStart = new Date(data.windowStart)
+    const windowEnd = new Date(data.windowEnd)
+
+    this.logger.info(
+      { windowStart, windowEnd },
+      'Processing weekly tasks digest',
+    )
+
+    // Single query: for every campaign with a future election date and at
+    // least MIN_TASKS incomplete tasks in the window, return the top
+    // MAX_TASKS incomplete tasks (outreach types prioritized, then by date).
+    // Each row denormalizes the campaign's counts so we can group in JS.
+    const rows = await this.client.$queryRaw<DigestRow[]>`
+      WITH eligible AS (
+        SELECT
+          c.id,
+          c.user_id,
+          COUNT(*) FILTER (WHERE t.completed = true)::int  AS completed_count,
+          COUNT(*) FILTER (WHERE t.completed = false)::int AS incomplete_count
+        FROM campaign c
+        JOIN campaign_task t ON t.campaign_id = c.id
+        WHERE c.details->>'electionDate' IS NOT NULL
+          AND (c.details->>'electionDate')::date > NOW()::date
+          AND t.date >= ${windowStart}
+          AND t.date < ${windowEnd}
+        GROUP BY c.id, c.user_id
+        HAVING COUNT(*) FILTER (WHERE t.completed = false) >= ${MIN_TASKS}
+      ),
+      ranked_tasks AS (
+        SELECT
+          t.campaign_id,
+          t.title,
+          t.description,
+          t.flow_type,
+          t.date,
+          t.week,
+          ROW_NUMBER() OVER (
+            PARTITION BY t.campaign_id
+            ORDER BY
+              CASE WHEN t.flow_type::text IN (${Prisma.join(OUTREACH_FLOW_TYPES)})
+                THEN 0 ELSE 1 END,
+              t.date ASC
+          ) AS slot
+        FROM campaign_task t
+        JOIN eligible e ON e.id = t.campaign_id
+        WHERE t.completed = false
+          AND t.date >= ${windowStart}
+          AND t.date < ${windowEnd}
+      )
+      SELECT
+        e.id           AS campaign_id,
+        e.user_id,
+        e.completed_count,
+        e.incomplete_count,
+        rt.slot::int   AS slot,
+        rt.title,
+        rt.description,
+        rt.flow_type,
+        rt.date,
+        rt.week
+      FROM eligible e
+      JOIN ranked_tasks rt ON rt.campaign_id = e.id
+      WHERE rt.slot <= ${MAX_TASKS}
+      ORDER BY e.id, rt.slot
+    `
+
+    const campaigns = groupByCampaign(rows)
+
+    let sent = 0
+    let failed = 0
+
+    for (const [campaignId, group] of campaigns) {
+      try {
+        const properties: WeeklyDigestProperties = {
+          plan_tasks_completed: group.completedCount,
+          plan_total_tasks: group.completedCount + group.incompleteCount,
+          ...buildTaskProperties(group.tasks),
+        }
+
+        await this.analytics.track(
+          group.userId,
+          EVENTS.CampaignPlan.WeeklyTasksDigest,
+          { ...properties },
+        )
+
+        this.logger.info(
+          {
+            campaignId,
+            userId: group.userId,
+            taskCount: group.tasks.length,
+          },
+          'Sent weekly tasks digest event',
+        )
+        sent++
+      } catch (error) {
+        this.logger.error(
+          { campaignId, error },
+          'Failed to process weekly digest for campaign',
+        )
+        failed++
+      }
+    }
+
+    this.logger.info(
+      { sent, failed, eligible: campaigns.size },
+      'Weekly tasks digest complete',
+    )
+  }
+}

--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.ts
@@ -250,6 +250,9 @@ export class WeeklyTasksDigestHandlerService extends createPrismaBase(
         await this.analytics.track(
           group.userId,
           EVENTS.CampaignPlan.WeeklyTasksDigest,
+          // The spread widens our strict WeeklyDigestProperties type to match
+          // analytics.track's `Record<string, unknown>` signature. See WEB-4530
+          // for the TODO to make the track signature generic.
           { ...properties },
         )
 

--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.ts
@@ -189,7 +189,7 @@ export class WeeklyTasksDigestHandlerService extends createPrismaBase(
           COUNT(*) FILTER (WHERE t.completed = false)::int AS incomplete_count
         FROM campaign c
         JOIN campaign_task t ON t.campaign_id = c.id
-        WHERE c.details->>'electionDate' IS NOT NULL
+        WHERE c.details->>'electionDate' ~ '^\\d{4}-\\d{2}-\\d{2}'
           AND (c.details->>'electionDate')::date > NOW()::date
           AND t.date >= ${windowStart}
           AND t.date < ${windowEnd}

--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.ts
@@ -24,7 +24,7 @@ interface DigestRow {
   title: string
   description: string
   flow_type: CampaignTaskType | null
-  date: Date | null
+  date: Date
   week: number
 }
 
@@ -32,7 +32,7 @@ interface TopTaskRow {
   title: string
   description: string
   flow_type: CampaignTaskType | null
-  date: Date | null
+  date: Date
   week: number
 }
 

--- a/src/queue/consumer/queueConsumer.service.test.ts
+++ b/src/queue/consumer/queueConsumer.service.test.ts
@@ -5,6 +5,7 @@ import { AiContentService } from '@/campaigns/ai/content/aiContent.service'
 import { CampaignsService } from '@/campaigns/services/campaigns.service'
 import { AiGenerationService } from '@/campaigns/tasks/services/aiGeneration.service'
 import { CampaignTasksService } from '@/campaigns/tasks/services/campaignTasks.service'
+import { WeeklyTasksDigestHandlerService } from '@/campaigns/tasks/services/weeklyTasksDigestHandler.service'
 import { CampaignTcrComplianceService } from '@/campaigns/tcrCompliance/services/campaignTcrCompliance.service'
 import { ContactsService } from '@/contacts/services/contacts.service'
 import { ElectedOfficeService } from '@/electedOffice/services/electedOffice.service'
@@ -215,6 +216,7 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
       electedOfficeService as never,
       contactsService as never,
       s3Service as never,
+      {} as never,
       {} as never,
       {} as never,
       createMockLogger(),
@@ -853,6 +855,7 @@ describe('QueueConsumerService - triggerPollExecution', () => {
       s3Service as never,
       usersService as never,
       {} as never,
+      {} as never,
       createMockLogger(),
     )
   })
@@ -972,6 +975,10 @@ describe('QueueConsumerService - message type routing', () => {
         { provide: SlackService, useValue: mockSlackService },
         { provide: UsersService, useValue: {} },
         { provide: AnalyticsService, useValue: {} },
+        {
+          provide: WeeklyTasksDigestHandlerService,
+          useValue: { handleWeeklyTasksDigest: vi.fn() },
+        },
         { provide: PinoLogger, useValue: createMockLogger() },
       ],
     }).compile()
@@ -1031,6 +1038,56 @@ describe('QueueConsumerService - message type routing', () => {
     const result = await service.processMessage(message)
 
     expect(result).toBe(true)
+  })
+
+  it('routes weeklyTasksDigest messages to the handler', async () => {
+    const handler = module.get(WeeklyTasksDigestHandlerService)
+    const handleSpy = vi
+      .spyOn(handler, 'handleWeeklyTasksDigest')
+      .mockResolvedValue(undefined)
+
+    const message: Message = {
+      MessageId: 'msg-digest-ok',
+      Body: JSON.stringify({
+        type: QueueType.WEEKLY_TASKS_DIGEST,
+        data: {
+          windowStart: '2026-04-20T00:00:00.000Z',
+          windowEnd: '2026-04-27T00:00:00.000Z',
+        },
+      }),
+    }
+
+    const result = await service.processMessage(message)
+
+    expect(result).toBe(true)
+    expect(handleSpy).toHaveBeenCalledOnce()
+    expect(handleSpy).toHaveBeenCalledWith({
+      windowStart: '2026-04-20T00:00:00.000Z',
+      windowEnd: '2026-04-27T00:00:00.000Z',
+    })
+  })
+
+  it('rejects weeklyTasksDigest messages with invalid payload and does not call handler', async () => {
+    const handler = module.get(WeeklyTasksDigestHandlerService)
+    const handleSpy = vi
+      .spyOn(handler, 'handleWeeklyTasksDigest')
+      .mockResolvedValue(undefined)
+
+    const message: Message = {
+      MessageId: 'msg-digest-invalid',
+      Body: JSON.stringify({
+        type: QueueType.WEEKLY_TASKS_DIGEST,
+        data: {
+          windowStart: 'not-a-date',
+        },
+      }),
+    }
+
+    // withLegacyErrorSwallowing catches the Zod parse failure and returns true
+    const result = await service.processMessage(message)
+
+    expect(result).toBe(true)
+    expect(handleSpy).not.toHaveBeenCalled()
   })
 
   it('discards campaignPlanComplete with permanent Prisma error instead of requeuing', async () => {

--- a/src/queue/consumer/queueConsumer.service.ts
+++ b/src/queue/consumer/queueConsumer.service.ts
@@ -49,6 +49,7 @@ import {
   CampaignPlanCompleteMessage,
   CampaignPlanCompleteMessageSchema,
   DomainEmailForwardingMessage,
+  WeeklyTasksDigestMessageSchema,
   PollAnalysisCompleteEvent,
   PollAnalysisCompleteEventSchema,
   PollCreationEvent,
@@ -62,6 +63,7 @@ import {
   TcrComplianceStatusCheckMessage,
 } from '../queue.types'
 import { PollIndividualMessageService } from '@/polls/services/pollIndividualMessage.service'
+import { WeeklyTasksDigestHandlerService } from '../../campaigns/tasks/services/weeklyTasksDigestHandler.service'
 import { v5 as uuidv5 } from 'uuid'
 import { PinoLogger } from 'nestjs-pino'
 import { OrgDistrict } from '@/organizations/organizations.types'
@@ -109,6 +111,7 @@ export class QueueConsumerService {
     private readonly s3Service: S3Service,
     private readonly usersService: UsersService,
     private readonly organizationsService: OrganizationsService,
+    private readonly weeklyTasksDigestHandler: WeeklyTasksDigestHandlerService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(QueueConsumerService.name)
@@ -342,6 +345,17 @@ export class QueueConsumerService {
             queueMessage.data,
           )
           await this.handleCampaignPlanComplete(campaignPlanData)
+          return true
+        })
+      case QueueType.WEEKLY_TASKS_DIGEST:
+        this.logger.info('received weeklyTasksDigest message')
+        return await this.withLegacyErrorSwallowing(message, async () => {
+          const digestData = WeeklyTasksDigestMessageSchema.parse(
+            queueMessage.data,
+          )
+          await this.weeklyTasksDigestHandler.handleWeeklyTasksDigest(
+            digestData,
+          )
           return true
         })
       default:

--- a/src/queue/producer/queueProducer.service.ts
+++ b/src/queue/producer/queueProducer.service.ts
@@ -45,19 +45,17 @@ export class QueueProducerService {
   async sendMessage(
     msg: QueueMessage,
     group: MessageGroup | string = MessageGroup.default,
-    options: { throwOnError?: boolean } = {},
+    options: { throwOnError?: boolean; deduplicationId?: string } = {},
   ) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const body: any = JSON.stringify(msg)
+    const body = JSON.stringify(msg)
 
     const uuid = Math.random().toString(36).substring(2, 12)
+    const deduplicationId = options.deduplicationId ?? uuid
 
     const message: Message = {
       id: uuid,
-      // Type narrowing from nullable/union — runtime context guarantees string but type is broader
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      body: body as string,
-      deduplicationId: uuid,
+      body,
+      deduplicationId,
       groupId: `gp-queue-${group}`,
     }
 

--- a/src/queue/queue.types.ts
+++ b/src/queue/queue.types.ts
@@ -9,6 +9,7 @@ export enum QueueType {
   POLL_CREATION = 'pollCreation',
   POLL_EXPANSION = 'pollExpansion',
   CAMPAIGN_PLAN_COMPLETE = 'campaignPlanComplete',
+  WEEKLY_TASKS_DIGEST = 'weeklyTasksDigest',
 }
 
 export type QueueMessage =
@@ -30,6 +31,10 @@ export type QueueMessage =
   | {
       type: QueueType.CAMPAIGN_PLAN_COMPLETE
       data: CampaignPlanCompleteMessage
+    }
+  | {
+      type: QueueType.WEEKLY_TASKS_DIGEST
+      data: WeeklyTasksDigestMessage
     }
 
 export type GenerateAiContentMessageData = {
@@ -112,12 +117,22 @@ export enum SqsConsumerErrorEventName {
   TIMEOUT_ERROR = 'timeout_error',
 }
 
+export const WeeklyTasksDigestMessageSchema = z.object({
+  windowStart: z.string().datetime(),
+  windowEnd: z.string().datetime(),
+})
+
+export type WeeklyTasksDigestMessage = z.infer<
+  typeof WeeklyTasksDigestMessageSchema
+>
+
 export enum MessageGroup {
   content = 'content',
   tcrCompliance = 'tcrCompliance',
   default = 'default',
   domainEmailRedirect = 'domainEmailRedirect',
   polls = 'polls',
+  weeklyTasksDigest = 'weeklyTasksDigest',
 }
 
 const PollResponseJsonRowSchema = z.object({

--- a/src/vendors/segment/HUBSPOT_INTEGRATION.md
+++ b/src/vendors/segment/HUBSPOT_INTEGRATION.md
@@ -1,6 +1,6 @@
 # Segment → HubSpot Integration
 
-This document describes how Segment events flow from the API to HubSpot and trigger workflows that update user compliance status.
+This document describes how Segment events flow from the API to HubSpot and trigger workflows that update contact/company fields.
 
 ## Overview
 
@@ -35,6 +35,48 @@ The compliance flow tracks user progress through these stages:
 | `Voter Outreach - 10DLC Compliance PIN Submitted` | Ops - Set 10 DLC Compliance Status to Compliance PIN Submitted | Compliance Pending | `CampaignTcrComplianceController.submitCampaignVerifyPIN()` |
 | `Voter Outreach - 10DLC Compliance Completed` | Ops - Set 10 DLC Compliance Status to 10 DLC Compliance Complete | Compliant | `QueueConsumerService.handleTcrComplianceCheckMessage()` |
 
+## Weekly Tasks Digest Flow
+
+A cron job (`WeeklyTasksDigestService`) fires every Sunday at 11 PM Central Time and sends a `WEEKLY_TASKS_DIGEST` message to the SQS queue. The consumer (`WeeklyTasksDigestHandlerService`) processes all campaigns with a future election date and fires a Segment event per campaign with up to 5 upcoming tasks due Monday through Sunday of the coming week.
+
+The event populates the `win_campaign_plan` fields on the HubSpot contact, which a HubSpot workflow uses to send weekly digest emails.
+
+| Event Name | HubSpot Contact Fields | Fired From |
+|-----------|----------------------|------------|
+| `Campaign Plan - Weekly Tasks Digest` | `plan_tasks_completed`, `plan_total_tasks`, `task_name_1`-`5`, `task_description_1`-`5`, `task_type_1`-`5`, `task_due_date_1`-`5`, `task_week_number_1`-`5` | `WeeklyTasksDigestHandlerService` (via SQS queue) |
+
+Rules:
+- Campaigns with a past election date are skipped
+- Campaigns with fewer than 3 incomplete tasks are skipped (stale data prevents HubSpot from sending the email)
+- Outreach tasks (`text`, `robocall`, `doorKnocking`, `phoneBanking`) are prioritized
+- Task due dates are sent as date-only strings (`yyyy-MM-dd`)
+
+Test script: `scripts/test-weekly-tasks-digest-event.ts`
+
+### Manual Recovery (if the cron fails)
+
+The cron enqueues the window in the SQS message itself, so manual triggering just means sending that same message shape by hand. Do this when the Sunday-night cron didn't fire (or the consumer was down) and you want to backfill HubSpot for the current week.
+
+1. Compute the window in UTC:
+   - `windowStart` = the Monday you want to cover, at `00:00:00.000Z`
+   - `windowEnd` = the following Monday, at `00:00:00.000Z`
+   - (Example for the week of April 20, 2026: `2026-04-20T00:00:00.000Z` → `2026-04-27T00:00:00.000Z`)
+
+2. Send this message body to the gp-api FIFO SQS queue (via AWS Console or CLI):
+   ```json
+   {
+     "type": "weeklyTasksDigest",
+     "data": {
+       "windowStart": "2026-04-20T00:00:00.000Z",
+       "windowEnd": "2026-04-27T00:00:00.000Z"
+     }
+   }
+   ```
+   - `MessageGroupId`: `gp-queue-weeklyTasksDigest`
+   - `MessageDeduplicationId`: anything unique (e.g. `manual-<timestamp>`)
+
+3. The consumer will query all campaigns, fire Segment events, and refresh the HubSpot contact fields. HubSpot's 5-day staleness check applies to whether the digest email sends — a manual recovery within ~5 days of the intended run should still trigger emails.
+
 ## Event Definitions
 
 File: `src/vendors/segment/segment.types.ts`
@@ -45,6 +87,7 @@ EVENTS.CandidateWebsite.PurchasedDomain     // 'Candidate Website - Purchased do
 EVENTS.Outreach.ComplianceFormSubmitted      // 'Voter Outreach - 10DLC Compliance Form Submitted'
 EVENTS.Outreach.CompliancePinSubmitted       // 'Voter Outreach - 10DLC Compliance PIN Submitted'
 EVENTS.Outreach.ComplianceCompleted          // 'Voter Outreach - 10DLC Compliance Completed'
+EVENTS.CampaignPlan.WeeklyTasksDigest       // 'Campaign Plan - Weekly Tasks Digest'
 ```
 
 ## Segment Configuration

--- a/src/vendors/segment/__tests__/segment-hubspot-events.test.ts
+++ b/src/vendors/segment/__tests__/segment-hubspot-events.test.ts
@@ -49,4 +49,12 @@ describe('Segment → HubSpot Event Names', () => {
       )
     })
   })
+
+  describe('Campaign Plan Events', () => {
+    it('should have the correct WeeklyTasksDigest event name for HubSpot', () => {
+      expect(EVENTS.CampaignPlan.WeeklyTasksDigest).toBe(
+        'Campaign Plan - Weekly Tasks Digest',
+      )
+    })
+  })
 })

--- a/src/vendors/segment/segment.types.ts
+++ b/src/vendors/segment/segment.types.ts
@@ -44,6 +44,10 @@ export const EVENTS = {
   Polls: {
     ResultsSynthesisCompleted: 'Poll - Results Synthesis Complete',
   },
+  CampaignPlan: {
+    //  ⚠️  DO NOT MODIFY - Used by HubSpot workflows for weekly task digest emails
+    WeeklyTasksDigest: 'Campaign Plan - Weekly Tasks Digest',
+  },
 }
 
 export type UserContext = {


### PR DESCRIPTION
Send weekly task digest to segment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new scheduled job and SQS message type that queries production campaign/task data and emits Segment events used by HubSpot workflows; mistakes could cause missed/duplicate digests or incorrect HubSpot field updates.
> 
> **Overview**
> Adds an automated **weekly tasks digest** pipeline that sends the `Campaign Plan - Weekly Tasks Digest` Segment event for eligible campaigns.
> 
> A new `WeeklyTasksDigestService` cron (Sunday 11pm Central) enqueues a `WEEKLY_TASKS_DIGEST` FIFO message with a deterministic dedupe id and a UTC Monday→Monday window; `QueueConsumerService` now routes that message to `WeeklyTasksDigestHandlerService`, which queries eligible campaigns (future `electionDate`, at least 3 incomplete tasks in-window), selects up to 5 tasks (outreach types prioritized), and tracks the event while always emitting all 5 task slots to clear stale HubSpot fields.
> 
> This also extends queue infrastructure (`QueueType`, `WeeklyTasksDigestMessageSchema`, `MessageGroup`, producer `deduplicationId` support), adds unit/integration test coverage for windowing/selection/payload, updates Segment event constants/tests, documents the HubSpot mapping flow, and includes a `scripts/test-weekly-tasks-digest-event.ts` helper for manual verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3c45493ac73e879a1077c4cb3f48df10bcb3aa4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->