### PR TITLE
Preview teardown: move drain logic from workflow bash into Pulumi

### DIFF
--- a/deploy/components/service.ts
+++ b/deploy/components/service.ts
@@ -51,16 +51,23 @@ export function createService({
   dependsOn,
 }: ServiceConfig): ServiceOutput {
   const isProd = environment === 'prod'
+  const isPreview = environment === 'preview'
   const serviceName = `gp-api-${stage}`
 
   const select = <T>(values: Record<'preview' | 'dev' | 'qa' | 'prod', T>): T =>
     values[environment]
 
   const clusterName = `gp-${stage}-fargateCluster`
-  const cluster = new aws.ecs.Cluster('ecsCluster', {
-    name: clusterName,
-    settings: [{ name: 'containerInsights', value: 'enabled' }],
-  })
+  // Preview cluster gets a wider delete timeout so pulumi destroy can keep
+  // retrying DeleteCluster while tasks drain, without workflow intervention.
+  const cluster = new aws.ecs.Cluster(
+    'ecsCluster',
+    {
+      name: clusterName,
+      settings: [{ name: 'containerInsights', value: 'enabled' }],
+    },
+    isPreview ? { customTimeouts: { delete: '30m' } } : undefined,
+  )
 
   const albSecurityGroup = new aws.ec2.SecurityGroup('albSecurityGroup', {
     name: select({
@@ -119,7 +126,7 @@ export function createService({
     protocol: 'HTTP',
     targetType: 'ip',
     vpcId,
-    deregistrationDelay: 120,
+    deregistrationDelay: isPreview ? 0 : 120,
     healthCheck: {
       path: '/v1/health',
       interval: 60,
@@ -238,6 +245,7 @@ export function createService({
           cpu: parseInt(cpu),
           memory: parseInt(memory),
           essential: true,
+          ...(isPreview ? { stopTimeout: 2 } : {}),
           secrets: sortBy(Object.entries(sec), [([name]) => name]).map(
             ([name, valueFrom]) => ({
               name,
@@ -301,6 +309,9 @@ export function createService({
       },
       enableExecuteCommand: true,
       waitForSteadyState: true,
+      // Preview: force-delete so pulumi destroy doesn't have to scale to 0
+      // and wait before calling DeleteService.
+      forceDelete: isPreview,
     },
     { dependsOn, customTimeouts: { create: '45m', update: '45m' } },
   )

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -97,7 +97,7 @@ export = async () => {
 
   const tevynPollCsvsBucket = new aws.s3.Bucket('tevyn-poll-csvs-bucket', {
     bucket: `tevyn-poll-csvs-${stage}`,
-    forceDestroy: false,
+    forceDestroy: environment === 'preview',
   })
 
   new aws.s3.BucketPublicAccessBlock('tevyn-poll-csvs-pab', {
@@ -110,7 +110,7 @@ export = async () => {
 
   const zipToAreaCodeBucket = new aws.s3.Bucket('zip-to-area-code-bucket', {
     bucket: `zip-to-area-code-mappings-${stage}`,
-    forceDestroy: false,
+    forceDestroy: environment === 'preview',
   })
   new aws.s3.BucketPublicAccessBlock('zip-to-area-code-mappings-pab', {
     bucket: zipToAreaCodeBucket.id,


### PR DESCRIPTION
## Why

#1497 patched the hard-failing cleanup-preview workflow by adding ~40 lines of bash (drain ECS, empty S3) before \`pulumi destroy\`. That works, but it pushes knowledge of preview-specific resource lifetimes into the workflow instead of the stack definition that owns them. The right home for \"this bucket is disposable\" and \"this service can be killed\" is the Pulumi program — then vanilla \`pulumi destroy\` just works, and the workflow stays dumb.

This PR reverses the approach: make preview resources inherently destroyable, then leave the workflow alone. #1497 should be closed in favor of this one.

## What changes (preview only; dev/qa/prod unchanged)

- \`tevyn-poll-csvs\` + \`zip-to-area-code-mappings\` buckets: \`forceDestroy\` flips from hardcoded \`false\` to \`environment === 'preview'\`. Keeps prod/qa/dev safe.
- ECS service: \`forceDelete: true\` for preview, so \`DeleteService\` doesn't require scaling to 0 first and tasks are reaped immediately.
- Target group \`deregistrationDelay\`: 120s → 0 for preview (no real traffic to drain).
- Container \`stopTimeout\`: 2s for preview (SIGKILL follows SIGTERM fast).
- ECS cluster: \`customTimeouts.delete: 30m\` for preview so Pulumi has a wide retry window on \`DeleteCluster\` while any stragglers transition to \`STOPPED\`.

The workflow file (\`cleanup-preview.yml\`) is intentionally untouched — the drain step from #1497 never merged, so there's nothing to revert here.

## Caveat: pre-existing stale stacks

Pulumi only applies \`forceDestroy\` / \`forceDelete\` to resources whose state it re-creates. Stacks whose state was written before this merges still have \`forceDestroy: false\` baked in and will keep failing the same way until manually cleaned up.

Stacks currently stuck in the cleanup-preview workflow (as of the last run before this PR, 2026-04-22 12:25 UTC — 25 stacks):

\`\`\`
gp-api-pr-1260   gp-api-pr-1437   gp-api-pr-1443   gp-api-pr-1462   gp-api-pr-1468
gp-api-pr-1471   gp-api-pr-1472   gp-api-pr-1473   gp-api-pr-1474   gp-api-pr-1476
gp-api-pr-1477   gp-api-pr-1479   gp-api-pr-1480   gp-api-pr-1482   gp-api-pr-1483
gp-api-pr-1484   gp-api-pr-1485   gp-api-pr-1486   gp-api-pr-1490   gp-api-pr-1491
gp-api-pr-1492   gp-api-pr-1493   gp-api-pr-1495   gp-api-pr-1496   gp-api-pr-1498
\`\`\`

Suggested one-shot: run the bash from #1497 manually (or as a throwaway script) against just these stacks, then let the workflow-as-is handle everything from here forward.

## Replaces

Closes and replaces #1497.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes ECS and S3 deletion/teardown behavior for the `preview` environment (force deletes, shortened drain/stop timings), which could cause abrupt shutdown or data loss if misapplied to non-preview stacks.
> 
> **Overview**
> Moves preview-environment teardown behavior into the Pulumi program so `pulumi destroy` can reliably clean up without workflow-side drain/empty steps.
> 
> For `preview` stacks, ECS resources are made more aggressively destroyable: the ECS cluster delete timeout is extended, the service uses `forceDelete`, the target group `deregistrationDelay` is set to `0`, and the task definition sets a short container `stopTimeout`.
> 
> Also marks the `tevyn-poll-csvs` and `zip-to-area-code-mappings` S3 buckets as disposable in `preview` by enabling `forceDestroy`; dev/qa/prod remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56a2379026e0475384ed2fc64becf3bd7074eb1e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->