### PR TITLE
ENG-7254 Pass additional fields to the campaign task lambda.

### DIFF
--- a/src/campaigns/tasks/services/aiGeneration.service.test.ts
+++ b/src/campaigns/tasks/services/aiGeneration.service.test.ts
@@ -286,6 +286,46 @@ describe('AiGenerationService', () => {
       )
     })
 
+    // updateCampaign.schema.ts permits "" on primaryElectionDate. Without the
+    // `|| null` coercion, the strict ISO validator in triggerGeneration would
+    // reject primaryElectionDate="" and the surrounding try/catch would
+    // silently drop event generation for those campaigns.
+    it('coerces empty-string primaryElectionDate to null instead of rejecting', async () => {
+      const result = await service.triggerEventGeneration(
+        makeCampaign({
+          details: {
+            city: 'Boston',
+            state: 'MA',
+            electionDate: '2026-11-04',
+            ballotLevel: 'CITY',
+            primaryElectionDate: '',
+          },
+        } as Partial<Campaign>),
+      )
+
+      expect(result).toBe(true)
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ primaryElectionDate: null }),
+      )
+    })
+
+    it('coerces empty-string state to null in the payload', async () => {
+      await service.triggerEventGeneration(
+        makeCampaign({
+          details: {
+            city: 'Boston',
+            state: '',
+            electionDate: '2026-11-04',
+            ballotLevel: 'CITY',
+          },
+        } as Partial<Campaign>),
+      )
+
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ state: null }),
+      )
+    })
+
     it('falls back to Google Places when details.city is missing but placeId is set', async () => {
       vi.mocked(mockGooglePlacesService.getAddressByPlaceId!).mockResolvedValue(
         placeResponseForCity('Cambridge'),

--- a/src/campaigns/tasks/services/aiGeneration.service.test.ts
+++ b/src/campaigns/tasks/services/aiGeneration.service.test.ts
@@ -313,7 +313,9 @@ describe('AiGenerationService', () => {
     })
 
     it('sends null officeName when organizationSlug is missing', async () => {
-      const campaign = makeCampaign({ organizationSlug: '' } as Partial<Campaign>)
+      const campaign = makeCampaign({
+        organizationSlug: '',
+      } as Partial<Campaign>)
 
       await service.triggerEventGeneration(campaign)
 

--- a/src/campaigns/tasks/services/aiGeneration.service.test.ts
+++ b/src/campaigns/tasks/services/aiGeneration.service.test.ts
@@ -3,9 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AiGenerationService } from './aiGeneration.service'
 import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
 import { S3Service } from 'src/vendors/aws/services/s3.service'
+import { OrganizationsService } from '@/organizations/services/organizations.service'
+import { GooglePlacesService } from '@/vendors/google/services/google-places.service'
 import { CampaignTaskType } from '../campaignTasks.types'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
 import { Campaign } from '@prisma/client'
+import { GooglePlacesApiResponse } from '@/shared/types/GooglePlaces.types'
 
 vi.mock('src/queue/queue.config', () => ({
   queueConfig: {
@@ -27,16 +30,37 @@ const mockS3Service: Partial<S3Service> = {
   getFile: vi.fn(),
 }
 
+const mockOrganizationsService: Partial<OrganizationsService> = {
+  resolvePositionNameByOrganizationSlug: vi.fn(),
+}
+
+const mockGooglePlacesService: Partial<GooglePlacesService> = {
+  getAddressByPlaceId: vi.fn(),
+}
+
 const makeCampaign = (overrides: Partial<Campaign> = {}): Campaign =>
   ({
     id: 1,
+    organizationSlug: 'campaign-1',
+    placeId: null,
     details: {
       city: 'Boston',
       state: 'MA',
       electionDate: '2026-11-04',
+      ballotLevel: 'CITY',
     },
     ...overrides,
   }) as Campaign
+
+const placeResponseForCity = (city: string): GooglePlacesApiResponse => ({
+  address_components: [
+    {
+      long_name: city,
+      short_name: city,
+      types: ['locality', 'political'],
+    },
+  ],
+})
 
 const validS3Payload = JSON.stringify({
   campaignId: 1,
@@ -60,50 +84,63 @@ describe('AiGenerationService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(
+      mockOrganizationsService.resolvePositionNameByOrganizationSlug!,
+    ).mockResolvedValue('Mayor')
     service = new AiGenerationService(
       mockQueueProducer as QueueProducerService,
       mockS3Service as S3Service,
+      mockOrganizationsService as OrganizationsService,
+      mockGooglePlacesService as GooglePlacesService,
       createMockLogger(),
     )
   })
 
   describe('triggerGeneration', () => {
-    it('sends SQS message with correct params', async () => {
+    it('sends the full SQS payload with camelCase keys', async () => {
       await service.triggerGeneration({
         campaignId: 1,
         electionDate: '2026-11-04',
-        city: 'Boston',
         state: 'MA',
+        city: 'Boston',
+        officeName: 'Mayor',
+        officeLevel: 'CITY',
+        primaryElectionDate: '2026-06-02',
       })
 
       expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith({
         campaignId: 1,
-        election_date: '2026-11-04',
-        city: 'Boston',
+        electionDate: '2026-11-04',
         state: 'MA',
+        city: 'Boston',
+        officeName: 'Mayor',
+        officeLevel: 'CITY',
+        primaryElectionDate: '2026-06-02',
       })
     })
 
-    it('throws BadRequestException when city is missing', async () => {
-      await expect(
-        service.triggerGeneration({
-          campaignId: 1,
-          electionDate: '2026-11-04',
-          city: '',
-          state: 'MA',
-        }),
-      ).rejects.toThrow(BadRequestException)
-    })
+    it('sends nulls for missing optional fields', async () => {
+      await service.triggerGeneration({
+        campaignId: 1,
+        electionDate: '2026-11-04',
+        state: null,
+        city: null,
+        officeName: null,
+        officeLevel: null,
+        primaryElectionDate: null,
+      })
 
-    it('throws BadRequestException when state is missing', async () => {
-      await expect(
-        service.triggerGeneration({
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
+        expect.objectContaining({
           campaignId: 1,
           electionDate: '2026-11-04',
-          city: 'Boston',
-          state: '',
+          state: null,
+          city: null,
+          officeName: null,
+          officeLevel: null,
+          primaryElectionDate: null,
         }),
-      ).rejects.toThrow(BadRequestException)
+      )
     })
 
     it('throws BadRequestException when electionDate is missing', async () => {
@@ -111,30 +148,190 @@ describe('AiGenerationService', () => {
         service.triggerGeneration({
           campaignId: 1,
           electionDate: '',
-          city: 'Boston',
           state: 'MA',
+          city: 'Boston',
+          officeName: null,
+          officeLevel: null,
+          primaryElectionDate: null,
         }),
       ).rejects.toThrow(BadRequestException)
+      expect(mockQueueProducer.sendToCampaignPlanQueue).not.toHaveBeenCalled()
+    })
+
+    it('throws BadRequestException when electionDate is malformed', async () => {
+      await expect(
+        service.triggerGeneration({
+          campaignId: 1,
+          electionDate: 'not-a-date',
+          state: 'MA',
+          city: 'Boston',
+          officeName: null,
+          officeLevel: null,
+          primaryElectionDate: null,
+        }),
+      ).rejects.toThrow(BadRequestException)
+      expect(mockQueueProducer.sendToCampaignPlanQueue).not.toHaveBeenCalled()
+    })
+
+    it('throws BadRequestException when electionDate has invalid calendar values', async () => {
+      await expect(
+        service.triggerGeneration({
+          campaignId: 1,
+          electionDate: '2026-13-45',
+          state: 'MA',
+          city: 'Boston',
+          officeName: null,
+          officeLevel: null,
+          primaryElectionDate: null,
+        }),
+      ).rejects.toThrow(BadRequestException)
+      expect(mockQueueProducer.sendToCampaignPlanQueue).not.toHaveBeenCalled()
+    })
+
+    it('throws BadRequestException when primaryElectionDate is malformed', async () => {
+      await expect(
+        service.triggerGeneration({
+          campaignId: 1,
+          electionDate: '2026-11-04',
+          state: 'MA',
+          city: 'Boston',
+          officeName: null,
+          officeLevel: null,
+          primaryElectionDate: 'not-a-date',
+        }),
+      ).rejects.toThrow(BadRequestException)
+      expect(mockQueueProducer.sendToCampaignPlanQueue).not.toHaveBeenCalled()
+    })
+
+    it('accepts null primaryElectionDate and a valid YYYY-MM-DD value', async () => {
+      await service.triggerGeneration({
+        campaignId: 1,
+        electionDate: '2026-11-04',
+        state: 'MA',
+        city: 'Boston',
+        officeName: null,
+        officeLevel: null,
+        primaryElectionDate: '2026-06-02',
+      })
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ primaryElectionDate: '2026-06-02' }),
+      )
     })
   })
 
   describe('triggerEventGeneration', () => {
-    it('returns true when triggered successfully', async () => {
+    it('builds full payload from campaign details + resolved officeName', async () => {
       const result = await service.triggerEventGeneration(makeCampaign())
 
       expect(result).toBe(true)
-      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalled()
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith({
+        campaignId: 1,
+        electionDate: '2026-11-04',
+        state: 'MA',
+        city: 'Boston',
+        officeName: 'Mayor',
+        officeLevel: 'CITY',
+        primaryElectionDate: null,
+      })
     })
 
-    it('returns false when city is missing', async () => {
+    it('includes primaryElectionDate when present', async () => {
+      await service.triggerEventGeneration(
+        makeCampaign({
+          details: {
+            city: 'Boston',
+            state: 'MA',
+            electionDate: '2026-11-04',
+            ballotLevel: 'CITY',
+            primaryElectionDate: '2026-06-02',
+          },
+        } as Partial<Campaign>),
+      )
+
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ primaryElectionDate: '2026-06-02' }),
+      )
+    })
+
+    it('falls back to Google Places when details.city is missing but placeId is set', async () => {
+      vi.mocked(mockGooglePlacesService.getAddressByPlaceId!).mockResolvedValue(
+        placeResponseForCity('Cambridge'),
+      )
       const campaign = makeCampaign({
+        placeId: 'ChIJexample',
+        details: { state: 'MA', electionDate: '2026-11-04' },
+      } as Partial<Campaign>)
+
+      await service.triggerEventGeneration(campaign)
+
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ city: 'Cambridge' }),
+      )
+    })
+
+    it('sends null city when details.city is missing and there is no placeId', async () => {
+      const campaign = makeCampaign({
+        placeId: null,
+        details: { state: 'MA', electionDate: '2026-11-04' },
+      } as Partial<Campaign>)
+
+      await service.triggerEventGeneration(campaign)
+
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ city: null }),
+      )
+    })
+
+    it('sends null city when Google Places call fails', async () => {
+      vi.mocked(mockGooglePlacesService.getAddressByPlaceId!).mockRejectedValue(
+        new Error('Places API down'),
+      )
+      const campaign = makeCampaign({
+        placeId: 'ChIJexample',
         details: { state: 'MA', electionDate: '2026-11-04' },
       } as Partial<Campaign>)
 
       const result = await service.triggerEventGeneration(campaign)
 
-      expect(result).toBe(false)
-      expect(mockQueueProducer.sendToCampaignPlanQueue).not.toHaveBeenCalled()
+      expect(result).toBe(true)
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ city: null }),
+      )
+    })
+
+    it('sends null officeName when organization resolver throws', async () => {
+      vi.mocked(
+        mockOrganizationsService.resolvePositionNameByOrganizationSlug!,
+      ).mockRejectedValue(new Error('election-api unreachable'))
+
+      const result = await service.triggerEventGeneration(makeCampaign())
+
+      expect(result).toBe(true)
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ officeName: null }),
+      )
+    })
+
+    it('sends null officeName when organizationSlug is missing', async () => {
+      const campaign = makeCampaign({ organizationSlug: '' } as Partial<Campaign>)
+
+      await service.triggerEventGeneration(campaign)
+
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ officeName: null }),
+      )
+    })
+
+    it('sends null officeLevel when ballotLevel is missing', async () => {
+      const campaign = makeCampaign({
+        details: { city: 'Boston', state: 'MA', electionDate: '2026-11-04' },
+      } as Partial<Campaign>)
+
+      await service.triggerEventGeneration(campaign)
+
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ officeLevel: null }),
+      )
     })
 
     it('returns false when SQS send fails', async () => {
@@ -306,7 +503,17 @@ describe('AiGenerationService', () => {
         1,
       )
 
-      expect(result[0].link).toBeUndefined()
+      expect(result[0]).toEqual({
+        id: 'event-1-0-2026-04-08T00:00:00Z',
+        title: 'No URL',
+        description: 'Desc',
+        cta: 'Go',
+        flowType: CampaignTaskType.events,
+        week: 1,
+        date: '2026-09-01',
+        link: undefined,
+        proRequired: false,
+      })
     })
   })
 })

