### PR TITLE
feat: add Primary/General Election Day awareness tasks (ENG-7344)

### DIFF
--- a/src/campaigns/tasks/fixtures/defaultAwarenessTasks.ts
+++ b/src/campaigns/tasks/fixtures/defaultAwarenessTasks.ts
@@ -25,6 +25,28 @@ export const designMaterialsAwarenessTask: Omit<CampaignTaskTemplate, 'week'> =
     isDefaultTask: true,
   }
 
+export const primaryElectionDayAwarenessTask: Omit<
+  CampaignTaskTemplate,
+  'week'
+> = {
+  title: 'Primary Election Day',
+  description:
+    'Today is Election Day! Get out and vote, and make sure your supporters do too. Good luck!',
+  flowType: CampaignTaskType.awareness,
+  isDefaultTask: true,
+}
+
+export const generalElectionDayAwarenessTask: Omit<
+  CampaignTaskTemplate,
+  'week'
+> = {
+  title: 'General Election Day',
+  description:
+    'Today is Election Day! Get out and vote, and make sure your supporters do too. Good luck!',
+  flowType: CampaignTaskType.awareness,
+  isDefaultTask: true,
+}
+
 export const generalAwarenessTasks: CampaignTaskTemplate[] = [
   {
     title: 'Reach 10% of your Voter Contact Goal',

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -852,7 +852,7 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(
-        generalDefaultTasks.length + generalAwarenessTasks.length + 3,
+        generalDefaultTasks.length + generalAwarenessTasks.length + 4,
       )
       expect(recurring).toHaveLength(169)
       expect(tasks[0].date).toBeInstanceOf(Date)
@@ -873,7 +873,7 @@ describe('CampaignTasksService', () => {
 
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
-      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length + 3)
+      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length + 4)
       expect(recurring).toHaveLength(85)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
@@ -898,7 +898,7 @@ describe('CampaignTasksService', () => {
         primaryDefaultTasks.length +
           generalDefaultTasks.length +
           generalAwarenessTasks.length +
-          3,
+          5,
       )
       expect(recurring).toHaveLength(169)
       expect(tasks[0].date).toBeInstanceOf(Date)
@@ -952,7 +952,7 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(
-        generalDefaultTasks.length + generalAwarenessTasks.length + 3,
+        generalDefaultTasks.length + generalAwarenessTasks.length + 4,
       )
       expect(recurring).toHaveLength(169)
     })
@@ -972,7 +972,7 @@ describe('CampaignTasksService', () => {
 
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
-      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length + 3)
+      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length + 4)
       expect(recurring).toHaveLength(85)
     })
 
@@ -1125,6 +1125,110 @@ describe('CampaignTasksService', () => {
       expect(tasks.find((t) => t.title === 'Design materials')).toBeUndefined()
     })
 
