### PR TITLE
fix(voters): accept new L2 numeric performance format in audience filters (ENG-7518)

### DIFF
--- a/src/voters/voterFile/util/voterFile.util.ts
+++ b/src/voters/voterFile/util/voterFile.util.ts
@@ -333,50 +333,50 @@ function customFiltersToQuery(filters: CustomFilter[]) {
     switch (filter) {
       case 'audience_superVoters':
         filterConditions.audience.push(`CASE
-                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
+                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?%?$'
                                           THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
                                           ELSE NULL
                                         END > 75`)
         break
       case 'audience_likelyVoters':
         filterConditions.audience.push(`(CASE
-                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
+                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?%?$'
                                           THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
                                           ELSE NULL
                                         END > 50 AND
                                         CASE
-                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
+                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?%?$'
                                           THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
                                           ELSE NULL
                                         END <= 75)`)
         break
       case 'audience_unreliableVoters':
         filterConditions.audience.push(`(CASE
-                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
+                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?%?$'
                                           THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
                                           ELSE NULL
                                         END > 25 AND
                                         CASE
-                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
+                                          WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?%?$'
                                           THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
                                           ELSE NULL
                                         END <= 50)`)
         break
       case 'audience_unlikelyVoters':
         filterConditions.audience.push(`(CASE
-                                              WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
+                                              WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?%?$'
                                               THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
                                               ELSE NULL
                                             END > 1 AND
                                             CASE
-                                              WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+%$'
+                                              WHEN "Voters_VotingPerformanceEvenYearGeneral" ~ '^[0-9]+(\\.[0-9]+)?%?$'
                                               THEN CAST(REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '') AS numeric)
                                               ELSE NULL
                                             END <= 25)`)
         break
       case 'audience_firstTimeVoters':
         filterConditions.audience.push(
-          `"Voters_VotingPerformanceEvenYearGeneral" IN ('0%', 'Not Eligible', '')`,
+          `("Voters_VotingPerformanceEvenYearGeneral" IN ('0', '0.0', '0%', 'Not Eligible', '') OR "Voters_VotingPerformanceEvenYearGeneral" IS NULL)`,
         )
         break
       case 'party_independent':


### PR DESCRIPTION
## Summary

Fixes [ENG-7518](https://goodparty.atlassian.net/browse/ENG-7518) — "Texting audience not populating" affecting prod users (shonraybrooks@gmail.com, hunnyforcitycouncil@gmail.com, cole.ty9@gmail.com, euanblackman@yahoo.com).

After #1502 pointed prod and qa at the re-cut voter cluster `gp-voter-db-20260420`, the `Voters_VotingPerformanceEvenYearGeneral` column now contains values like `'75.0'` / `'0.0'` / `NULL` instead of the legacy `'75%'` / `'0%'` strings. Every audience filter in `customFiltersToQuery` was gated on a regex `^[0-9]+%$` that no longer matches anything in the new format, so:

- `audience_superVoters`, `audience_likelyVoters`, `audience_unreliableVoters`, `audience_unlikelyVoters` → CASE returns `NULL` for every row → `NULL > 75` is `NULL` → row excluded → **0 results regardless of city / party / age / gender**
- `audience_firstTimeVoters` → `IN ('0%', 'Not Eligible', '')` no longer matches `'0.0'` / `NULL`

This was originally surfaced and diagnosed by @cmecca / @danpelota (suggestion in #1519). This PR ships an equivalent fix that's tolerant of **both** formats so it works on prod/qa (new cluster, numeric format) **and** dev (`gp-voter-db-develop`, still on the legacy `'75%'` format).

## Changes

`src/voters/voterFile/util/voterFile.util.ts`:

- Loosen the audience CASE regex from `'^[0-9]+%$'` → `'^[0-9]+(\.[0-9]+)?%?$'` so it accepts both `'75%'` and `'75.0'` / `'75'`. The existing `REPLACE("Voters_VotingPerformanceEvenYearGeneral", '%', '')` is preserved as a no-op on values that lack a `%`.
- Expand `audience_firstTimeVoters` to also match `'0'`, `'0.0'`, and `NULL` so first-time voters previously surfaced via the legacy `'Not Eligible'` / `''` sentinels are still captured.

## Tradeoff vs #1519

#1519 hard-switches the regex to `'^[0-9]+(\.[0-9]+)?$'` (no `%`). That works on prod/qa today but would silently return 0 on dev (which still has `'75%'` data) and would re-break dev the moment its voter DB is also re-cut from L2. The tolerant version here avoids that whiplash.

## Testing

- [ ] Verified with audience filter selected against prod cluster (`gp-voter-db-20260420`) — counts populate.
- [ ] Verified with audience filter selected against dev cluster (`gp-voter-db-develop`) — counts populate (no regression).
- [ ] No new lint/type errors introduced (file already exceeds preexisting complexity caps).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies SQL filter generation for voter audience segmentation; a regex/NULL-handling mistake could change targeting counts or exclude/include voters unexpectedly.
> 
> **Overview**
> Fixes audience segmentation queries when `Voters_VotingPerformanceEvenYearGeneral` is stored as numeric/decimal strings instead of legacy percent strings.
> 
> The audience CASE expressions now match integers/decimals with an optional `%`, and the `audience_firstTimeVoters` condition also treats `'0'`/`'0.0'` and `NULL` as first-time voters, restoring results across DB formats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be245c322d15da40a844d065ee73ec27c8efaeaa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->