### PR TITLE
bumping the timeouts again to get DEV deployments unblocked

### DIFF
--- a/deploy/components/service.ts
+++ b/deploy/components/service.ts
@@ -298,7 +298,7 @@ export function createService({
           containerPort: 80,
         },
       ],
-      healthCheckGracePeriodSeconds: 120,
+      healthCheckGracePeriodSeconds: 600,
       deploymentCircuitBreaker: {
         enable: true,
         rollback: false,
@@ -308,7 +308,7 @@ export function createService({
       enableExecuteCommand: true,
       waitForSteadyState: true,
     },
-    { customTimeouts: { create: '5m', update: '5m' } },
+    { customTimeouts: { create: '15m', update: '15m' } },
   )
 
   new aws.route53.Record('dnsARecord', {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to deployment timing; may slow feedback but helps avoid premature health check failures and resource timeout errors during deploys.
> 
> **Overview**
> Increases ECS `healthCheckGracePeriodSeconds` from `120` to `600` to give new tasks more time to become healthy during deployments.
> 
> Extends Pulumi `customTimeouts` for ECS service `create`/`update` from `5m` to `15m` to prevent infrastructure updates from timing out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a16d28177de2b7ef2d534d3d8fb1077c80092a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->