### PR TITLE
fix(ENG-7327): surface missing L2 district data error to users

### DIFF
--- a/src/vendors/peerly/p2p.controller.test.ts
+++ b/src/vendors/peerly/p2p.controller.test.ts
@@ -1,5 +1,5 @@
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
-import { BadGatewayException } from '@nestjs/common'
+import { BadGatewayException, BadRequestException } from '@nestjs/common'
 import { FastifyReply } from 'fastify'
 import { Campaign } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -248,6 +248,21 @@ describe('P2pController', () => {
       ).rejects.toMatchObject({
         message: 'Failed to upload phone list.',
       })
+    })
+
+    it('preserves HttpException from the service (e.g. MISSING_L2_DISTRICT_DATA)', async () => {
+      const structured = new BadRequestException({
+        statusCode: 400,
+        message: 'Voter data is not available for your selected office.',
+        errorCode: 'MISSING_L2_DISTRICT_DATA',
+      })
+      vi.mocked(
+        mockP2pPhoneListUploadService.uploadPhoneList,
+      ).mockRejectedValue(structured)
+
+      await expect(
+        controller.uploadPhoneList(mockCampaign, { name: 'My List' }),
+      ).rejects.toBe(structured)
     })
   })
 })

--- a/src/vendors/peerly/p2p.controller.test.ts
+++ b/src/vendors/peerly/p2p.controller.test.ts
@@ -1,5 +1,5 @@
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
-import { BadGatewayException, BadRequestException } from '@nestjs/common'
+import { BadGatewayException, ConflictException } from '@nestjs/common'
 import { FastifyReply } from 'fastify'
 import { Campaign } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -251,8 +251,8 @@ describe('P2pController', () => {
     })
 
     it('preserves HttpException from the service (e.g. MISSING_L2_DISTRICT_DATA)', async () => {
-      const structured = new BadRequestException({
-        statusCode: 400,
+      const structured = new ConflictException({
+        statusCode: 409,
         message: 'Voter data is not available for your selected office.',
         errorCode: 'MISSING_L2_DISTRICT_DATA',
       })

--- a/src/vendors/peerly/p2p.controller.ts
+++ b/src/vendors/peerly/p2p.controller.ts
@@ -3,6 +3,7 @@ import {
   Body,
   Controller,
   Get,
+  HttpException,
   HttpStatus,
   Param,
   Post,
@@ -112,6 +113,9 @@ export class P2pController {
 
       return { token }
     } catch (error) {
+      if (error instanceof HttpException) {
+        throw error
+      }
       this.logger.error({ error }, 'Failed to upload phone list')
       throw new BadGatewayException('Failed to upload phone list.')
     }

--- a/src/vendors/peerly/services/p2pPhoneListUpload.service.ts
+++ b/src/vendors/peerly/services/p2pPhoneListUpload.service.ts
@@ -57,13 +57,17 @@ export class P2pPhoneListUploadService {
         filters,
       )
     } catch (error) {
+      if (error instanceof HttpException) {
+        this.logger.warn(
+          { error },
+          `CSV generation rejected for campaign ${campaign.id} (HttpException passthrough)`,
+        )
+        throw error
+      }
       this.logger.error(
         { error },
         `Failed to generate CSV buffer for campaign ${campaign.id}:`,
       )
-      if (error instanceof HttpException) {
-        throw error
-      }
       throw new BadRequestException(
         'Failed to generate voter data for phone list',
       )

--- a/src/vendors/peerly/services/p2pPhoneListUpload.service.ts
+++ b/src/vendors/peerly/services/p2pPhoneListUpload.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common'
+import { BadRequestException, HttpException, Injectable } from '@nestjs/common'
 import { PinoLogger } from 'nestjs-pino'
 import { Readable } from 'stream'
 import { Campaign } from '@prisma/client'
@@ -61,6 +61,9 @@ export class P2pPhoneListUploadService {
         { error },
         `Failed to generate CSV buffer for campaign ${campaign.id}:`,
       )
+      if (error instanceof HttpException) {
+        throw error
+      }
       throw new BadRequestException(
         'Failed to generate voter data for phone list',
       )

--- a/src/voters/voterFile/util/voterFile.util.ts
+++ b/src/voters/voterFile/util/voterFile.util.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common'
+import { ConflictException } from '@nestjs/common'
 import { Campaign } from '@prisma/client'
 import { OrgDistrict } from 'src/organizations/organizations.types'
 import { GetVoterFileSchema } from '../schemas/GetVoterFile.schema'
@@ -83,8 +83,8 @@ export function typeToQuery(
       },
       'Missing L2 district data for voter file query',
     )
-    throw new BadRequestException({
-      statusCode: 400,
+    throw new ConflictException({
+      statusCode: 409,
       message: MISSING_L2_DISTRICT_DATA_USER_MESSAGE,
       errorCode: MISSING_L2_DISTRICT_DATA_ERROR_CODE,
     })

--- a/src/voters/voterFile/util/voterFile.util.ts
+++ b/src/voters/voterFile/util/voterFile.util.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common'
 import { Campaign } from '@prisma/client'
 import { OrgDistrict } from 'src/organizations/organizations.types'
 import { GetVoterFileSchema } from '../schemas/GetVoterFile.schema'
@@ -7,6 +8,11 @@ import {
   VoterFileType,
 } from '../voterFile.types'
 import { PinoLogger } from 'nestjs-pino'
+
+export const MISSING_L2_DISTRICT_DATA_ERROR_CODE = 'MISSING_L2_DISTRICT_DATA'
+
+export const MISSING_L2_DISTRICT_DATA_USER_MESSAGE =
+  'Voter data is not available for your selected office. The district record is missing L2 location data. Please contact support to resolve this.'
 
 const VOTER_FILE_LATEST_EVEN_YEAR = Number(
   process.env.VOTER_FILE_LATEST_EVEN_YEAR,
@@ -66,11 +72,22 @@ export function typeToQuery(
 
   if (!isStatewideOffice && (!l2ColumnName || !l2ColumnValue)) {
     logger.warn(
-      `Missing L2 data for campaign ${campaign.id}. l2ColumnName: ${l2ColumnName}, l2ColumnValue: ${l2ColumnValue}`,
+      {
+        campaignId: campaign.id,
+        organizationSlug: campaign.organizationSlug,
+        ballotLevel: campaign.details?.ballotLevel,
+        districtId: district?.id,
+        l2Type: l2ColumnName,
+        l2Name: l2ColumnValue,
+        errorCode: MISSING_L2_DISTRICT_DATA_ERROR_CODE,
+      },
+      'Missing L2 district data for voter file query',
     )
-    throw new Error(
-      'L2 data is required to generate voter file. Ensure the organization has district data (election type and location) for this race.',
-    )
+    throw new BadRequestException({
+      statusCode: 400,
+      message: MISSING_L2_DISTRICT_DATA_USER_MESSAGE,
+      errorCode: MISSING_L2_DISTRICT_DATA_ERROR_CODE,
+    })
   }
 
   if (l2ColumnName && l2ColumnValue && !isStatewideOffice) {


### PR DESCRIPTION
## ENG-7327 — Error counting records in voter data

### Problem
When a campaign's `position.district` is missing `L2DistrictType` / `L2DistrictName`, `typeToQuery` in `voterFile.util.ts` produced a malformed SQL clause and crashed with a 500. This surfaced to users on the voter records page and during P2P phone list creation as a generic "something went wrong," with no actionable signal — and downstream the P2P upload service masked it further by wrapping it in its own generic exception.

### Changes
- **`voterFile.util.ts`** — Detects null `L2DistrictType` / `L2DistrictName` and throws a structured `BadRequestException` with `errorCode: 'MISSING_L2_DISTRICT_DATA'` and a user-facing message directing them to support. Logs context via `logger.warn` for ops.
- **`p2pPhoneListUpload.service.ts`** — Re-throws `HttpException`s as-is so the structured 400 reaches the client; only unknown errors are wrapped as a generic 400.
- Exports `MISSING_L2_DISTRICT_DATA_ERROR_CODE` and `MISSING_L2_DISTRICT_DATA_USER_MESSAGE` constants for cross-package consistency (frontend matches on the same string).

### Companion PR
gp-webapp: https://github.com/thegoodparty/gp-webapp/pull/new/fix/ENG-7327-l2-district-missing

### Out of scope / follow-ups
- Backfilling affected positions' district records lives behind the Election API and requires a separate Win Team / data fix.
- Admin remediation of these candidates is currently blocked by ENG-7355 (admin PATCH 404s due to ownerId-scoped `findUnique`); independent fix needed there.

### Tests
- `npx vitest run src/voters/voterFile/util src/vendors/peerly/services/p2pPhoneListUpload.service.test.ts` — green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error handling and propagation for voter-file query generation and P2P phone-list upload, which can alter API status codes/payloads seen by clients. Risk is moderate due to new exception passthrough behavior but scoped to specific failure cases.
> 
> **Overview**
> Surfaces a specific, user-actionable error when voter-file queries lack required district L2 data by throwing a structured `BadRequestException` with `errorCode: 'MISSING_L2_DISTRICT_DATA'` and added warning logs.
> 
> Stops masking structured `HttpException`s during P2P phone-list creation by rethrowing them from `P2pPhoneListUploadService` and `P2pController`, so clients receive the original 4xx instead of a generic 400/502; adds a controller test to ensure passthrough behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26a1c314cb3a0459c4b2139b224d87cde05cc53a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->