### PR TITLE
feat: add Meta verified and design materials awareness tasks (ENG-7308)

### DIFF
--- a/src/campaigns/tasks/fixtures/defaultAwarenessTasks.ts
+++ b/src/campaigns/tasks/fixtures/defaultAwarenessTasks.ts
@@ -9,6 +9,22 @@ export const campaignFinanceAwarenessTask: Omit<CampaignTaskTemplate, 'week'> =
     isDefaultTask: true,
   }
 
+export const metaVerifiedAwarenessTask: Omit<CampaignTaskTemplate, 'week'> = {
+  title: 'Get Meta verified',
+  description: 'Get identity verified on Meta to run advertising on FB and IG.',
+  flowType: CampaignTaskType.awareness,
+  isDefaultTask: true,
+}
+
+export const designMaterialsAwarenessTask: Omit<CampaignTaskTemplate, 'week'> =
+  {
+    title: 'Design materials',
+    description:
+      'Design materials such as yard signs, door hangers, palm cards, etc.',
+    flowType: CampaignTaskType.awareness,
+    isDefaultTask: true,
+  }
+
 export const generalAwarenessTasks: CampaignTaskTemplate[] = [
   {
     title: 'Reach 10% of your Voter Contact Goal',

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -820,7 +820,7 @@ describe('CampaignTasksService', () => {
       await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(generalDefaultTasks.length + 1)
+      expect(tasks).toHaveLength(generalDefaultTasks.length + 3)
       expect(tasks[0].date).toBeInstanceOf(Date)
     })
 
@@ -835,7 +835,7 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(generalDefaultTasks.length + 1)
+      expect(tasks).toHaveLength(generalDefaultTasks.length + 3)
       expect(tasks[0].date).toBeInstanceOf(Date)
     })
 
@@ -852,7 +852,7 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(
-        generalDefaultTasks.length + generalAwarenessTasks.length + 1,
+        generalDefaultTasks.length + generalAwarenessTasks.length + 3,
       )
       expect(recurring).toHaveLength(169)
       expect(tasks[0].date).toBeInstanceOf(Date)
@@ -873,7 +873,7 @@ describe('CampaignTasksService', () => {
 
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
-      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length + 1)
+      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length + 3)
       expect(recurring).toHaveLength(85)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
@@ -898,7 +898,7 @@ describe('CampaignTasksService', () => {
         primaryDefaultTasks.length +
           generalDefaultTasks.length +
           generalAwarenessTasks.length +
-          1,
+          3,
       )
       expect(recurring).toHaveLength(169)
       expect(tasks[0].date).toBeInstanceOf(Date)
@@ -952,7 +952,7 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(
-        generalDefaultTasks.length + generalAwarenessTasks.length + 1,
+        generalDefaultTasks.length + generalAwarenessTasks.length + 3,
       )
       expect(recurring).toHaveLength(169)
     })
@@ -972,7 +972,7 @@ describe('CampaignTasksService', () => {
 
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
-      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length + 1)
+      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length + 3)
       expect(recurring).toHaveLength(85)
     })
 
