### PR TITLE
ENG-7490: gp-api configuration for pmf engine

### DIFF
--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -372,6 +372,13 @@ export = async () => {
         // prod: 'campaign-plan-results-prod',
         prod: '',
       }),
+      AGENT_DISPATCH_QUEUE_NAME: select({
+        // Preview intentionally omitted — dispatch fails at runtime with a log
+        preview: '',
+        dev: 'agent-dispatch-dev.fifo',
+        qa: 'agent-dispatch-qa.fifo',
+        prod: 'agent-dispatch-prod.fifo',
+      }),
       SERVE_ANALYSIS_BUCKET_NAME: `serve-analyze-data-${environment === 'preview' ? 'dev' : environment}`,
       MEETING_PIPELINE_BUCKET: 'meeting-pipeline-dev',
       TEVYN_POLL_CSVS_BUCKET: tevynPollCsvsBucket.bucket,

--- a/prisma/schema/experimentRun.prisma
+++ b/prisma/schema/experimentRun.prisma
@@ -1,0 +1,30 @@
+enum ExperimentRunStatus {
+  RUNNING
+  COMPLETED
+  FAILED
+}
+
+model ExperimentRun {
+  runId String @unique @default(uuid(7)) @map("run_id")
+
+  organizationSlug String       @map("organization_slug")
+  organization     Organization @relation(fields: [organizationSlug], references: [slug], onDelete: Cascade)
+
+  // e.g. "district_intel"
+  experimentType String @map("experiment_type")
+
+  status ExperimentRunStatus @default(RUNNING)
+
+  params Json @default("{}") @db.JsonB
+
+  artifactBucket  String? @map("artifact_bucket")
+  artifactKey     String? @map("artifact_key")
+  durationSeconds Float?  @map("duration_seconds")
+  error           String?
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@index([organizationSlug, experimentType])
+  @@map("experiment_run")
+}

