### PR TITLE
Fix cleanup-preview: drain ECS tasks and empty buckets before pulumi destroy

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   schedule:
     # Run every 3 hours
-    - cron: "0 */3 * * *"
+    - cron: '0 */3 * * *'
 
 jobs:
   discover-stale-stacks:
@@ -34,7 +34,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/actions@v6
         with:
-          pulumi-version: "^3"
+          pulumi-version: '^3'
 
       - run: npm ci
 
@@ -75,7 +75,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/actions@v6
         with:
-          pulumi-version: "^3"
+          pulumi-version: '^3'
 
       - run: npm ci
 
@@ -124,6 +124,46 @@ jobs:
             --query 'tasks[0].containers[0].exitCode' \
             --output text 2>/dev/null || echo "unknown")
           echo "Clerk cleanup task exit code: $EXIT_CODE"
+
+      - name: Drain ECS tasks and empty preview buckets
+        run: |
+          STACK_NAME="${{ matrix.stack }}"
+          PR_NUM="${STACK_NAME#gp-api-pr-}"
+          CLUSTER="gp-pr-${PR_NUM}-fargateCluster"
+
+          # Scale services to 0 and stop any running tasks so pulumi destroy can
+          # delete the cluster without hitting ClusterContainsTasksException.
+          CLUSTER_STATUS=$(aws ecs describe-clusters --clusters "$CLUSTER" --query 'clusters[0].status' --output text 2>/dev/null || echo "MISSING")
+          if [ "$CLUSTER_STATUS" = "ACTIVE" ]; then
+            SERVICE_ARNS=$(aws ecs list-services --cluster "$CLUSTER" --query 'serviceArns[]' --output text 2>/dev/null || true)
+            for SERVICE in $SERVICE_ARNS; do
+              echo "Scaling $SERVICE to 0"
+              aws ecs update-service --cluster "$CLUSTER" --service "$SERVICE" --desired-count 0 --no-cli-pager >/dev/null || true
+            done
+
+            TASK_ARNS=$(aws ecs list-tasks --cluster "$CLUSTER" --desired-status RUNNING --query 'taskArns[]' --output text 2>/dev/null || true)
+            if [ -n "$TASK_ARNS" ]; then
+              echo "Stopping active tasks in $CLUSTER: $TASK_ARNS"
+              for TASK in $TASK_ARNS; do
+                aws ecs stop-task --cluster "$CLUSTER" --task "$TASK" --reason "cleanup-preview" --no-cli-pager >/dev/null || true
+              done
+              echo "Waiting for tasks to stop..."
+              aws ecs wait tasks-stopped --cluster "$CLUSTER" --tasks $TASK_ARNS || true
+            fi
+          else
+            echo "Cluster $CLUSTER status=$CLUSTER_STATUS — skipping task drain"
+          fi
+
+          # Preview-scoped buckets have forceDestroy=false in Pulumi (intentional for
+          # prod), so empty them here to avoid BucketNotEmpty on destroy.
+          for BUCKET in "tevyn-poll-csvs-pr-${PR_NUM}" "zip-to-area-code-mappings-pr-${PR_NUM}"; do
+            if aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+              echo "Emptying $BUCKET"
+              aws s3 rm "s3://$BUCKET" --recursive --only-show-errors || true
+            else
+              echo "Bucket $BUCKET not found — skipping"
+            fi
+          done
 
       - name: Destroy Stack
         working-directory: ./deploy


### PR DESCRIPTION
## Why

The scheduled Cleanup Preview workflow has failed every run for the past 4+ cycles (see [recent runs](https://github.com/thegoodparty/gp-api/actions/workflows/cleanup-preview.yml)). Stale preview stacks are accumulating in AWS — cost leak and resource clutter.

## Root cause

Two failure modes, both at the **Destroy Stack** step, after `pulumi destroy` starts:

1. **Every stale stack hits this:**
   ```
   aws:ecs:Cluster ecsCluster deleting (600s) error: ...
   ClusterContainsTasksException: The Cluster cannot be deleted while Tasks are active.
   ```
   Pulumi deletes the ECS Service, but the service's running tasks don't drain within the provider's 10-minute `DeleteCluster` wait, so the cluster delete fails.

2. **Stacks with CSV objects additionally hit:**
   ```
   aws:s3:Bucket tevyn-poll-csvs-bucket deleting (0s) error: ...
   BucketNotEmpty: The bucket you tried to delete is not empty
   ```
   `tevyn-poll-csvs-${stage}` and `zip-to-area-code-mappings-${stage}` are declared with `forceDestroy: false` in `deploy/index.ts`. Intentional for prod, but blocks cleanup for preview.

Flipping `forceDestroy` in Pulumi wouldn't help the already-stuck stacks (their state was written with `forceDestroy: false`), so the workflow handles both cleanups directly before calling `pulumi destroy`.

## Fix

New `Drain ECS tasks and empty preview buckets` step runs between the Clerk cleanup and the Pulumi destroy. For each stale stack it:

- scales the ECS service `desiredCount` to 0
- force-stops any remaining running tasks and waits for them to reach `STOPPED`
- empties the per-PR `tevyn-poll-csvs-pr-N` and `zip-to-area-code-mappings-pr-N` buckets

Everything is guarded with `|| true` / conditional checks so partially-destroyed stacks (missing cluster, missing bucket) don't explode the step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the automated preview cleanup workflow to actively scale down/stop ECS services and delete S3 objects before `pulumi destroy`, which can impact running preview environments if PR/stack identification is wrong or AWS calls behave unexpectedly.
> 
> **Overview**
> Fixes the `cleanup-preview` GitHub Actions workflow so stale preview stacks can be reliably destroyed.
> 
> Before running `pulumi destroy`, the workflow now drains ECS by scaling services to 0 and stopping/waiting for running tasks, and it empties the preview S3 buckets `tevyn-poll-csvs-pr-<N>` and `zip-to-area-code-mappings-pr-<N>` to prevent `ClusterContainsTasksException` and `BucketNotEmpty` failures during teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd1d5cc5c97d7ab5b8171d91415ecdd495d45a1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->