### PR TITLE
feat: Add campaign finance awareness task to campaign plan (ENG-7325)

### DIFF
--- a/src/campaigns/tasks/fixtures/defaultAwarenessTasks.ts
+++ b/src/campaigns/tasks/fixtures/defaultAwarenessTasks.ts
@@ -1,5 +1,14 @@
 import { CampaignTaskTemplate, CampaignTaskType } from '../campaignTasks.types'
 
+export const campaignFinanceAwarenessTask: Omit<CampaignTaskTemplate, 'week'> =
+  {
+    title: 'Add your campaign finance deadlines to your calendar',
+    description:
+      "Most campaigns have statutory requirements about when you have to submit your campaign finance report. Add those dates to your campaign calendar to ensure you don't miss the deadlines!",
+    flowType: CampaignTaskType.awareness,
+    isDefaultTask: true,
+  }
+
 export const generalAwarenessTasks: CampaignTaskTemplate[] = [
   {
     title: 'Reach 10% of your Voter Contact Goal',

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -820,8 +820,7 @@ describe('CampaignTasksService', () => {
       await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(generalDefaultTasks.length)
-      expect(tasks[0].title).toBe(generalDefaultTasks[0].title)
+      expect(tasks).toHaveLength(generalDefaultTasks.length + 1)
       expect(tasks[0].date).toBeInstanceOf(Date)
     })
 
@@ -836,8 +835,7 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(generalDefaultTasks.length)
-      expect(tasks[0].title).toBe(generalDefaultTasks[0].title)
+      expect(tasks).toHaveLength(generalDefaultTasks.length + 1)
       expect(tasks[0].date).toBeInstanceOf(Date)
     })
 
@@ -854,7 +852,7 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(
-        generalDefaultTasks.length + generalAwarenessTasks.length,
+        generalDefaultTasks.length + generalAwarenessTasks.length + 1,
       )
       expect(recurring).toHaveLength(169)
       expect(tasks[0].date).toBeInstanceOf(Date)