--- a/src/campaigns/tasks/services/aiGeneration.service.test.ts
+++ b/src/campaigns/tasks/services/aiGeneration.service.test.ts
@@ -1,5 +1,5 @@
 import { BadGatewayException, BadRequestException } from '@nestjs/common'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AiGenerationService } from './aiGeneration.service'
 import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
 import { S3Service } from 'src/vendors/aws/services/s3.service'
@@ -84,6 +84,11 @@ describe('AiGenerationService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Freeze time so assertions against hard-coded future dates (e.g. the 2026
+    // electionDate in makeCampaign) stay stable after that date has passed in
+    // real life. Fakes only Date — setTimeout/setInterval stay real.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-04-01T12:00:00Z'))
     vi.mocked(
       mockOrganizationsService.resolvePositionNameByOrganizationSlug!,
     ).mockResolvedValue('Mayor')
@@ -94,6 +99,10 @@ describe('AiGenerationService', () => {
       mockGooglePlacesService as GooglePlacesService,
       createMockLogger(),
     )
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   describe('triggerGeneration', () => {
@@ -217,6 +226,30 @@ describe('AiGenerationService', () => {
         expect.objectContaining({ primaryElectionDate: '2026-06-02' }),
       )
     })
+
+    // date-fns parse is lenient about zero-padding and trailing whitespace —
+    // each case below would slip past a pure date-fns check but is rejected
+    // by the regex guard.
+    it.each([
+      ['non-zero-padded month+day', '2026-1-4'],
+      ['non-zero-padded day', '2026-11-4'],
+      ['trailing whitespace', '2026-11-04 '],
+      ['slash separator', '2026/11/04'],
+      ['iso datetime', '2026-11-04T10:00:00'],
+    ])('rejects electionDate with %s (%s)', async (_label, electionDate) => {
+      await expect(
+        service.triggerGeneration({
+          campaignId: 1,
+          electionDate,
+          state: 'MA',
+          city: 'Boston',
+          officeName: null,
+          officeLevel: null,
+          primaryElectionDate: null,
+        }),
+      ).rejects.toThrow(BadRequestException)
+      expect(mockQueueProducer.sendToCampaignPlanQueue).not.toHaveBeenCalled()
+    })
   })
 
   describe('triggerEventGeneration', () => {
@@ -279,6 +312,22 @@ describe('AiGenerationService', () => {
 
       expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
         expect.objectContaining({ city: null }),
+      )
+    })
+
+    it('trims whitespace around details.city before sending', async () => {
+      const campaign = makeCampaign({
+        details: {
+          city: '  Boston  ',
+          state: 'MA',
+          electionDate: '2026-11-04',
+        },
+      } as Partial<Campaign>)
+
+      await service.triggerEventGeneration(campaign)
+
+      expect(mockQueueProducer.sendToCampaignPlanQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ city: 'Boston' }),
       )
     })
 