+    it('includes a General Election Day awareness task on the general election date', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { electionDate: FUTURE_GENERAL },
+        }),
+        TODAY,
+      )
+
+      const electionDayTasks = getCreatedTaskData().filter(
+        (t) => t.title === 'General Election Day',
+      )
+      expect(electionDayTasks).toHaveLength(1)
+      const [electionDayTask] = electionDayTasks
+      expect(electionDayTask.flowType).toBe(CampaignTaskType.awareness)
+      expect(electionDayTask.isDefaultTask).toBe(true)
+      expect(electionDayTask.week).toBe(0)
+      expect(electionDayTask.date).toEqual(
+        startOfDay(parseIsoDateString(FUTURE_GENERAL)),
+      )
+    })
+
+    it('includes a Primary Election Day awareness task on the primary election date when only primary is future', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: { primaryElectionDate: FUTURE_PRIMARY },
+        }),
+        TODAY,
+      )
+
+      const electionDayTasks = getCreatedTaskData().filter(
+        (t) => t.title === 'Primary Election Day',
+      )
+      expect(electionDayTasks).toHaveLength(1)
+      expect(electionDayTasks[0].date).toEqual(
+        startOfDay(parseIsoDateString(FUTURE_PRIMARY)),
+      )
+    })
+
+    it('includes Election Day awareness tasks on both primary and general election dates', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: {
+            primaryElectionDate: FUTURE_PRIMARY,
+            electionDate: FUTURE_GENERAL,
+          },
+        }),
+        TODAY,
+      )
+
+      const tasks = getCreatedTaskData()
+      const primaryDay = tasks.find((t) => t.title === 'Primary Election Day')
+      const generalDay = tasks.find((t) => t.title === 'General Election Day')
+      expect(primaryDay).toBeDefined()
+      expect(primaryDay!.date).toEqual(
+        startOfDay(parseIsoDateString(FUTURE_PRIMARY)),
+      )
+      expect(generalDay).toBeDefined()
+      expect(generalDay!.date).toEqual(
+        startOfDay(parseIsoDateString(FUTURE_GENERAL)),
+      )
+    })
+
+    it('does not include any Election Day awareness task when no election date is set', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
+
+      const tasks = getCreatedTaskData()
+      expect(
+        tasks.find((t) => t.title === 'Primary Election Day'),
+      ).toBeUndefined()
+      expect(
+        tasks.find((t) => t.title === 'General Election Day'),
+      ).toBeUndefined()
+    })
+
+    it('does not include any Election Day awareness task when both election dates are past', async () => {
+      setupForCreation()
+
+      await service.generateDefaultTasks(
+        makeCampaign({
+          details: {
+            primaryElectionDate: PAST_PRIMARY,
+            electionDate: PAST_GENERAL,
+          },
+        }),
+        TODAY,
+      )
+
+      const tasks = getCreatedTaskData()
+      expect(
+        tasks.find((t) => t.title === 'Primary Election Day'),
+      ).toBeUndefined()
+      expect(
+        tasks.find((t) => t.title === 'General Election Day'),
+      ).toBeUndefined()
+    })
+
     it('assigns dates in chronological order', async () => {
       setupForCreation()
 
@@ -1170,7 +1274,7 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(generalDefaultTasks.length + 1)
+      expect(tasks).toHaveLength(generalDefaultTasks.length + 2)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
       expect(tasks[tasks.length - 1].date).toBeInstanceOf(Date)

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -771,6 +771,16 @@ describe('CampaignTasksService', () => {
     const PAST_PRIMARY = '2024-03-01'
     const PAST_GENERAL = '2024-11-04'
 
+    const CAMPAIGN_FINANCE_AWARENESS_COUNT = 1
+    const SIGNUP_AWARENESS_COUNT = 2
+    const ELECTION_DAY_AWARENESS_COUNT_PER_DATE = 1
+    const SIGNUP_WEEK_AWARENESS_COUNT =
+      CAMPAIGN_FINANCE_AWARENESS_COUNT + SIGNUP_AWARENESS_COUNT
+    const SIGNUP_WEEK_AWARENESS_PLUS_ONE_ELECTION_DAY =
+      SIGNUP_WEEK_AWARENESS_COUNT + ELECTION_DAY_AWARENESS_COUNT_PER_DATE
+    const SIGNUP_WEEK_AWARENESS_PLUS_TWO_ELECTION_DAYS =
+      SIGNUP_WEEK_AWARENESS_COUNT + 2 * ELECTION_DAY_AWARENESS_COUNT_PER_DATE
+
     const setupForCreation = () => {
       mockTxModel.count.mockResolvedValueOnce(0)
       mockTxModel.deleteMany.mockResolvedValue({ count: 0 })
@@ -820,7 +830,9 @@ describe('CampaignTasksService', () => {
       await service.generateDefaultTasks(makeCampaign({ details: {} }), TODAY)
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(generalDefaultTasks.length + 3)
+      expect(tasks).toHaveLength(
+        generalDefaultTasks.length + SIGNUP_WEEK_AWARENESS_COUNT,
+      )
       expect(tasks[0].date).toBeInstanceOf(Date)
     })
 
@@ -835,7 +847,9 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(generalDefaultTasks.length + 3)
+      expect(tasks).toHaveLength(
+        generalDefaultTasks.length + SIGNUP_WEEK_AWARENESS_COUNT,
+      )
       expect(tasks[0].date).toBeInstanceOf(Date)
     })
 
@@ -852,7 +866,9 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(
-        generalDefaultTasks.length + generalAwarenessTasks.length + 4,
+        generalDefaultTasks.length +
+          generalAwarenessTasks.length +
+          SIGNUP_WEEK_AWARENESS_PLUS_ONE_ELECTION_DAY,
       )
       expect(recurring).toHaveLength(169)
       expect(tasks[0].date).toBeInstanceOf(Date)
@@ -873,7 +889,10 @@ describe('CampaignTasksService', () => {
 
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
-      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length + 4)
+      expect(nonRecurring).toHaveLength(
+        primaryDefaultTasks.length +
+          SIGNUP_WEEK_AWARENESS_PLUS_ONE_ELECTION_DAY,
+      )
       expect(recurring).toHaveLength(85)
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
@@ -898,7 +917,7 @@ describe('CampaignTasksService', () => {
         primaryDefaultTasks.length +
           generalDefaultTasks.length +
           generalAwarenessTasks.length +
-          5,
+          SIGNUP_WEEK_AWARENESS_PLUS_TWO_ELECTION_DAYS,
       )
       expect(recurring).toHaveLength(169)
       expect(tasks[0].date).toBeInstanceOf(Date)
@@ -952,7 +971,9 @@ describe('CampaignTasksService', () => {
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
       expect(nonRecurring).toHaveLength(
-        generalDefaultTasks.length + generalAwarenessTasks.length + 4,
+        generalDefaultTasks.length +
+          generalAwarenessTasks.length +
+          SIGNUP_WEEK_AWARENESS_PLUS_ONE_ELECTION_DAY,
       )
       expect(recurring).toHaveLength(169)
     })
@@ -972,7 +993,10 @@ describe('CampaignTasksService', () => {
 
       const tasks = getCreatedTaskData()
       const { nonRecurring, recurring } = splitByRecurring(tasks)
-      expect(nonRecurring).toHaveLength(primaryDefaultTasks.length + 4)
+      expect(nonRecurring).toHaveLength(
+        primaryDefaultTasks.length +
+          SIGNUP_WEEK_AWARENESS_PLUS_ONE_ELECTION_DAY,
+      )
       expect(recurring).toHaveLength(85)
     })
 
@@ -1274,7 +1298,11 @@ describe('CampaignTasksService', () => {
       )
 
       const tasks = getCreatedTaskData()
-      expect(tasks).toHaveLength(generalDefaultTasks.length + 2)
+      expect(tasks).toHaveLength(
+        generalDefaultTasks.length +
+          CAMPAIGN_FINANCE_AWARENESS_COUNT +
+          ELECTION_DAY_AWARENESS_COUNT_PER_DATE,
+      )
       expect(tasks[0].date).toBeInstanceOf(Date)
       expect(tasks[0].isDefaultTask).toBe(true)
       expect(tasks[tasks.length - 1].date).toBeInstanceOf(Date)

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -38,7 +38,9 @@ import {
   campaignFinanceAwarenessTask,
   designMaterialsAwarenessTask,
   generalAwarenessTasks,
+  generalElectionDayAwarenessTask,
   metaVerifiedAwarenessTask,
+  primaryElectionDayAwarenessTask,
 } from '../fixtures/defaultAwarenessTasks'
 import { defaultRecurringTasks } from '../fixtures/defaultRecurringTasks'
 import { generalDefaultTasks } from '../fixtures/defaultTasks'
@@ -460,6 +462,16 @@ export class CampaignTasksService extends createPrismaBase(
         ),
         this.buildCampaignFinanceAwarenessTask(today, generalDate),
         ...this.buildSignupAwarenessTasks(today, generalDate),
+        this.buildElectionDayAwarenessTask(
+          primaryElectionDayAwarenessTask,
+          primaryDate,
+          generalDate,
+        ),
+        this.buildElectionDayAwarenessTask(
+          generalElectionDayAwarenessTask,
+          generalDate,
+          generalDate,
+        ),
       ])
     }
 
@@ -477,6 +489,11 @@ export class CampaignTasksService extends createPrismaBase(
         ),
         this.buildCampaignFinanceAwarenessTask(today, primaryDate),
         ...this.buildSignupAwarenessTasks(today, primaryDate),
+        this.buildElectionDayAwarenessTask(
+          primaryElectionDayAwarenessTask,
+          primaryDate,
+          primaryDate,
+        ),
       ])
     }
 
