### PR TITLE
QA <- Dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,7 +74,6 @@ WINNERS_ELECTION_YEAR='2024'
 PEERLY_MD5_EMAIL=MD5(email@domain.io)
 PEERLY_MD5_PASSWORD=MD5(password)
 PEERLY_ACCOUNT_NUMBER=12345678
-PEERLY_SCHEDULE_ID=1058113 # Default schedule ID for P2P jobs in Peerly DEV account, change for Peerly PROD account
 PEERLY_API_BASE_URL=https://app.peerly.com/api
 PEERLY_HTTP_TIMEOUT=10000 # 10 seconds
 EXPLICITLY_LOG_PEERLY_TOKEN=false # Set to true to log Peerly token in the logs (useful for debugging, but sensitive information)

--- a/.env.test
+++ b/.env.test
@@ -74,7 +74,6 @@ WINNERS_ELECTION_YEAR='2024'
 PEERLY_MD5_EMAIL=dummy-value
 PEERLY_MD5_PASSWORD=dummy-value
 PEERLY_ACCOUNT_NUMBER=12345678
-PEERLY_SCHEDULE_ID=1058113 # Default schedule ID for P2P jobs in Peerly DEV account, change for Peerly PROD account
 PEERLY_API_BASE_URL=https://app.peerly.com/api
 PEERLY_HTTP_TIMEOUT=10000 # 10 seconds
 EXPLICITLY_LOG_PEERLY_TOKEN=false # Set to true to log Peerly token in the logs (useful for debugging, but sensitive information)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,20 @@ jobs:
     concurrency:
       group: deploy-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || github.ref_name }}
       cancel-in-progress: false
+    services:
+      shadow-db:
+        image: postgres:16
+        env:
+          POSTGRES_USER: prisma
+          POSTGRES_PASSWORD: prisma
+          POSTGRES_DB: shadow
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U prisma"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=5
     outputs:
       environment: ${{ steps.context.outputs.environment }}
       service_url: ${{ steps.pulumi.outputs.service_url }}
@@ -51,6 +65,14 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
+
+      - name: Check Prisma schema is in sync with migrations
+        run: |
+          npx prisma migrate diff \
+            --from-migrations ./prisma/schema/migrations \
+            --to-schema-datamodel ./prisma/schema \
+            --shadow-database-url "postgresql://prisma:prisma@localhost:5432/shadow" \
+            --exit-code
 
       # Validation
       - run: npm run generate

