### PR TITLE
this should let us rerun builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,7 +214,21 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Check if image already exists in ECR
+        id: ecr-check
+        run: |
+          if aws ecr describe-images \
+            --repository-name gp-api \
+            --image-ids imageTag="${{ github.sha }}" \
+            --region "${AWS_REGION}" >/dev/null 2>&1; then
+            echo "Image ${IMAGE_URI} already exists in ECR; skipping build/push."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push Docker image
+        if: steps.ecr-check.outputs.exists != 'true'
         run: |
           docker build -t "${IMAGE_URI}" -f deploy/Dockerfile .
           docker push "${IMAGE_URI}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow change limited to the Docker build/push step; main risk is incorrectly skipping a rebuild if an image with the same tag exists but needs to be replaced.
> 
> **Overview**
> Adds an ECR pre-check in `.github/workflows/main.yml` to detect whether the `gp-api` image tagged with the current `github.sha` already exists, and **conditionally skips** the Docker `build`/`push` step when it does.
> 
> This enables rerunning the workflow without failing or re-uploading the same image, while leaving the Pulumi deploy flow unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a98f91c24f83d997ddbe0cbe23a96769561162b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->