@@ -875,8 +873,7 @@ describe('CampaignTasksService', () => {
 
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
-      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
-      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
+      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length + 1)
       expect(recurring).toHaveLength(85)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
@@ -900,7 +897,8 @@ describe('CampaignTasksService', () => {
       expect(nonRecurring).toHaveLength(
         primaryDefaultTasks.length +
           generalDefaultTasks.length +
-          generalAwarenessTasks.length,
+          generalAwarenessTasks.length +
+          1,
       )
       expect(recurring).toHaveLength(169)
       expect(tasks[0].date).toBeInstanceOf(Date)
@@ -954,7 +952,7 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(
-        generalDefaultTasks.length + generalAwarenessTasks.length,
+        generalDefaultTasks.length + generalAwarenessTasks.length + 1,
       )
       expect(recurring).toHaveLength(169)
     })
@@ -974,9 +972,67 @@ describe('CampaignTasksService', () => {
 
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
-      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length)
-      expect(nonRecurring[0].title).toBe(primaryDefaultTasks[0].title)
+      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length + 1)
       expect(recurring).toHaveLength(85)
+    })
+
+    it('includes the campaign finance awareness task on the Saturday of the signup week', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: FUTURE_GENERAL },
+        }),
+        TODAY,
+      )
+
+      const financeTasks = getCreatedTaskData().filter(
+        (t) =>
+          t.title === 'Add your campaign finance deadlines to your calendar',
+      )
+      expect(financeTasks).toHaveLength(1)
+      const [financeTask] = financeTasks
+      expect(financeTask.flowType).toBe(CampaignTaskType.awareness)
+      expect(financeTask.isDefaultTask).toBe(true)
+      expect(financeTask.date).toEqual(
+        startOfDay(parseIsoDateString('2025-06-07')),
+      )
+    })
+
+    it('includes the campaign finance awareness task when no election date is set', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
+
+      const financeTasks = getCreatedTaskData().filter(
+        (t) =>
+          t.title === 'Add your campaign finance deadlines to your calendar',
+      )
+      expect(financeTasks).toHaveLength(1)
+      expect(financeTasks[0].week).toBe(0)
+      expect(financeTasks[0].date).toEqual(
+        startOfDay(parseIsoDateString('2025-06-07')),
+      )
+    })
+
+    it('does not include the campaign finance awareness task when both election dates are past', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: {
+            primaryElectionDate: PAST_PRIMARY,
+            electionDate: PAST_GENERAL,
+          },
+        }),
+        TODAY,
+      )
+
+      const financeTasks = getCreatedTaskData().filter(
+        (t) =>
+          t.title === 'Add your campaign finance deadlines to your calendar',
+      )
+      expect(financeTasks).toHaveLength(0)
     })
 
     it('assigns dates in chronological order', async () => {
@@ -1024,7 +1080,7 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(generalDefaultTasks.length)
+      expect(tasks).toHaveLength(generalDefaultTasks.length + 1)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
       expect(tasks[tasks.length - 1].date).toBeInstanceOf(Date)

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -417,23 +417,35 @@ export class CampaignTasksService extends createPrismaBase(
     campaign: Campaign,
     today: Date,
   ): CampaignTask[] {
+    if (this.hasExpiredElectionOnly(campaign, today)) {
+      return []
+    }
+    const baseTasks = this.buildBaseDefaultTasks(campaign, today)
+    const electionDate = this.resolveElectionDate(campaign, today)
+    return this.sortTasksByDate([
+      ...baseTasks,
+      this.buildCampaignFinanceAwarenessTask(today, electionDate),
+    ])
+  }
+
+  private buildBaseDefaultTasks(
+    campaign: Campaign,
+    today: Date,
+  ): CampaignTask[] {
     const { details } = campaign
     if (!details) {
-      return this.sortTasksByDate([
-        ...this.distributeTasksOverWindow(
-          generalDefaultTasks,
-          today,
-          addDays(today, MAX_TASK_WINDOW_DAYS),
-        ),
-        this.buildCampaignFinanceAwarenessTask(today, null),
-      ])
+      return this.distributeTasksOverWindow(
+        generalDefaultTasks,
+        today,
+        addDays(today, MAX_TASK_WINDOW_DAYS),
+      )
     }
 
     const primaryDate = this.hasFutureDate(details.primaryElectionDate, today)
     const generalDate = this.hasFutureDate(details.electionDate, today)
 
     if (primaryDate && generalDate) {
-      return this.sortTasksByDate([
+      return [
         ...this.distributeTasksOverWindow(
           primaryDefaultTasks,
           today,
@@ -454,12 +466,11 @@ export class CampaignTasksService extends createPrismaBase(
           today,
           generalDate,
         ),
-        this.buildCampaignFinanceAwarenessTask(today, generalDate),
-      ])
+      ]
     }
 
     if (primaryDate) {
-      return this.sortTasksByDate([
+      return [
         ...this.distributeTasksOverWindow(
           primaryDefaultTasks,
           today,
@@ -470,12 +481,11 @@ export class CampaignTasksService extends createPrismaBase(
           today,
           primaryDate,
         ),
-        this.buildCampaignFinanceAwarenessTask(today, primaryDate),
-      ])
+      ]
     }
 
     if (generalDate) {
-      return this.sortTasksByDate([
+      return [
         ...this.distributeTasksOverWindow(
           generalDefaultTasks,
           today,
@@ -491,22 +501,34 @@ export class CampaignTasksService extends createPrismaBase(
           today,
           generalDate,
         ),
-        this.buildCampaignFinanceAwarenessTask(today, generalDate),
-      ])
+      ]
     }
 
-    const hasAnyElectionDate =
-      details.primaryElectionDate || details.electionDate
-    return hasAnyElectionDate
-      ? []
-      : this.sortTasksByDate([
-          ...this.distributeTasksOverWindow(
-            generalDefaultTasks,
-            today,
-            addDays(today, MAX_TASK_WINDOW_DAYS),
-          ),
-          this.buildCampaignFinanceAwarenessTask(today, null),
-        ])
+    return this.distributeTasksOverWindow(
+      generalDefaultTasks,
+      today,
+      addDays(today, MAX_TASK_WINDOW_DAYS),
+    )
+  }
+
+  private resolveElectionDate(campaign: Campaign, today: Date): Date | null {
+    const { details } = campaign
+    if (!details) return null
+    const primaryDate = this.hasFutureDate(details.primaryElectionDate, today)
+    const generalDate = this.hasFutureDate(details.electionDate, today)
+    return generalDate ?? primaryDate ?? null
+  }
+
+  private hasExpiredElectionOnly(campaign: Campaign, today: Date): boolean {
+    const { details } = campaign
+    if (!details) return false
+    const hasAnyElectionDate = Boolean(
+      details.primaryElectionDate || details.electionDate,
+    )
+    if (!hasAnyElectionDate) return false
+    const primaryDate = this.hasFutureDate(details.primaryElectionDate, today)
+    const generalDate = this.hasFutureDate(details.electionDate, today)
+    return !primaryDate && !generalDate
   }
 
   private hasFutureDate(

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -34,7 +34,10 @@ import {
   RecurrenceRule,
   RecurringTaskTemplate,
 } from '../campaignTasks.types'
-import { generalAwarenessTasks } from '../fixtures/defaultAwarenessTasks'
+import {
+  campaignFinanceAwarenessTask,
+  generalAwarenessTasks,
+} from '../fixtures/defaultAwarenessTasks'
 import { defaultRecurringTasks } from '../fixtures/defaultRecurringTasks'
 import { generalDefaultTasks } from '../fixtures/defaultTasks'
 import { primaryDefaultTasks } from '../fixtures/defaultTasksForPrimary'
@@ -416,11 +419,14 @@ export class CampaignTasksService extends createPrismaBase(
   ): CampaignTask[] {
     const { details } = campaign
     if (!details) {
-      return this.distributeTasksOverWindow(
-        generalDefaultTasks,
-        today,
-        addDays(today, MAX_TASK_WINDOW_DAYS),
-      )
+      return this.sortTasksByDate([
+        ...this.distributeTasksOverWindow(
+          generalDefaultTasks,
+          today,
+          addDays(today, MAX_TASK_WINDOW_DAYS),
+        ),
+        this.buildCampaignFinanceAwarenessTask(today, null),
+      ])
     }
 
     const primaryDate = this.hasFutureDate(details.primaryElectionDate, today)
@@ -448,6 +454,7 @@ export class CampaignTasksService extends createPrismaBase(
           today,
           generalDate,
         ),
+        this.buildCampaignFinanceAwarenessTask(today, generalDate),
       ])
     }
 
@@ -463,6 +470,7 @@ export class CampaignTasksService extends createPrismaBase(
           today,
           primaryDate,
         ),
+        this.buildCampaignFinanceAwarenessTask(today, primaryDate),
       ])
     }
 
@@ -483,6 +491,7 @@ export class CampaignTasksService extends createPrismaBase(
           today,
           generalDate,
         ),
+        this.buildCampaignFinanceAwarenessTask(today, generalDate),
       ])
     }
 