--- a/README.md
+++ b/README.md
@@ -149,8 +149,6 @@ CAMPAIGN_PLAN_LOCAL_URL=http://localhost:8089/generate
 CAMPAIGN_PLAN_RESULTS_BUCKET=campaign-plan-results-dev
 ```
 
-The local server also needs `OUTPUT_SQS_QUEUE_URL` set to your personal SQS queue (e.g. `YourName_Queue.fifo`). Each engineer should have their own dedicated queue.
-
 See `gp-ai-projects/campaign_plan_lambda/README.md` for full setup instructions including AWS credentials and SQS queue configuration.
 
 ### AWS Setup

--- a/prisma/schema/campaignTask.prisma
+++ b/prisma/schema/campaignTask.prisma
@@ -34,5 +34,6 @@ model CampaignTask {
 
   @@index([campaignId])
   @@index([campaignId, completed])
+  @@index([date])
   @@map("campaign_task")
 }

--- a/prisma/schema/migrations/20260413000000_clear_campaign_plan_and_tasks/migration.sql
+++ b/prisma/schema/migrations/20260413000000_clear_campaign_plan_and_tasks/migration.sql
@@ -1,4 +1,4 @@
 -- Clear all campaign tasks and campaign plans for a clean slate.
 -- Campaign tasks will be regenerated when users visit their dashboard.
-TRUNCATE TABLE "campaign_task" CASCADE;
-TRUNCATE TABLE "campaign_plan" CASCADE;
+TRUNCATE TABLE "campaign_task";
+TRUNCATE TABLE "campaign_plan";

--- a/prisma/schema/migrations/20260413000000_clear_campaign_plan_and_tasks/migration.sql
+++ b/prisma/schema/migrations/20260413000000_clear_campaign_plan_and_tasks/migration.sql
@@ -1,0 +1,4 @@
+-- Clear all campaign tasks and campaign plans for a clean slate.
+-- Campaign tasks will be regenerated when users visit their dashboard.
+TRUNCATE TABLE "campaign_task" CASCADE;
+TRUNCATE TABLE "campaign_plan" CASCADE;

--- a/prisma/schema/migrations/20260420233738_add_campaign_task_date_index/migration.sql
+++ b/prisma/schema/migrations/20260420233738_add_campaign_task_date_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "campaign_task_date_idx" ON "campaign_task"("date");

--- a/scripts/test-weekly-tasks-digest-event.ts
+++ b/scripts/test-weekly-tasks-digest-event.ts
@@ -1,0 +1,190 @@
+/**
+ * Test script: Campaign Plan - Weekly Tasks Digest (Segment event)
+ *
+ * Picks a single campaign, finds its incomplete tasks due in the next
+ * Monday-to-Monday window, and fires the "Campaign Plan - Weekly Tasks Digest"
+ * Segment event so you can verify the pipeline in Segment Debugger → HubSpot.
+ *
+ * Usage:
+ *   npx tsx scripts/test-weekly-tasks-digest-event.ts --campaign=<ID> [--dry-run]
+ *
+ * Options:
+ *   --campaign=<ID>  Required. The campaign ID to fire the event for.
+ *   --dry-run        Print the event payload without sending to Segment.
+ *
+ * Requires DATABASE_URL and SEGMENT_WRITE_KEY in .env.
+ * ONLY reads from the database — never writes.
+ */
+import 'dotenv/config'
+import pg from 'pg'
+import Analytics from '@segment/analytics-node'
+import { addDays, format, nextMonday, startOfDay } from 'date-fns'
+
+const OUTREACH_FLOW_TYPES = ['text', 'robocall', 'doorKnocking', 'phoneBanking']
+const MAX_TASKS = 5
+
+const campaignArg = process.argv.find((a) => a.startsWith('--campaign='))
+if (!campaignArg) {
+  console.error('Usage: npx tsx scripts/test-weekly-tasks-digest-event.ts --campaign=<ID> [--dry-run]')
+  process.exit(1)
+}
+const CAMPAIGN_ID = parseInt(campaignArg.split('=')[1], 10)
+if (isNaN(CAMPAIGN_ID)) {
+  throw new Error('--campaign must be a number')
+}
+const DRY_RUN = process.argv.includes('--dry-run')
+
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) throw new Error('DATABASE_URL is not set.')
+if (!DRY_RUN && !process.env.SEGMENT_WRITE_KEY) {
+  throw new Error('SEGMENT_WRITE_KEY is not set (required unless --dry-run).')
+}
+
+interface CampaignRow {
+  campaign_id: number
+  user_id: number
+  email: string
+  hubspot_id: string | null
+  election_date: string | null
+}
+
+interface TaskRow {
+  id: string
+  title: string
+  description: string
+  flow_type: string | null
+  week: number
+  date: string
+  completed: boolean
+}
+
+async function main() {
+  const db = new pg.Client({ connectionString: databaseUrl })
+  await db.connect()
+
+  try {
+    const { rows: campaigns } = await db.query<CampaignRow>(`
+      SELECT
+        c.id AS campaign_id,
+        c.user_id,
+        u.email,
+        u.meta_data->>'hubspotId' AS hubspot_id,
+        c.details->>'electionDate' AS election_date
+      FROM campaign c
+      JOIN "user" u ON u.id = c.user_id
+      WHERE c.id = $1
+    `, [CAMPAIGN_ID])
+
+    if (campaigns.length === 0) {
+      console.error(`Campaign ${CAMPAIGN_ID} not found.`)
+      process.exit(1)
+    }
+
+    const campaign = campaigns[0]
+    console.log(`\nCampaign: ${campaign.campaign_id}`)
+    console.log(`User:     ${campaign.email} (id: ${campaign.user_id})`)
+    console.log(`HubSpot:  ${campaign.hubspot_id ?? '(none)'}`)
+    console.log(`Election: ${campaign.election_date ?? '(none)'}`)
+
+    if (campaign.election_date) {
+      const electionDate = new Date(campaign.election_date)
+      if (electionDate <= new Date()) {
+        console.error(`\nElection date ${campaign.election_date} is in the past — would skip in production.`)
+        if (!DRY_RUN) process.exit(1)
+        console.log('Continuing anyway because --dry-run...')
+      }
+    }
+
+    const windowStart = startOfDay(nextMonday(new Date()))
+    const windowEnd = addDays(windowStart, 7)
+
+    console.log(`\nTask window: ${windowStart.toISOString().split('T')[0]} → ${windowEnd.toISOString().split('T')[0]}`)
+
+    const { rows: allWindowTasks } = await db.query<TaskRow>(`
+      SELECT id, title, description, flow_type, week, date, completed
+      FROM campaign_task
+      WHERE campaign_id = $1
+        AND date >= $2
+        AND date < $3
+      ORDER BY date ASC
+    `, [CAMPAIGN_ID, windowStart, windowEnd])
+
+    const completedCount = allWindowTasks.filter((t) => t.completed).length
+    const tasks = allWindowTasks.filter((t) => !t.completed)
+
+    console.log(`Found ${allWindowTasks.length} task(s) in window (${completedCount} completed, ${tasks.length} incomplete)`)
+
+    if (tasks.length < 3) {
+      console.log(`\nOnly ${tasks.length} incomplete task(s) — in production, no event would be sent (minimum 3).`)
+      process.exit(0)
+    }
+
+    for (const t of tasks) {
+      console.log(`  [${t.flow_type ?? 'none'}] ${t.title} (week ${t.week}, due ${t.date})`)
+    }
+
+    const sorted = [...tasks].sort((a, b) => {
+      const aIsOutreach = OUTREACH_FLOW_TYPES.includes(a.flow_type ?? '')
+      const bIsOutreach = OUTREACH_FLOW_TYPES.includes(b.flow_type ?? '')
+      if (aIsOutreach && !bIsOutreach) return -1
+      if (!aIsOutreach && bIsOutreach) return 1
+      return 0
+    })
+
+    const selected = sorted.slice(0, MAX_TASKS)
+    console.log(`\nSelected ${selected.length} task(s) (outreach prioritized):`)
+    for (const t of selected) {
+      console.log(`  [${t.flow_type ?? 'none'}] ${t.title}`)
+    }
+
+    const properties: Record<string, unknown> = {
+      email: campaign.email,
+      plan_tasks_completed: completedCount,
+      plan_total_tasks: allWindowTasks.length,
+    }
+
+    // Always emit all 5 slots so HubSpot clears any stale values from prior weeks.
+    for (let i = 0; i < MAX_TASKS; i++) {
+      const n = i + 1
+      const task = selected[i]
+      properties[`task_name_${n}`] = task?.title ?? ''
+      properties[`task_description_${n}`] = task?.description ?? ''
+      properties[`task_type_${n}`] = task?.flow_type ?? ''
+      properties[`task_due_date_${n}`] = task?.date ? format(new Date(task.date), 'yyyy-MM-dd') : ''
+      properties[`task_week_number_${n}`] = task?.week ?? null
+    }
+
+    const eventName = 'Campaign Plan - Weekly Tasks Digest'
+
+    console.log(`\nEvent: "${eventName}"`)
+    console.log('Properties:', JSON.stringify(properties, null, 2))
+
+    if (DRY_RUN) {
+      console.log('\n--dry-run: Segment event NOT sent.')
+      return
+    }
+
+    const analytics = new Analytics({ writeKey: process.env.SEGMENT_WRITE_KEY! })
+
+    const traits: Record<string, string> = {}
+    if (campaign.email) traits.email = campaign.email
+    if (campaign.hubspot_id) traits.hubspotId = campaign.hubspot_id
+
+    analytics.track({
+      event: eventName,
+      userId: String(campaign.user_id),
+      properties,
+      context: { traits },
+    })
+
+    await analytics.closeAndFlush()
+    console.log('\nSegment event sent. Check the Segment Debugger to verify.')
+  } finally {
+    await db.end()
+  }
+}
+
+main().catch((error) => {
+  console.error('Error:', error)
+  process.exit(1)
+})

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -30,6 +30,8 @@ import { CampaignTasksService } from './tasks/services/campaignTasks.service'
 import { AiGenerationService } from './tasks/services/aiGeneration.service'
 import { CampaignTcrComplianceController } from './tcrCompliance/campaignTcrCompliance.controller'
 import { CampaignTcrComplianceService } from './tcrCompliance/services/campaignTcrCompliance.service'
+import { WeeklyTasksDigestService } from './tasks/services/weeklyTasksDigest.service'
+import { WeeklyTasksDigestHandlerService } from './tasks/services/weeklyTasksDigestHandler.service'
 import { CampaignUpdateHistoryController } from './updateHistory/campaignUpdateHistory.controller'
 import { CampaignUpdateHistoryService } from './updateHistory/campaignUpdateHistory.service'
 
@@ -73,6 +75,8 @@ import { CampaignUpdateHistoryService } from './updateHistory/campaignUpdateHist
     LegacyCampaignTasksService,
     AiGenerationService,
     CampaignTcrComplianceService,
+    WeeklyTasksDigestService,
+    WeeklyTasksDigestHandlerService,
   ],
   exports: [
     CampaignsService,
@@ -81,6 +85,7 @@ import { CampaignUpdateHistoryService } from './updateHistory/campaignUpdateHist
     CampaignTcrComplianceService,
     CampaignTasksService,
     AiGenerationService,
+    WeeklyTasksDigestHandlerService,
   ],
 })
 export class CampaignsModule {}

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -114,6 +114,7 @@ describe('CampaignTasksService', () => {
   let service: CampaignTasksService
 
   beforeEach(() => {
+    vi.clearAllMocks()
     service = new CampaignTasksService(
       mockAiGeneration as AiGenerationService,
       mockSlackService as SlackService,
@@ -479,11 +480,36 @@ describe('CampaignTasksService', () => {
   })
 
   describe('generateTasksStream', () => {
+    it('skips default task generation and AI trigger when any tasks exist', async () => {
+      const existingTasks = [
+        makeDbTask({ id: 'default-1', isDefaultTask: true }),
+      ]
+
+      mockModel.findMany.mockResolvedValueOnce(existingTasks)
+
+      const observable = service.generateTasksStream(makeCampaign())
+      const events = await firstValueFrom(observable.pipe(toArray()))
+
+      const completeEvent = events.find(
+        (e) => (e.data as { type: string }).type === 'complete',
+      )
+      expect(completeEvent).toBeDefined()
+      expect((completeEvent!.data as { tasks: unknown[] }).tasks).toEqual(
+        existingTasks,
+      )
+      // generateDefaultTasks should not have been called (no transaction)
+      expect(mockTransaction).not.toHaveBeenCalled()
+      // triggerEventGeneration should not have been called
+      expect(mockAiGeneration.triggerEventGeneration).not.toHaveBeenCalled()
+    })
+
     it('returns existing tasks immediately when not triggered', async () => {
       const existingTasks = [makeDbTask({ id: 'existing-1' })]
 
+      mockModel.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(existingTasks)
       mockTxModel.count.mockResolvedValueOnce(1)
-      mockModel.findMany.mockResolvedValueOnce(existingTasks)
       vi.mocked(mockAiGeneration.triggerEventGeneration!).mockResolvedValue(
         false,
       )
@@ -503,6 +529,9 @@ describe('CampaignTasksService', () => {
     it('polls DB for plan completion and returns tasks when plan exists', async () => {
       const savedTasks = [makeDbTask()]
 
+      mockModel.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(savedTasks)
       mockTxModel.count.mockResolvedValueOnce(1)
       mockTxModel.deleteMany.mockResolvedValue({ count: 0 })
       mockTxModel.createMany.mockResolvedValue({ count: 1 })
@@ -513,7 +542,6 @@ describe('CampaignTasksService', () => {
       vi.mocked(mockAiGeneration.triggerEventGeneration!).mockResolvedValue(
         true,
       )
-      mockModel.findMany.mockResolvedValue(savedTasks)
 
       const observable = service.generateTasksStream(makeCampaign())
       const events = await firstValueFrom(observable.pipe(toArray()))
@@ -530,8 +558,10 @@ describe('CampaignTasksService', () => {
     it('handles error during stream and returns existing tasks', async () => {
       const existingTasks = [makeDbTask({ isDefaultTask: true })]
 
+      mockModel.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(existingTasks)
       mockTxModel.count.mockResolvedValueOnce(1)
-      mockModel.findMany.mockResolvedValue(existingTasks)
       vi.mocked(mockAiGeneration.triggerEventGeneration!).mockRejectedValue(
         new Error('Lambda trigger failed'),
       )

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -60,7 +60,7 @@ export class CampaignTasksService extends createPrismaBase(
 
   async nonDefaultTasksExist(campaignId: number): Promise<boolean> {
     const count = await this.model.count({
-      where: { campaignId, isDefaultTask: false },
+      where: { campaignId, NOT: { isDefaultTask: true } },
     })
     return count > 0
   }
@@ -226,8 +226,6 @@ export class CampaignTasksService extends createPrismaBase(
     subscriber: Subscriber<MessageEvent>,
   ): Promise<void> {
     try {
-      await this.generateDefaultTasks(campaign)
-
       subscriber.next({
         data: {
           type: 'progress',
@@ -235,15 +233,16 @@ export class CampaignTasksService extends createPrismaBase(
           message: 'Starting task generation...',
         },
       })
-      const hasEventTasks = await this.nonDefaultTasksExist(campaign.id)
-      if (hasEventTasks) {
-        const tasks = await this.listCampaignTasks(campaign)
+      const existingTasks = await this.listCampaignTasks(campaign)
+      if (existingTasks.length > 0) {
         subscriber.next({
-          data: { type: 'complete', tasks },
+          data: { type: 'complete', tasks: existingTasks },
         })
         subscriber.complete()
         return
       }
+
+      await this.generateDefaultTasks(campaign)
 
       const triggered =
         await this.aiGenerationService.triggerEventGeneration(campaign)

--- a/src/campaigns/tasks/services/weeklyTasksDigest.service.test.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigest.service.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
+import { MessageGroup, QueueType } from 'src/queue/queue.types'
+import { WeeklyTasksDigestService } from './weeklyTasksDigest.service'
+
+describe('WeeklyTasksDigestService', () => {
+  let service: WeeklyTasksDigestService
+  let sendMessage: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    sendMessage = vi.fn().mockResolvedValue(undefined)
+    const queueService = {
+      sendMessage,
+    } as unknown as QueueProducerService
+
+    service = new WeeklyTasksDigestService(queueService, createMockLogger())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('window calculation', () => {
+    it('sends a window covering Monday Apr 20 through Sunday Apr 26 when today is Sunday Apr 19 Central', async () => {
+      // Sunday April 19, 2026 at 11:00 PM Central Daylight Time = 04:00 UTC Monday April 20
+      vi.setSystemTime(new Date('2026-04-20T04:00:00.000Z'))
+
+      await service.triggerWeeklyDigest()
+
+      expect(sendMessage).toHaveBeenCalledOnce()
+      const [message] = sendMessage.mock.calls[0]
+      expect(message.type).toBe(QueueType.WEEKLY_TASKS_DIGEST)
+      expect(message.data.windowStart).toBe('2026-04-20T00:00:00.000Z')
+      expect(message.data.windowEnd).toBe('2026-04-27T00:00:00.000Z')
+    })
+
+    it('still targets the same Monday when the cron fires later Sunday night (11:59 PM Central)', async () => {
+      // Sunday April 19, 2026 at 11:59 PM CDT = 04:59 UTC Monday April 20
+      vi.setSystemTime(new Date('2026-04-20T04:59:00.000Z'))
+
+      await service.triggerWeeklyDigest()
+
+      const [message] = sendMessage.mock.calls[0]
+      expect(message.data.windowStart).toBe('2026-04-20T00:00:00.000Z')
+      expect(message.data.windowEnd).toBe('2026-04-27T00:00:00.000Z')
+    })
+
+    it('uses the upcoming Monday when fired on Saturday night Central', async () => {
+      // Saturday April 18, 2026 at 11:00 PM CDT = 04:00 UTC Sunday April 19
+      vi.setSystemTime(new Date('2026-04-19T04:00:00.000Z'))
+
+      await service.triggerWeeklyDigest()
+
+      const [message] = sendMessage.mock.calls[0]
+      expect(message.data.windowStart).toBe('2026-04-20T00:00:00.000Z')
+      expect(message.data.windowEnd).toBe('2026-04-27T00:00:00.000Z')
+    })
+
+    it('handles standard time (non-DST) correctly', async () => {
+      // Sunday January 4, 2026 at 11:00 PM CST = 05:00 UTC Monday January 5
+      vi.setSystemTime(new Date('2026-01-05T05:00:00.000Z'))
+
+      await service.triggerWeeklyDigest()
+
+      const [message] = sendMessage.mock.calls[0]
+      expect(message.data.windowStart).toBe('2026-01-05T00:00:00.000Z')
+      expect(message.data.windowEnd).toBe('2026-01-12T00:00:00.000Z')
+    })
+  })
+
+  describe('queue message', () => {
+    it('sends to the weeklyTasksDigest message group', async () => {
+      vi.setSystemTime(new Date('2026-04-20T04:00:00.000Z'))
+
+      await service.triggerWeeklyDigest()
+
+      const [, group] = sendMessage.mock.calls[0]
+      expect(group).toBe(MessageGroup.weeklyTasksDigest)
+    })
+
+    it('uses a deterministic deduplicationId derived from windowStart so multiple ECS instances collapse to a single SQS message', async () => {
+      vi.setSystemTime(new Date('2026-04-20T04:00:00.000Z'))
+
+      await service.triggerWeeklyDigest()
+      await service.triggerWeeklyDigest()
+
+      const [, , optionsA] = sendMessage.mock.calls[0]
+      const [, , optionsB] = sendMessage.mock.calls[1]
+      expect(optionsA.deduplicationId).toBe(
+        'weeklyTasksDigest-2026-04-20T00:00:00.000Z',
+      )
+      expect(optionsB.deduplicationId).toBe(optionsA.deduplicationId)
+    })
+  })
+})

--- a/src/campaigns/tasks/services/weeklyTasksDigest.service.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigest.service.ts
@@ -1,0 +1,68 @@
+import { Injectable } from '@nestjs/common'
+import { Cron } from '@nestjs/schedule'
+import { addDays, nextMonday } from 'date-fns'
+import { toZonedTime } from 'date-fns-tz'
+import { PinoLogger } from 'nestjs-pino'
+import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
+import { MessageGroup, QueueType } from 'src/queue/queue.types'
+
+const CENTRAL_TIMEZONE = 'America/Chicago'
+
+// Task dates are stored as calendar dates (e.g. "2026-04-20 00:00:00"). To
+// filter Monday-through-Sunday of the upcoming week, we need windowStart and
+// windowEnd to be UTC midnight of the calendar date, regardless of DST.
+function nextMondayUtcMidnight(now: Date, timeZone: string): Date {
+  // Shift the current instant into the target timezone so nextMonday() picks
+  // the right calendar Monday (e.g. Sunday 11pm Central is still "Sunday" in
+  // Central, but "Monday" in UTC — we want Central's view).
+  const nowInZone = toZonedTime(now, timeZone)
+  const monday = nextMonday(nowInZone)
+  // Reconstruct as UTC midnight of that calendar date so the window aligns
+  // with how tasks are stored (naive timestamps at midnight UTC).
+  return new Date(
+    Date.UTC(monday.getFullYear(), monday.getMonth(), monday.getDate()),
+  )
+}
+
+@Injectable()
+export class WeeklyTasksDigestService {
+  constructor(
+    private readonly queueService: QueueProducerService,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(WeeklyTasksDigestService.name)
+  }
+
+  // Every Sunday at 11 PM Central Time
+  @Cron('0 23 * * 0', {
+    name: 'weeklyTasksDigest',
+    timeZone: CENTRAL_TIMEZONE,
+  })
+  async triggerWeeklyDigest() {
+    const windowStart = nextMondayUtcMidnight(new Date(), CENTRAL_TIMEZONE)
+    const windowEnd = addDays(windowStart, 7)
+
+    this.logger.info(
+      { windowStart, windowEnd },
+      'Triggering weekly tasks digest',
+    )
+
+    // Every ECS instance runs its own @Cron, so all of them enqueue a message
+    // when this fires. We use a deterministic deduplicationId derived from
+    // windowStart so SQS FIFO collapses them into a single message (within
+    // the 5-minute dedup window), ensuring the handler runs once per week.
+    await this.queueService.sendMessage(
+      {
+        type: QueueType.WEEKLY_TASKS_DIGEST,
+        data: {
+          windowStart: windowStart.toISOString(),
+          windowEnd: windowEnd.toISOString(),
+        },
+      },
+      MessageGroup.weeklyTasksDigest,
+      {
+        deduplicationId: `weeklyTasksDigest-${windowStart.toISOString()}`,
+      },
+    )
+  }
+}

--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.integration.test.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.integration.test.ts
@@ -1,0 +1,557 @@
+import { useTestService } from '@/test-service'
+import { CampaignTaskType } from '@prisma/client'
+import { describe, expect, it, vi } from 'vitest'
+import { AnalyticsService } from '@/analytics/analytics.service'
+import { EVENTS } from '@/vendors/segment/segment.types'
+import { WeeklyTasksDigestHandlerService } from './weeklyTasksDigestHandler.service'
+
+const service = useTestService()
+
+const WINDOW_START = '2026-04-20T00:00:00.000Z' // Monday
+const WINDOW_END = '2026-04-27T00:00:00.000Z' // Following Monday (exclusive)
+const FUTURE_ELECTION = '2027-11-03'
+const PAST_ELECTION = '2020-01-01'
+
+type TrackSpy = ReturnType<typeof vi.spyOn>
+
+function getTrackSpy(): TrackSpy {
+  const analytics = service.app.get(AnalyticsService)
+  return vi.spyOn(analytics, 'track').mockResolvedValue({} as never)
+}
+
+async function makeCampaign(
+  opts: {
+    electionDate?: string | null
+  } = {},
+) {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const user = await service.prisma.user.create({
+    data: {
+      email: `digest-${unique}@test.goodparty.org`,
+      firstName: 'Test',
+      lastName: 'User',
+    },
+  })
+  const org = await service.prisma.organization.create({
+    data: {
+      slug: `digest-org-${unique}`,
+      ownerId: user.id,
+    },
+  })
+  // `null` = omit the key entirely; any string (including '') = use as-is;
+  // `undefined` (not provided) = use the default future election date.
+  const details =
+    opts.electionDate === null
+      ? {}
+      : opts.electionDate !== undefined
+        ? { electionDate: opts.electionDate }
+        : { electionDate: FUTURE_ELECTION }
+  return service.prisma.campaign.create({
+    data: {
+      userId: user.id,
+      slug: `digest-${unique}`,
+      details,
+      organizationSlug: org.slug,
+    },
+  })
+}
+
+async function makeTask(
+  campaignId: number,
+  overrides: {
+    date?: Date
+    completed?: boolean
+    flowType?: CampaignTaskType
+    title?: string
+    description?: string
+    week?: number
+  } = {},
+) {
+  return service.prisma.campaignTask.create({
+    data: {
+      campaignId,
+      title: overrides.title ?? 'Task',
+      description: overrides.description ?? 'A task',
+      flowType: overrides.flowType ?? CampaignTaskType.education,
+      week: overrides.week ?? 10,
+      date: overrides.date ?? new Date('2026-04-22T00:00:00.000Z'),
+      completed: overrides.completed ?? false,
+    },
+  })
+}
+
+describe('WeeklyTasksDigestHandlerService integration', () => {
+  describe('campaign eligibility', () => {
+    it('excludes campaigns with a past election date', async () => {
+      const campaign = await makeCampaign({ electionDate: PAST_ELECTION })
+      for (let i = 0; i < 5; i++) await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).not.toHaveBeenCalled()
+    })
+
+    it('excludes campaigns with no electionDate in details', async () => {
+      const campaign = await makeCampaign({ electionDate: null })
+      for (let i = 0; i < 5; i++) await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).not.toHaveBeenCalled()
+    })
+
+    it('skips (does not crash) when electionDate is an empty string or malformed', async () => {
+      const emptyCampaign = await makeCampaign({ electionDate: '' })
+      const malformedCampaign = await makeCampaign({ electionDate: 'TBD' })
+      const validCampaign = await makeCampaign()
+      for (let i = 0; i < 5; i++) await makeTask(emptyCampaign.id)
+      for (let i = 0; i < 5; i++) await makeTask(malformedCampaign.id)
+      for (let i = 0; i < 3; i++) await makeTask(validCampaign.id)
+
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      // The valid campaign still fires; the bad rows are silently filtered by the SQL regex.
+      expect(trackSpy).toHaveBeenCalledOnce()
+      expect(trackSpy).toHaveBeenCalledWith(
+        validCampaign.userId,
+        expect.any(String),
+        expect.any(Object),
+      )
+    })
+
+    it('excludes campaigns with fewer than 3 incomplete tasks in window', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).not.toHaveBeenCalled()
+    })
+
+    it('includes campaigns with exactly 3 incomplete tasks', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).toHaveBeenCalledOnce()
+    })
+
+    it('does not count completed tasks toward the MIN_TASKS threshold', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, { completed: true })
+      await makeTask(campaign.id, { completed: true })
+      await makeTask(campaign.id) // only 1 incomplete
+      await makeTask(campaign.id) // 2 incomplete
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('task selection', () => {
+    it('returns exactly 5 tasks when a campaign has more than 5 incomplete', async () => {
+      const campaign = await makeCampaign()
+      for (let i = 0; i < 8; i++) {
+        await makeTask(campaign.id, { title: `Task ${i}` })
+      }
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      expect(properties.task_name_5).not.toBe('')
+      // Since we always send 5 slots, check that plan_total_tasks reflects the real count
+      expect(properties.plan_total_tasks).toBe(8)
+    })
+
+    it('prioritizes outreach task types (text, robocall, doorKnocking, phoneBanking) over others', async () => {
+      const campaign = await makeCampaign()
+      // 2 non-outreach + 2 outreach, all same date so only outreach priority matters
+      const sameDate = new Date('2026-04-22T00:00:00.000Z')
+      await makeTask(campaign.id, {
+        title: 'Education Task',
+        flowType: CampaignTaskType.education,
+        date: sameDate,
+      })
+      await makeTask(campaign.id, {
+        title: 'Social Media Task',
+        flowType: CampaignTaskType.socialMedia,
+        date: sameDate,
+      })
+      await makeTask(campaign.id, {
+        title: 'Text Task',
+        flowType: CampaignTaskType.text,
+        date: sameDate,
+      })
+      await makeTask(campaign.id, {
+        title: 'Door Knocking Task',
+        flowType: CampaignTaskType.doorKnocking,
+        date: sameDate,
+      })
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      // First two slots should be the outreach tasks
+      const slot1And2 = [properties.task_name_1, properties.task_name_2]
+      expect(slot1And2).toContain('Text Task')
+      expect(slot1And2).toContain('Door Knocking Task')
+    })
+
+    it('prioritizes robocall and phoneBanking as outreach types', async () => {
+      const campaign = await makeCampaign()
+      const sameDate = new Date('2026-04-22T00:00:00.000Z')
+      await makeTask(campaign.id, {
+        title: 'Education Task',
+        flowType: CampaignTaskType.education,
+        date: sameDate,
+      })
+      await makeTask(campaign.id, {
+        title: 'Events Task',
+        flowType: CampaignTaskType.events,
+        date: sameDate,
+      })
+      await makeTask(campaign.id, {
+        title: 'Robocall Task',
+        flowType: CampaignTaskType.robocall,
+        date: sameDate,
+      })
+      await makeTask(campaign.id, {
+        title: 'Phone Banking Task',
+        flowType: CampaignTaskType.phoneBanking,
+        date: sameDate,
+      })
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      const slot1And2 = [properties.task_name_1, properties.task_name_2]
+      expect(slot1And2).toContain('Robocall Task')
+      expect(slot1And2).toContain('Phone Banking Task')
+    })
+
+    it('orders tasks by date within the same priority category', async () => {
+      const campaign = await makeCampaign()
+      // All outreach, different dates
+      await makeTask(campaign.id, {
+        title: 'Friday Task',
+        flowType: CampaignTaskType.text,
+        date: new Date('2026-04-24T00:00:00.000Z'),
+      })
+      await makeTask(campaign.id, {
+        title: 'Monday Task',
+        flowType: CampaignTaskType.text,
+        date: new Date('2026-04-20T00:00:00.000Z'),
+      })
+      await makeTask(campaign.id, {
+        title: 'Wednesday Task',
+        flowType: CampaignTaskType.text,
+        date: new Date('2026-04-22T00:00:00.000Z'),
+      })
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      expect(properties.task_name_1).toBe('Monday Task')
+      expect(properties.task_name_2).toBe('Wednesday Task')
+      expect(properties.task_name_3).toBe('Friday Task')
+    })
+
+    it('does not include completed tasks in the slots', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, { title: 'Completed', completed: true })
+      await makeTask(campaign.id, { title: 'Incomplete 1' })
+      await makeTask(campaign.id, { title: 'Incomplete 2' })
+      await makeTask(campaign.id, { title: 'Incomplete 3' })
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      const taskNames = [
+        properties.task_name_1,
+        properties.task_name_2,
+        properties.task_name_3,
+      ]
+      expect(taskNames).not.toContain('Completed')
+    })
+  })
+
+  describe('date window bounds', () => {
+    it('includes tasks dated exactly at windowStart (Monday 00:00)', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, {
+        title: 'Monday 00:00 Task',
+        date: new Date('2026-04-20T00:00:00.000Z'),
+      })
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).toHaveBeenCalledOnce()
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      const titles = [
+        properties.task_name_1,
+        properties.task_name_2,
+        properties.task_name_3,
+      ]
+      expect(titles).toContain('Monday 00:00 Task')
+    })
+
+    it('includes tasks dated Sunday 23:59:59.999', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, {
+        title: 'Sunday Late Task',
+        date: new Date('2026-04-26T23:59:59.999Z'),
+      })
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).toHaveBeenCalledOnce()
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      const titles = [
+        properties.task_name_1,
+        properties.task_name_2,
+        properties.task_name_3,
+      ]
+      expect(titles).toContain('Sunday Late Task')
+    })
+
+    it('excludes tasks dated exactly at windowEnd (next Monday 00:00)', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, {
+        title: 'Next Monday Task',
+        date: new Date('2026-04-27T00:00:00.000Z'),
+      })
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      // Only 2 tasks in window (the 3rd is outside), below MIN_TASKS → not eligible
+      expect(trackSpy).not.toHaveBeenCalled()
+    })
+
+    it('excludes tasks dated before windowStart (Sunday before)', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, {
+        title: 'Sunday Before',
+        date: new Date('2026-04-19T23:59:59.999Z'),
+      })
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      // Only 2 tasks in window → not eligible
+      expect(trackSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('event payload', () => {
+    it('reports completed and total task counts correctly', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, { completed: true })
+      await makeTask(campaign.id, { completed: true })
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      expect(properties.plan_tasks_completed).toBe(2)
+      expect(properties.plan_total_tasks).toBe(5)
+    })
+
+    it('emits all 5 task slots with blank values when fewer than 5 tasks exist', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id, { title: 'T1' })
+      await makeTask(campaign.id, { title: 'T2' })
+      await makeTask(campaign.id, { title: 'T3' })
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      const [, , properties] = trackSpy.mock.calls[0] as [
+        number,
+        string,
+        Record<string, unknown>,
+      ]
+      expect(properties.task_name_4).toBe('')
+      expect(properties.task_description_4).toBe('')
+      expect(properties.task_type_4).toBe('')
+      expect(properties.task_due_date_4).toBe('')
+      expect(properties.task_week_number_4).toBe(null)
+      expect(properties.task_name_5).toBe('')
+      expect(properties.task_week_number_5).toBe(null)
+    })
+
+    it('uses the correct event name', async () => {
+      const campaign = await makeCampaign()
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      await makeTask(campaign.id)
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).toHaveBeenCalledWith(
+        campaign.userId,
+        EVENTS.CampaignPlan.WeeklyTasksDigest,
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe('multiple campaigns', () => {
+    it('fires one event per eligible campaign', async () => {
+      const c1 = await makeCampaign()
+      const c2 = await makeCampaign()
+      const c3Ineligible = await makeCampaign({ electionDate: PAST_ELECTION })
+
+      for (let i = 0; i < 3; i++) await makeTask(c1.id)
+      for (let i = 0; i < 3; i++) await makeTask(c2.id)
+      for (let i = 0; i < 5; i++) await makeTask(c3Ineligible.id)
+
+      const trackSpy = getTrackSpy()
+
+      const handler = service.app.get(WeeklyTasksDigestHandlerService)
+      await handler.handleWeeklyTasksDigest({
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      })
+
+      expect(trackSpy).toHaveBeenCalledTimes(2)
+      const userIds = trackSpy.mock.calls.map((call) => call[0]).sort()
+      expect(userIds).toEqual([c1.userId, c2.userId].sort())
+    })
+  })
+})

--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.test.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CampaignTaskType } from '@prisma/client'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { AnalyticsService } from 'src/analytics/analytics.service'
+import { EVENTS } from 'src/vendors/segment/segment.types'
+import { WeeklyTasksDigestHandlerService } from './weeklyTasksDigestHandler.service'
+
+const mockAnalytics: Partial<AnalyticsService> = {
+  track: vi.fn().mockResolvedValue(undefined),
+}
+
+const mockQueryRaw = vi.fn()
+
+const WINDOW_START = '2026-04-20T00:00:00.000Z'
+const WINDOW_END = '2026-04-27T00:00:00.000Z'
+
+const makeDigestRow = (overrides = {}) => ({
+  campaign_id: 1,
+  user_id: 100,
+  completed_count: 0,
+  incomplete_count: 3,
+  slot: 1,
+  title: 'Task',
+  description: 'Description',
+  flow_type: CampaignTaskType.education,
+  date: new Date('2026-04-21T00:00:00.000Z'),
+  week: 10,
+  ...overrides,
+})
+
+describe('WeeklyTasksDigestHandlerService', () => {
+  let service: WeeklyTasksDigestHandlerService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    service = new WeeklyTasksDigestHandlerService(
+      mockAnalytics as AnalyticsService,
+    )
+
+    Object.defineProperty(service, '_prisma', {
+      get: () => ({
+        $queryRaw: mockQueryRaw,
+      }),
+    })
+    Object.defineProperty(service, 'logger', {
+      get: () => createMockLogger(),
+    })
+  })
+
+  it('does not track when no eligible campaigns', async () => {
+    mockQueryRaw.mockResolvedValueOnce([])
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    expect(mockAnalytics.track).not.toHaveBeenCalled()
+  })
+
+  it('sends event with 3 tasks populated and slots 4/5 blank to clear stale HubSpot data', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeDigestRow({
+        slot: 1,
+        title: 'Task A',
+        flow_type: CampaignTaskType.text,
+        completed_count: 1,
+        incomplete_count: 3,
+      }),
+      makeDigestRow({
+        slot: 2,
+        title: 'Task B',
+        flow_type: CampaignTaskType.doorKnocking,
+        completed_count: 1,
+        incomplete_count: 3,
+      }),
+      makeDigestRow({
+        slot: 3,
+        title: 'Task C',
+        flow_type: CampaignTaskType.education,
+        completed_count: 1,
+        incomplete_count: 3,
+      }),
+    ])
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    expect(mockAnalytics.track).toHaveBeenCalledOnce()
+    const [, , properties] = (mockAnalytics.track as ReturnType<typeof vi.fn>)
+      .mock.calls[0]
+
+    expect(properties.plan_tasks_completed).toBe(1)
+    expect(properties.plan_total_tasks).toBe(4)
+
+    expect(properties.task_name_1).toBe('Task A')
+    expect(properties.task_name_2).toBe('Task B')
+    expect(properties.task_name_3).toBe('Task C')
+
+    expect(properties.task_due_date_1).toBe('2026-04-21')
+    expect(properties.task_due_date_1).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+
+    // Slots 4 and 5 are still sent, but blank/null, so HubSpot clears any
+    // stale values left over from prior weeks' digests.
+    expect(properties.task_name_4).toBe('')
+    expect(properties.task_description_4).toBe('')
+    expect(properties.task_type_4).toBe('')
+    expect(properties.task_due_date_4).toBe('')
+    expect(properties.task_week_number_4).toBe(null)
+    expect(properties.task_name_5).toBe('')
+    expect(properties.task_description_5).toBe('')
+    expect(properties.task_type_5).toBe('')
+    expect(properties.task_due_date_5).toBe('')
+    expect(properties.task_week_number_5).toBe(null)
+  })
+
+  it('sends event with all 5 task slots when 5 tasks exist', async () => {
+    mockQueryRaw.mockResolvedValueOnce(
+      [1, 2, 3, 4, 5].map((slot) =>
+        makeDigestRow({
+          slot,
+          title: `T${slot}`,
+          completed_count: 0,
+          incomplete_count: 7,
+        }),
+      ),
+    )
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    const [, , properties] = (mockAnalytics.track as ReturnType<typeof vi.fn>)
+      .mock.calls[0]
+
+    expect(properties.task_name_1).toBe('T1')
+    expect(properties.task_name_5).toBe('T5')
+    expect(properties.plan_total_tasks).toBe(7)
+  })
+
+  it('tracks the correct event name and user id', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeDigestRow({ user_id: 100, slot: 1 }),
+      makeDigestRow({ user_id: 100, slot: 2 }),
+      makeDigestRow({ user_id: 100, slot: 3 }),
+    ])
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    expect(mockAnalytics.track).toHaveBeenCalledWith(
+      100,
+      EVENTS.CampaignPlan.WeeklyTasksDigest,
+      expect.any(Object),
+    )
+  })
+
+  it('fires one event per campaign when multiple campaigns are eligible', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeDigestRow({ campaign_id: 1, user_id: 100, slot: 1 }),
+      makeDigestRow({ campaign_id: 1, user_id: 100, slot: 2 }),
+      makeDigestRow({ campaign_id: 1, user_id: 100, slot: 3 }),
+      makeDigestRow({ campaign_id: 2, user_id: 200, slot: 1 }),
+      makeDigestRow({ campaign_id: 2, user_id: 200, slot: 2 }),
+      makeDigestRow({ campaign_id: 2, user_id: 200, slot: 3 }),
+    ])
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    expect(mockAnalytics.track).toHaveBeenCalledTimes(2)
+    const userIds = (mockAnalytics.track as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c[0])
+      .sort()
+    expect(userIds).toEqual([100, 200])
+  })
+
+  it('continues processing remaining campaigns when analytics fails for one', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeDigestRow({ campaign_id: 1, user_id: 100, slot: 1 }),
+      makeDigestRow({ campaign_id: 1, user_id: 100, slot: 2 }),
+      makeDigestRow({ campaign_id: 1, user_id: 100, slot: 3 }),
+      makeDigestRow({ campaign_id: 2, user_id: 200, slot: 1 }),
+      makeDigestRow({ campaign_id: 2, user_id: 200, slot: 2 }),
+      makeDigestRow({ campaign_id: 2, user_id: 200, slot: 3 }),
+    ])
+    ;(mockAnalytics.track as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('Segment down'))
+      .mockResolvedValueOnce(undefined)
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    expect(mockAnalytics.track).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.ts
@@ -1,0 +1,282 @@
+import { Injectable } from '@nestjs/common'
+import { CampaignTaskType, Prisma } from '@prisma/client'
+import { AnalyticsService } from 'src/analytics/analytics.service'
+import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
+import { toDateOnlyString } from 'src/shared/util/date.util'
+import { EVENTS } from 'src/vendors/segment/segment.types'
+import { WeeklyTasksDigestMessage } from 'src/queue/queue.types'
+
+const OUTREACH_FLOW_TYPES: CampaignTaskType[] = [
+  CampaignTaskType.text,
+  CampaignTaskType.robocall,
+  CampaignTaskType.doorKnocking,
+  CampaignTaskType.phoneBanking,
+]
+const MAX_TASKS = 5
+const MIN_TASKS = 3
+
+interface DigestRow {
+  campaign_id: number
+  user_id: number
+  completed_count: number
+  incomplete_count: number
+  slot: number
+  title: string
+  description: string
+  flow_type: CampaignTaskType | null
+  date: Date
+  week: number
+}
+
+interface TopTaskRow {
+  title: string
+  description: string
+  flow_type: CampaignTaskType | null
+  date: Date
+  week: number
+}
+
+interface WeeklyDigestProperties {
+  plan_tasks_completed: number
+  plan_total_tasks: number
+  task_name_1: string
+  task_description_1: string
+  task_type_1: string
+  task_due_date_1: string
+  task_week_number_1: number | null
+  task_name_2: string
+  task_description_2: string
+  task_type_2: string
+  task_due_date_2: string
+  task_week_number_2: number | null
+  task_name_3: string
+  task_description_3: string
+  task_type_3: string
+  task_due_date_3: string
+  task_week_number_3: number | null
+  task_name_4: string
+  task_description_4: string
+  task_type_4: string
+  task_due_date_4: string
+  task_week_number_4: number | null
+  task_name_5: string
+  task_description_5: string
+  task_type_5: string
+  task_due_date_5: string
+  task_week_number_5: number | null
+}
+
+type TaskSlotProperties = Pick<
+  WeeklyDigestProperties,
+  | 'task_name_1'
+  | 'task_description_1'
+  | 'task_type_1'
+  | 'task_due_date_1'
+  | 'task_week_number_1'
+  | 'task_name_2'
+  | 'task_description_2'
+  | 'task_type_2'
+  | 'task_due_date_2'
+  | 'task_week_number_2'
+  | 'task_name_3'
+  | 'task_description_3'
+  | 'task_type_3'
+  | 'task_due_date_3'
+  | 'task_week_number_3'
+  | 'task_name_4'
+  | 'task_description_4'
+  | 'task_type_4'
+  | 'task_due_date_4'
+  | 'task_week_number_4'
+  | 'task_name_5'
+  | 'task_description_5'
+  | 'task_type_5'
+  | 'task_due_date_5'
+  | 'task_week_number_5'
+>
+
+// Always emits all 5 task slots. Empty slots send blank/null values so HubSpot
+// clears stale data from the previous week's digest.
+function buildTaskProperties(tasks: TopTaskRow[]): TaskSlotProperties {
+  const [t1, t2, t3, t4, t5] = tasks
+  return {
+    task_name_1: t1?.title ?? '',
+    task_description_1: t1?.description ?? '',
+    task_type_1: t1?.flow_type ?? '',
+    task_due_date_1: toDateOnlyString(t1?.date) ?? '',
+    task_week_number_1: t1?.week ?? null,
+    task_name_2: t2?.title ?? '',
+    task_description_2: t2?.description ?? '',
+    task_type_2: t2?.flow_type ?? '',
+    task_due_date_2: toDateOnlyString(t2?.date) ?? '',
+    task_week_number_2: t2?.week ?? null,
+    task_name_3: t3?.title ?? '',
+    task_description_3: t3?.description ?? '',
+    task_type_3: t3?.flow_type ?? '',
+    task_due_date_3: toDateOnlyString(t3?.date) ?? '',
+    task_week_number_3: t3?.week ?? null,
+    task_name_4: t4?.title ?? '',
+    task_description_4: t4?.description ?? '',
+    task_type_4: t4?.flow_type ?? '',
+    task_due_date_4: toDateOnlyString(t4?.date) ?? '',
+    task_week_number_4: t4?.week ?? null,
+    task_name_5: t5?.title ?? '',
+    task_description_5: t5?.description ?? '',
+    task_type_5: t5?.flow_type ?? '',
+    task_due_date_5: toDateOnlyString(t5?.date) ?? '',
+    task_week_number_5: t5?.week ?? null,
+  }
+}
+
+interface CampaignDigestGroup {
+  userId: number
+  completedCount: number
+  incompleteCount: number
+  tasks: TopTaskRow[]
+}
+
+function groupByCampaign(rows: DigestRow[]): Map<number, CampaignDigestGroup> {
+  const groups = new Map<number, CampaignDigestGroup>()
+  for (const row of rows) {
+    let group = groups.get(row.campaign_id)
+    if (!group) {
+      group = {
+        userId: row.user_id,
+        completedCount: row.completed_count,
+        incompleteCount: row.incomplete_count,
+        tasks: [],
+      }
+      groups.set(row.campaign_id, group)
+    }
+    group.tasks.push({
+      title: row.title,
+      description: row.description,
+      flow_type: row.flow_type,
+      date: row.date,
+      week: row.week,
+    })
+  }
+  return groups
+}
+
+@Injectable()
+export class WeeklyTasksDigestHandlerService extends createPrismaBase(
+  MODELS.CampaignTask,
+) {
+  constructor(private readonly analytics: AnalyticsService) {
+    super()
+  }
+
+  async handleWeeklyTasksDigest(data: WeeklyTasksDigestMessage) {
+    const windowStart = new Date(data.windowStart)
+    const windowEnd = new Date(data.windowEnd)
+
+    this.logger.info(
+      { windowStart, windowEnd },
+      'Processing weekly tasks digest',
+    )
+
+    // Single query: for every campaign with a future election date and at
+    // least MIN_TASKS incomplete tasks in the window, return the top
+    // MAX_TASKS incomplete tasks (outreach types prioritized, then by date).
+    // Each row denormalizes the campaign's counts so we can group in JS.
+    const rows = await this.client.$queryRaw<DigestRow[]>`
+      WITH eligible AS (
+        SELECT
+          c.id,
+          c.user_id,
+          COUNT(*) FILTER (WHERE t.completed = true)::int  AS completed_count,
+          COUNT(*) FILTER (WHERE t.completed = false)::int AS incomplete_count
+        FROM campaign c
+        JOIN campaign_task t ON t.campaign_id = c.id
+        WHERE c.details->>'electionDate' ~ '^\\d{4}-\\d{2}-\\d{2}'
+          AND (c.details->>'electionDate')::date > NOW()::date
+          AND t.date >= ${windowStart}
+          AND t.date < ${windowEnd}
+        GROUP BY c.id, c.user_id
+        HAVING COUNT(*) FILTER (WHERE t.completed = false) >= ${MIN_TASKS}
+      ),
+      ranked_tasks AS (
+        SELECT
+          t.campaign_id,
+          t.title,
+          t.description,
+          t.flow_type,
+          t.date,
+          t.week,
+          ROW_NUMBER() OVER (
+            PARTITION BY t.campaign_id
+            ORDER BY
+              CASE WHEN t.flow_type::text IN (${Prisma.join(OUTREACH_FLOW_TYPES)})
+                THEN 0 ELSE 1 END,
+              t.date ASC
+          ) AS slot
+        FROM campaign_task t
+        JOIN eligible e ON e.id = t.campaign_id
+        WHERE t.completed = false
+          AND t.date >= ${windowStart}
+          AND t.date < ${windowEnd}
+      )
+      SELECT
+        e.id           AS campaign_id,
+        e.user_id,
+        e.completed_count,
+        e.incomplete_count,
+        rt.slot::int   AS slot,
+        rt.title,
+        rt.description,
+        rt.flow_type,
+        rt.date,
+        rt.week
+      FROM eligible e
+      JOIN ranked_tasks rt ON rt.campaign_id = e.id
+      WHERE rt.slot <= ${MAX_TASKS}
+      ORDER BY e.id, rt.slot
+    `
+
+    const campaigns = groupByCampaign(rows)
+
+    let sent = 0
+    let failed = 0
+
+    for (const [campaignId, group] of campaigns) {
+      try {
+        const properties: WeeklyDigestProperties = {
+          plan_tasks_completed: group.completedCount,
+          plan_total_tasks: group.completedCount + group.incompleteCount,
+          ...buildTaskProperties(group.tasks),
+        }
+
+        await this.analytics.track(
+          group.userId,
+          EVENTS.CampaignPlan.WeeklyTasksDigest,
+          // The spread widens our strict WeeklyDigestProperties type to match
+          // analytics.track's `Record<string, unknown>` signature. See WEB-4530
+          // for the TODO to make the track signature generic.
+          { ...properties },
+        )
+
+        this.logger.info(
+          {
+            campaignId,
+            userId: group.userId,
+            taskCount: group.tasks.length,
+          },
+          'Sent weekly tasks digest event',
+        )
+        sent++
+      } catch (error) {
+        this.logger.error(
+          { campaignId, error },
+          'Failed to process weekly digest for campaign',
+        )
+        failed++
+      }
+    }
+
+    this.logger.info(
+      { sent, failed, eligible: campaigns.size },
+      'Weekly tasks digest complete',
+    )
+  }
+}

--- a/src/queue/consumer/queueConsumer.service.test.ts
+++ b/src/queue/consumer/queueConsumer.service.test.ts
@@ -5,6 +5,7 @@ import { AiContentService } from '@/campaigns/ai/content/aiContent.service'
 import { CampaignsService } from '@/campaigns/services/campaigns.service'
 import { AiGenerationService } from '@/campaigns/tasks/services/aiGeneration.service'
 import { CampaignTasksService } from '@/campaigns/tasks/services/campaignTasks.service'
+import { WeeklyTasksDigestHandlerService } from '@/campaigns/tasks/services/weeklyTasksDigestHandler.service'
 import { CampaignTcrComplianceService } from '@/campaigns/tcrCompliance/services/campaignTcrCompliance.service'
 import { ContactsService } from '@/contacts/services/contacts.service'
 import { ElectedOfficeService } from '@/electedOffice/services/electedOffice.service'
@@ -215,6 +216,7 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
       electedOfficeService as never,
       contactsService as never,
       s3Service as never,
+      {} as never,
       {} as never,
       {} as never,
       createMockLogger(),
@@ -853,6 +855,7 @@ describe('QueueConsumerService - triggerPollExecution', () => {
       s3Service as never,
       usersService as never,
       {} as never,
+      {} as never,
       createMockLogger(),
     )
   })
@@ -972,6 +975,10 @@ describe('QueueConsumerService - message type routing', () => {
         { provide: SlackService, useValue: mockSlackService },
         { provide: UsersService, useValue: {} },
         { provide: AnalyticsService, useValue: {} },
+        {
+          provide: WeeklyTasksDigestHandlerService,
+          useValue: { handleWeeklyTasksDigest: vi.fn() },
+        },
         { provide: PinoLogger, useValue: createMockLogger() },
       ],
     }).compile()
@@ -1031,6 +1038,56 @@ describe('QueueConsumerService - message type routing', () => {
     const result = await service.processMessage(message)
 
     expect(result).toBe(true)
+  })
+
+  it('routes weeklyTasksDigest messages to the handler', async () => {
+    const handler = module.get(WeeklyTasksDigestHandlerService)
+    const handleSpy = vi
+      .spyOn(handler, 'handleWeeklyTasksDigest')
+      .mockResolvedValue(undefined)
+
+    const message: Message = {
+      MessageId: 'msg-digest-ok',
+      Body: JSON.stringify({
+        type: QueueType.WEEKLY_TASKS_DIGEST,
+        data: {
+          windowStart: '2026-04-20T00:00:00.000Z',
+          windowEnd: '2026-04-27T00:00:00.000Z',
+        },
+      }),
+    }
+
+    const result = await service.processMessage(message)
+
+    expect(result).toBe(true)
+    expect(handleSpy).toHaveBeenCalledOnce()
+    expect(handleSpy).toHaveBeenCalledWith({
+      windowStart: '2026-04-20T00:00:00.000Z',
+      windowEnd: '2026-04-27T00:00:00.000Z',
+    })
+  })
+
+  it('rejects weeklyTasksDigest messages with invalid payload and does not call handler', async () => {
+    const handler = module.get(WeeklyTasksDigestHandlerService)
+    const handleSpy = vi
+      .spyOn(handler, 'handleWeeklyTasksDigest')
+      .mockResolvedValue(undefined)
+
+    const message: Message = {
+      MessageId: 'msg-digest-invalid',
+      Body: JSON.stringify({
+        type: QueueType.WEEKLY_TASKS_DIGEST,
+        data: {
+          windowStart: 'not-a-date',
+        },
+      }),
+    }
+
+    // withLegacyErrorSwallowing catches the Zod parse failure and returns true
+    const result = await service.processMessage(message)
+
+    expect(result).toBe(true)
+    expect(handleSpy).not.toHaveBeenCalled()
   })
 
   it('discards campaignPlanComplete with permanent Prisma error instead of requeuing', async () => {

--- a/src/queue/consumer/queueConsumer.service.ts
+++ b/src/queue/consumer/queueConsumer.service.ts
@@ -49,6 +49,7 @@ import {
   CampaignPlanCompleteMessage,
   CampaignPlanCompleteMessageSchema,
   DomainEmailForwardingMessage,
+  WeeklyTasksDigestMessageSchema,
   PollAnalysisCompleteEvent,
   PollAnalysisCompleteEventSchema,
   PollCreationEvent,
@@ -62,6 +63,7 @@ import {
   TcrComplianceStatusCheckMessage,
 } from '../queue.types'
 import { PollIndividualMessageService } from '@/polls/services/pollIndividualMessage.service'
+import { WeeklyTasksDigestHandlerService } from '../../campaigns/tasks/services/weeklyTasksDigestHandler.service'
 import { v5 as uuidv5 } from 'uuid'
 import { PinoLogger } from 'nestjs-pino'
 import { OrgDistrict } from '@/organizations/organizations.types'
@@ -109,6 +111,7 @@ export class QueueConsumerService {
     private readonly s3Service: S3Service,
     private readonly usersService: UsersService,
     private readonly organizationsService: OrganizationsService,
+    private readonly weeklyTasksDigestHandler: WeeklyTasksDigestHandlerService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(QueueConsumerService.name)
@@ -342,6 +345,17 @@ export class QueueConsumerService {
             queueMessage.data,
           )
           await this.handleCampaignPlanComplete(campaignPlanData)
+          return true
+        })
+      case QueueType.WEEKLY_TASKS_DIGEST:
+        this.logger.info('received weeklyTasksDigest message')
+        return await this.withLegacyErrorSwallowing(message, async () => {
+          const digestData = WeeklyTasksDigestMessageSchema.parse(
+            queueMessage.data,
+          )
+          await this.weeklyTasksDigestHandler.handleWeeklyTasksDigest(
+            digestData,
+          )
           return true
         })
       default:

--- a/src/queue/producer/queueProducer.service.ts
+++ b/src/queue/producer/queueProducer.service.ts
@@ -45,19 +45,17 @@ export class QueueProducerService {
   async sendMessage(
     msg: QueueMessage,
     group: MessageGroup | string = MessageGroup.default,
-    options: { throwOnError?: boolean } = {},
+    options: { throwOnError?: boolean; deduplicationId?: string } = {},
   ) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const body: any = JSON.stringify(msg)
+    const body = JSON.stringify(msg)
 
     const uuid = Math.random().toString(36).substring(2, 12)
+    const deduplicationId = options.deduplicationId ?? uuid
 
     const message: Message = {
       id: uuid,
-      // Type narrowing from nullable/union — runtime context guarantees string but type is broader
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      body: body as string,
-      deduplicationId: uuid,
+      body,
+      deduplicationId,
       groupId: `gp-queue-${group}`,
     }
 

--- a/src/queue/queue.types.ts
+++ b/src/queue/queue.types.ts
@@ -9,6 +9,7 @@ export enum QueueType {
   POLL_CREATION = 'pollCreation',
   POLL_EXPANSION = 'pollExpansion',
   CAMPAIGN_PLAN_COMPLETE = 'campaignPlanComplete',
+  WEEKLY_TASKS_DIGEST = 'weeklyTasksDigest',
 }
 
 export type QueueMessage =
@@ -30,6 +31,10 @@ export type QueueMessage =
   | {
       type: QueueType.CAMPAIGN_PLAN_COMPLETE
       data: CampaignPlanCompleteMessage
+    }
+  | {
+      type: QueueType.WEEKLY_TASKS_DIGEST
+      data: WeeklyTasksDigestMessage
     }
 
 export type GenerateAiContentMessageData = {
@@ -112,12 +117,22 @@ export enum SqsConsumerErrorEventName {
   TIMEOUT_ERROR = 'timeout_error',
 }
 
+export const WeeklyTasksDigestMessageSchema = z.object({
+  windowStart: z.string().datetime(),
+  windowEnd: z.string().datetime(),
+})
+
+export type WeeklyTasksDigestMessage = z.infer<
+  typeof WeeklyTasksDigestMessageSchema
+>
+
 export enum MessageGroup {
   content = 'content',
   tcrCompliance = 'tcrCompliance',
   default = 'default',
   domainEmailRedirect = 'domainEmailRedirect',
   polls = 'polls',
+  weeklyTasksDigest = 'weeklyTasksDigest',
 }
 
 const PollResponseJsonRowSchema = z.object({

--- a/src/vendors/peerly/config/peerlyBaseConfig.ts
+++ b/src/vendors/peerly/config/peerlyBaseConfig.ts
@@ -8,7 +8,6 @@ const {
   PEERLY_HTTP_TIMEOUT = '60000', // 60 seconds default
   PEERLY_UPLOAD_TIMEOUT_MS = '60000', // 60 seconds for uploads
   PEERLY_TEST_ENVIRONMENT,
-  PEERLY_SCHEDULE_ID, // Default schedule ID for P2P jobs
 } = process.env
 
 if (!PEERLY_API_BASE_URL) {
@@ -23,9 +22,6 @@ if (!PEERLY_ACCOUNT_NUMBER) {
   throw new Error('Missing PEERLY_ACCOUNT_NUMBER config')
 }
 
-if (!PEERLY_SCHEDULE_ID) {
-  throw new Error('Missing PEERLY_SCHEDULE_ID config')
-}
 export class PeerlyBaseConfig {
   readonly baseUrl = PEERLY_API_BASE_URL
   readonly email = PEERLY_MD5_EMAIL
@@ -34,7 +30,6 @@ export class PeerlyBaseConfig {
   readonly httpTimeoutMs = parseInt(PEERLY_HTTP_TIMEOUT!, 10)
   readonly uploadTimeoutMs = parseInt(PEERLY_UPLOAD_TIMEOUT_MS!, 10)
   readonly isTestEnvironment = Boolean(PEERLY_TEST_ENVIRONMENT === 'true')
-  readonly scheduleId = parseInt(PEERLY_SCHEDULE_ID!, 10)
 
   constructor(protected readonly logger: PinoLogger) {
     this.logger.setContext(this.constructor.name)

--- a/src/vendors/peerly/constants/p2pJob.constants.ts
+++ b/src/vendors/peerly/constants/p2pJob.constants.ts
@@ -23,5 +23,12 @@ export const P2P_PHONE_LIST_MAP = {
   zip: 6,
 } as const
 
+export const P2P_SCHEDULE_DEFAULTS = {
+  START_TIME: '09:00:00',
+  END_TIME: '21:00:00',
+  TIMEZONE: 'LOCAL',
+  IS_GLOBAL: 1,
+} as const
+
 export const P2P_DNC_SCRUBBING = 0
 export const P2P_DNC_SUPPRESS_INITIALS = 'GE' // GoodParty Engineering Peerly user

--- a/src/vendors/peerly/peerly.module.ts
+++ b/src/vendors/peerly/peerly.module.ts
@@ -18,6 +18,7 @@ import { PeerlyIdentityService } from './services/peerlyIdentity.service'
 import { PeerlyMediaService } from './services/peerlyMedia.service'
 import { PeerlyP2pJobService } from './services/peerlyP2pJob.service'
 import { PeerlyPhoneListService } from './services/peerlyPhoneList.service'
+import { PeerlyScheduleService } from './services/peerlySchedule.service'
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { PeerlyPhoneListService } from './services/peerlyPhoneList.service'
     PeerlyIdentityService,
     PeerlyPhoneListService,
     PeerlyMediaService,
+    PeerlyScheduleService,
     P2pPhoneListUploadService,
     PeerlyP2pJobService,
   ],

--- a/src/vendors/peerly/peerly.types.ts
+++ b/src/vendors/peerly/peerly.types.ts
@@ -412,6 +412,7 @@ export interface CreateJobParams {
   didNpaSubset?: string[]
   identityId?: string
   scheduledDate?: string
+  scheduleId: number
 }
 
 export type PeerlyRecoveryInfo = Record<string, string | number | undefined>

--- a/src/vendors/peerly/schemas/peerlySchedule.schema.ts
+++ b/src/vendors/peerly/schemas/peerlySchedule.schema.ts
@@ -1,0 +1,14 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+const createScheduleResponseSchema = z.object({
+  Data: z.object({
+    schedule_id: z.number(),
+    schedule_name: z.string(),
+    account: z.string(),
+  }),
+})
+
+export class CreateScheduleResponseDto extends createZodDto(
+  createScheduleResponseSchema,
+) {}

--- a/src/vendors/peerly/services/peerlyP2pJob.service.test.ts
+++ b/src/vendors/peerly/services/peerlyP2pJob.service.test.ts
@@ -6,12 +6,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { P2P_JOB_DEFAULTS } from '../constants/p2pJob.constants'
 import { PeerlyMediaService } from './peerlyMedia.service'
 import { PeerlyP2pJobService } from './peerlyP2pJob.service'
+import { PeerlyScheduleService } from './peerlySchedule.service'
 import { PeerlyErrorHandlingService } from './peerlyErrorHandling.service'
 import { PeerlyHttpService } from './peerlyHttp.service'
 
 describe('PeerlyP2pJobService', () => {
   let service: PeerlyP2pJobService
   let mockMediaService: { createMedia: ReturnType<typeof vi.fn> }
+  let mockScheduleService: { createSchedule: ReturnType<typeof vi.fn> }
   let mockHttpService: {
     post: ReturnType<typeof vi.fn>
     get: ReturnType<typeof vi.fn>
@@ -38,6 +40,9 @@ describe('PeerlyP2pJobService', () => {
   beforeEach(async () => {
     mockMediaService = {
       createMedia: vi.fn().mockResolvedValue('media-456'),
+    }
+    mockScheduleService = {
+      createSchedule: vi.fn().mockResolvedValue(99999),
     }
     mockHttpService = {
       post: vi.fn(),
@@ -69,6 +74,7 @@ describe('PeerlyP2pJobService', () => {
         PeerlyP2pJobService,
         { provide: PinoLogger, useValue: createMockLogger() },
         { provide: PeerlyMediaService, useValue: mockMediaService },
+        { provide: PeerlyScheduleService, useValue: mockScheduleService },
         { provide: PeerlyHttpService, useValue: mockHttpService },
         {
           provide: PeerlyErrorHandlingService,
@@ -129,11 +135,15 @@ describe('PeerlyP2pJobService', () => {
       expect(jobPostCall![1]).not.toHaveProperty('did_npa_subset')
     })
 
-    it('calls media, createJob, assignList in order', async () => {
+    it('calls media, createSchedule, createJob, assignList in order', async () => {
       const callOrder: string[] = []
       mockMediaService.createMedia.mockImplementation(async () => {
         callOrder.push('createMedia')
         return 'media-456'
+      })
+      mockScheduleService.createSchedule.mockImplementation(async () => {
+        callOrder.push('createSchedule')
+        return 99999
       })
       mockHttpService.post.mockImplementation(async (path: string) => {
         if (
@@ -148,10 +158,6 @@ describe('PeerlyP2pJobService', () => {
           callOrder.push('assignListToJob')
           return { data: {} }
         }
-        if (path.includes('request_canvassers')) {
-          callOrder.push('requestCanvassers')
-          return { data: {} }
-        }
         return { data: {} }
       })
 
@@ -161,7 +167,41 @@ describe('PeerlyP2pJobService', () => {
         didNpaSubset: ['212'],
       })
 
-      expect(callOrder).toEqual(['createMedia', 'createJob', 'assignListToJob'])
+      expect(callOrder).toEqual([
+        'createMedia',
+        'createSchedule',
+        'createJob',
+        'assignListToJob',
+      ])
+    })
+
+    it('uses dynamic schedule_id from createSchedule in job creation', async () => {
+      mockScheduleService.createSchedule.mockResolvedValue(77777)
+
+      await service.createPeerlyP2pJob(baseJobParams)
+
+      const jobPostCall = mockHttpService.post.mock.calls.find(
+        (c) => c[0] === '/1to1/jobs',
+      )
+      expect(jobPostCall).toBeDefined()
+      expect(jobPostCall![1]).toEqual(
+        expect.objectContaining({ schedule_id: 77777 }),
+      )
+    })
+
+    it('fails job creation when createSchedule rejects', async () => {
+      mockScheduleService.createSchedule.mockRejectedValue(
+        new BadGatewayException('Schedule API down'),
+      )
+
+      await expect(service.createPeerlyP2pJob(baseJobParams)).rejects.toThrow(
+        BadGatewayException,
+      )
+
+      expect(mockMediaService.createMedia).toHaveBeenCalled()
+      expect(
+        mockHttpService.post.mock.calls.some((c) => c[0] === '/1to1/jobs'),
+      ).toBe(false)
     })
 
     it('passes media ID from createMedia to createJob templates', async () => {

--- a/src/vendors/peerly/services/peerlyP2pJob.service.ts
+++ b/src/vendors/peerly/services/peerlyP2pJob.service.ts
@@ -1,4 +1,5 @@
 import { BadGatewayException, Injectable } from '@nestjs/common'
+import { formatISO } from 'date-fns'
 import { Headers } from 'http-constants-ts'
 import { Readable } from 'stream'
 import { PinoLogger } from 'nestjs-pino'
@@ -10,6 +11,7 @@ import { PeerlyBaseConfig } from '../config/peerlyBaseConfig'
 import { PeerlyErrorHandlingService } from './peerlyErrorHandling.service'
 import { PeerlyHttpService } from './peerlyHttp.service'
 import { PeerlyMediaService } from './peerlyMedia.service'
+import { PeerlyScheduleService } from './peerlySchedule.service'
 import { CreateJobResponseDto } from '../schemas/peerlyP2pSms.schema'
 import { CreateJobParams, PeerlyJob } from '../peerly.types'
 
@@ -36,6 +38,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
   constructor(
     protected readonly logger: PinoLogger,
     private readonly peerlyMediaService: PeerlyMediaService,
+    private readonly peerlyScheduleService: PeerlyScheduleService,
     private readonly peerlyHttpService: PeerlyHttpService,
     private readonly peerlyErrorHandling: PeerlyErrorHandlingService,
   ) {
@@ -54,6 +57,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
     scheduledDate,
   }: CreateP2pJobParams): Promise<string> {
     let jobId: string | undefined
+    let scheduleId: number | undefined
 
     try {
       this.logger.info('Creating media for P2P job')
@@ -69,6 +73,11 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
 
       // extract date portion directly from ISO string to preserve the user's intended date
       const dateOnly = scheduledDate?.slice(0, 10)
+
+      const targetDate = dateOnly || 'no-date'
+      const createdAt = formatISO(new Date())
+      const scheduleName = `GP P2P - Campaign ${campaignId} - ${targetDate} - ${createdAt}`
+      scheduleId = await this.peerlyScheduleService.createSchedule(scheduleName)
 
       this.logger.info('Creating P2P job')
       jobId = await this.createJob({
@@ -89,11 +98,12 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
         didNpaSubset,
         identityId,
         scheduledDate: dateOnly,
+        scheduleId,
       })
       this.logger.info(`Job created with ID: ${jobId}`)
 
       this.logger.info(`Assigning list ${listId} to job ${jobId}`)
-      await this.assignListToJob(jobId, listId, { campaignId })
+      await this.assignListToJob(jobId, listId, { campaignId, scheduleId })
       this.logger.info('List assigned successfully')
 
       this.logger.info(
@@ -108,7 +118,10 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
       if (isListAssignmentFailure) {
         throw error
       }
-      this.logger.error({ error }, P2P_ERROR_MESSAGES.JOB_CREATION_FAILED)
+      this.logger.error(
+        { error, scheduleId },
+        P2P_ERROR_MESSAGES.JOB_CREATION_FAILED,
+      )
       throw new BadGatewayException(P2P_ERROR_MESSAGES.JOB_CREATION_FAILED)
     }
   }
@@ -150,6 +163,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
     didNpaSubset = [],
     identityId,
     scheduledDate,
+    scheduleId,
   }: CreateJobParams): Promise<string> {
     const hasMms = templates.some((t) => !!t.media)
 
@@ -160,7 +174,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
       did_state: didState,
       ...(didNpaSubset.length > 0 && { did_npa_subset: didNpaSubset }),
       can_use_mms: hasMms,
-      schedule_id: this.scheduleId,
+      schedule_id: scheduleId,
       ...(identityId && { identity_id: identityId }),
       ...(scheduledDate && {
         start_date: scheduledDate,
@@ -213,7 +227,7 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
   private async assignListToJob(
     jobId: string,
     listId: number,
-    context?: { campaignId?: number },
+    context?: { campaignId?: number; scheduleId?: number },
   ): Promise<void> {
     try {
       await this.peerlyHttpService.post(`/1to1/jobs/${jobId}/assignlist`, {
@@ -229,6 +243,9 @@ export class PeerlyP2pJobService extends PeerlyBaseConfig {
             listId,
             ...(context?.campaignId != null && {
               campaignId: context.campaignId,
+            }),
+            ...(context?.scheduleId != null && {
+              scheduleId: context.scheduleId,
             }),
           },
         },

--- a/src/vendors/peerly/services/peerlySchedule.service.test.ts
+++ b/src/vendors/peerly/services/peerlySchedule.service.test.ts
@@ -1,0 +1,108 @@
+import { BadGatewayException } from '@nestjs/common'
+import { Test, TestingModule } from '@nestjs/testing'
+import { createMockLogger } from 'src/shared/test-utils/mockLogger.util'
+import { PinoLogger } from 'nestjs-pino'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { P2P_SCHEDULE_DEFAULTS } from '../constants/p2pJob.constants'
+import { PeerlyScheduleService } from './peerlySchedule.service'
+import { PeerlyErrorHandlingService } from './peerlyErrorHandling.service'
+import { PeerlyHttpService } from './peerlyHttp.service'
+
+describe('PeerlyScheduleService', () => {
+  let service: PeerlyScheduleService
+  let mockHttpService: {
+    post: ReturnType<typeof vi.fn>
+    validateResponse: ReturnType<typeof vi.fn>
+  }
+  let mockErrorHandling: {
+    handleApiError: ReturnType<typeof vi.fn>
+  }
+
+  const mockScheduleResponse = {
+    Data: {
+      schedule_id: 12345,
+      schedule_name: 'GP P2P - Campaign 1 - 2026-04-15 - Test',
+      account: '88889754',
+    },
+  }
+
+  beforeEach(async () => {
+    mockHttpService = {
+      post: vi.fn().mockResolvedValue({ data: mockScheduleResponse }),
+      validateResponse: vi.fn().mockImplementation((_data) => _data),
+    }
+    mockErrorHandling = {
+      handleApiError: vi.fn().mockImplementation(() => {
+        throw new BadGatewayException('mock error')
+      }),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PeerlyScheduleService,
+        { provide: PinoLogger, useValue: createMockLogger() },
+        { provide: PeerlyHttpService, useValue: mockHttpService },
+        {
+          provide: PeerlyErrorHandlingService,
+          useValue: mockErrorHandling,
+        },
+      ],
+    }).compile()
+
+    service = module.get(PeerlyScheduleService)
+    Object.defineProperty(service, 'logger', {
+      get: () => createMockLogger(),
+      configurable: true,
+    })
+  })
+
+  describe('createSchedule', () => {
+    it('returns schedule_id from validated response', async () => {
+      const result = await service.createSchedule('Test Schedule')
+
+      expect(result).toBe(12345)
+    })
+
+    it('posts to /schedule with correct body structure', async () => {
+      await service.createSchedule('My Schedule')
+
+      expect(mockHttpService.post).toHaveBeenCalledWith(
+        '/schedule',
+        expect.objectContaining({
+          schedule_name: 'My Schedule',
+          schedule_timezone: P2P_SCHEDULE_DEFAULTS.TIMEZONE,
+          is_global: P2P_SCHEDULE_DEFAULTS.IS_GLOBAL,
+          mon_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          mon_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+          tue_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          tue_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+          wed_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          wed_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+          thu_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          thu_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+          fri_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          fri_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+          sat_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          sat_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+          sun_start: P2P_SCHEDULE_DEFAULTS.START_TIME,
+          sun_end: P2P_SCHEDULE_DEFAULTS.END_TIME,
+        }),
+      )
+    })
+
+    it('includes account number in request body', async () => {
+      await service.createSchedule('Test')
+
+      const postCall = mockHttpService.post.mock.calls[0]
+      expect(postCall[1].account).toBe(service.accountNumber)
+    })
+
+    it('throws BadGatewayException on API failure', async () => {
+      mockHttpService.post.mockRejectedValue(new Error('API down'))
+
+      await expect(service.createSchedule('Fail')).rejects.toThrow(
+        BadGatewayException,
+      )
+    })
+  })
+})

--- a/src/vendors/peerly/services/peerlySchedule.service.ts
+++ b/src/vendors/peerly/services/peerlySchedule.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common'
+import { PinoLogger } from 'nestjs-pino'
+import { P2P_SCHEDULE_DEFAULTS } from '../constants/p2pJob.constants'
+import { PeerlyBaseConfig } from '../config/peerlyBaseConfig'
+import { PeerlyErrorHandlingService } from './peerlyErrorHandling.service'
+import { PeerlyHttpService } from './peerlyHttp.service'
+import { CreateScheduleResponseDto } from '../schemas/peerlySchedule.schema'
+
+const SCHEDULE_DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const
+
+@Injectable()
+export class PeerlyScheduleService extends PeerlyBaseConfig {
+  constructor(
+    protected readonly logger: PinoLogger,
+    private readonly peerlyHttpService: PeerlyHttpService,
+    private readonly peerlyErrorHandling: PeerlyErrorHandlingService,
+  ) {
+    super(logger)
+  }
+
+  async createSchedule(scheduleName: string): Promise<number> {
+    const body = this.buildScheduleBody(scheduleName)
+
+    try {
+      this.logger.info(`Creating Peerly schedule: ${scheduleName}`)
+      const response = await this.peerlyHttpService.post('/schedule', body)
+
+      const { data } = response
+      const validated = this.peerlyHttpService.validateResponse(
+        data,
+        CreateScheduleResponseDto,
+        'create schedule',
+      )
+
+      const scheduleId = validated.Data.schedule_id
+      this.logger.info(`Schedule created with ID: ${scheduleId}`)
+      return scheduleId
+    } catch (error) {
+      return this.peerlyErrorHandling.handleApiError({
+        error,
+        logger: this.logger,
+      })
+    }
+  }
+
+  private buildScheduleBody(scheduleName: string) {
+    const dayFields = Object.fromEntries(
+      SCHEDULE_DAYS.flatMap((day) => [
+        [`${day}_start`, P2P_SCHEDULE_DEFAULTS.START_TIME],
+        [`${day}_end`, P2P_SCHEDULE_DEFAULTS.END_TIME],
+      ]),
+    )
+
+    return {
+      schedule_name: scheduleName,
+      account: this.accountNumber,
+      schedule_timezone: P2P_SCHEDULE_DEFAULTS.TIMEZONE,
+      is_global: P2P_SCHEDULE_DEFAULTS.IS_GLOBAL,
+      ...dayFields,
+    }
+  }
+}

--- a/src/vendors/segment/HUBSPOT_INTEGRATION.md
+++ b/src/vendors/segment/HUBSPOT_INTEGRATION.md
@@ -1,6 +1,6 @@
 # Segment → HubSpot Integration
 
-This document describes how Segment events flow from the API to HubSpot and trigger workflows that update user compliance status.
+This document describes how Segment events flow from the API to HubSpot and trigger workflows that update contact/company fields.
 
 ## Overview
 
@@ -35,6 +35,48 @@ The compliance flow tracks user progress through these stages:
 | `Voter Outreach - 10DLC Compliance PIN Submitted` | Ops - Set 10 DLC Compliance Status to Compliance PIN Submitted | Compliance Pending | `CampaignTcrComplianceController.submitCampaignVerifyPIN()` |
 | `Voter Outreach - 10DLC Compliance Completed` | Ops - Set 10 DLC Compliance Status to 10 DLC Compliance Complete | Compliant | `QueueConsumerService.handleTcrComplianceCheckMessage()` |
 
+## Weekly Tasks Digest Flow
+
+A cron job (`WeeklyTasksDigestService`) fires every Sunday at 11 PM Central Time and sends a `WEEKLY_TASKS_DIGEST` message to the SQS queue. The consumer (`WeeklyTasksDigestHandlerService`) processes all campaigns with a future election date and fires a Segment event per campaign with up to 5 upcoming tasks due Monday through Sunday of the coming week.
+
+The event populates the `win_campaign_plan` fields on the HubSpot contact, which a HubSpot workflow uses to send weekly digest emails.
+
+| Event Name | HubSpot Contact Fields | Fired From |
+|-----------|----------------------|------------|
+| `Campaign Plan - Weekly Tasks Digest` | `plan_tasks_completed`, `plan_total_tasks`, `task_name_1`-`5`, `task_description_1`-`5`, `task_type_1`-`5`, `task_due_date_1`-`5`, `task_week_number_1`-`5` | `WeeklyTasksDigestHandlerService` (via SQS queue) |
+
+Rules:
+- Campaigns with a past election date are skipped
+- Campaigns with fewer than 3 incomplete tasks are skipped (stale data prevents HubSpot from sending the email)
+- Outreach tasks (`text`, `robocall`, `doorKnocking`, `phoneBanking`) are prioritized
+- Task due dates are sent as date-only strings (`yyyy-MM-dd`)
+
+Test script: `scripts/test-weekly-tasks-digest-event.ts`
+
+### Manual Recovery (if the cron fails)
+
+The cron enqueues the window in the SQS message itself, so manual triggering just means sending that same message shape by hand. Do this when the Sunday-night cron didn't fire (or the consumer was down) and you want to backfill HubSpot for the current week.
+
+1. Compute the window in UTC:
+   - `windowStart` = the Monday you want to cover, at `00:00:00.000Z`
+   - `windowEnd` = the following Monday, at `00:00:00.000Z`
+   - (Example for the week of April 20, 2026: `2026-04-20T00:00:00.000Z` → `2026-04-27T00:00:00.000Z`)
+
+2. Send this message body to the gp-api FIFO SQS queue (via AWS Console or CLI):
+   ```json
+   {
+     "type": "weeklyTasksDigest",
+     "data": {
+       "windowStart": "2026-04-20T00:00:00.000Z",
+       "windowEnd": "2026-04-27T00:00:00.000Z"
+     }
+   }
+   ```
+   - `MessageGroupId`: `gp-queue-weeklyTasksDigest`
+   - `MessageDeduplicationId`: anything unique (e.g. `manual-<timestamp>`)
+
+3. The consumer will query all campaigns, fire Segment events, and refresh the HubSpot contact fields. HubSpot's 5-day staleness check applies to whether the digest email sends — a manual recovery within ~5 days of the intended run should still trigger emails.
+
 ## Event Definitions
 
 File: `src/vendors/segment/segment.types.ts`
@@ -45,6 +87,7 @@ EVENTS.CandidateWebsite.PurchasedDomain     // 'Candidate Website - Purchased do
 EVENTS.Outreach.ComplianceFormSubmitted      // 'Voter Outreach - 10DLC Compliance Form Submitted'
 EVENTS.Outreach.CompliancePinSubmitted       // 'Voter Outreach - 10DLC Compliance PIN Submitted'
 EVENTS.Outreach.ComplianceCompleted          // 'Voter Outreach - 10DLC Compliance Completed'
+EVENTS.CampaignPlan.WeeklyTasksDigest       // 'Campaign Plan - Weekly Tasks Digest'
 ```
 
 ## Segment Configuration