--- a/prisma/schema/migrations/20260421200307_experiment_runs/migration.sql
+++ b/prisma/schema/migrations/20260421200307_experiment_runs/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "ExperimentRunStatus" AS ENUM ('RUNNING', 'COMPLETED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "experiment_run" (
+    "run_id" TEXT NOT NULL,
+    "organization_slug" TEXT NOT NULL,
+    "experiment_type" TEXT NOT NULL,
+    "status" "ExperimentRunStatus" NOT NULL DEFAULT 'RUNNING',
+    "params" JSONB NOT NULL DEFAULT '{}',
+    "artifact_bucket" TEXT,
+    "artifact_key" TEXT,
+    "duration_seconds" DOUBLE PRECISION,
+    "error" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "experiment_run_run_id_key" ON "experiment_run"("run_id");
+
+-- CreateIndex
+CREATE INDEX "experiment_run_organization_slug_experiment_type_idx" ON "experiment_run"("organization_slug", "experiment_type");
+
+-- AddForeignKey
+ALTER TABLE "experiment_run" ADD CONSTRAINT "experiment_run_organization_slug_fkey" FOREIGN KEY ("organization_slug") REFERENCES "organization"("slug") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema/organization.prisma
+++ b/prisma/schema/organization.prisma
@@ -10,6 +10,7 @@ model Organization {
   campaign           Campaign?
   electedOffice      ElectedOffice?
   voterFileFilters   VoterFileFilter[]
+  experimentRuns     ExperimentRun[]
 
   @@index([ownerId])
   @@map("organization")

--- a/src/agentExperiments/CLAUDE.md
+++ b/src/agentExperiments/CLAUDE.md
@@ -1,0 +1,115 @@
+# Agent Experiments Module
+
+gp-api's side of the PMF Engine contract. Dispatches agent experiment runs to SQS, records them in the `experiment_run` table, and reconciles results from the agent-results queue.
+
+This module is intentionally thin — it is a **transport layer**, not a product layer. It does not know which experiments exist, what params they need, who is allowed to run them, or how artifacts are consumed. Callers own all of that; this module only moves runs through states.
+
+## How It Works
+
+```
+caller (gp-api service)
+   │
+   │  ExperimentRunsService.dispatchRun({ experimentType, organizationSlug, params })
+   ▼
+DB: INSERT experiment_run (status=RUNNING)      SQS: agent-dispatch-{env}.fifo
+                                                         │
+                                                         ▼
+                                                Lambda → Fargate (PMF Engine)
+                                                         │
+                                                         ▼
+                                                S3: artifact upload
+                                                         │
+                                                         ▼
+                                           SQS: agent-results queue
+                                                         │
+                                                         ▼
+QueueConsumerService.handleAgentExperimentResult
+   │
+   │  optimistic-locking UPDATE experiment_run
+   ▼
+status RUNNING → COMPLETED | FAILED,  artifactKey/Bucket, durationSeconds, error
+```
+
+### Lifecycle
+
+```
+RUNNING ──► COMPLETED        (result.status = "success")
+        └─► FAILED           (result.status = "failed" or "contract_violation",
+                              or sweeper timeout at 45 min, or SQS dispatch error)
+```
+
+Three terminal states only. `contract_violation` at the queue boundary collapses to `FAILED` — the distinction belongs (if anywhere) in the `error` column, not the enum.
+
+### Callback idempotency
+
+`handleAgentExperimentResult` uses `optimisticLockingUpdate` on `updatedAt` and guards on `status === RUNNING` before patching. A duplicate result for an already-terminal run is logged and dropped.
+
+## Files
+
+| File                                 | Purpose                                                                |
+| ------------------------------------ | ---------------------------------------------------------------------- |
+| `agentExperiments.module.ts`         | Nest module — exports `ExperimentRunsService`                          |
+| `services/experimentRuns.service.ts` | `dispatchRun()`, `sweepStaleRuns()` (`@Cron`), + inherited Prisma CRUD |
+
+No controller, no schemas, no other services. HTTP surface is a caller concern.
+
+## SQS message shapes
+
+**Dispatch** (gp-api → agent) — produced by `ExperimentRunsService.dispatchRun()`:
+
+```json
+{
+  "run_id": "<uuid>",
+  "params": { ... },
+  "organization_slug": "...",
+  "experiment_type": "..."
+}
+```
+
+Sent to the queue named by `AGENT_DISPATCH_QUEUE_NAME` (e.g. `agent-dispatch-dev.fifo`). The URL is resolved once on first dispatch via `sqs:GetQueueUrl` and cached on the service instance. `MessageGroupId = "agent-dispatch-{organizationSlug}"` (per-org FIFO ordering), with a random `MessageDeduplicationId`.
+
+**Result** (agent → gp-api) — consumed by `QueueConsumerService.handleAgentExperimentResult`. Schema in `src/queue/queue.types.ts` (`AgentExperimentResultSchema`):
+
+```ts
+{
+  runId: string,
+  status: 'success' | 'failed' | 'contract_violation',
+  artifactKey?: string,
+  artifactBucket?: string,
+  durationSeconds?: number,
+  error?: string,      // truncated to 1000 chars on write
+}
+```
+
+Envelope: `{ type: QueueType.AGENT_EXPERIMENT_RESULT, data: <above> }`.
+
+## Stale-run sweeper
+
+`ExperimentRunsService.sweepStaleRuns` runs on `*/15 * * * *`. Any `RUNNING` run with `createdAt` older than 45 minutes is flipped to `FAILED` with a timeout-error message. Runs on every replica — safe because the `UPDATE` is idempotent.
+
+## Data model
+
+`experiment_run` (see `prisma/schema/experimentRun.prisma`):
+
+- `runId` — unique, uuid7, used in SQS messages and by callers
+- `organizationSlug` → `Organization.slug`, `onDelete: Cascade`
+- `experimentType: String` — opaque to this module; callers define the value space
+- `status: ExperimentRunStatus { RUNNING, COMPLETED, FAILED }`
+- `params: Json`, `artifactBucket/Key`, `durationSeconds`, `error`
+- `@@index([organizationSlug, experimentType])`
+
+## Testing
+
+```bash
+npx vitest run src/agentExperiments/
+npx vitest run src/queue/consumer/queueConsumer.service.test.ts
+```
+
+## Environment Variables
+
+- `AGENT_DISPATCH_QUEUE_NAME` — FIFO queue name (e.g. `agent-dispatch-dev.fifo`). The URL is resolved at runtime via `GetQueueUrl` and cached.
+- AWS credentials from the standard provider chain (env, IAM role, etc.)
+
+### Preview environments
+
+`AGENT_DISPATCH_QUEUE_NAME` is **not set** in preview envs. Dispatch fails at runtime: the DB row is flipped to `FAILED`, an error is logged, and `dispatchRun` throws `BadGatewayException`. Callers that want to exercise agent dispatch on a PR branch should merge to `develop` and test against dev. (Rationale: per-PR agent queues would require provisioning a matching consumer in `gp-ai-projects` per preview, which isn't worth the cost for a PR verification step.)

--- a/src/agentExperiments/agentExperiments.module.ts
+++ b/src/agentExperiments/agentExperiments.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { AwsModule } from '@/vendors/aws/aws.module'
+import { ExperimentRunsService } from './services/experimentRuns.service'
+
+@Module({
+  imports: [AwsModule],
+  controllers: [],
+  providers: [ExperimentRunsService],
+  exports: [ExperimentRunsService],
+})
+export class AgentExperimentsModule {}

--- a/src/agentExperiments/services/experimentResultHandler.test.ts
+++ b/src/agentExperiments/services/experimentResultHandler.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Message } from '@aws-sdk/client-sqs'
+import { ExperimentRunStatus } from '@prisma/client'
+import { PinoLogger } from 'nestjs-pino'
+import { QueueType } from '@/queue/queue.types'
+import { QueueConsumerService } from '@/queue/consumer/queueConsumer.service'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+
+vi.mock('@/polls/utils/polls.utils', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  sendTevynAPIPollMessage: vi.fn(),
+}))
+
+const RUN_ID = 'run-abc'
+
+type ResultOverrides = {
+  runId?: string
+  status?: 'success' | 'failed' | 'contract_violation' | string
+  artifactKey?: string
+  artifactBucket?: string
+  durationSeconds?: number
+  error?: string
+}
+
+const makeMessage = (overrides: ResultOverrides = {}): Message => ({
+  MessageId: 'msg-1',
+  Body: JSON.stringify({
+    type: QueueType.AGENT_EXPERIMENT_RESULT,
+    data: {
+      runId: RUN_ID,
+      status: 'success',
+      artifactKey: 'district_intel/run-abc/result.json',
+      artifactBucket: 'gp-agent-artifacts-dev',
+      durationSeconds: 42,
+      ...overrides,
+    },
+  }),
+})
+
+const callModifier = async (
+  mod: (run: Record<string, unknown>) => Promise<Record<string, unknown>>,
+) =>
+  mod({
+    runId: RUN_ID,
+    status: ExperimentRunStatus.RUNNING,
+    artifactKey: null,
+    artifactBucket: null,
+    durationSeconds: null,
+    error: null,
+    updatedAt: new Date(),
+  })
+
+describe('QueueConsumerService - handleAgentExperimentResult', () => {
+  let service: QueueConsumerService
+  let experimentRunsService: {
+    findUnique: ReturnType<typeof vi.fn>
+    optimisticLockingUpdate: ReturnType<typeof vi.fn>
+  }
+  let logger: PinoLogger
+
+  beforeEach(() => {
+    logger = createMockLogger()
+    experimentRunsService = {
+      findUnique: vi.fn().mockResolvedValue({
+        runId: RUN_ID,
+        status: ExperimentRunStatus.RUNNING,
+        organizationSlug: 'org-1',
+        experimentType: 'district_intel',
+        updatedAt: new Date(),
+      }),
+      optimisticLockingUpdate: vi
+        .fn()
+        .mockImplementation(
+          async (
+            _params: unknown,
+            mod: (
+              run: Record<string, unknown>,
+            ) => Promise<Record<string, unknown>>,
+          ) => callModifier(mod),
+        ),
+    }
+
+    service = new QueueConsumerService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      experimentRunsService as never,
+      logger,
+    )
+  })
+
+  it('transitions RUNNING -> COMPLETED on success, writes artifact + duration, and acks', async () => {
+    const result = await service.processMessage(
+      makeMessage({ status: 'success' }),
+    )
+
+    expect(result).toBe(true)
+    expect(experimentRunsService.findUnique).toHaveBeenCalledWith({
+      where: { runId: RUN_ID },
+    })
+    expect(experimentRunsService.optimisticLockingUpdate).toHaveBeenCalledWith(
+      { where: { runId: RUN_ID } },
+      expect.any(Function),
+    )
+
+    const [, modifier] = experimentRunsService.optimisticLockingUpdate.mock
+      .calls[0] as [
+      unknown,
+      (run: Record<string, unknown>) => Promise<Record<string, unknown>>,
+    ]
+    const patched = await callModifier(modifier)
+    expect(patched.status).toBe(ExperimentRunStatus.COMPLETED)
+    expect(patched.artifactKey).toBe('district_intel/run-abc/result.json')
+    expect(patched.artifactBucket).toBe('gp-agent-artifacts-dev')
+    expect(patched.durationSeconds).toBe(42)
+    expect(patched.error).toBeNull()
+  })
+
+  it('maps "failed" to FAILED and preserves the error string', async () => {
+    await service.processMessage(
+      makeMessage({ status: 'failed', error: 'Agent crashed' }),
+    )
+
+    const [, modifier] = experimentRunsService.optimisticLockingUpdate.mock
+      .calls[0] as [
+      unknown,
+      (run: Record<string, unknown>) => Promise<Record<string, unknown>>,
+    ]
+    const patched = await callModifier(modifier)
+    expect(patched.status).toBe(ExperimentRunStatus.FAILED)
+    expect(patched.error).toBe('Agent crashed')
+  })
+
+  it('collapses "contract_violation" to FAILED at the boundary', async () => {
+    await service.processMessage(
+      makeMessage({ status: 'contract_violation', error: 'missing field' }),
+    )
+
+    const [, modifier] = experimentRunsService.optimisticLockingUpdate.mock
+      .calls[0] as [
+      unknown,
+      (run: Record<string, unknown>) => Promise<Record<string, unknown>>,
+    ]
+    const patched = await callModifier(modifier)
+    expect(patched.status).toBe(ExperimentRunStatus.FAILED)
+    expect(patched.error).toBe('missing field')
+  })
+
+  it('truncates error to 1000 chars to keep the column bounded', async () => {
+    await service.processMessage(
+      makeMessage({ status: 'failed', error: 'x'.repeat(2000) }),
+    )
+
+    const [, modifier] = experimentRunsService.optimisticLockingUpdate.mock
+      .calls[0] as [
+      unknown,
+      (run: Record<string, unknown>) => Promise<Record<string, unknown>>,
+    ]
+    const patched = await callModifier(modifier)
+    expect(typeof patched.error).toBe('string')
+    expect((patched.error as string).length).toBe(1000)
+  })
+
+  it('acks and skips update when run does not exist (prevents DLQ loop)', async () => {
+    experimentRunsService.findUnique.mockResolvedValue(null)
+
+    const result = await service.processMessage(makeMessage())
+
+    expect(result).toBe(true)
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ runId: RUN_ID }),
+      }),
+      'Experiment run not found',
+    )
+    expect(experimentRunsService.optimisticLockingUpdate).not.toHaveBeenCalled()
+  })
+
+  it('acks and skips update when run is already terminal COMPLETED', async () => {
+    experimentRunsService.findUnique.mockResolvedValue({
+      runId: RUN_ID,
+      status: ExperimentRunStatus.COMPLETED,
+      updatedAt: new Date(),
+    })
+
+    const result = await service.processMessage(makeMessage())
+
+    expect(result).toBe(true)
+    expect(logger.info).toHaveBeenCalledWith(
+      { runId: RUN_ID },
+      'Experiment run already completed, skipping',
+    )
+    expect(experimentRunsService.optimisticLockingUpdate).not.toHaveBeenCalled()
+  })
+
+  it('acks and skips update when run is already terminal FAILED', async () => {
+    experimentRunsService.findUnique.mockResolvedValue({
+      runId: RUN_ID,
+      status: ExperimentRunStatus.FAILED,
+      updatedAt: new Date(),
+    })
+
+    const result = await service.processMessage(makeMessage())
+
+    expect(result).toBe(true)
+    expect(experimentRunsService.optimisticLockingUpdate).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown status values at Zod parse', async () => {
+    await expect(
+      service.processMessage(makeMessage({ status: 'weird' })),
+    ).rejects.toThrow()
+    expect(experimentRunsService.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('rejects messages missing runId at Zod parse', async () => {
+    const message: Message = {
+      MessageId: 'msg-1',
+      Body: JSON.stringify({
+        type: QueueType.AGENT_EXPERIMENT_RESULT,
+        data: { status: 'success' },
+      }),
+    }
+    await expect(service.processMessage(message)).rejects.toThrow()
+    expect(experimentRunsService.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('propagates errors from optimisticLockingUpdate', async () => {
+    experimentRunsService.optimisticLockingUpdate.mockRejectedValue(
+      new Error('db timeout'),
+    )
+
+    await expect(service.processMessage(makeMessage())).rejects.toThrow(
+      'db timeout',
+    )
+  })
+})

--- a/src/agentExperiments/services/experimentRuns.service.test.ts
+++ b/src/agentExperiments/services/experimentRuns.service.test.ts
@@ -1,0 +1,247 @@
+import {
+  GetQueueUrlCommand,
+  SendMessageCommand,
+  SQSClient,
+} from '@aws-sdk/client-sqs'
+import { BadGatewayException } from '@nestjs/common'
+import { ExperimentRunStatus } from '@prisma/client'
+import { mockClient } from 'aws-sdk-client-mock'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { ExperimentRunsService } from './experimentRuns.service'
+
+const sqsMock = mockClient(SQSClient)
+const RESOLVED_URL =
+  'https://sqs.us-west-2.amazonaws.com/123/agent-dispatch-dev.fifo'
+
+describe('ExperimentRunsService', () => {
+  let service: ExperimentRunsService
+  let mockModel: {
+    create: ReturnType<typeof vi.fn>
+    update: ReturnType<typeof vi.fn>
+    updateMany: ReturnType<typeof vi.fn>
+  }
+  const logger = createMockLogger()
+
+  beforeEach(() => {
+    sqsMock.reset()
+    vi.clearAllMocks()
+    process.env.AGENT_DISPATCH_QUEUE_NAME = 'agent-dispatch-dev.fifo'
+    sqsMock.on(GetQueueUrlCommand).resolves({ QueueUrl: RESOLVED_URL })
+
+    mockModel = {
+      create: vi.fn().mockImplementation(async ({ data }) => data),
+      update: vi.fn().mockResolvedValue({}),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    }
+
+    service = new ExperimentRunsService()
+    Object.defineProperty(service, 'model', {
+      get: () => mockModel,
+      configurable: true,
+    })
+    Object.defineProperty(service, 'logger', {
+      get: () => logger,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    delete process.env.AGENT_DISPATCH_QUEUE_NAME
+  })
+
+  describe('dispatchRun', () => {
+    it('creates a RUNNING row and sends an SQS dispatch message', async () => {
+      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' })
+
+      const result = await service.dispatchRun({
+        experimentType: 'district_intel',
+        organizationSlug: 'org-1',
+        params: { foo: 'bar' },
+      })
+
+      expect(mockModel.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          runId: expect.any(String),
+          experimentType: 'district_intel',
+          organizationSlug: 'org-1',
+          status: ExperimentRunStatus.RUNNING,
+          params: { foo: 'bar' },
+        }),
+      })
+
+      const [call] = sqsMock.commandCalls(SendMessageCommand)
+      expect(call).toBeDefined()
+      const input = call.args[0].input
+      expect(input.QueueUrl).toBe(RESOLVED_URL)
+      expect(input.MessageGroupId).toBe('agent-dispatch-org-1')
+      expect(input.MessageDeduplicationId).toEqual(expect.any(String))
+      const body = JSON.parse(input.MessageBody as string) as Record<
+        string,
+        unknown
+      >
+      expect(body).toMatchObject({
+        params: { foo: 'bar' },
+        organization_slug: 'org-1',
+        experiment_type: 'district_intel',
+        run_id: expect.any(String),
+      })
+
+      expect(result).toMatchObject({
+        runId: expect.any(String),
+        experimentType: 'district_intel',
+        organizationSlug: 'org-1',
+        status: ExperimentRunStatus.RUNNING,
+      })
+    })
+
+    it('writes the same run_id to the DB row and the SQS message body', async () => {
+      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' })
+
+      await service.dispatchRun({
+        experimentType: 'district_intel',
+        organizationSlug: 'org-1',
+        params: {},
+      })
+
+      const dbRunId = mockModel.create.mock.calls[0][0].data.runId as string
+      const [call] = sqsMock.commandCalls(SendMessageCommand)
+      const body = JSON.parse(call.args[0].input.MessageBody as string) as {
+        run_id: string
+      }
+      expect(body.run_id).toBe(dbRunId)
+    })
+
+    it('namespaces FIFO group per organization so runs for one org serialize', async () => {
+      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' })
+
+      await service.dispatchRun({
+        experimentType: 'a',
+        organizationSlug: 'org-alpha',
+        params: {},
+      })
+      await service.dispatchRun({
+        experimentType: 'a',
+        organizationSlug: 'org-beta',
+        params: {},
+      })
+
+      const calls = sqsMock.commandCalls(SendMessageCommand)
+      expect(calls[0].args[0].input.MessageGroupId).toBe(
+        'agent-dispatch-org-alpha',
+      )
+      expect(calls[1].args[0].input.MessageGroupId).toBe(
+        'agent-dispatch-org-beta',
+      )
+    })
+
+    it('flips the row to FAILED and throws BadGateway when SQS send fails', async () => {
+      sqsMock.on(SendMessageCommand).rejects(new Error('SQS unavailable'))
+
+      await expect(
+        service.dispatchRun({
+          experimentType: 'district_intel',
+          organizationSlug: 'org-1',
+          params: {},
+        }),
+      ).rejects.toThrow(BadGatewayException)
+
+      expect(mockModel.update).toHaveBeenCalledWith({
+        where: { runId: expect.any(String) },
+        data: { status: 'FAILED', error: 'SQS dispatch failed' },
+      })
+      expect(logger.error).toHaveBeenCalled()
+    })
+
+    it('does not send to SQS when the DB create fails', async () => {
+      mockModel.create.mockRejectedValue(new Error('db down'))
+
+      await expect(
+        service.dispatchRun({
+          experimentType: 'district_intel',
+          organizationSlug: 'org-1',
+          params: {},
+        }),
+      ).rejects.toThrow('db down')
+
+      expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
+    })
+
+    it('generates a unique run_id per dispatch', async () => {
+      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' })
+
+      await service.dispatchRun({
+        experimentType: 'a',
+        organizationSlug: 'org-1',
+        params: {},
+      })
+      await service.dispatchRun({
+        experimentType: 'a',
+        organizationSlug: 'org-1',
+        params: {},
+      })
+
+      const id1 = mockModel.create.mock.calls[0][0].data.runId as string
+      const id2 = mockModel.create.mock.calls[1][0].data.runId as string
+      expect(id1).not.toBe(id2)
+    })
+  })
+
+  describe('sweepStaleRuns', () => {
+    it('marks RUNNING rows older than 45 minutes as FAILED with a timeout error', async () => {
+      mockModel.updateMany.mockResolvedValue({ count: 3 })
+
+      await service.sweepStaleRuns()
+
+      expect(mockModel.updateMany).toHaveBeenCalledWith({
+        where: {
+          status: { in: [ExperimentRunStatus.RUNNING] },
+          createdAt: { lt: expect.any(Date) },
+        },
+        data: {
+          status: ExperimentRunStatus.FAILED,
+          error: expect.stringContaining('45 minutes'),
+        },
+      })
+
+      const cutoff = mockModel.updateMany.mock.calls[0][0].where.createdAt
+        .lt as Date
+      const fortyFiveMinutesAgo = Date.now() - 45 * 60 * 1000
+      expect(Math.abs(cutoff.getTime() - fortyFiveMinutesAgo)).toBeLessThan(
+        5000,
+      )
+    })
+
+    it('does not target terminal states', async () => {
+      mockModel.updateMany.mockResolvedValue({ count: 0 })
+
+      await service.sweepStaleRuns()
+
+      const where = mockModel.updateMany.mock.calls[0][0].where as {
+        status: { in: ExperimentRunStatus[] }
+      }
+      expect(where.status.in).toEqual([ExperimentRunStatus.RUNNING])
+      expect(where.status.in).not.toContain(ExperimentRunStatus.COMPLETED)
+      expect(where.status.in).not.toContain(ExperimentRunStatus.FAILED)
+    })
+
+    it('logs a warning with the swept count when rows are found', async () => {
+      mockModel.updateMany.mockResolvedValue({ count: 2 })
+
+      await service.sweepStaleRuns()
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ count: 2 }),
+        expect.stringContaining('stale'),
+      )
+    })
+
+    it('stays quiet when there is nothing to sweep', async () => {
+      mockModel.updateMany.mockResolvedValue({ count: 0 })
+
+      await service.sweepStaleRuns()
+
+      expect(logger.warn).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/agentExperiments/services/experimentRuns.service.ts
+++ b/src/agentExperiments/services/experimentRuns.service.ts
@@ -1,0 +1,123 @@
+import { BadGatewayException, Injectable } from '@nestjs/common'
+import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
+import { v7 as uuidv7 } from 'uuid'
+import { SQS } from '@aws-sdk/client-sqs'
+import { ExperimentRunStatus } from '@prisma/client'
+import { Cron } from '@nestjs/schedule'
+import { randomUUID } from 'crypto'
+
+const sqs = new SQS({})
+
+export type ExperimentRunDispatchInput = {
+  experimentType: string
+  organizationSlug: string
+  params: Record<string, unknown>
+}
+
+const STALE_THRESHOLD_MINUTES = 45
+
+@Injectable()
+export class ExperimentRunsService extends createPrismaBase(
+  MODELS.ExperimentRun,
+) {
+  private async resolveQueueUrl(): Promise<string | undefined> {
+    const queueName = process.env.AGENT_DISPATCH_QUEUE_NAME
+    if (!queueName) {
+      return
+    }
+
+    const { QueueUrl } = await sqs.getQueueUrl({ QueueName: queueName })
+
+    return QueueUrl
+  }
+
+  async dispatchRun(input: ExperimentRunDispatchInput) {
+    const QueueUrl = await this.resolveQueueUrl()
+    if (!QueueUrl) {
+      this.logger.warn(
+        'No Queue Url found for agent dispatch, not configured for this environment',
+      )
+      return
+    }
+
+    const runId = uuidv7()
+
+    const result = await this.model.create({
+      data: {
+        runId,
+        experimentType: input.experimentType,
+        organizationSlug: input.organizationSlug,
+        status: ExperimentRunStatus.RUNNING,
+        params: input.params,
+      },
+    })
+
+    const messageBody = {
+      run_id: runId,
+      params: input.params,
+      organization_slug: input.organizationSlug,
+      experiment_type: input.experimentType,
+    }
+
+    const deduplicationId = randomUUID()
+
+    try {
+      await sqs.sendMessage({
+        QueueUrl,
+        MessageBody: JSON.stringify(messageBody),
+        MessageGroupId: `agent-dispatch-${input.organizationSlug}`,
+        MessageDeduplicationId: deduplicationId,
+      })
+    } catch (error) {
+      this.logger.error(
+        {
+          error,
+          runId,
+          experimentType: input.experimentType,
+          organizationSlug: input.organizationSlug,
+        },
+        'Failed to send dispatch message to SQS',
+      )
+      await this.model.update({
+        where: { runId },
+        data: { status: 'FAILED', error: 'SQS dispatch failed' },
+      })
+      throw new BadGatewayException(
+        'Failed to dispatch experiment. Please try again.',
+      )
+    }
+
+    this.logger.info(
+      {
+        runId,
+        experimentType: input.experimentType,
+        organizationSlug: input.organizationSlug,
+      },
+      'Experiment dispatched',
+    )
+
+    return result
+  }
+
+  @Cron('*/15 * * * *')
+  async sweepStaleRuns() {
+    const cutoff = new Date(Date.now() - STALE_THRESHOLD_MINUTES * 60 * 1000)
+    const result = await this.model.updateMany({
+      where: {
+        status: { in: [ExperimentRunStatus.RUNNING] },
+        createdAt: { lt: cutoff },
+      },
+      data: {
+        status: ExperimentRunStatus.FAILED,
+        error: `Timed out waiting for callback after ${STALE_THRESHOLD_MINUTES} minutes`,
+      },
+    })
+
+    if (result.count > 0) {
+      this.logger.warn(
+        { count: result.count, cutoff: cutoff.toISOString() },
+        'Marked stale experiment runs as FAILED',
+      )
+    }
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,3 +1,4 @@
+import { AgentExperimentsModule } from '@/agentExperiments/agentExperiments.module'
 import { AdminModule } from '@/admin/admin.module'
 import { AnalyticsModule } from '@/analytics/analytics.module'
 import { AuthenticationModule } from '@/authentication/authentication.module'
@@ -58,6 +59,7 @@ import { loggerModule } from './observability/logging/logger-module'
     ElectionsModule,
     TopIssuesModule,
     AdminModule,
+    AgentExperimentsModule,
     SharedModule,
     PaymentsModule,
     VotersModule,

--- a/src/authentication/guards/Roles.guard.test.ts
+++ b/src/authentication/guards/Roles.guard.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RolesGuard } from './Roles.guard'
+import { Reflector } from '@nestjs/core'
+import { ExecutionContext } from '@nestjs/common'
+import { UserRole } from '@prisma/client'
+
+function makeContext(user: Record<string, unknown>): ExecutionContext {
+  return {
+    getHandler: vi.fn(),
+    getClass: vi.fn(),
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+  } as unknown as ExecutionContext
+}
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard
+  let reflector: Reflector
+
+  beforeEach(() => {
+    reflector = { getAllAndOverride: vi.fn() } as unknown as Reflector
+    guard = new RolesGuard(reflector)
+  })
+
+  it('allows when no roles are required', () => {
+    vi.mocked(reflector.getAllAndOverride).mockReturnValue(undefined)
+
+    expect(guard.canActivate(makeContext({ roles: [] }))).toBe(true)
+  })
+
+  it('allows when user has a required role', () => {
+    vi.mocked(reflector.getAllAndOverride).mockReturnValue([UserRole.candidate])
+
+    expect(
+      guard.canActivate(makeContext({ roles: [UserRole.candidate] })),
+    ).toBe(true)
+  })
+
+  it('rejects when user lacks the required role', () => {
+    vi.mocked(reflector.getAllAndOverride).mockReturnValue([
+      UserRole.candidate,
+      UserRole.admin,
+    ])
+
+    expect(guard.canActivate(makeContext({ roles: [UserRole.sales] }))).toBe(
+      false,
+    )
+  })
+
+  it('allows impersonating users regardless of role', () => {
+    vi.mocked(reflector.getAllAndOverride).mockReturnValue([
+      UserRole.candidate,
+      UserRole.admin,
+    ])
+
+    expect(
+      guard.canActivate(
+        makeContext({ roles: [UserRole.sales], impersonating: true }),
+      ),
+    ).toBe(true)
+  })
+})

--- a/src/authentication/guards/Roles.guard.ts
+++ b/src/authentication/guards/Roles.guard.ts
@@ -15,8 +15,9 @@ export class RolesGuard implements CanActivate {
       return true
     }
     const { user } = context.switchToHttp().getRequest<{
-      user: { roles?: UserRole[] }
+      user: { roles?: UserRole[]; impersonating?: boolean }
     }>()
+    if (user.impersonating) return true
     return requiredRoles.some((role) => user.roles?.includes(role))
   }
 }

--- a/src/queue/consumer/queueConsumer.module.ts
+++ b/src/queue/consumer/queueConsumer.module.ts
@@ -13,6 +13,7 @@ import { SlackModule } from 'src/vendors/slack/slack.module'
 import { PollsModule } from 'src/polls/polls.module'
 import { ElectedOfficeModule } from 'src/electedOffice/electedOffice.module'
 import { ContactsModule } from 'src/contacts/contacts.module'
+import { AgentExperimentsModule } from 'src/agentExperiments/agentExperiments.module'
 import { AwsModule } from 'src/vendors/aws/aws.module'
 
 @Module({
@@ -37,6 +38,7 @@ import { AwsModule } from 'src/vendors/aws/aws.module'
     PollsModule,
     ContactsModule,
     AwsModule,
+    AgentExperimentsModule,
   ],
   providers: [QueueConsumerService],
 })

--- a/src/queue/consumer/queueConsumer.service.test.ts
+++ b/src/queue/consumer/queueConsumer.service.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { InternalServerErrorException } from '@nestjs/common'
+import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
 import { AiContentService } from '@/campaigns/ai/content/aiContent.service'
 import { CampaignsService } from '@/campaigns/services/campaigns.service'
 import { AiGenerationService } from '@/campaigns/tasks/services/aiGeneration.service'
@@ -219,22 +220,23 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
       {} as never,
       {} as never,
       {} as never,
+      {} as never,
       createMockLogger(),
     )
   })
 