@@ -490,11 +499,14 @@ export class CampaignTasksService extends createPrismaBase(
       details.primaryElectionDate || details.electionDate
     return hasAnyElectionDate
       ? []
-      : this.distributeTasksOverWindow(
-          generalDefaultTasks,
-          today,
-          addDays(today, MAX_TASK_WINDOW_DAYS),
-        )
+      : this.sortTasksByDate([
+          ...this.distributeTasksOverWindow(
+            generalDefaultTasks,
+            today,
+            addDays(today, MAX_TASK_WINDOW_DAYS),
+          ),
+          this.buildCampaignFinanceAwarenessTask(today, null),
+        ])
   }
 
   private hasFutureDate(
@@ -567,6 +579,21 @@ export class CampaignTasksService extends createPrismaBase(
         }
       })
       .filter((task) => !isBefore(parseIsoDateString(task.date), today))
+  }
+
+  private buildCampaignFinanceAwarenessTask(
+    today: Date,
+    electionDate: Date | null,
+  ): CampaignTask {
+    const saturday = addDays(startOfWeek(today), 6)
+    const week = electionDate
+      ? differenceInWeeks(electionDate, saturday, { roundingMethod: 'ceil' })
+      : 0
+    return {
+      ...campaignFinanceAwarenessTask,
+      week,
+      date: formatDate(saturday, DateFormats.isoDate),
+    }
   }
 
   private computeRecurringTasks(


### PR DESCRIPTION
## Summary

Adds a Campaign Finance awareness task to every new campaign plan as part of ENG-7325.

## Changes

- Added `campaignFinanceAwarenessTask` template to `defaultAwarenessTasks.ts`
- Added `buildCampaignFinanceAwarenessTask()` helper in `CampaignTasksService` that pins the task to the Saturday of the candidate's signup week
- Wired the task into all non-empty branches of `orderDefaultTasksForCampaign` (general, primary, both, and no-election-date paths)
- Task is skipped only when both election dates are in the past

## Task details

- **Title:** Add your campaign finance deadlines to your calendar
- **Description:** Most campaigns have statutory requirements about when you have to submit your campaign finance report. Add those dates to your campaign calendar to ensure you don't miss the deadlines!
- **Date:** Saturday of the week the candidate signs up
- **Type:** `awareness`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches default task generation and ordering logic across multiple election-date branches, which can affect campaign plan contents and scheduling for all new campaigns. Risk is mainly around off-by-one/week/date calculations and unexpected task ordering/count changes.
> 
> **Overview**
> Adds a new default *awareness* task, `campaignFinanceAwarenessTask` ("Add your campaign finance deadlines to your calendar"), to every newly generated campaign plan.
> 
> `CampaignTasksService.orderDefaultTasksForCampaign` now appends this task across the general/primary/both/no-election-date paths via `buildCampaignFinanceAwarenessTask()`, which pins the due date to the Saturday of the signup week (and sets `week` relative to the relevant election date, or `0` when none). Tests are updated to expect the extra task and to cover inclusion/omission and date/week behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8f27ce48c3864b8ba162a80f862023de2f3383. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->