### PR TITLE
Remove temporary deleteAllTasks endpoint

### DIFF
--- a/src/campaigns/tasks/campaignTasks.controller.ts
+++ b/src/campaigns/tasks/campaignTasks.controller.ts
@@ -3,8 +3,6 @@ import {
   Controller,
   Delete,
   Get,
-  HttpCode,
-  HttpStatus,
   MessageEvent,
   Param,
   Put,
@@ -46,13 +44,6 @@ export class CampaignTasksController {
     @Param('id') id: string,
   ) {
     return this.tasksService.unCompleteTask(campaign, id)
-  }
-
-  // TODO: This is a temporary endpoint to delete all tasks for a campaign for testing purposes
-  @Delete()
-  @HttpCode(HttpStatus.NO_CONTENT)
-  async deleteAllTasks(@ReqCampaign() campaign: Campaign) {
-    await this.tasksService.deleteAllTasks(campaign.id)
   }
 
   @Sse('generate/stream')

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -335,12 +335,6 @@ export class CampaignTasksService extends createPrismaBase(
     }
   }
 
-  async deleteAllTasks(campaignId: number) {
-    await this.model.deleteMany({
-      where: { campaignId },
-    })
-  }
-
   async generateDefaultTasks(
     campaign: Campaign,
     today = startOfDay(new Date()),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: removes a testing-only API and its service method; no changes to task generation/completion logic beyond eliminating the bulk-delete capability.
> 
> **Overview**
> Removes the temporary `DELETE /campaigns/tasks` endpoint that bulk-deleted all tasks for a campaign, along with the backing `CampaignTasksService.deleteAllTasks` method.
> 
> Also cleans up now-unused Nest imports (`HttpCode`, `HttpStatus`) from the controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4269ae3e1110f5bdd3e714d9346fbc54d2c79eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->