-  it('returns undefined and does not create messages when poll is not found', async () => {
+  it('acks and does not create messages when poll is not found', async () => {
     pollsService.findUnique.mockResolvedValue(null)
     const message = createPollAnalysisCompleteMessage({ pollId })
 
     const result = await service.processMessage(message)
 
-    expect(result).toBeUndefined()
+    expect(result).toBe(true)
     expect(s3Service.getFile).not.toHaveBeenCalled()
     expect(pollIssuesService.model.deleteMany).not.toHaveBeenCalled()
   })
 
-  it('returns undefined and does not create messages when poll is not SCHEDULED or IN_PROGRESS', async () => {
+  it('acks and does not create messages when poll is not SCHEDULED or IN_PROGRESS', async () => {
     pollsService.findUnique.mockResolvedValue({
       id: pollId,
       electedOfficeId,
@@ -245,7 +247,7 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
 
     const result = await service.processMessage(message)
 
-    expect(result).toBeUndefined()
+    expect(result).toBe(true)
     expect(s3Service.getFile).not.toHaveBeenCalled()
   })
 
@@ -856,6 +858,7 @@ describe('QueueConsumerService - triggerPollExecution', () => {
       usersService as never,
       {} as never,
       {} as never,
+      {} as never,
       createMockLogger(),
     )
   })
@@ -979,6 +982,7 @@ describe('QueueConsumerService - message type routing', () => {
           provide: WeeklyTasksDigestHandlerService,
           useValue: { handleWeeklyTasksDigest: vi.fn() },
         },
+        { provide: ExperimentRunsService, useValue: {} },
         { provide: PinoLogger, useValue: createMockLogger() },
       ],
     }).compile()

--- a/src/queue/consumer/queueConsumer.service.ts
+++ b/src/queue/consumer/queueConsumer.service.ts
@@ -48,6 +48,7 @@ import { DomainsService } from '../../websites/services/domains.service'
 import {
   CampaignPlanCompleteMessage,
   CampaignPlanCompleteMessageSchema,
+  AgentExperimentResultSchema,
   DomainEmailForwardingMessage,
   WeeklyTasksDigestMessageSchema,
   PollAnalysisCompleteEvent,
@@ -62,11 +63,16 @@ import {
   SqsConsumerErrorEventName,
   TcrComplianceStatusCheckMessage,
 } from '../queue.types'
+import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
 import { PollIndividualMessageService } from '@/polls/services/pollIndividualMessage.service'
 import { WeeklyTasksDigestHandlerService } from '../../campaigns/tasks/services/weeklyTasksDigestHandler.service'
 import { v5 as uuidv5 } from 'uuid'
 import { PinoLogger } from 'nestjs-pino'
 import { OrgDistrict } from '@/organizations/organizations.types'
+
+import type { AgentExperimentResultData } from '../queue.types'
+
+import { ExperimentRunStatus } from '@prisma/client'
 
 type PollAnalysisIssue = PollAnalysisCompleteEvent['data']['issues'][number]
 
@@ -112,6 +118,7 @@ export class QueueConsumerService {
     private readonly usersService: UsersService,
     private readonly organizationsService: OrganizationsService,
     private readonly weeklyTasksDigestHandler: WeeklyTasksDigestHandlerService,
+    private readonly experimentRunsService: ExperimentRunsService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(QueueConsumerService.name)
@@ -260,7 +267,7 @@ export class QueueConsumerService {
   //  misinterpreted by other modules/services.
   //
   //  https://goodparty.atlassian.net/browse/WEB-4518
-  async processMessage(message: Message) {
+  async processMessage(message: Message): Promise<boolean> {
     if (!message || !message.Body) {
       return true // Delete invalid messages from queue
     }
@@ -358,6 +365,10 @@ export class QueueConsumerService {
           )
           return true
         })
+      case QueueType.AGENT_EXPERIMENT_RESULT:
+        return await this.handleAgentExperimentResult(
+          AgentExperimentResultSchema.parse(queueMessage.data),
+        )
       default:
         this.logger.warn(
           { messageId: message.MessageId, body: message.Body },
@@ -523,13 +534,15 @@ export class QueueConsumerService {
     return true
   }
 
-  private async handlePollAnalysisComplete(event: PollAnalysisCompleteEvent) {
+  private async handlePollAnalysisComplete(
+    event: PollAnalysisCompleteEvent,
+  ): Promise<boolean> {
     const { pollId, totalResponses, responsesLocation, issues } = event.data
     this.logger.info(`Handling poll analysis complete event for poll ${pollId}`)
     const data = await this.getPollAndOrganization(pollId)
     if (!data) {
       this.logger.info('Poll not found, ignoring event')
-      return
+      return true
     }
     const { poll, office, organization } = data
     const { electedOfficeId } = poll
@@ -553,7 +566,7 @@ export class QueueConsumerService {
         },
         'Poll is not in expected state, ignoring event',
       )
-      return
+      return true
     }
 
     const constituency = await this.contactsService.findContacts(
@@ -797,16 +810,64 @@ export class QueueConsumerService {
     })
   }
 
+  private async handleAgentExperimentResult(data: AgentExperimentResultData) {
+    const run = await this.experimentRunsService.findUnique({
+      where: { runId: data.runId },
+    })
+
+    if (!run) {
+      this.logger.error({ data }, 'Experiment run not found')
+      return true
+    }
+
+    if (run.status !== ExperimentRunStatus.RUNNING) {
+      this.logger.info(
+        { runId: data.runId },
+        'Experiment run already completed, skipping',
+      )
+      return true
+    }
+
+    const updatedRun = await this.experimentRunsService.optimisticLockingUpdate(
+      { where: { runId: data.runId } },
+      async (run) => {
+        if (run.status !== ExperimentRunStatus.RUNNING) {
+          this.logger.info(
+            { runId: data.runId },
+            'Experiment run already completed, skipping',
+          )
+          throw new Error('Experiment run already completed')
+        }
+        run.status = {
+          success: ExperimentRunStatus.COMPLETED,
+          failed: ExperimentRunStatus.FAILED,
+          contract_violation: ExperimentRunStatus.FAILED,
+        }[data.status]
+        run.artifactKey = data.artifactKey ?? null
+        run.artifactBucket = data.artifactBucket ?? null
+        run.durationSeconds = data.durationSeconds ?? null
+        run.error = data.error?.slice(0, 1000) ?? null
+        return run
+      },
+    )
+
+    this.logger.info(
+      { updatedRun, data },
+      'Updated experiment run from queue event',
+    )
+    return true
+  }
+
   private async triggerPollExecution(params: {
     pollId: string
     messageId: string
     sampleParams: (poll: Poll) => Promise<SampleContacts> | SampleContacts
     isExpansion: boolean
-  }) {
+  }): Promise<boolean> {
     const data = await this.getPollAndOrganization(params.pollId)
     if (!data) {
       this.logger.info(`${params.pollId} Poll not found, ignoring event`)
-      return
+      return true
     }
     const { poll, office, organization } = data
 
@@ -817,7 +878,7 @@ export class QueueConsumerService {
 
     if (!user) {
       this.logger.info(`${params.pollId} User not found, ignoring event`)
-      return
+      return true
     }
 
     const bucket = process.env.TEVYN_POLL_CSVS_BUCKET

--- a/src/queue/queue.types.ts
+++ b/src/queue/queue.types.ts
@@ -10,6 +10,7 @@ export enum QueueType {
   POLL_EXPANSION = 'pollExpansion',
   CAMPAIGN_PLAN_COMPLETE = 'campaignPlanComplete',
   WEEKLY_TASKS_DIGEST = 'weeklyTasksDigest',
+  AGENT_EXPERIMENT_RESULT = 'agentExperimentResult',
 }
 
 export type QueueMessage =
@@ -35,6 +36,10 @@ export type QueueMessage =
   | {
       type: QueueType.WEEKLY_TASKS_DIGEST
       data: WeeklyTasksDigestMessage
+    }
+  | {
+      type: QueueType.AGENT_EXPERIMENT_RESULT
+      data: AgentExperimentResultData
     }
 
 export type GenerateAiContentMessageData = {
@@ -155,4 +160,17 @@ export type PollResponseJsonRow = z.infer<typeof PollResponseJsonRowSchema>
 export const PollClusterAnalysisJsonSchema = z.array(PollResponseJsonRowSchema)
 export type PollClusterAnalysisJson = z.infer<
   typeof PollClusterAnalysisJsonSchema
+>
+
+export const AgentExperimentResultSchema = z.object({
+  runId: z.string(),
+  status: z.enum(['success', 'failed', 'contract_violation']),
+  artifactKey: z.string().optional(),
+  artifactBucket: z.string().optional(),
+  durationSeconds: z.number().optional(),
+  error: z.string().optional(),
+})
+
+export type AgentExperimentResultData = z.infer<
+  typeof AgentExperimentResultSchema
 >


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new persistent `experiment_run` table plus SQS dispatch/result handling, which impacts background processing and production data. Moderate risk due to new queue message type routing and cron-based state transitions that could affect message ack/requeue behavior if misconfigured.
> 
> **Overview**
> Adds end-to-end plumbing for “agent experiments”: a new Prisma `ExperimentRun` model/migration and an `AgentExperimentsModule` exposing `ExperimentRunsService` to create `RUNNING` rows, dispatch FIFO SQS messages (per-org `MessageGroupId`), and periodically fail stale runs after 45 minutes.
> 
> Extends the queue consumer with a new `QueueType.AGENT_EXPERIMENT_RESULT` + Zod schema and a handler that idempotently transitions runs `RUNNING → COMPLETED|FAILED` via `optimisticLockingUpdate`, persisting artifact pointers/duration and truncating error strings.
> 
> Wires new infra/config by adding `AGENT_DISPATCH_QUEUE_NAME` to Pulumi env vars (dev/qa/prod) and registers `AgentExperimentsModule` in both `AppModule` and `QueueConsumerModule`; also updates `RolesGuard` to allow requests marked `impersonating` to bypass role checks, with new unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34905b2dd62e6bdcf5159c0c8471862791e5b711. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->