@@ -1033,6 +1033,96 @@ describe('CampaignTasksService', () => {
           t.title === 'Add your campaign finance deadlines to your calendar',
       )
       expect(financeTasks).toHaveLength(0)
+    })
+
+    it('includes the Meta and design materials awareness tasks on Wed/Thu of the week after signup', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: FUTURE_GENERAL },
+        }),
+        TODAY,
+      )
+
+      const tasks = getCreatedTaskData()
+      const meta = tasks.find((t) => t.title === 'Get Meta verified')
+      const design = tasks.find((t) => t.title === 'Design materials')
+
+      expect(meta).toBeDefined()
+      expect(meta!.flowType).toBe(CampaignTaskType.awareness)
+      expect(meta!.isDefaultTask).toBe(true)
+      expect(meta!.date).toEqual(startOfDay(parseIsoDateString('2025-06-11')))
+
+      expect(design).toBeDefined()
+      expect(design!.flowType).toBe(CampaignTaskType.awareness)
+      expect(design!.isDefaultTask).toBe(true)
+      expect(design!.date).toEqual(startOfDay(parseIsoDateString('2025-06-12')))
+    })
+
+    it('includes the Meta and design materials awareness tasks when no election date is set', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
+
+      const tasks = getCreatedTaskData()
+      const meta = tasks.find((t) => t.title === 'Get Meta verified')
+      const design = tasks.find((t) => t.title === 'Design materials')
+
+      expect(meta).toBeDefined()
+      expect(meta!.week).toBe(0)
+      expect(meta!.date).toEqual(startOfDay(parseIsoDateString('2025-06-11')))
+      expect(design).toBeDefined()
+      expect(design!.week).toBe(0)
+      expect(design!.date).toEqual(startOfDay(parseIsoDateString('2025-06-12')))
+    })
+
+    it('omits the Meta and design materials awareness tasks when the election is less than 42 days away', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: '2025-07-12' },
+        }),
+        TODAY,
+      )
+
+      const tasks = getCreatedTaskData()
+      expect(tasks.find((t) => t.title === 'Get Meta verified')).toBeUndefined()
+      expect(tasks.find((t) => t.title === 'Design materials')).toBeUndefined()
+    })
+
+    it('includes the Meta and design materials awareness tasks when the election is exactly 42 days away', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: '2025-07-13' },
+        }),
+        TODAY,
+      )
+
+      const tasks = getCreatedTaskData()
+      expect(tasks.find((t) => t.title === 'Get Meta verified')).toBeDefined()
+      expect(tasks.find((t) => t.title === 'Design materials')).toBeDefined()
+    })
+
+    it('does not include the Meta and design materials awareness tasks when both election dates are past', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: {
+            primaryElectionDate: PAST_PRIMARY,
+            electionDate: PAST_GENERAL,
+          },
+        }),
+        TODAY,
+      )
+
+      const tasks = getCreatedTaskData()
+      expect(tasks.find((t) => t.title === 'Get Meta verified')).toBeUndefined()
+      expect(tasks.find((t) => t.title === 'Design materials')).toBeUndefined()
     })
 
     it('assigns dates in chronological order', async () => {

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -36,7 +36,9 @@ import {
 } from '../campaignTasks.types'
 import {
   campaignFinanceAwarenessTask,
+  designMaterialsAwarenessTask,
   generalAwarenessTasks,
+  metaVerifiedAwarenessTask,
 } from '../fixtures/defaultAwarenessTasks'
 import { defaultRecurringTasks } from '../fixtures/defaultRecurringTasks'
 import { generalDefaultTasks } from '../fixtures/defaultTasks'
@@ -49,6 +51,7 @@ const VOTER_GOALS_ADVISORY_LOCK_KEY = 918_274
 const MAX_TASK_WINDOW_DAYS = 49
 const SHORTENED_WINDOW_BUFFER_DAYS = 7
 const FULL_WINDOW_THRESHOLD_DAYS = 56
+const SIGNUP_AWARENESS_MIN_DAYS_TO_ELECTION = 42
 
 @Injectable()
 export class CampaignTasksService extends createPrismaBase(
@@ -426,6 +429,7 @@ export class CampaignTasksService extends createPrismaBase(
           addDays(today, MAX_TASK_WINDOW_DAYS),
         ),
         this.buildCampaignFinanceAwarenessTask(today, null),
+        ...this.buildSignupAwarenessTasks(today, null),
       ])
     }
 
@@ -455,6 +459,7 @@ export class CampaignTasksService extends createPrismaBase(
           generalDate,
         ),
         this.buildCampaignFinanceAwarenessTask(today, generalDate),
+        ...this.buildSignupAwarenessTasks(today, generalDate),
       ])
     }
 
@@ -471,6 +476,7 @@ export class CampaignTasksService extends createPrismaBase(
           primaryDate,
         ),
         this.buildCampaignFinanceAwarenessTask(today, primaryDate),
+        ...this.buildSignupAwarenessTasks(today, primaryDate),
       ])
     }
 
@@ -492,6 +498,7 @@ export class CampaignTasksService extends createPrismaBase(
           generalDate,
         ),
         this.buildCampaignFinanceAwarenessTask(today, generalDate),
