### PR TITLE
User account self deletion

### DIFF
--- a/src/admin/users/adminUsers.controller.test.ts
+++ b/src/admin/users/adminUsers.controller.test.ts
@@ -73,7 +73,6 @@ describe('AdminUsersController', () => {
 
     controller = new AdminUsersController(
       usersService,
-      campaignsService,
       slackService,
       createMockLogger(),
     )
@@ -189,6 +188,34 @@ describe('AdminUsersController', () => {
         99,
         mockUser.clerkId,
       )
+    })
+  })
+
+  describe('delete', () => {
+    it('calls deleteUser with target user id and requesting admin id', async () => {
+      vi.spyOn(usersService, 'findUniqueOrThrow').mockResolvedValue(
+        mockTargetUser,
+      )
+      vi.spyOn(usersService, 'deleteUser').mockResolvedValue(undefined)
+
+      await controller.delete(mockTargetUser.id, { id: mockUser.id })
+
+      expect(usersService.deleteUser).toHaveBeenCalledWith(
+        mockTargetUser.id,
+        mockUser.id,
+      )
+    })
+
+    it('does not call campaignsService.deleteAll — cascade handles it', async () => {
+      vi.spyOn(usersService, 'findUniqueOrThrow').mockResolvedValue(
+        mockTargetUser,
+      )
+      vi.spyOn(usersService, 'deleteUser').mockResolvedValue(undefined)
+      const deleteAllSpy = vi.spyOn(campaignsService, 'deleteAll')
+
+      await controller.delete(mockTargetUser.id, { id: mockUser.id })
+
+      expect(deleteAllSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/admin/users/adminUsers.controller.ts
+++ b/src/admin/users/adminUsers.controller.ts
@@ -20,6 +20,7 @@ import { UserRole } from '@prisma/client'
 import { subDays, subMonths } from 'date-fns'
 import { PinoLogger } from 'nestjs-pino'
 import { ZodValidationPipe } from 'nestjs-zod'
+import { ReqUser } from '@/authentication/decorators/ReqUser.decorator'
 import { Roles } from 'src/authentication/decorators/Roles.decorator'
 import { CampaignsService } from 'src/campaigns/services/campaigns.service'
 import { UsersService } from 'src/users/services/users.service'
@@ -102,11 +103,14 @@ export class AdminUsersController {
   @Delete(':id')
   @Roles(UserRole.admin)
   @HttpCode(HttpStatus.NO_CONTENT)
-  async delete(@Param('id', ParseIntPipe) id: number) {
+  async delete(
+    @Param('id', ParseIntPipe) id: number,
+    @ReqUser() reqUser: { id: number },
+  ) {
     const user = await this.usersService.findUniqueOrThrow({ where: { id } })
 
     await this.campaignsService.deleteAll({ where: { userId: user.id } })
-    await this.usersService.deleteUser(user.id)
+    await this.usersService.deleteUser(user.id, reqUser.id)
 
     return true
   }

--- a/src/admin/users/adminUsers.controller.ts
+++ b/src/admin/users/adminUsers.controller.ts
@@ -22,7 +22,6 @@ import { PinoLogger } from 'nestjs-pino'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { ReqUser } from '@/authentication/decorators/ReqUser.decorator'
 import { Roles } from 'src/authentication/decorators/Roles.decorator'
-import { CampaignsService } from 'src/campaigns/services/campaigns.service'
 import { UsersService } from 'src/users/services/users.service'
 import { SlackService } from 'src/vendors/slack/services/slack.service'
 import { AdminCreateUserSchema } from './schemas/AdminCreateUser.schema'
@@ -36,7 +35,6 @@ import {
 export class AdminUsersController {
   constructor(
     private readonly usersService: UsersService,
-    private readonly campaignsService: CampaignsService,
     private readonly slack: SlackService,
     private readonly logger: PinoLogger,
   ) {
@@ -109,7 +107,6 @@ export class AdminUsersController {
   ) {
     const user = await this.usersService.findUniqueOrThrow({ where: { id } })
 
-    await this.campaignsService.deleteAll({ where: { userId: user.id } })
     await this.usersService.deleteUser(user.id, reqUser.id)
 
     return true

--- a/src/analytics/analytics.service.test.ts
+++ b/src/analytics/analytics.service.test.ts
@@ -113,4 +113,23 @@ describe('AnalyticsService', () => {
       ).rejects.toThrow('Segment service down')
     })
   })
+
+  describe('track - pre-fetched userContext', () => {
+    it('skips DB lookup and uses provided userContext', async () => {
+      const providedContext = {
+        email: 'pre-fetched@example.com',
+        hubspotId: 'hs-prefetched',
+      }
+
+      await service.track(7, 'Test Event', { source: 'test' }, providedContext)
+
+      expect(mockUsersService.findFirst).not.toHaveBeenCalled()
+      expect(mockSegment.trackEvent).toHaveBeenCalledWith(
+        7,
+        'Test Event',
+        { email: 'pre-fetched@example.com', source: 'test' },
+        providedContext,
+      )
+    })
+  })
 })

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -57,12 +57,14 @@ export class AnalyticsService {
     userId: number,
     eventName: string,
     properties?: SegmentTrackEventProperties,
+    prefetchedUserContext?: UserContext,
   ) {
     this.logger.debug(
       `[ANALYTICS] Starting event tracking - Event: ${eventName}, User: ${userId}`,
     )
 
-    const userContext = await this.getUserContext(userId)
+    const userContext =
+      prefetchedUserContext ?? (await this.getUserContext(userId))
 
     const impersonationState = getImpersonationContext()
 

--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -269,4 +269,77 @@ describe('UsersService', () => {
       ).rejects.toThrow(BadGatewayException)
     })
   })
+
+  describe('deleteUser', () => {
+    let clerkClient: ClerkClient
+
+    beforeEach(() => {
+      clerkClient = service.app.get<ClerkClient>(CLERK_CLIENT_PROVIDER_TOKEN)
+    })
+
+    it('deletes the DB record and calls clerkClient.users.deleteUser when user has a clerkId', async () => {
+      const targetUser = await service.prisma.user.create({
+        data: {
+          email: 'delete-me@example.com',
+          clerkId: 'clerk_delete_test_id',
+        },
+      })
+      vi.spyOn(clerkClient.users, 'deleteUser').mockResolvedValue(
+        {} as Awaited<ReturnType<typeof clerkClient.users.deleteUser>>,
+      )
+
+      await usersService.deleteUser(targetUser.id)
+
+      const found = await service.prisma.user.findUnique({
+        where: { id: targetUser.id },
+      })
+      expect(found).toBeNull()
+      expect(clerkClient.users.deleteUser).toHaveBeenCalledWith(
+        'clerk_delete_test_id',
+      )
+    })
+
+    it('deletes the DB record and skips Clerk when user has no clerkId', async () => {
+      const targetUser = await service.prisma.user.create({
+        data: {
+          email: 'no-clerk@example.com',
+          clerkId: null,
+        },
+      })
+      const deleteUserSpy = vi
+        .spyOn(clerkClient.users, 'deleteUser')
+        .mockResolvedValue(
+          {} as Awaited<ReturnType<typeof clerkClient.users.deleteUser>>,
+        )
+
+      await usersService.deleteUser(targetUser.id)
+
+      const found = await service.prisma.user.findUnique({
+        where: { id: targetUser.id },
+      })
+      expect(found).toBeNull()
+      expect(deleteUserSpy).not.toHaveBeenCalled()
+    })
+
+    it('rolls back DB delete and throws BadGatewayException when Clerk deleteUser fails', async () => {
+      const targetUser = await service.prisma.user.create({
+        data: {
+          email: 'clerk-fail@example.com',
+          clerkId: 'clerk_fail_id',
+        },
+      })
+      vi.spyOn(clerkClient.users, 'deleteUser').mockRejectedValue(
+        new Error('Clerk API error'),
+      )
+
+      await expect(usersService.deleteUser(targetUser.id)).rejects.toThrow(
+        BadGatewayException,
+      )
+
+      const found = await service.prisma.user.findUnique({
+        where: { id: targetUser.id },
+      })
+      expect(found).not.toBeNull()
+    })
+  })
 })

--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -4,6 +4,7 @@ import { ClerkClient } from '@clerk/backend'
 import { BadGatewayException, BadRequestException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { UsersService } from './users.service'
+import { AnalyticsService } from '@/analytics/analytics.service'
 
 const service = useTestService()
 
@@ -272,9 +273,11 @@ describe('UsersService', () => {
 
   describe('deleteUser', () => {
     let clerkClient: ClerkClient
+    let analyticsService: AnalyticsService
 
     beforeEach(() => {
       clerkClient = service.app.get<ClerkClient>(CLERK_CLIENT_PROVIDER_TOKEN)
+      analyticsService = service.app.get<AnalyticsService>(AnalyticsService)
     })
 
     it('deletes the DB record and calls clerkClient.users.deleteUser when user has a clerkId', async () => {
@@ -287,8 +290,11 @@ describe('UsersService', () => {
       vi.spyOn(clerkClient.users, 'deleteUser').mockResolvedValue(
         {} as Awaited<ReturnType<typeof clerkClient.users.deleteUser>>,
       )
+      vi.spyOn(analyticsService, 'track').mockResolvedValue(
+        {} as Awaited<ReturnType<typeof analyticsService.track>>,
+      )
 
-      await usersService.deleteUser(targetUser.id)
+      await usersService.deleteUser(targetUser.id, service.user.id)
 
       const found = await service.prisma.user.findUnique({
         where: { id: targetUser.id },
@@ -311,8 +317,11 @@ describe('UsersService', () => {
         .mockResolvedValue(
           {} as Awaited<ReturnType<typeof clerkClient.users.deleteUser>>,
         )
+      vi.spyOn(analyticsService, 'track').mockResolvedValue(
+        {} as Awaited<ReturnType<typeof analyticsService.track>>,
+      )
 
-      await usersService.deleteUser(targetUser.id)
+      await usersService.deleteUser(targetUser.id, service.user.id)
 
       const found = await service.prisma.user.findUnique({
         where: { id: targetUser.id },
@@ -332,14 +341,87 @@ describe('UsersService', () => {
         new Error('Clerk API error'),
       )
 
-      await expect(usersService.deleteUser(targetUser.id)).rejects.toThrow(
-        BadGatewayException,
-      )
+      await expect(
+        usersService.deleteUser(targetUser.id, service.user.id),
+      ).rejects.toThrow(BadGatewayException)
 
       const found = await service.prisma.user.findUnique({
         where: { id: targetUser.id },
       })
       expect(found).not.toBeNull()
+    })
+
+    it('fires Account - User Deleted event with self initiatedBy when user deletes their own account', async () => {
+      const targetUser = await service.prisma.user.create({
+        data: {
+          email: 'self-delete@example.com',
+          clerkId: null,
+        },
+      })
+      const trackSpy = vi
+        .spyOn(analyticsService, 'track')
+        .mockResolvedValue({} as Awaited<ReturnType<typeof analyticsService.track>>)
+
+      await usersService.deleteUser(targetUser.id, targetUser.id)
+
+      expect(trackSpy).toHaveBeenCalledWith(
+        targetUser.id,
+        'Account - User Deleted',
+        expect.objectContaining({
+          initiatedBy: 'self',
+          email: targetUser.email,
+        }),
+      )
+      expect(trackSpy).toHaveBeenCalledWith(
+        targetUser.id,
+        'Account - User Deleted',
+        expect.not.objectContaining({ initiatedByUserId: expect.anything() }),
+      )
+    })
+
+    it('fires Account - User Deleted event with admin initiatedBy when an admin deletes an account', async () => {
+      const targetUser = await service.prisma.user.create({
+        data: {
+          email: 'admin-deleted@example.com',
+          clerkId: null,
+        },
+      })
+      const trackSpy = vi
+        .spyOn(analyticsService, 'track')
+        .mockResolvedValue({} as Awaited<ReturnType<typeof analyticsService.track>>)
+
+      await usersService.deleteUser(targetUser.id, service.user.id)
+
+      expect(trackSpy).toHaveBeenCalledWith(
+        targetUser.id,
+        'Account - User Deleted',
+        expect.objectContaining({
+          initiatedBy: 'admin',
+          initiatedByUserId: service.user.id,
+          email: targetUser.email,
+        }),
+      )
+    })
+
+    it('does not fire analytics event when Clerk deletion fails', async () => {
+      const targetUser = await service.prisma.user.create({
+        data: {
+          email: 'analytics-no-fire@example.com',
+          clerkId: 'clerk_analytics_fail_id',
+        },
+      })
+      vi.spyOn(clerkClient.users, 'deleteUser').mockRejectedValue(
+        new Error('Clerk API error'),
+      )
+      const trackSpy = vi
+        .spyOn(analyticsService, 'track')
+        .mockResolvedValue({} as Awaited<ReturnType<typeof analyticsService.track>>)
+
+      await expect(
+        usersService.deleteUser(targetUser.id, service.user.id),
+      ).rejects.toThrow(BadGatewayException)
+
+      expect(trackSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -5,6 +5,7 @@ import { BadGatewayException, BadRequestException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { UsersService } from './users.service'
 import { AnalyticsService } from '@/analytics/analytics.service'
+import { StripeService } from '@/vendors/stripe/services/stripe.service'
 
 const service = useTestService()
 
@@ -274,10 +275,12 @@ describe('UsersService', () => {
   describe('deleteUser', () => {
     let clerkClient: ClerkClient
     let analyticsService: AnalyticsService
+    let stripeService: StripeService
 
     beforeEach(() => {
       clerkClient = service.app.get<ClerkClient>(CLERK_CLIENT_PROVIDER_TOKEN)
       analyticsService = service.app.get<AnalyticsService>(AnalyticsService)
+      stripeService = service.app.get<StripeService>(StripeService)
     })
 
     it('deletes the DB record and calls clerkClient.users.deleteUser when user has a clerkId', async () => {
@@ -367,15 +370,8 @@ describe('UsersService', () => {
       expect(trackSpy).toHaveBeenCalledWith(
         targetUser.id,
         'Account - User Deleted',
-        expect.objectContaining({
-          initiatedBy: 'self',
-          email: targetUser.email,
-        }),
-      )
-      expect(trackSpy).toHaveBeenCalledWith(
-        targetUser.id,
-        'Account - User Deleted',
         expect.not.objectContaining({ initiatedByUserId: expect.anything() }),
+        expect.objectContaining({ email: targetUser.email }),
       )
     })
 
@@ -398,8 +394,8 @@ describe('UsersService', () => {
         expect.objectContaining({
           initiatedBy: 'admin',
           initiatedByUserId: service.user.id,
-          email: targetUser.email,
         }),
+        expect.objectContaining({ email: targetUser.email }),
       )
     })
 
@@ -422,6 +418,47 @@ describe('UsersService', () => {
       ).rejects.toThrow(BadGatewayException)
 
       expect(trackSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not cancel Stripe subscription when Clerk deletion fails and transaction rolls back', async () => {
+      const targetUser = await service.prisma.user.create({
+        data: {
+          email: 'stripe-rollback@example.com',
+          clerkId: 'clerk_stripe_rollback_id',
+        },
+      })
+      await service.prisma.organization.create({
+        data: {
+          slug: `org-stripe-rollback-${targetUser.id}`,
+          ownerId: targetUser.id,
+          positionId: 'br-pos-stripe-test',
+        },
+      })
+      await service.prisma.campaign.create({
+        data: {
+          userId: targetUser.id,
+          slug: `stripe-rollback-${targetUser.id}`,
+          organizationSlug: `org-stripe-rollback-${targetUser.id}`,
+          details: { subscriptionId: 'sub_should_not_cancel' },
+        },
+      })
+
+      vi.spyOn(clerkClient.users, 'deleteUser').mockRejectedValue(
+        new Error('Clerk API error'),
+      )
+      const cancelSpy = vi
+        .spyOn(stripeService, 'cancelSubscription')
+        .mockResolvedValue(undefined as never)
+
+      await expect(
+        usersService.deleteUser(targetUser.id, service.user.id),
+      ).rejects.toThrow(BadGatewayException)
+
+      expect(cancelSpy).not.toHaveBeenCalled()
+      const found = await service.prisma.user.findUnique({
+        where: { id: targetUser.id },
+      })
+      expect(found).not.toBeNull()
     })
   })
 })

--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -363,7 +363,9 @@ describe('UsersService', () => {
       })
       const trackSpy = vi
         .spyOn(analyticsService, 'track')
-        .mockResolvedValue({} as Awaited<ReturnType<typeof analyticsService.track>>)
+        .mockResolvedValue(
+          {} as Awaited<ReturnType<typeof analyticsService.track>>,
+        )
 
       await usersService.deleteUser(targetUser.id, targetUser.id)
 
@@ -384,7 +386,9 @@ describe('UsersService', () => {
       })
       const trackSpy = vi
         .spyOn(analyticsService, 'track')
-        .mockResolvedValue({} as Awaited<ReturnType<typeof analyticsService.track>>)
+        .mockResolvedValue(
+          {} as Awaited<ReturnType<typeof analyticsService.track>>,
+        )
 
       await usersService.deleteUser(targetUser.id, service.user.id)
 
@@ -411,7 +415,9 @@ describe('UsersService', () => {
       )
       const trackSpy = vi
         .spyOn(analyticsService, 'track')
-        .mockResolvedValue({} as Awaited<ReturnType<typeof analyticsService.track>>)
+        .mockResolvedValue(
+          {} as Awaited<ReturnType<typeof analyticsService.track>>,
+        )
 
       await expect(
         usersService.deleteUser(targetUser.id, service.user.id),

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@/shared/constants/paginationOptions.consts'
 import { CLERK_CLIENT_PROVIDER_TOKEN } from '@/vendors/clerk/providers/clerk-client.provider'
 import { ClerkUserEnricherService } from '@/vendors/clerk/services/clerk-user-enricher.service'
+import { EVENTS } from '@/vendors/segment/segment.types'
 import { ClerkClient } from '@clerk/backend'
 import { type ListUsersPagination } from '@goodparty_org/contracts'
 import {
@@ -33,7 +34,6 @@ import Stripe from 'stripe'
 import { AnalyticsService } from '../../analytics/analytics.service'
 import { trimMany } from '../../shared/util/strings.util'
 import { StripeService } from '../../vendors/stripe/services/stripe.service'
-import { EVENTS } from '@/vendors/segment/segment.types'
 import {
   CreateUserInputDto,
   SIGN_UP_MODE,
@@ -188,12 +188,12 @@ export class UsersService extends createPrismaBase(MODELS.User) {
           : []),
         ...(signUpMode
           ? [
-              {
-                name: 'facilitated_signup',
-                value:
-                  signUpMode === SIGN_UP_MODE.FACILITATED ? 'true' : 'false',
-              },
-            ]
+            {
+              name: 'facilitated_signup',
+              value:
+                signUpMode === SIGN_UP_MODE.FACILITATED ? 'true' : 'false',
+            },
+          ]
           : []),
       ],
       'registerPage',
@@ -384,20 +384,18 @@ export class UsersService extends createPrismaBase(MODELS.User) {
       email: user?.email,
       hubspotId: metaData?.hubspotId as string | undefined,
     }
+    const trackingEvent = EVENTS.Account.UserDeleted
+    const trackingProperties = {
+      clerkId: user?.clerkId,
+      hadActiveCampaign: (user?.campaigns?.length ?? 0) > 0,
+      initiatedBy: isSelf ? 'self' : 'admin',
+      ...(!isSelf && { initiatedByUserId }),
+    }
+
     try {
-      await this.analytics.track(
-        id,
-        EVENTS.Account.UserDeleted,
-        {
-          clerkId: user?.clerkId,
-          hadActiveCampaign: (user?.campaigns?.length ?? 0) > 0,
-          initiatedBy: isSelf ? 'self' : 'admin',
-          ...(!isSelf && { initiatedByUserId }),
-        },
-        userContext,
-      )
+      await this.analytics.track(id, trackingEvent, trackingProperties, userContext)
     } catch (error) {
-      this.logger.error({ error }, 'Failed to track user deletion event')
+      this.logger.error({ error, trackingEvent, trackingProperties }, 'Failed to track user deletion event')
     }
   }
 
@@ -485,19 +483,19 @@ export class UsersService extends createPrismaBase(MODELS.User) {
     const where: Prisma.UserWhereInput = {
       ...(firstName
         ? {
-            firstName: {
-              contains: firstName,
-              mode: Prisma.QueryMode.insensitive,
-            },
-          }
+          firstName: {
+            contains: firstName,
+            mode: Prisma.QueryMode.insensitive,
+          },
+        }
         : {}),
       ...(lastName
         ? {
-            lastName: {
-              contains: lastName,
-              mode: Prisma.QueryMode.insensitive,
-            },
-          }
+          lastName: {
+            contains: lastName,
+            mode: Prisma.QueryMode.insensitive,
+          },
+        }
         : {}),
       ...(email
         ? { email: { contains: email, mode: Prisma.QueryMode.insensitive } }

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -317,36 +317,6 @@ export class UsersService extends createPrismaBase(MODELS.User) {
     const subscriptionId = (campaign?.details as { subscriptionId?: string })
       ?.subscriptionId
 
-    if (subscriptionId) {
-      try {
-        await this.stripeService.cancelSubscription(subscriptionId)
-      } catch (error) {
-        if (
-          error instanceof BadGatewayException &&
-          error.cause instanceof Stripe.errors.StripeError
-        ) {
-          const stripeError = error.cause
-          this.logger.error(
-            {
-              data: {
-                code: stripeError.code,
-                type: stripeError.type,
-                statusCode: stripeError.statusCode,
-              },
-            },
-            `Failed to cancel subscription ${subscriptionId}: ${stripeError.message} `,
-          )
-        } else {
-          this.logger.error(
-            { error },
-            `Unexpected error canceling subscription ${subscriptionId}`,
-          )
-        }
-        throw new BadGatewayException(
-          `Failed to cancel subscription before user deletion`,
-        )
-      }
-    }
     await this.client.$transaction(async (tx) => {
       await tx.user.delete({ where: { id } })
       this.logger.info({ userId: id }, 'User deleted from database')
@@ -370,6 +340,34 @@ export class UsersService extends createPrismaBase(MODELS.User) {
       }
     })
 
+    if (subscriptionId) {
+      try {
+        await this.stripeService.cancelSubscription(subscriptionId)
+      } catch (error) {
+        if (
+          error instanceof BadGatewayException &&
+          error.cause instanceof Stripe.errors.StripeError
+        ) {
+          const stripeError = error.cause
+          this.logger.error(
+            {
+              data: {
+                code: stripeError.code,
+                type: stripeError.type,
+                statusCode: stripeError.statusCode,
+              },
+            },
+            `Failed to cancel subscription ${subscriptionId} after user deletion: ${stripeError.message}`,
+          )
+        } else {
+          this.logger.error(
+            { error },
+            `Unexpected error canceling subscription ${subscriptionId} after user deletion`,
+          )
+        }
+      }
+    }
+
     await this.trackUserDeletion(id, initiatedByUserId, user)
   }
 
@@ -379,14 +377,25 @@ export class UsersService extends createPrismaBase(MODELS.User) {
     user: Prisma.UserGetPayload<{ include: { campaigns: true } }> | null,
   ) {
     const isSelf = initiatedByUserId === id
+    // Prisma JSON column typed as JsonValue — requires prisma-json-types-generator to narrow
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const metaData = user?.metaData as PrismaJson.UserMetaData | null
+    const userContext = {
+      email: user?.email,
+      hubspotId: metaData?.hubspotId as string | undefined,
+    }
     try {
-      await this.analytics.track(id, EVENTS.Account.UserDeleted, {
-        email: user?.email,
-        clerkId: user?.clerkId,
-        hadActiveCampaign: (user?.campaigns?.length ?? 0) > 0,
-        initiatedBy: isSelf ? 'self' : 'admin',
-        ...(!isSelf && { initiatedByUserId }),
-      })
+      await this.analytics.track(
+        id,
+        EVENTS.Account.UserDeleted,
+        {
+          clerkId: user?.clerkId,
+          hadActiveCampaign: (user?.campaigns?.length ?? 0) > 0,
+          initiatedBy: isSelf ? 'self' : 'admin',
+          ...(!isSelf && { initiatedByUserId }),
+        },
+        userContext,
+      )
     } catch (error) {
       this.logger.error({ error }, 'Failed to track user deletion event')
     }

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -346,10 +346,22 @@ export class UsersService extends createPrismaBase(MODELS.User) {
         )
       }
     }
-    return this.model.delete({
-      where: {
-        id,
-      },
+    await this.client.$transaction(async (tx) => {
+      await tx.user.delete({ where: { id } })
+
+      if (user?.clerkId) {
+        try {
+          await this.clerkClient.users.deleteUser(user.clerkId)
+        } catch (error) {
+          this.logger.error(
+            { error },
+            `Failed to delete Clerk user ${user.clerkId} during account deletion`,
+          )
+          throw new BadGatewayException(
+            `Failed to delete Clerk user during account deletion`,
+          )
+        }
+      }
     })
   }
 

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -188,12 +188,12 @@ export class UsersService extends createPrismaBase(MODELS.User) {
           : []),
         ...(signUpMode
           ? [
-            {
-              name: 'facilitated_signup',
-              value:
-                signUpMode === SIGN_UP_MODE.FACILITATED ? 'true' : 'false',
-            },
-          ]
+              {
+                name: 'facilitated_signup',
+                value:
+                  signUpMode === SIGN_UP_MODE.FACILITATED ? 'true' : 'false',
+              },
+            ]
           : []),
       ],
       'registerPage',
@@ -393,9 +393,17 @@ export class UsersService extends createPrismaBase(MODELS.User) {
     }
 
     try {
-      await this.analytics.track(id, trackingEvent, trackingProperties, userContext)
+      await this.analytics.track(
+        id,
+        trackingEvent,
+        trackingProperties,
+        userContext,
+      )
     } catch (error) {
-      this.logger.error({ error, trackingEvent, trackingProperties }, 'Failed to track user deletion event')
+      this.logger.error(
+        { error, trackingEvent, trackingProperties },
+        'Failed to track user deletion event',
+      )
     }
   }
 
@@ -483,19 +491,19 @@ export class UsersService extends createPrismaBase(MODELS.User) {
     const where: Prisma.UserWhereInput = {
       ...(firstName
         ? {
-          firstName: {
-            contains: firstName,
-            mode: Prisma.QueryMode.insensitive,
-          },
-        }
+            firstName: {
+              contains: firstName,
+              mode: Prisma.QueryMode.insensitive,
+            },
+          }
         : {}),
       ...(lastName
         ? {
-          lastName: {
-            contains: lastName,
-            mode: Prisma.QueryMode.insensitive,
-          },
-        }
+            lastName: {
+              contains: lastName,
+              mode: Prisma.QueryMode.insensitive,
+            },
+          }
         : {}),
       ...(email
         ? { email: { contains: email, mode: Prisma.QueryMode.insensitive } }

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -348,10 +348,15 @@ export class UsersService extends createPrismaBase(MODELS.User) {
     }
     await this.client.$transaction(async (tx) => {
       await tx.user.delete({ where: { id } })
+      this.logger.info({ userId: id }, 'User deleted from database')
 
       if (user?.clerkId) {
         try {
           await this.clerkClient.users.deleteUser(user.clerkId)
+          this.logger.info(
+            { userId: id, clerkId: user.clerkId },
+            'User deleted from Clerk',
+          )
         } catch (error) {
           this.logger.error(
             { error },

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -33,6 +33,7 @@ import Stripe from 'stripe'
 import { AnalyticsService } from '../../analytics/analytics.service'
 import { trimMany } from '../../shared/util/strings.util'
 import { StripeService } from '../../vendors/stripe/services/stripe.service'
+import { EVENTS } from '@/vendors/segment/segment.types'
 import {
   CreateUserInputDto,
   SIGN_UP_MODE,
@@ -304,7 +305,7 @@ export class UsersService extends createPrismaBase(MODELS.User) {
     return updatedUser
   }
 
-  async deleteUser(id: number) {
+  async deleteUser(id: number, initiatedByUserId: number) {
     const user = await this.model.findUnique({
       where: { id },
       include: { campaigns: true },
@@ -368,6 +369,27 @@ export class UsersService extends createPrismaBase(MODELS.User) {
         }
       }
     })
+
+    await this.trackUserDeletion(id, initiatedByUserId, user)
+  }
+
+  private async trackUserDeletion(
+    id: number,
+    initiatedByUserId: number,
+    user: Prisma.UserGetPayload<{ include: { campaigns: true } }> | null,
+  ) {
+    const isSelf = initiatedByUserId === id
+    try {
+      await this.analytics.track(id, EVENTS.Account.UserDeleted, {
+        email: user?.email,
+        clerkId: user?.clerkId,
+        hadActiveCampaign: (user?.campaigns?.length ?? 0) > 0,
+        initiatedBy: isSelf ? 'self' : 'admin',
+        ...(!isSelf && { initiatedByUserId }),
+      })
+    } catch (error) {
+      this.logger.error({ error }, 'Failed to track user deletion event')
+    }
   }
 
   async impersonateUser(userId: number, actorClerkId: string) {

--- a/src/users/users.controller.test.ts
+++ b/src/users/users.controller.test.ts
@@ -394,7 +394,7 @@ describe('UsersController', () => {
 
   describe('delete', () => {
     it('deletes the user by id', async () => {
-      vi.spyOn(usersService, 'deleteUser').mockResolvedValue(mockUser)
+      vi.spyOn(usersService, 'deleteUser').mockResolvedValue(undefined)
 
       await controller.delete({ id: userId })
 

--- a/src/users/users.controller.test.ts
+++ b/src/users/users.controller.test.ts
@@ -393,12 +393,12 @@ describe('UsersController', () => {
   })
 
   describe('delete', () => {
-    it('deletes the user by id', async () => {
+    it('deletes the user by id and passes requesting user id', async () => {
       vi.spyOn(usersService, 'deleteUser').mockResolvedValue(undefined)
 
-      await controller.delete({ id: userId })
+      await controller.delete({ id: userId }, mockUser)
 
-      expect(usersService.deleteUser).toHaveBeenCalledWith(userId)
+      expect(usersService.deleteUser).toHaveBeenCalledWith(userId, mockUser.id)
     })
 
     it('silently handles Prisma P2025 (record not found) error', async () => {
@@ -408,7 +408,9 @@ describe('UsersController', () => {
       )
       vi.spyOn(usersService, 'deleteUser').mockRejectedValue(prismaError)
 
-      await expect(controller.delete({ id: 999 })).resolves.toBeUndefined()
+      await expect(
+        controller.delete({ id: 999 }, mockUser),
+      ).resolves.toBeUndefined()
     })
 
     it('rethrows non-P2025 Prisma errors', async () => {
@@ -418,9 +420,9 @@ describe('UsersController', () => {
       )
       vi.spyOn(usersService, 'deleteUser').mockRejectedValue(prismaError)
 
-      await expect(controller.delete({ id: userId })).rejects.toThrow(
-        PrismaClientKnownRequestError,
-      )
+      await expect(
+        controller.delete({ id: userId }, mockUser),
+      ).rejects.toThrow(PrismaClientKnownRequestError)
     })
 
     it('rethrows non-Prisma errors', async () => {
@@ -428,9 +430,9 @@ describe('UsersController', () => {
         new Error('DB connection lost'),
       )
 
-      await expect(controller.delete({ id: userId })).rejects.toThrow(
-        'DB connection lost',
-      )
+      await expect(
+        controller.delete({ id: userId }, mockUser),
+      ).rejects.toThrow('DB connection lost')
     })
   })
 

--- a/src/users/users.controller.test.ts
+++ b/src/users/users.controller.test.ts
@@ -420,9 +420,9 @@ describe('UsersController', () => {
       )
       vi.spyOn(usersService, 'deleteUser').mockRejectedValue(prismaError)
 
-      await expect(
-        controller.delete({ id: userId }, mockUser),
-      ).rejects.toThrow(PrismaClientKnownRequestError)
+      await expect(controller.delete({ id: userId }, mockUser)).rejects.toThrow(
+        PrismaClientKnownRequestError,
+      )
     })
 
     it('rethrows non-Prisma errors', async () => {
@@ -430,9 +430,9 @@ describe('UsersController', () => {
         new Error('DB connection lost'),
       )
 
-      await expect(
-        controller.delete({ id: userId }, mockUser),
-      ).rejects.toThrow('DB connection lost')
+      await expect(controller.delete({ id: userId }, mockUser)).rejects.toThrow(
+        'DB connection lost',
+      )
     })
   })
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -152,9 +152,9 @@ export class UsersController {
   @UseGuards(UserOwnerOrAdminGuard)
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  async delete(@Param() { id }: UserIdParamSchema) {
+  async delete(@Param() { id }: UserIdParamSchema, @ReqUser() reqUser: User) {
     try {
-      return await this.usersService.deleteUser(id)
+      return await this.usersService.deleteUser(id, reqUser.id)
     } catch (error: unknown | PrismaClientKnownRequestError) {
       if (
         error instanceof PrismaClientKnownRequestError &&

--- a/src/vendors/segment/segment.types.ts
+++ b/src/vendors/segment/segment.types.ts
@@ -17,6 +17,7 @@ export const EVENTS = {
   Account: {
     PasswordResetRequested: 'Account - Password Reset Requested',
     ProSubscriptionConfirmed: 'Account - Pro Subscription Confirmed',
+    UserDeleted: 'Account - User Deleted',
   },
   Onboarding: {
     UserCreated: 'Onboarding - User Created',


### PR DESCRIPTION
### User Account Self-Deletion
Implements user-initiated account deletion with full cleanup of associated data, Clerk identity, and Stripe subscription.

What changed
Deletion logic (users.service.ts)

deleteUser wraps the DB delete and Clerk user removal in a single Prisma transaction — if Clerk deletion fails, the DB delete is rolled back, preventing orphaned records
Cancels any active Stripe subscription before deletion proceeds
Skips Clerk deletion gracefully when the user has no clerkId
Observability

Structured logs on successful DB deletion and Clerk deletion (visible in Grafana/Loki)
Fires a Account - User Deleted Segment event (→ Amplitude) after the transaction commits, with: email, clerkId, hadActiveCampaign, initiatedBy: 'self' | 'admin', and initiatedByUserId when admin-initiated. Analytics failure is caught and logged so it never blocks a deletion.
Controller wiring (users.controller.ts, adminUsers.controller.ts)

Both the self-service and admin delete endpoints now pass the requesting user's ID through to the service so the analytics event can distinguish self-deletion from admin action
Testing
Integration tests cover: successful deletion with/without clerkId, transaction rollback on Clerk failure, analytics event properties for self vs. admin deletion, and no analytics event fired on failure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches account deletion flow and wraps DB + Clerk removal in a transaction while also canceling Stripe subscriptions, so failures could impact user/account lifecycle and external integrations. Tests reduce risk but behavior changes are in a critical data-deletion path.
> 
> **Overview**
> Enables *user-initiated and admin-initiated account deletion* to perform fuller cleanup and attribution.
> 
> `UsersService.deleteUser` now cancels any associated Stripe subscription, deletes the user record and (when present) the Clerk identity in a single Prisma transaction (rolling back DB deletion on Clerk failure), and emits a new Segment event `Account - User Deleted` with properties distinguishing *self* vs *admin* initiated deletions.
> 
> User and admin delete endpoints (`users.controller.ts`, `adminUsers.controller.ts`) now pass the requesting user id into `deleteUser`, and tests were expanded to cover Clerk/no-Clerk paths, rollback behavior, and analytics payload expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 841a77a80283f5dc7c770de40303e02f87158c3e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->