### PR TITLE
[ENG-7338] - reverts longer timeouts post user migration

### DIFF
--- a/.cursor/rules/plans-must-show-diffs.mdc
+++ b/.cursor/rules/plans-must-show-diffs.mdc
@@ -1,0 +1,36 @@
+---
+description: Plans for code changes MUST present code as diffs, not current or target state alone
+alwaysApply: true
+---
+
+# Plans Must Show Code Diffs
+
+When the user asks for a plan that involves code changes, ALWAYS present the proposed changes as code DIFFS / DELTAS. Never present only the current state, only the target state, or a prose-only description of the edit.
+
+REQUIRED:
+- Show the change as a unified diff with `-` for removed lines and `+` for added lines.
+- Include enough surrounding context lines to make the location unambiguous.
+- Use fenced code blocks with the `diff` language tag, e.g.:
+
+```diff
+-      await signOut({ redirectUrl: getMarketingUrl('/blog') })
++      await signOut({ redirectUrl: getMarketingUrl('/run-for-office') })
+```
+
+- For multi-file plans, provide a separate diff block per file and label each with the file path above the block as a markdown link, e.g. `[app/foo/bar.tsx](app/foo/bar.tsx)`.
+- If a change adds new lines with no removals (or vice versa), still use the `diff` block with `+` (or `-`) prefixes so the delta is unambiguous.
+
+PROHIBITED:
+- Showing the current code only and describing the change in prose.
+- Showing the final/target code only without the prior state.
+- Mixing current and target snippets in separate blocks without diff markers.
+- Any plan for code changes that does not surface every concrete edit as a diff.
+
+RATIONALE:
+- Diffs make the exact change reviewable at a glance.
+- Prevents ambiguity about what is being added, removed, or left alone.
+- Matches how the change will appear in PR review.
+
+ENFORCEMENT:
+- This rule applies to EVERY plan that modifies code, in every repo.
+- If a diff cannot be produced (e.g. brand-new file with no prior content), state that explicitly and still show the full new file inside a normal fenced code block, noting it is a new file.

--- a/deploy/components/service.ts
+++ b/deploy/components/service.ts
@@ -298,7 +298,7 @@ export function createService({
           containerPort: 80,
         },
       ],
-      healthCheckGracePeriodSeconds: 1800,
+      healthCheckGracePeriodSeconds: 120,
       deploymentCircuitBreaker: {
         enable: true,
         rollback: false,
@@ -306,7 +306,7 @@ export function createService({
       enableExecuteCommand: true,
       waitForSteadyState: true,
     },
-    { customTimeouts: { create: '45m', update: '45m' } },
+    { customTimeouts: { create: '5m', update: '5m' } },
   )
 
   new aws.route53.Record('dnsARecord', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "gp-api",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "CC0-1.0",
       "workspaces": [
         "contracts"
@@ -181,7 +182,7 @@
     },
     "contracts": {
       "name": "@goodparty_org/contracts",
-      "version": "0.0.1",
+      "version": "0.2.0",
       "dependencies": {
         "validator": "^13.12.0",
         "zod": "^3.23.8"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Infrastructure deployment settings are tightened (shorter ECS health check grace period and Pulumi create/update timeouts), which could cause service updates to fail or roll back more quickly if startup is slower than expected. Other changes are low risk (editor rule file and lockfile metadata/version bump).
> 
> **Overview**
> **Reverts longer deployment tolerances** by reducing the ECS service `healthCheckGracePeriodSeconds` from `1800` to `120` and Pulumi `customTimeouts` from `45m` to `5m` in `deploy/components/service.ts`.
> 
> Adds a Cursor rule (`.cursor/rules/plans-must-show-diffs.mdc`) enforcing that code-change plans must be presented as unified `diff` blocks, and updates `package-lock.json` metadata (sets root `hasInstallScript: true` and bumps workspace `contracts` version to `0.2.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eadf428e2230f069783f8f0d0b4bc2faa402edc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->