--- a/src/vendors/segment/__tests__/segment-hubspot-events.test.ts
+++ b/src/vendors/segment/__tests__/segment-hubspot-events.test.ts
@@ -49,4 +49,12 @@ describe('Segment → HubSpot Event Names', () => {
       )
     })
   })
+
+  describe('Campaign Plan Events', () => {
+    it('should have the correct WeeklyTasksDigest event name for HubSpot', () => {
+      expect(EVENTS.CampaignPlan.WeeklyTasksDigest).toBe(
+        'Campaign Plan - Weekly Tasks Digest',
+      )
+    })
+  })
 })

--- a/src/vendors/segment/segment.types.ts
+++ b/src/vendors/segment/segment.types.ts
@@ -44,6 +44,10 @@ export const EVENTS = {
   Polls: {
     ResultsSynthesisCompleted: 'Poll - Results Synthesis Complete',
   },
+  CampaignPlan: {
+    //  ⚠️  DO NOT MODIFY - Used by HubSpot workflows for weekly task digest emails
+    WeeklyTasksDigest: 'Campaign Plan - Weekly Tasks Digest',
+  },
 }
 
 export type UserContext = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new scheduled SQS→consumer→Segment/HubSpot workflow and changes Peerly P2P job creation to create schedules dynamically; both impact production integrations and background processing. Also includes Prisma migrations (including a TRUNCATE) and a new DB index, which require careful deployment sequencing.
> 
> **Overview**
> Adds a **Weekly Tasks Digest** background flow: a Sunday 11pm Central `@Cron` enqueues a `WEEKLY_TASKS_DIGEST` SQS message (with FIFO deduplication), the queue consumer routes it to a new handler, and the handler queries eligible campaigns/tasks and fires the Segment event `Campaign Plan - Weekly Tasks Digest` with up to 5 prioritized upcoming tasks (always emitting all 5 slots to clear HubSpot fields).
> 
> Updates campaign task generation to **short-circuit** when *any* tasks already exist (skip default-task creation and AI event generation), and adds a Prisma `@@index([date])` plus migrations (including a one-time `TRUNCATE` of `campaign_task`/`campaign_plan`).
> 
> Refactors Peerly P2P job creation to **remove `PEERLY_SCHEDULE_ID`** configuration and instead create a schedule per job via a new `PeerlyScheduleService`, passing the returned `schedule_id` into job creation and surfacing it in error recovery/logging. CI is also updated to validate Prisma migrations using a Postgres shadow DB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbeb210bb0a3a7c6fed448262f5c1dc5db66c6fa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->