### PR TITLE
Simplify Slack notification: plain HubSpot ID without bold or link

### DIFF
--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -375,14 +375,10 @@ export class CampaignTasksService extends createPrismaBase(
 
       const { hubspotId } = campaign.data
 
-      const hubspotLink = hubspotId
-        ? `<https://app.hubspot.com/contacts/21589597/record/0-2/${hubspotId}|${hubspotId}>`
-        : 'N/A'
-
       const slackBody = [
         ':white_check_mark: *AI Campaign Plan Created*',
-        `*Candidate:* ${candidateName}`,
-        `*HubSpot ID:* ${hubspotLink}`,
+        `Candidate: ${candidateName}`,
+        `HubSpot ID: ${hubspotId ?? 'N/A'}`,
         '',
         `*Outreach Tasks (${outreachTasks.length}):*`,
         ...(taskLines.length > 0 ? taskLines : ['None']),


### PR DESCRIPTION
Per request from CAS team:

- Removed bold formatting from `Candidate:` and `HubSpot ID:` labels
- Replaced linked HubSpot ID with plain text (just the ID, no clickable link)

### Before
```
*Candidate:* Daniel Alvarez
*HubSpot ID:* <https://app.hubspot.com/contacts/21589597/record/0-2/12345|12345>
```

### After
```
Candidate: Daniel Alvarez
HubSpot ID: 12345
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk string-formatting change to a Slack message; only affects how the HubSpot ID and candidate label are rendered in notifications.
> 
> **Overview**
> Simplifies the Slack notification sent by `notifySlackDefaultTasksCreated` when an AI campaign plan is created.
> 
> Removes the bolded label formatting and replaces the clickable HubSpot record link with a plain `hubspotId` (or `N/A`) string in the message body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5063e4e2cefdea88e23532db96a951f6e45e78ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->