--- a/src/campaigns/tasks/services/aiGeneration.service.ts
+++ b/src/campaigns/tasks/services/aiGeneration.service.ts
@@ -10,7 +10,14 @@ import { QueueProducerService } from 'src/queue/producer/queueProducer.service'
 import { S3Service } from 'src/vendors/aws/services/s3.service'
 import { campaignPlanQueueConfig } from 'src/queue/queue.config'
 import { CampaignPlanCompleteMessage } from 'src/queue/queue.types'
-import { isDateTodayOrFuture } from 'src/shared/util/date.util'
+import { isValid } from 'date-fns'
+import {
+  isDateTodayOrFuture,
+  parseIsoDateString,
+} from 'src/shared/util/date.util'
+import { OrganizationsService } from '@/organizations/services/organizations.service'
+import { GooglePlacesService } from '@/vendors/google/services/google-places.service'
+import { extractCity } from '@/vendors/google/util/GooglePlaces.util'
 import { CampaignTask, CampaignTaskType } from '../campaignTasks.types'
 
 const LambdaEventTaskSchema = z.object({
@@ -33,47 +40,52 @@ const LambdaResultPayloadSchema = z.object({
 export type LambdaEventTask = z.infer<typeof LambdaEventTaskSchema>
 export type LambdaResultPayload = z.infer<typeof LambdaResultPayloadSchema>
 
+export type CampaignPlanLambdaPayload = {
+  campaignId: number
+  electionDate: string
+  state: string | null
+  city: string | null
+  officeName: string | null
+  officeLevel: string | null
+  primaryElectionDate: string | null
+}
+
 @Injectable()
 export class AiGenerationService {
   constructor(
     private readonly queueProducerService: QueueProducerService,
     private readonly s3Service: S3Service,
+    private readonly organizationsService: OrganizationsService,
+    private readonly googlePlacesService: GooglePlacesService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(AiGenerationService.name)
   }
 
-  async triggerGeneration(params: {
-    campaignId: number
-    electionDate: string
-    city: string
-    state: string
-  }): Promise<void> {
-    if (!params.city || !params.state || !params.electionDate) {
-      this.logger.error(
-        {
-          campaignId: params.campaignId,
-          city: params.city,
-          state: params.state,
-          electionDate: params.electionDate,
-        },
-        'missing required fields for event generation',
-      )
+  async triggerGeneration(payload: CampaignPlanLambdaPayload): Promise<void> {
+    if (
+      !payload.electionDate ||
+      !isValid(parseIsoDateString(payload.electionDate))
+    ) {
       throw new BadRequestException(
-        'Missing required campaign fields for event generation',
+        'electionDate must be a YYYY-MM-DD date string',
+      )
+    }
+    if (
+      payload.primaryElectionDate !== null &&
+      !isValid(parseIsoDateString(payload.primaryElectionDate))
+    ) {
+      throw new BadRequestException(
+        'primaryElectionDate must be a YYYY-MM-DD date string when provided',
       )
     }
 
-    await this.queueProducerService.sendToCampaignPlanQueue({
-      campaignId: params.campaignId,
-      election_date: params.electionDate,
-      city: params.city,
-      state: params.state,
-    })
+    await this.queueProducerService.sendToCampaignPlanQueue(payload)
   }
 
   async triggerEventGeneration(campaign: Campaign): Promise<boolean> {
-    const { city, state, electionDate } = campaign.details ?? {}
+    const details = campaign.details ?? {}
+    const { state, electionDate, ballotLevel, primaryElectionDate } = details
 
     if (!isDateTodayOrFuture(electionDate)) {
       this.logger.info(
@@ -83,13 +95,27 @@ export class AiGenerationService {
       return false
     }
 
+    const [city, officeName] = await Promise.all([
+      this.resolveCity(campaign),
+      this.resolveOfficeName(campaign),
+    ])
+
+    const payload: CampaignPlanLambdaPayload = {
+      campaignId: campaign.id,
+      electionDate: electionDate ?? '',
+      state: state ?? null,
+      city,
+      officeName,
+      officeLevel: ballotLevel ?? null,
+      primaryElectionDate: primaryElectionDate ?? null,
+    }
+
     try {
-      await this.triggerGeneration({
-        campaignId: campaign.id,
-        electionDate: electionDate ?? '',
-        city: city ?? '',
-        state: state ?? '',
-      })
+      this.logger.info(
+        { campaignId: campaign.id, payload },
+        'triggering campaign plan Lambda generation',
+      )
+      await this.triggerGeneration(payload)
     } catch (error) {
       this.logger.warn(
         { campaignId: campaign.id, error },
@@ -98,12 +124,45 @@ export class AiGenerationService {
       return false
     }
 
-    this.logger.info(
-      { campaignId: campaign.id },
-      'triggered campaign plan Lambda generation',
-    )
-
     return true
+  }
+
+  private async resolveCity(campaign: Campaign): Promise<string | null> {
+    const detailsCity = campaign.details?.city
+    if (typeof detailsCity === 'string' && detailsCity.trim() !== '') {
+      return detailsCity
+    }
+
+    if (!campaign.placeId) return null
+
+    try {
+      const place = await this.googlePlacesService.getAddressByPlaceId(
+        campaign.placeId,
+      )
+      return extractCity(place)?.long_name ?? null
+    } catch (error) {
+      this.logger.warn(
+        { campaignId: campaign.id, placeId: campaign.placeId, error },
+        'Google Places city fallback failed — sending null city',
+      )
+      return null
+    }
+  }
+
+  private async resolveOfficeName(campaign: Campaign): Promise<string | null> {
+    if (!campaign.organizationSlug) return null
+
+    try {
+      return await this.organizationsService.resolvePositionNameByOrganizationSlug(
+        campaign.organizationSlug,
+      )
+    } catch (error) {
+      this.logger.warn(
+        { campaignId: campaign.id, error },
+        'office name resolution failed — sending null officeName',
+      )
+      return null
+    }
   }
 
   async readResultFromS3(s3Key: string): Promise<LambdaResultPayload> {

--- a/src/campaigns/tasks/services/aiGeneration.service.ts
+++ b/src/campaigns/tasks/services/aiGeneration.service.ts
@@ -105,14 +105,18 @@ export class AiGenerationService {
       this.resolveOfficeName(campaign),
     ])
 
+    // `|| null` (not `??`) so empty strings in the stored details collapse to
+    // null. updateCampaign.schema.ts lets `primaryElectionDate` be "" — without
+    // this coercion the strict ISO check in triggerGeneration would reject and
+    // the surrounding try/catch would silently drop event generation.
     const payload: CampaignPlanLambdaPayload = {
       campaignId: campaign.id,
       electionDate: electionDate ?? '',
-      state: state ?? null,
+      state: state || null,
       city,
       officeName,
-      officeLevel: ballotLevel ?? null,
-      primaryElectionDate: primaryElectionDate ?? null,
+      officeLevel: ballotLevel || null,
+      primaryElectionDate: primaryElectionDate || null,
     }
 
     try {

--- a/src/campaigns/tasks/services/aiGeneration.service.ts
+++ b/src/campaigns/tasks/services/aiGeneration.service.ts
@@ -50,6 +50,14 @@ export type CampaignPlanLambdaPayload = {
   primaryElectionDate: string | null
 }
 
+const YYYY_MM_DD = /^\d{4}-\d{2}-\d{2}$/
+
+// date-fns parse is permissive with zero-padding (e.g. "2026-1-4" is VALID
+// even with a zero-padded format string), so pair the regex with the calendar
+// validity check.
+const isStrictIsoDate = (s: string): boolean =>
+  YYYY_MM_DD.test(s) && isValid(parseIsoDateString(s))
+
 @Injectable()
 export class AiGenerationService {
   constructor(
@@ -63,17 +71,14 @@ export class AiGenerationService {
   }
 
   async triggerGeneration(payload: CampaignPlanLambdaPayload): Promise<void> {
-    if (
-      !payload.electionDate ||
-      !isValid(parseIsoDateString(payload.electionDate))
-    ) {
+    if (!payload.electionDate || !isStrictIsoDate(payload.electionDate)) {
       throw new BadRequestException(
         'electionDate must be a YYYY-MM-DD date string',
       )
     }
     if (
       payload.primaryElectionDate !== null &&
-      !isValid(parseIsoDateString(payload.primaryElectionDate))
+      !isStrictIsoDate(payload.primaryElectionDate)
     ) {
       throw new BadRequestException(
         'primaryElectionDate must be a YYYY-MM-DD date string when provided',
@@ -129,8 +134,9 @@ export class AiGenerationService {
 
   private async resolveCity(campaign: Campaign): Promise<string | null> {
     const detailsCity = campaign.details?.city
-    if (typeof detailsCity === 'string' && detailsCity.trim() !== '') {
-      return detailsCity
+    if (typeof detailsCity === 'string') {
+      const trimmed = detailsCity.trim()
+      if (trimmed !== '') return trimmed
     }
 
     if (!campaign.placeId) return null

--- a/src/queue/producer/queueProducer.service.ts
+++ b/src/queue/producer/queueProducer.service.ts
@@ -97,9 +97,12 @@ export class QueueProducerService {
 
   async sendToCampaignPlanQueue(body: {
     campaignId: number
-    election_date: string
-    city: string
-    state: string
+    electionDate: string
+    state: string | null
+    city: string | null
+    officeName: string | null
+    officeLevel: string | null
+    primaryElectionDate: string | null
   }): Promise<void> {
     const { localUrl, inputQueueUrl } = campaignPlanQueueConfig
 


### PR DESCRIPTION
Note: The lambda code has to be merged before this code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the SQS payload contract (field names + additional nullable fields) and adds new external lookups (Organizations + Google Places) that affect campaign plan generation triggering.
> 
> **Overview**
> Updates campaign plan generation to send a **new camelCase Lambda payload** including `officeName`, `officeLevel`, and `primaryElectionDate`, and changes `state`/`city` to nullable (replacing the previous `election_date` format).
> 
> `AiGenerationService` now validates `electionDate` (and optional `primaryElectionDate`) as real `YYYY-MM-DD` dates, resolves `officeName` via `OrganizationsService`, and falls back to Google Places to derive `city` from `placeId`—logging and sending `null` when those lookups fail. Tests are expanded to cover the new payload shape, validation, and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd966df583a3b24f91e2c2e1eff7fc00124288b4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->