@@ -499,6 +516,11 @@ export class CampaignTasksService extends createPrismaBase(
         ),
         this.buildCampaignFinanceAwarenessTask(today, generalDate),
         ...this.buildSignupAwarenessTasks(today, generalDate),
+        this.buildElectionDayAwarenessTask(
+          generalElectionDayAwarenessTask,
+          generalDate,
+          generalDate,
+        ),
       ])
     }
 
@@ -635,6 +657,20 @@ export class CampaignTasksService extends createPrismaBase(
       buildTask(metaVerifiedAwarenessTask, wednesday),
       buildTask(designMaterialsAwarenessTask, thursday),
     ]
+  }
+
+  private buildElectionDayAwarenessTask(
+    template: Omit<CampaignTaskTemplate, 'week'>,
+    electionDayDate: Date,
+    referenceElectionDate: Date,
+  ): CampaignTask {
+    return {
+      ...template,
+      week: differenceInWeeks(referenceElectionDate, electionDayDate, {
+        roundingMethod: 'ceil',
+      }),
+      date: formatDate(electionDayDate, DateFormats.isoDate),
+    }
   }
 
   private computeRecurringTasks(


### PR DESCRIPTION
## Summary

Implements ENG-7344: adds an Election Day awareness item to every campaign plan timeline so candidates see Election Day itself on their timeline.

Per product (Patrick), the items are split by election type so the title makes it obvious which one is which:

- **Primary Election Day** — placed on the candidate's `primaryElectionDate` when it is in the future.
- **General Election Day** — placed on the candidate's `electionDate` when it is in the future.

Both share the description: _"Today is Election Day! Get out and vote, and make sure your supporters do too. Good luck!"_ — descriptions can be tweaked later by product if desired.

## Implementation

- New `primaryElectionDayAwarenessTask` and `generalElectionDayAwarenessTask` fixtures in `defaultAwarenessTasks.ts`.
- New `buildElectionDayAwarenessTask` helper in `campaignTasks.service.ts` that takes a template + election date and builds the awareness task with the correct `week` (relative to the reference election date) and ISO date.

## Tests

Updates the existing distribution test counts (+1 per future election date) Updates the existing distribution test counts (+1 per future election date) Updates the existintureUpdates the existing distribution test counts (+1 per future election date) Updates the existing distribution test counts (+1 per future election date) Updates the existintureUpdauture.
- Neither task appears when no election date is set.
- Neither task appears when both election dates are past.

All 66 tests in `campaignTasks.service.test.ts` pass.

Stacked on top of #1496 (ENG-7308), which is stacked on #1493 (ENG-7325).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new default awareness tasks and wires them into existing default-task generation logic, with test coverage verifying inclusion/exclusion and dates.
> 
> **Overview**
> Adds new default *awareness* tasks for **`Primary Election Day`** and **`General Election Day`**, scheduled exactly on their respective election dates when those dates are present and not in the past.
> 
> Updates default task generation to append these Election Day items (via a new `buildElectionDayAwarenessTask` helper) across the primary-only, general-only, and combined primary+general timelines, and extends/adjusts unit tests to account for the new tasks and validate correct placement and omission rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87f582e28d6374c0a4c573ad1f7cab39c5b29fe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->