### PR TITLE
point to new voter db in prod

### DIFF
--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -286,6 +286,10 @@ export = async () => {
           engineVersion: voterClusterLatest.engineVersion,
         })
         voterCluster = voterClusterLatest
+
+        voterCluster = await aws.rds.getCluster({
+          clusterIdentifier: 'gp-voter-db-20260420',
+        })
       }
       break
     case 'preview':
@@ -295,7 +299,7 @@ export = async () => {
       break
     case 'qa':
       voterCluster = await aws.rds.getCluster({
-        clusterIdentifier: 'gp-voter-db-20250728',
+        clusterIdentifier: 'gp-voter-db-20260420',
       })
       break
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Production deploy now resolves the voter database connection to a different existing RDS cluster, which can redirect prod traffic to the wrong dataset or break connectivity if the cluster isn’t ready/compatible.
> 
> **Overview**
> Updates the prod deployment to **override `voterCluster`** by fetching an existing RDS cluster (`gp-voter-db-20260420`) and using it for `VOTER_DB_*` environment variables, instead of the newly created `voterClusterLatest`.
> 
> This effectively repoints the prod voter DB host/user/name to the new cluster identifier while leaving the cluster/instance creation logic in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9893282725a6bf6220a899e1fd4fdc59294ad842. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->