### PR TITLE
ENG 7273 no tasks past election

### DIFF
--- a/src/campaigns/tasks/services/aiGeneration.service.test.ts
+++ b/src/campaigns/tasks/services/aiGeneration.service.test.ts
@@ -146,6 +146,28 @@ describe('AiGenerationService', () => {
 
       expect(result).toBe(false)
     })
+
+    it('returns false without sending when election date is in the past', async () => {
+      const campaign = makeCampaign({
+        details: { city: 'Boston', state: 'MA', electionDate: '2020-11-03' },
+      } as Partial<Campaign>)
+
+      const result = await service.triggerEventGeneration(campaign)
+
+      expect(result).toBe(false)
+      expect(mockQueueProducer.sendToCampaignPlanQueue).not.toHaveBeenCalled()
+    })
+
+    it('returns false without sending when election date is missing', async () => {
+      const campaign = makeCampaign({
+        details: { city: 'Boston', state: 'MA' },
+      } as Partial<Campaign>)
+
+      const result = await service.triggerEventGeneration(campaign)
+
+      expect(result).toBe(false)
+      expect(mockQueueProducer.sendToCampaignPlanQueue).not.toHaveBeenCalled()
+    })
   })
 
   describe('readResultFromS3', () => {

--- a/src/campaigns/tasks/services/aiGeneration.service.ts
+++ b/src/campaigns/tasks/services/aiGeneration.service.ts
@@ -10,6 +10,7 @@ import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
 import { S3Service } from 'src/vendors/aws/services/s3.service'
 import { campaignPlanQueueConfig } from 'src/queue/queue.config'
 import { CampaignPlanCompleteMessage } from 'src/queue/queue.types'
+import { isDateTodayOrFuture } from 'src/shared/util/date.util'
 import { CampaignTask, CampaignTaskType } from '../campaignTasks.types'
 
 const LambdaEventTaskSchema = z.object({
@@ -73,6 +74,14 @@ export class AiGenerationService {
 
   async triggerEventGeneration(campaign: Campaign): Promise<boolean> {
     const { city, state, electionDate } = campaign.details ?? {}
+
+    if (!isDateTodayOrFuture(electionDate)) {
+      this.logger.info(
+        { campaignId: campaign.id, electionDate },
+        'skipping event generation: election date missing or past',
+      )
+      return false
+    }
 
     try {
       await this.triggerGeneration({

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -480,6 +480,11 @@ describe('CampaignTasksService', () => {
   })
 
   describe('generateTasksStream', () => {
+    const campaignWithFutureElection = () =>
+      makeCampaign({
+        details: { electionDate: '2099-11-03' },
+      })
+
     it('skips default task generation and AI trigger when any tasks exist', async () => {
       const existingTasks = [
         makeDbTask({ id: 'default-1', isDefaultTask: true }),
@@ -487,7 +492,9 @@ describe('CampaignTasksService', () => {
 
       mockModel.findMany.mockResolvedValueOnce(existingTasks)
 
-      const observable = service.generateTasksStream(makeCampaign())
+      const observable = service.generateTasksStream(
+        campaignWithFutureElection(),
+      )
       const events = await firstValueFrom(observable.pipe(toArray()))
 
       const completeEvent = events.find(
@@ -497,9 +504,7 @@ describe('CampaignTasksService', () => {
       expect((completeEvent!.data as { tasks: unknown[] }).tasks).toEqual(
         existingTasks,
       )
-      // generateDefaultTasks should not have been called (no transaction)
       expect(mockTransaction).not.toHaveBeenCalled()
-      // triggerEventGeneration should not have been called
       expect(mockAiGeneration.triggerEventGeneration).not.toHaveBeenCalled()
     })
 
@@ -514,7 +519,9 @@ describe('CampaignTasksService', () => {
         false,
       )
 
-      const observable = service.generateTasksStream(makeCampaign())
+      const observable = service.generateTasksStream(
+        campaignWithFutureElection(),
+      )
       const events = await firstValueFrom(observable.pipe(toArray()))
 
       const completeEvent = events.find(
@@ -543,7 +550,9 @@ describe('CampaignTasksService', () => {
         true,
       )
 
-      const observable = service.generateTasksStream(makeCampaign())
+      const observable = service.generateTasksStream(
+        campaignWithFutureElection(),
+      )
       const events = await firstValueFrom(observable.pipe(toArray()))
 
       const completeEvent = events.find(
@@ -566,9 +575,51 @@ describe('CampaignTasksService', () => {
         new Error('Lambda trigger failed'),
       )
 
-      const observable = service.generateTasksStream(makeCampaign())
+      const observable = service.generateTasksStream(
+        campaignWithFutureElection(),
+      )
       const events = await firstValueFrom(observable.pipe(toArray()))
 
+      const completeEvent = events.find(
+        (e) => (e.data as { type: string }).type === 'complete',
+      )
+      expect(completeEvent).toBeDefined()
+      expect((completeEvent!.data as { tasks: unknown[] }).tasks).toEqual(
+        existingTasks,
+      )
+    })
+
+    it('short-circuits with existing tasks when election is in the past', async () => {
+      const existingTasks = [makeDbTask({ id: 'existing-1' })]
+      mockModel.findMany.mockResolvedValueOnce(existingTasks)
+
+      const observable = service.generateTasksStream(
+        makeCampaign({ details: { electionDate: '2020-11-03' } }),
+      )
+      const events = await firstValueFrom(observable.pipe(toArray()))
+
+      expect(mockTransaction).not.toHaveBeenCalled()
+      expect(mockAiGeneration.triggerEventGeneration).not.toHaveBeenCalled()
+      const completeEvent = events.find(
+        (e) => (e.data as { type: string }).type === 'complete',
+      )
+      expect(completeEvent).toBeDefined()
+      expect((completeEvent!.data as { tasks: unknown[] }).tasks).toEqual(
+        existingTasks,
+      )
+    })
+
+    it('short-circuits when no election date is set', async () => {
+      const existingTasks: unknown[] = []
+      mockModel.findMany.mockResolvedValueOnce(existingTasks)
+
+      const observable = service.generateTasksStream(
+        makeCampaign({ details: {} }),
+      )
+      const events = await firstValueFrom(observable.pipe(toArray()))
+
+      expect(mockTransaction).not.toHaveBeenCalled()
+      expect(mockAiGeneration.triggerEventGeneration).not.toHaveBeenCalled()
       const completeEvent = events.find(
         (e) => (e.data as { type: string }).type === 'complete',
       )
@@ -671,13 +722,101 @@ describe('CampaignTasksService', () => {
 
       vi.useRealTimers()
     })
+
+    it('drops tasks dated after the election date', async () => {
+      mockCampaignModel.findUniqueOrThrow.mockResolvedValue({
+        details: { electionDate: '2025-04-07' },
+      })
+      const tasks: CampaignTask[] = [
+        {
+          id: 'before',
+          title: 'Before election',
+          description: 'Valid',
+          flowType: CampaignTaskType.events,
+          week: 1,
+          date: '2025-04-01',
+        },
+        {
+          id: 'on-day',
+          title: 'On election day',
+          description: 'Valid',
+          flowType: CampaignTaskType.events,
+          week: 0,
+          date: '2025-04-07',
+        },
+        {
+          id: 'after',
+          title: 'After election',
+          description: 'Should drop',
+          flowType: CampaignTaskType.events,
+          week: -30,
+          date: '2025-11-07',
+        },
+      ]
+      mockModel.createMany.mockResolvedValue({ count: 2 })
+
+      await service.addEventTasks(1, tasks)
+
+      const createCall = mockModel.createMany.mock.calls[0][0]
+      expect(createCall.data).toHaveLength(2)
+      expect(createCall.data.map((t: { id: string }) => t.id)).toEqual([
+        'before',
+        'on-day',
+      ])
+    })
+
+    it('drops all tasks when campaign has no election date', async () => {
+      mockCampaignModel.findUniqueOrThrow.mockResolvedValue({
+        details: {},
+      })
+      const tasks: CampaignTask[] = [
+        {
+          id: 'orphan',
+          title: 'No election',
+          description: 'Should drop',
+          flowType: CampaignTaskType.events,
+          week: 1,
+          date: '2025-04-01',
+        },
+      ]
+
+      await service.addEventTasks(1, tasks)
+
+      expect(mockModel.createMany).not.toHaveBeenCalled()
+    })
+
+    it('drops all tasks when electionDate is malformed', async () => {
+      mockCampaignModel.findUniqueOrThrow.mockResolvedValue({
+        details: { electionDate: 'TBD' },
+      })
+      const tasks: CampaignTask[] = [
+        {
+          id: 'orphan',
+          title: 'Malformed election',
+          description: 'Should drop',
+          flowType: CampaignTaskType.events,
+          week: 1,
+          date: '2025-04-01',
+        },
+      ]
+
+      await service.addEventTasks(1, tasks)
+
+      expect(mockModel.createMany).not.toHaveBeenCalled()
+    })
   })
 
   describe('generateDefaultTasks', () => {
+    const TODAY = startOfDay(parseIsoDateString('2026-01-01'))
+    const campaignWithFutureElection = () =>
+      makeCampaign({
+        details: { electionDate: '2026-11-03' },
+      })
+
     it('skips if defaults already exist', async () => {
       mockTxModel.count.mockResolvedValueOnce(1)
 
-      await service.generateDefaultTasks(makeCampaign())
+      await service.generateDefaultTasks(campaignWithFutureElection(), TODAY)
 
       expect(mockTransaction).toHaveBeenCalled()
       expect(mockTxModel.deleteMany).not.toHaveBeenCalled()
@@ -702,7 +841,7 @@ describe('CampaignTasksService', () => {
         ],
       })
 
-      await service.generateDefaultTasks(makeCampaign())
+      await service.generateDefaultTasks(campaignWithFutureElection(), TODAY)
 
       expect(mockTransaction).toHaveBeenCalled()
       expect(mockTxModel.createMany).toHaveBeenCalled()
@@ -736,7 +875,7 @@ describe('CampaignTasksService', () => {
         ],
       })
 
-      await service.generateDefaultTasks(makeCampaign())
+      await service.generateDefaultTasks(campaignWithFutureElection(), TODAY)
 
       const messageMock = vi.mocked(mockSlackService.message!)
       const slackCall = messageMock.mock.calls[0]
@@ -758,9 +897,27 @@ describe('CampaignTasksService', () => {
       )
 
       await expect(
-        service.generateDefaultTasks(makeCampaign()),
+        service.generateDefaultTasks(campaignWithFutureElection(), TODAY),
       ).resolves.not.toThrow()
       expect(mockTxModel.createMany).toHaveBeenCalled()
+    })
+
+    it('skips entirely when no election date is set', async () => {
+      await service.generateDefaultTasks(makeCampaign({ details: {} }))
+
+      expect(mockTransaction).not.toHaveBeenCalled()
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
+      expect(mockSlackService.message).not.toHaveBeenCalled()
+    })
+
+    it('skips entirely when election date is in the past', async () => {
+      await service.generateDefaultTasks(
+        makeCampaign({ details: { electionDate: '2020-11-03' } }),
+      )
+
+      expect(mockTransaction).not.toHaveBeenCalled()
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
+      expect(mockSlackService.message).not.toHaveBeenCalled()
     })
   })
 
@@ -824,19 +981,15 @@ describe('CampaignTasksService', () => {
       nonRecurring: tasks.filter((t) => !recurringTitles.has(t.title)),
     })
 
-    it('distributes general tasks with dates when details is empty', async () => {
+    it('creates no tasks when details is empty', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
 
-      const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(
-        generalDefaultTasks.length + SIGNUP_WEEK_AWARENESS_COUNT,
-      )
-      expect(tasks[0].date).toBeInstanceOf(Date)
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
     })
 
-    it('distributes general tasks when details is null', async () => {
+    it('creates no tasks when details is null', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(
@@ -846,11 +999,7 @@ describe('CampaignTasksService', () => {
         TODAY,
       )
 
-      const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(
-        generalDefaultTasks.length + SIGNUP_WEEK_AWARENESS_COUNT,
-      )
-      expect(tasks[0].date).toBeInstanceOf(Date)
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
     })
 
     it('distributes general tasks when only general date is future', async () => {
@@ -937,8 +1086,7 @@ describe('CampaignTasksService', () => {
         TODAY,
       )
 
-      const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(0)
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
     })
 
     it('returns empty when only general date is in the past', async () => {
@@ -951,8 +1099,7 @@ describe('CampaignTasksService', () => {
         TODAY,
       )
 
-      const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(0)
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
     })
 
     it('distributes only general when primary is past and general is future', async () => {
@@ -1023,23 +1170,15 @@ describe('CampaignTasksService', () => {
       )
     })
 
-    it('includes the campaign finance awareness task when no election date is set', async () => {
+    it('does not create the campaign finance awareness task when no election date is set', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
 
-      const financeTasks = getCreatedTaskData().filter(
-        (t) =>
-          t.title === 'Add your campaign finance deadlines to your calendar',
-      )
-      expect(financeTasks).toHaveLength(1)
-      expect(financeTasks[0].week).toBe(0)
-      expect(financeTasks[0].date).toEqual(
-        startOfDay(parseIsoDateString('2025-06-07')),
-      )
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
     })
 
-    it('does not include the campaign finance awareness task when both election dates are past', async () => {
+    it('does not create the campaign finance awareness task when both election dates are past', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(
@@ -1052,11 +1191,7 @@ describe('CampaignTasksService', () => {
         TODAY,
       )
 
-      const financeTasks = getCreatedTaskData().filter(
-        (t) =>
-          t.title === 'Add your campaign finance deadlines to your calendar',
-      )
-      expect(financeTasks).toHaveLength(0)
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
     })
 
     it('includes the Meta and design materials awareness tasks on Wed/Thu of the week after signup', async () => {
@@ -1084,21 +1219,12 @@ describe('CampaignTasksService', () => {
       expect(design!.date).toEqual(startOfDay(parseIsoDateString('2025-06-12')))
     })
 
-    it('includes the Meta and design materials awareness tasks when no election date is set', async () => {
+    it('does not create the Meta and design materials awareness tasks when no election date is set', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
 
-      const tasks = getCreatedTaskData()
-      const meta = tasks.find((t) => t.title === 'Get Meta verified')
-      const design = tasks.find((t) => t.title === 'Design materials')
-
-      expect(meta).toBeDefined()
-      expect(meta!.week).toBe(0)
-      expect(meta!.date).toEqual(startOfDay(parseIsoDateString('2025-06-11')))
-      expect(design).toBeDefined()
-      expect(design!.week).toBe(0)
-      expect(design!.date).toEqual(startOfDay(parseIsoDateString('2025-06-12')))
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
     })
 
     it('omits the Meta and design materials awareness tasks when the election is less than 42 days away', async () => {
@@ -1131,7 +1257,7 @@ describe('CampaignTasksService', () => {
       expect(tasks.find((t) => t.title === 'Design materials')).toBeDefined()
     })
 
-    it('does not include the Meta and design materials awareness tasks when both election dates are past', async () => {
+    it('does not create the Meta and design materials awareness tasks when both election dates are past', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(
@@ -1144,9 +1270,7 @@ describe('CampaignTasksService', () => {
         TODAY,
       )
 
-      const tasks = getCreatedTaskData()
-      expect(tasks.find((t) => t.title === 'Get Meta verified')).toBeUndefined()
-      expect(tasks.find((t) => t.title === 'Design materials')).toBeUndefined()
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
     })
 
     it('includes a General Election Day awareness task on the general election date', async () => {
@@ -1217,21 +1341,15 @@ describe('CampaignTasksService', () => {
       )
     })
 
-    it('does not include any Election Day awareness task when no election date is set', async () => {
+    it('does not create any Election Day awareness task when no election date is set', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
 
-      const tasks = getCreatedTaskData()
-      expect(
-        tasks.find((t) => t.title === 'Primary Election Day'),
-      ).toBeUndefined()
-      expect(
-        tasks.find((t) => t.title === 'General Election Day'),
-      ).toBeUndefined()
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
     })
 
-    it('does not include any Election Day awareness task when both election dates are past', async () => {
+    it('does not create any Election Day awareness task when both election dates are past', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(
@@ -1244,13 +1362,7 @@ describe('CampaignTasksService', () => {
         TODAY,
       )
 
-      const tasks = getCreatedTaskData()
-      expect(
-        tasks.find((t) => t.title === 'Primary Election Day'),
-      ).toBeUndefined()
-      expect(
-        tasks.find((t) => t.title === 'General Election Day'),
-      ).toBeUndefined()
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
     })
 
     it('assigns dates in chronological order', async () => {
@@ -1543,13 +1655,12 @@ describe('CampaignTasksService', () => {
       expect(recurring[recurring.length - 1].date).toBeInstanceOf(Date)
     })
 
-    it('does not generate recurring tasks when no election dates exist', async () => {
+    it('does not generate any tasks when no election dates exist', async () => {
       setupForCreation()
 
       await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
 
-      const { recurring } = splitByRecurring(getCreatedTaskData())
-      expect(recurring).toHaveLength(0)
+      expect(mockTxModel.createMany).not.toHaveBeenCalled()
     })
   })
 

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -9,6 +9,7 @@ import {
   getDay,
   isAfter,
   isBefore,
+  isValid,
   startOfDay,
   startOfWeek,
   subWeeks,
@@ -18,6 +19,7 @@ import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import {
   DateFormats,
   formatDate,
+  isDateTodayOrFuture,
   parseIsoDateString,
 } from 'src/shared/util/date.util'
 import { sleep } from 'src/shared/util/sleep.util'
@@ -234,6 +236,22 @@ export class CampaignTasksService extends createPrismaBase(
     subscriber: Subscriber<MessageEvent>,
   ): Promise<void> {
     try {
+      const today = startOfDay(new Date())
+      if (!this.hasActiveElection(campaign, today)) {
+        this.logger.info(
+          {
+            campaignId: campaign.id,
+            electionDate: campaign.details?.electionDate,
+            primaryElectionDate: campaign.details?.primaryElectionDate,
+          },
+          'skipping task generation: no active election',
+        )
+        const tasks = await this.listCampaignTasks(campaign)
+        subscriber.next({ data: { type: 'complete', tasks } })
+        subscriber.complete()
+        return
+      }
+
       subscriber.next({
         data: {
           type: 'progress',
@@ -250,7 +268,7 @@ export class CampaignTasksService extends createPrismaBase(
         return
       }
 
-      await this.generateDefaultTasks(campaign)
+      await this.generateDefaultTasks(campaign, today)
 
       const triggered =
         await this.aiGenerationService.triggerEventGeneration(campaign)
@@ -327,6 +345,10 @@ export class CampaignTasksService extends createPrismaBase(
     campaign: Campaign,
     today = startOfDay(new Date()),
   ) {
+    if (!this.hasActiveElection(campaign, today)) {
+      return
+    }
+
     let created = false
     await this.client.$transaction(async (tx) => {
       await tx.$executeRaw`SELECT pg_advisory_xact_lock(${CAMPAIGN_DEFAULT_TASKS_ADVISORY_LOCK_KEY}::integer, ${campaign.id}::integer)`
@@ -468,13 +490,7 @@ export class CampaignTasksService extends createPrismaBase(
     today: Date,
   ): CampaignTask[] {
     const { details } = campaign
-    if (!details) {
-      return this.distributeTasksOverWindow(
-        generalDefaultTasks,
-        today,
-        addDays(today, MAX_TASK_WINDOW_DAYS),
-      )
-    }
+    if (!details) return []
 
     const primaryDate = this.hasFutureDate(details.primaryElectionDate, today)
     const generalDate = this.hasFutureDate(details.electionDate, today)
@@ -539,11 +555,7 @@ export class CampaignTasksService extends createPrismaBase(
       ]
     }
 
-    return this.distributeTasksOverWindow(
-      generalDefaultTasks,
-      today,
-      addDays(today, MAX_TASK_WINDOW_DAYS),
-    )
+    return []
   }
 
   private resolveElectionDate(campaign: Campaign, today: Date): Date | null {
@@ -571,8 +583,16 @@ export class CampaignTasksService extends createPrismaBase(
     today: Date,
   ): Date | null {
     if (!dateString) return null
-    const date = startOfDay(parseIsoDateString(dateString))
-    return isBefore(date, today) ? null : date
+    if (!isDateTodayOrFuture(dateString, today)) return null
+    return startOfDay(parseIsoDateString(dateString))
+  }
+
+  private hasActiveElection(campaign: Campaign, today: Date): boolean {
+    const { primaryElectionDate, electionDate } = campaign.details ?? {}
+    return (
+      isDateTodayOrFuture(primaryElectionDate, today) ||
+      isDateTodayOrFuture(electionDate, today)
+    )
   }
 
   private distributeTasksOverWindow(
@@ -882,9 +902,31 @@ export class CampaignTasksService extends createPrismaBase(
       select: { details: true },
     })
     const electionDate = campaign.details?.electionDate
+    const electionDay = electionDate
+      ? startOfDay(parseIsoDateString(electionDate))
+      : null
+    if (!electionDay || !isValid(electionDay)) {
+      this.logger.info(
+        { campaignId, electionDate },
+        'skipping event task insert: no valid election date',
+      )
+      return
+    }
     const paradeTasks = this.buildParadeAwarenessTasks(tasks, electionDate)
     const allTasks = [...tasks, ...paradeTasks]
-    const tasksToCreate = this.mapTasksToCreateData(campaignId, allTasks)
+    const filteredTasks = allTasks.filter(
+      (task) =>
+        !isAfter(startOfDay(parseIsoDateString(task.date)), electionDay),
+    )
+    const dropped = allTasks.length - filteredTasks.length
+    if (dropped > 0) {
+      this.logger.info(
+        { campaignId, electionDate, dropped },
+        'dropped event tasks dated after election',
+      )
+    }
+    if (filteredTasks.length === 0) return
+    const tasksToCreate = this.mapTasksToCreateData(campaignId, filteredTasks)
     await this.model.createMany({
       data: tasksToCreate,
       skipDuplicates: true,

--- a/src/campaigns/tasks/tests/complete-tasks.e2e.ts
+++ b/src/campaigns/tasks/tests/complete-tasks.e2e.ts
@@ -33,6 +33,20 @@ test.describe('Campaigns Tasks - Complete Tasks', () => {
     })
     orgSlug = campaignOrgSlug(reg.campaign.id)
 
+    // Default-task generation requires a today-or-future election date.
+    const futureElectionDate = new Date(Date.now() + 180 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10)
+    const updateResponse = await request.put('/v1/campaigns/mine', {
+      headers: authHeaders(reg.token, orgSlug),
+      data: { details: { electionDate: futureElectionDate } },
+    })
+    if (!updateResponse.ok()) {
+      throw new Error(
+        `Campaign update failed: ${updateResponse.status()} ${await updateResponse.text()}`,
+      )
+    }
+
     // Trigger the SSE stream to create default tasks.
     // Use native fetch with AbortController — abort after 5s which is enough
     // for generateDefaultTasks to complete. Playwright's request API blocks

--- a/src/shared/util/date.util.ts
+++ b/src/shared/util/date.util.ts
@@ -1,4 +1,13 @@
-import { DateArg, endOfDay, format, parse, startOfDay, subDays } from 'date-fns'
+import {
+  DateArg,
+  endOfDay,
+  format,
+  isBefore,
+  isValid,
+  parse,
+  startOfDay,
+  subDays,
+} from 'date-fns'
 
 export const toDateOnlyString = (d?: Date | null) => {
   return d ? d.toISOString().slice(0, 10) : undefined
@@ -25,6 +34,16 @@ export const getMidnightForDate = (date: Date) =>
 
 export const parseIsoDateString = (dateString: string) =>
   parse(dateString, DateFormats.isoDate, new Date())
+
+export const isDateTodayOrFuture = (
+  dateString: string | undefined | null,
+  today: Date = startOfDay(new Date()),
+): boolean => {
+  if (!dateString) return false
+  const date = parseIsoDateString(dateString)
+  if (!isValid(date)) return false
+  return !isBefore(startOfDay(date), today)
+}
 
 export const getDateRangeWithDefaults = (
   startDate?: Date,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core campaign task generation behavior by short-circuiting when election dates are missing/past and filtering AI event tasks beyond election day, which could reduce or eliminate task creation for some campaigns if date data is incorrect.
> 
> **Overview**
> Prevents generating tasks for campaigns without an *active* election: `generateTasksStream` now short-circuits (no default tasks, no AI trigger) when both `electionDate` and `primaryElectionDate` are missing or in the past, and `generateDefaultTasks` becomes a no-op in the same cases.
> 
> Adds a shared `isDateTodayOrFuture` date guard and uses it in both task generation and `AiGenerationService.triggerEventGeneration`, so AI event generation is skipped when the election date is missing/past. When ingesting AI results, `addEventTasks` now drops any tasks dated after election day (and drops all tasks if the campaign has no election date), with added logging and updated tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f07bfd2f986efe4ea0cf9a15ea34a24061ce849. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->