### PR TITLE
Force destroy s3 buckets in preview

### DIFF
--- a/deploy/components/service.ts
+++ b/deploy/components/service.ts
@@ -57,10 +57,14 @@ export function createService({
     values[environment]
 
   const clusterName = `gp-${stage}-fargateCluster`
-  const cluster = new aws.ecs.Cluster('ecsCluster', {
-    name: clusterName,
-    settings: [{ name: 'containerInsights', value: 'enabled' }],
-  })
+  const cluster = new aws.ecs.Cluster(
+    'ecsCluster',
+    {
+      name: clusterName,
+      settings: [{ name: 'containerInsights', value: 'enabled' }],
+    },
+    { dependsOn },
+  )
 
   const albSecurityGroup = new aws.ec2.SecurityGroup('albSecurityGroup', {
     name: select({
@@ -302,7 +306,7 @@ export function createService({
       enableExecuteCommand: true,
       waitForSteadyState: true,
     },
-    { dependsOn, customTimeouts: { create: '45m', update: '45m' } },
+    { customTimeouts: { create: '45m', update: '45m' } },
   )
 
   new aws.route53.Record('dnsARecord', {

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -97,7 +97,7 @@ export = async () => {
 
   const tevynPollCsvsBucket = new aws.s3.Bucket('tevyn-poll-csvs-bucket', {
     bucket: `tevyn-poll-csvs-${stage}`,
-    forceDestroy: false,
+    forceDestroy: environment === 'preview',
   })
 
   new aws.s3.BucketPublicAccessBlock('tevyn-poll-csvs-pab', {
@@ -110,7 +110,7 @@ export = async () => {
 
   const zipToAreaCodeBucket = new aws.s3.Bucket('zip-to-area-code-bucket', {
     bucket: `zip-to-area-code-mappings-${stage}`,
-    forceDestroy: false,
+    forceDestroy: environment === 'preview',
   })
   new aws.s3.BucketPublicAccessBlock('zip-to-area-code-mappings-pab', {
     bucket: zipToAreaCodeBucket.id,


### PR DESCRIPTION
## Why
Preview environments are getting orphaned because the destroys are failing. They're failing because we're missing this flag -- by default, pulumi won't destroy an S3 bucket that still has items in it. This removes the items.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables automatic deletion of objects when destroying preview stacks, which is intentionally destructive but scoped to `environment === 'preview'` buckets.
> 
> **Overview**
> Preview stack teardown is unblocked by setting `forceDestroy: environment === 'preview'` on the `tevyn-poll-csvs` and `zip-to-area-code-mappings` S3 buckets, allowing Pulumi to delete non-empty buckets during destroy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74720201967bf048b97e1f9b7923b6f77037f809. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->