### PR TITLE
[ENG-7471] - Adds isPro as filterable field for users

### DIFF
--- a/contracts/.changeset/list-users-is-pro-filter.md
+++ b/contracts/.changeset/list-users-is-pro-filter.md
@@ -1,0 +1,5 @@
+---
+'@goodparty_org/contracts': patch
+---
+
+Add optional `isPro` to `ListUsersPagination` for filtering users by pro campaign status.

--- a/contracts/src/users/ListUsersPagination.schema.ts
+++ b/contracts/src/users/ListUsersPagination.schema.ts
@@ -15,6 +15,10 @@ export const ListUsersPaginationSchema = FilterablePaginationSchema({
     firstName: paginationFilter,
     lastName: paginationFilter,
     email: paginationFilter,
+    isPro: z
+      .enum(['true', 'false'])
+      .transform((v) => v === 'true')
+      .optional(),
   },
 })
 

--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -41,6 +41,114 @@ describe('UsersService', () => {
     })
   })
 
+  describe('listUsers', () => {
+    let proUserId: number
+    let nonProUserId: number
+    let noCampaignUserId: number
+
+    beforeEach(async () => {
+      const prisma = service.prisma
+      const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+
+      const proUser = await prisma.user.create({
+        data: {
+          email: `pro-user-${suffix}@test.goodparty.org`,
+          firstName: 'Pro',
+          lastName: 'User',
+          name: 'Pro User',
+        },
+      })
+      proUserId = proUser.id
+
+      const orgProSlug = `org-pro-${suffix}`
+      await prisma.organization.create({
+        data: {
+          slug: orgProSlug,
+          ownerId: proUserId,
+        },
+      })
+      await prisma.campaign.create({
+        data: {
+          slug: `camp-pro-${suffix}`,
+          organizationSlug: orgProSlug,
+          userId: proUserId,
+          isPro: true,
+        },
+      })
+
+      const nonProUser = await prisma.user.create({
+        data: {
+          email: `non-pro-user-${suffix}@test.goodparty.org`,
+          firstName: 'NonPro',
+          lastName: 'User',
+          name: 'NonPro User',
+        },
+      })
+      nonProUserId = nonProUser.id
+
+      const orgNpSlug = `org-np-${suffix}`
+      await prisma.organization.create({
+        data: {
+          slug: orgNpSlug,
+          ownerId: nonProUserId,
+        },
+      })
+      await prisma.campaign.create({
+        data: {
+          slug: `camp-np-${suffix}`,
+          organizationSlug: orgNpSlug,
+          userId: nonProUserId,
+          isPro: false,
+        },
+      })
+
+      const noCampaignUser = await prisma.user.create({
+        data: {
+          email: `no-camp-user-${suffix}@test.goodparty.org`,
+          firstName: 'NoCamp',
+          lastName: 'User',
+          name: 'NoCamp User',
+        },
+      })
+      noCampaignUserId = noCampaignUser.id
+    })
+
+    it('returns only users with at least one Pro campaign when isPro=true', async () => {
+      const { data, meta } = await usersService.listUsers({
+        isPro: true,
+        email: '@test.goodparty.org',
+      })
+      const ids = data.map((u) => u.id)
+      expect(ids).toContain(proUserId)
+      expect(ids).not.toContain(nonProUserId)
+      expect(ids).not.toContain(noCampaignUserId)
+      expect(meta.total).toBe(1)
+    })
+
+    it('excludes users with any Pro campaign when isPro=false', async () => {
+      const { data, meta } = await usersService.listUsers({
+        isPro: false,
+        email: '@test.goodparty.org',
+      })
+      const ids = data.map((u) => u.id)
+      expect(ids).not.toContain(proUserId)
+      expect(ids).toContain(nonProUserId)
+      expect(ids).toContain(noCampaignUserId)
+      expect(meta.total).toBe(2)
+    })
+
+    it('returns all seeded users when isPro is omitted', async () => {
+      const { data, meta } = await usersService.listUsers({
+        email: '@test.goodparty.org',
+      })
+      const ids = data.map((u) => u.id)
+      expect(meta.total).toBe(3)
+      expect(ids.sort((a, b) => a - b)).toEqual(
+        [proUserId, nonProUserId, noCampaignUserId].sort((a, b) => a - b),
+      )
+    })
+  })
+
   describe('patchUserMetaData', () => {
     it('should set metadata on user with no existing metadata', async () => {
       const updated = await usersService.patchUserMetaData(service.user.id, {

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -487,6 +487,7 @@ export class UsersService extends createPrismaBase(MODELS.User) {
     firstName,
     lastName,
     email,
+    isPro,
   }: ListUsersPagination): Promise<PaginatedResults<User>> {
     const where: Prisma.UserWhereInput = {
       ...(firstName
@@ -508,6 +509,8 @@ export class UsersService extends createPrismaBase(MODELS.User) {
       ...(email
         ? { email: { contains: email, mode: Prisma.QueryMode.insensitive } }
         : {}),
+      ...(isPro === true ? { campaigns: { some: { isPro: true } } } : {}),
+      ...(isPro === false ? { campaigns: { none: { isPro: true } } } : {}),
     }
 
     const data = await this.model.findMany({

--- a/src/users/users.controller.test.ts
+++ b/src/users/users.controller.test.ts
@@ -172,6 +172,23 @@ describe('UsersController', () => {
       expect(usersService.listUsers).toHaveBeenCalledWith(query)
     })
 
+    it('forwards the isPro filter to the service', async () => {
+      vi.spyOn(usersService, 'listUsers').mockResolvedValue({
+        data: [],
+        meta: { total: 0, offset: 0, limit: 10 },
+      })
+
+      await controller.list({ offset: 0, limit: 10, isPro: true })
+      expect(usersService.listUsers).toHaveBeenCalledWith(
+        expect.objectContaining({ isPro: true }),
+      )
+
+      await controller.list({ offset: 0, limit: 10, isPro: false })
+      expect(usersService.listUsers).toHaveBeenCalledWith(
+        expect.objectContaining({ isPro: false }),
+      )
+    })
+
     it('returns empty data array when no users match', async () => {
       vi.spyOn(usersService, 'listUsers').mockResolvedValue({
         data: [],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new relational filter to the `listUsers` query (`campaigns` some/none `isPro`), which can change result sets and may impact query performance depending on data volume and indexing.
> 
> **Overview**
> Adds support for filtering `listUsers` by `isPro`, parsing the query value as a boolean in `ListUsersPaginationSchema`.
> 
> Updates `UsersService.listUsers` to include Prisma `campaigns` relation predicates: `isPro=true` returns users with at least one Pro campaign, while `isPro=false` excludes any user with a Pro campaign. Tests were added to verify service filtering behavior and that the controller forwards the `isPro` parameter to the service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faeb922f0025b9b3f296373080dab4e56bbf6506. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->