### PR TITLE
Fix voter export audience filter after voter DB refresh

### DIFF
--- a/src/voters/voterFile/util/voterFile.util.ts
+++ b/src/voters/voterFile/util/voterFile.util.ts
@@ -333,50 +333,50 @@ function customFiltersToQuery(filters: CustomFilter[]) {
     switch (filter) {
       case 'audience_superVoters':
         filterConditions.audience.push(`CASE
-                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
-                                          THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
+                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?$'
+                                          THEN CAST("Voters_VotingPerformanceEvenYearGeneral" AS numeric)
                                           ELSE NULL
                                         END > 75`)
         break
       case 'audience_likelyVoters':
         filterConditions.audience.push(`(CASE
-                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
-                                          THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
+                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?$'
+                                          THEN CAST("Voters_VotingPerformanceEvenYearGeneral" AS numeric)
                                           ELSE NULL
                                         END > 50 AND
                                         CASE
-                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
-                                          THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
+                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?$'
+                                          THEN CAST("Voters_VotingPerformanceEvenYearGeneral" AS numeric)
                                           ELSE NULL
                                         END <= 75)`)
         break
       case 'audience_unreliableVoters':
         filterConditions.audience.push(`(CASE
-                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
-                                          THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
+                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?$'
+                                          THEN CAST("Voters_VotingPerformanceEvenYearGeneral" AS numeric)
                                           ELSE NULL
                                         END > 25 AND
                                         CASE
-                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
-                                          THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
+                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?$'
+                                          THEN CAST("Voters_VotingPerformanceEvenYearGeneral" AS numeric)
                                           ELSE NULL
                                         END <= 50)`)
         break
       case 'audience_unlikelyVoters':
         filterConditions.audience.push(`(CASE
-                                              WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
-                                              THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
+                                              WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?$'
+                                              THEN CAST("Voters_VotingPerformanceEvenYearGeneral" AS numeric)
                                               ELSE NULL
                                             END > 1 AND
                                             CASE
-                                              WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
-                                              THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
+                                              WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?$'
+                                              THEN CAST("Voters_VotingPerformanceEvenYearGeneral" AS numeric)
                                               ELSE NULL
                                             END <= 25)`)
         break
       case 'audience_firstTimeVoters':
         filterConditions.audience.push(
-          `"Voters_VotingPerformanceEvenYearGeneral" IN ('0%', 'Not Eligible', '')`,
+          `"Voters_VotingPerformanceEvenYearGeneral" IN ('0.0', '0%', 'Not Eligible', '')`,
         )
         break
       case 'party_independent':

--- a/src/voters/voterFile/util/voterFile.util.ts
+++ b/src/voters/voterFile/util/voterFile.util.ts
@@ -376,7 +376,7 @@ function customFiltersToQuery(filters: CustomFilter[]) {
         break
       case 'audience_firstTimeVoters':
         filterConditions.audience.push(
-          `"Voters_VotingPerformanceEvenYearGeneral" IN ('0.0', '0%', 'Not Eligible', '')`,
+          `("Voters_VotingPerformanceEvenYearGeneral" IS NULL OR "Voters_VotingPerformanceEvenYearGeneral" = '0.0')`,
         )
         break
       case 'party_independent':


### PR DESCRIPTION
**DO NOT MERGE**, For reference only to illustrate the root cause of the bug.

## Summary

After #1502 pointed prod at `gp-voter-db-20260420`, all voter exports using a Super Voters / Likely / Unreliable / Unlikely audience started returning zero rows.

Root cause: the new voter DB changed `Voters_VotingPerformanceEvenYearGeneral` from percent strings (`"75%"`, `"0%"`) to decimal strings (`"75.0"`, `"0.0"` / `NULL`). The audience filters in `voterFile.util.ts` gate on the regex `^[0-9]+%$`, which matches zero rows in the new data (verified: 0 / 17.96M rows in `VoterTX`).

## Changes

- Update all four `audience_*Voters` CASE expressions to match `^[0-9]+(\.[0-9]+)?$` and cast the column directly (no `%` to strip anymore). Double-backslash in the JS template literal so the regex reaches Postgres as `\.`.
- Add `'0.0'` to the `audience_firstTimeVoters` IN list alongside the legacy `'0%'` / `'Not Eligible'` / `''` sentinels, which no longer appear in the new data.

## Verification

Ran the original failing query (Super Voters 75%+, Independent/Non-Partisan, 18-35, M/F) against `psql service=voters` for `City = 'ROSENBERG CITY'` using the fixed SQL: returns 181 rows (was 0).

Sampled 100 random `VoterTX` rows from the old DB (`voters_old`) and new DB (`voters`) and profiled every shared column. The only other format-level change I found is election-history columns (`General_YYYY`, `Primary_YYYY`, `AnyElection_YYYY`, `OtherElection_YYYY`, `PresidentialPrimary_YYYY`) moving from `"Y"` / empty to `"true"` / empty. These columns are only SELECTed for CSV output, never used in WHERE clauses, so no filter code is affected — flagging it here because the exported CSV will now contain `true` instead of `Y` for consumers downstream.

## Test plan

- [ ] Attempt a voter export with audience = Super Voters 75%+ and confirm a non-zero row count for a known city.
- [ ] Confirm each audience bucket (Super / Likely / Unreliable / Unlikely / First-time) returns a sensible distribution.
- [ ] Spot-check that the exported CSV's "Likelihood to vote" column now shows decimal values (e.g. `75.0`) instead of percent strings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized SQL filter updates that only affect voter export audience segmentation based on `Voters_VotingPerformanceEvenYearGeneral`. Main risk is unintended row selection changes if the new numeric/decimal formats vary from expectations.
> 
> **Overview**
> Voter export audience segmentation now treats `Voters_VotingPerformanceEvenYearGeneral` as a *decimal-formatted* numeric string rather than a percent string.
> 
> This updates the `audience_superVoters` / `audience_likelyVoters` / `audience_unreliableVoters` / `audience_unlikelyVoters` CASE/regex checks to match and cast `^[0-9]+(\.[0-9]+)?$` values, and expands `audience_firstTimeVoters` to include `'0.0'` alongside legacy sentinel values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a30ebdfd7af4802d9b4764f6893353699ae0eef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->