+        ...this.buildSignupAwarenessTasks(today, generalDate),
       ])
     }
 
@@ -506,6 +513,7 @@ export class CampaignTasksService extends createPrismaBase(
             addDays(today, MAX_TASK_WINDOW_DAYS),
           ),
           this.buildCampaignFinanceAwarenessTask(today, null),
+          ...this.buildSignupAwarenessTasks(today, null),
         ])
   }
 
@@ -594,6 +602,39 @@ export class CampaignTasksService extends createPrismaBase(
       week,
       date: formatDate(saturday, DateFormats.isoDate),
     }
+  }
+
+  private buildSignupAwarenessTasks(
+    today: Date,
+    electionDate: Date | null,
+  ): CampaignTask[] {
+    if (
+      electionDate &&
+      differenceInCalendarDays(electionDate, today) <
+        SIGNUP_AWARENESS_MIN_DAYS_TO_ELECTION
+    ) {
+      return []
+    }
+
+    const startOfNextWeek = addDays(startOfWeek(today), 7)
+    const wednesday = addDays(startOfNextWeek, 3)
+    const thursday = addDays(startOfNextWeek, 4)
+
+    const buildTask = (
+      template: Omit<CampaignTaskTemplate, 'week'>,
+      date: Date,
+    ): CampaignTask => ({
+      ...template,
+      week: electionDate
+        ? differenceInWeeks(electionDate, date, { roundingMethod: 'ceil' })
+        : 0,
+      date: formatDate(date, DateFormats.isoDate),
+    })
+
+    return [
+      buildTask(metaVerifiedAwarenessTask, wednesday),
+      buildTask(designMaterialsAwarenessTask, thursday),
+    ]
   }
 
   private computeRecurringTasks(


### PR DESCRIPTION
## Summary

Implements ENG-7308: adds two default awareness items to every campaign plan timeline, designed in the "awareness" style:

- **Get Meta verified** — "Get identity verified on Meta to run advertising on FB and IG."
- **Design materials** — "Design materials such as yard signs, door hangers, palm cards, etc."

## Date logic

- Both tasks are placed in the week **after** the candidate signs up:
  - Meta verified → **Wednesday**
  - Design materials → **Thursday**
- If the next election is **less than 6 weeks (< 42 days)** away, neither task is added.
- If both election dates are in the past, neither task is added (consistent with existing default-task behavior).

## Implementation

- New fixtures `metaVerifiedAwarenessTask` and `designMaterialsAwarenessTask` in `defaultAwarenessTasks.ts`.
- New `buildSignupAwarenessTasks` helper in `campaignTasks.service.ts` that computes the Wed/Thu of the week following `today` from `startOfWeek(today)` and respects the 42-day cutoff.
- Wired into all branches of `orderDefaultTasksForCampaign`, alongside the campaign-finance awareness task added in ENG-7325.

## Tests

Updates the existing distribution tests for the new total counts and adds 5 new tests:

- Wed/Thu placement when general election is future (TODAY = 2025-06-01 → 2025-06-11 / 2025-06-12).
- Both tasks present (week 0) when no election date is set.
- Excluded when election is **41 days** away (\`2025-07-12\`).
- Included when election is exactly **42 days** away (\`2025-07-13\`).
- Excluded when both election dates are past.

All 61 tests in \`campaignTasks.service.test.ts\` pass.

Stacked on top of #1493 (ENG-7325).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default campaign plan generation to insert two new dated awareness tasks and conditionally omit them based on a 42-day election cutoff, which can affect timelines for all new campaigns. Risk is limited to task scheduling/counts and is covered by updated and new unit tests.
> 
> **Overview**
> Adds two new default *awareness* tasks—`Get Meta verified` and `Design materials`—to newly generated campaign plans.
> 
> Updates default-task generation to schedule these on **Wednesday/Thursday of the week after signup**, and to **skip both** when an election date is **< 42 days away** (or when no future election dates exist). Tests are updated for new task counts and expanded with coverage for the Wed/Thu placement and the 42-day boundary/omission cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2126bff08aacbad2da51d24cf570a54ba9bd88c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->