### PR TITLE
ENG-7494: Send campaign plan Slack message only on free→Pro upgrade

### DIFF
--- a/prisma/schema/campaign.jsonTypes.d.ts
+++ b/prisma/schema/campaign.jsonTypes.d.ts
@@ -29,6 +29,7 @@ declare global {
       runForOffice?: 'yes' | 'no' | null
       pledged?: boolean
       isProUpdatedAt?: number // TODO: make this an ISO dateTime string
+      proUpgradeSlackNotifiedAt?: number
       customIssues?: Record<'title' | 'position', string>[]
       runningAgainst?: Record<'name' | 'party' | 'description', string>[]
       geoLocation?: {

--- a/src/campaigns/schemas/updateCampaign.schema.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.ts
@@ -26,6 +26,7 @@ const CampaignDetailsSchema = z
     runForOffice: z.enum(['yes', 'no']),
     pledged: z.boolean(),
     isProUpdatedAt: z.number(),
+    proUpgradeSlackNotifiedAt: z.number(),
     customIssues: z.array(
       z.object({
         title: z.string(),

--- a/src/campaigns/services/campaigns.service.test.ts
+++ b/src/campaigns/services/campaigns.service.test.ts
@@ -25,6 +25,7 @@ import {
 import { CampaignPlanVersionsService } from './campaignPlanVersions.service'
 import { CampaignsService } from './campaigns.service'
 import { CrmCampaignsService } from './crmCampaigns.service'
+import { CampaignTasksService } from '../tasks/services/campaignTasks.service'
 
 const GP_POSITION_ID = 'gp-position-uuid-123'
 const BR_POSITION_ID = 'br-position-456'
@@ -113,6 +114,10 @@ const buildOrgSyncModule = async (overrides?: {
       },
       { provide: OrganizationsService, useValue: {} },
       { provide: SlackService, useValue: {} },
+      {
+        provide: CampaignTasksService,
+        useValue: { notifySlackOnProUpgrade: vi.fn() },
+      },
       { provide: PinoLogger, useValue: createMockLogger() },
       CampaignsService,
     ],
@@ -484,6 +489,10 @@ describe('CampaignsService - redeemFreeTexts', () => {
         {
           provide: SlackService,
           useValue: {},
+        },
+        {
+          provide: CampaignTasksService,
+          useValue: { notifySlackOnProUpgrade: vi.fn() },
         },
         // Provide CampaignsService LAST - all dependencies are now available
         { provide: PinoLogger, useValue: createMockLogger() },
@@ -863,6 +872,7 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
       mockElections as ElectionsService,
       mockOrganizations as OrganizationsService,
       {} as SlackService,
+      { notifySlackOnProUpgrade: vi.fn() } as unknown as CampaignTasksService,
     )
   })
 

--- a/src/campaigns/services/campaigns.service.ts
+++ b/src/campaigns/services/campaigns.service.ts
@@ -41,6 +41,7 @@ import {
 } from '../campaigns.types'
 import { CampaignPlanVersionsService } from './campaignPlanVersions.service'
 import { CrmCampaignsService } from './crmCampaigns.service'
+import { CampaignTasksService } from '../tasks/services/campaignTasks.service'
 
 enum CandidateVerification {
   yes = 'YES',
@@ -61,6 +62,8 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
     private readonly elections: ElectionsService,
     private readonly organizations: OrganizationsService,
     private readonly slack: SlackService,
+    @Inject(forwardRef(() => CampaignTasksService))
+    private readonly campaignTasks: WrapperType<CampaignTasksService>,
   ) {
     super()
   }
@@ -416,6 +419,10 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
     await this.patchCampaignDetails(campaignId, {
       isProUpdatedAt: Date.now(),
     }) // TODO: this should be an ISO dateTime string, not a unix timestamp
+
+    if (isBecomingProFirstTime) {
+      void this.campaignTasks.notifySlackOnProUpgrade(campaignId)
+    }
 
     if (trackCampaign) {
       const updatedIsPro = campaign?.isPro

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -67,6 +67,10 @@ const mockSlackService: Partial<SlackService> = {
   message: vi.fn(),
 }
 
+const mockCampaignsService = {
+  patchCampaignDetails: vi.fn(),
+}
+
 type CampaignOverrides = Partial<
   Omit<Campaign, 'details' | 'data' | 'aiContent'>
 > & {
@@ -119,6 +123,7 @@ describe('CampaignTasksService', () => {
     service = new CampaignTasksService(
       mockAiGeneration as AiGenerationService,
       mockSlackService as SlackService,
+      mockCampaignsService as never,
     )
     Object.defineProperty(service, '_prisma', {
       get: () => ({
@@ -969,19 +974,15 @@ describe('CampaignTasksService', () => {
       mockCampaignModel.findUnique = vi.fn().mockResolvedValue({ details: {} })
       mockModel.count.mockResolvedValueOnce(1)
       mockCampaignModel.findUniqueOrThrow.mockResolvedValue(candidateMock)
-      mockCampaignModel.update.mockResolvedValue({})
+      mockCampaignsService.patchCampaignDetails.mockResolvedValue({})
 
       await service.notifySlackOnProUpgrade(1)
 
       expect(mockSlackService.message).toHaveBeenCalledTimes(1)
-      expect(mockCampaignModel.update).toHaveBeenCalledWith({
-        where: { id: 1 },
-        data: {
-          details: expect.objectContaining({
-            proUpgradeSlackNotifiedAt: expect.any(Number),
-          }),
-        },
-      })
+      expect(mockCampaignsService.patchCampaignDetails).toHaveBeenCalledWith(
+        1,
+        { proUpgradeSlackNotifiedAt: expect.any(Number) },
+      )
     })
 
     it('does nothing if proUpgradeSlackNotifiedAt is already set', async () => {
@@ -993,7 +994,7 @@ describe('CampaignTasksService', () => {
 
       expect(mockModel.count).not.toHaveBeenCalled()
       expect(mockSlackService.message).not.toHaveBeenCalled()
-      expect(mockCampaignModel.update).not.toHaveBeenCalled()
+      expect(mockCampaignsService.patchCampaignDetails).not.toHaveBeenCalled()
     })
 
     it('does not send Slack if no default tasks exist', async () => {
@@ -1003,7 +1004,7 @@ describe('CampaignTasksService', () => {
       await service.notifySlackOnProUpgrade(1)
 
       expect(mockSlackService.message).not.toHaveBeenCalled()
-      expect(mockCampaignModel.update).not.toHaveBeenCalled()
+      expect(mockCampaignsService.patchCampaignDetails).not.toHaveBeenCalled()
     })
 
     it('does nothing when the campaign has no details', async () => {
@@ -1019,7 +1020,7 @@ describe('CampaignTasksService', () => {
       mockCampaignModel.findUnique = vi.fn().mockResolvedValue({ details: {} })
       mockModel.count.mockResolvedValueOnce(1)
       mockCampaignModel.findUniqueOrThrow.mockResolvedValue(candidateMock)
-      mockCampaignModel.update.mockResolvedValue({})
+      mockCampaignsService.patchCampaignDetails.mockResolvedValue({})
 
       const messageMock = vi.mocked(mockSlackService.message!)
       messageMock.mockReset()
@@ -1031,14 +1032,14 @@ describe('CampaignTasksService', () => {
       await service.notifySlackOnProUpgrade(1)
 
       expect(messageMock).toHaveBeenCalledTimes(3)
-      expect(mockCampaignModel.update).toHaveBeenCalled()
+      expect(mockCampaignsService.patchCampaignDetails).toHaveBeenCalled()
     })
 
     it('swallows errors when slack fails on all 3 attempts', async () => {
       mockCampaignModel.findUnique = vi.fn().mockResolvedValue({ details: {} })
       mockModel.count.mockResolvedValueOnce(1)
       mockCampaignModel.findUniqueOrThrow.mockResolvedValue(candidateMock)
-      mockCampaignModel.update.mockClear()
+      mockCampaignsService.patchCampaignDetails.mockClear()
 
       const messageMock = vi.mocked(mockSlackService.message!)
       messageMock.mockReset()
@@ -1046,7 +1047,7 @@ describe('CampaignTasksService', () => {
 
       await expect(service.notifySlackOnProUpgrade(1)).resolves.not.toThrow()
       expect(messageMock).toHaveBeenCalledTimes(3)
-      expect(mockCampaignModel.update).not.toHaveBeenCalled()
+      expect(mockCampaignsService.patchCampaignDetails).not.toHaveBeenCalled()
     })
   })
 

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -975,6 +975,7 @@ describe('CampaignTasksService', () => {
       mockModel.count.mockResolvedValueOnce(1)
       mockCampaignModel.findUniqueOrThrow.mockResolvedValue(candidateMock)
       mockCampaignsService.patchCampaignDetails.mockResolvedValue({})
+      vi.mocked(mockSlackService.message!).mockResolvedValue('ok')
 
       await service.notifySlackOnProUpgrade(1)
 
@@ -1027,12 +1028,27 @@ describe('CampaignTasksService', () => {
       messageMock
         .mockRejectedValueOnce(new Error('boom1'))
         .mockRejectedValueOnce(new Error('boom2'))
-        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce('ok')
 
       await service.notifySlackOnProUpgrade(1)
 
       expect(messageMock).toHaveBeenCalledTimes(3)
       expect(mockCampaignsService.patchCampaignDetails).toHaveBeenCalled()
+    })
+
+    it('retries when slack returns no data (swallowed failure)', async () => {
+      mockCampaignModel.findUnique = vi.fn().mockResolvedValue({ details: {} })
+      mockModel.count.mockResolvedValueOnce(1)
+      mockCampaignModel.findUniqueOrThrow.mockResolvedValue(candidateMock)
+      mockCampaignsService.patchCampaignDetails.mockClear()
+
+      const messageMock = vi.mocked(mockSlackService.message!)
+      messageMock.mockReset()
+      messageMock.mockResolvedValue(undefined)
+
+      await expect(service.notifySlackOnProUpgrade(1)).resolves.not.toThrow()
+      expect(messageMock).toHaveBeenCalledTimes(3)
+      expect(mockCampaignsService.patchCampaignDetails).not.toHaveBeenCalled()
     })
 
     it('swallows errors when slack fails on all 3 attempts', async () => {

--- a/src/campaigns/tasks/services/campaignTasks.service.test.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.test.ts
@@ -42,6 +42,7 @@ const mockCampaignUpdateHistoryModel = {
 }
 
 const mockCampaignModel = {
+  findUnique: vi.fn(),
   findUniqueOrThrow: vi.fn(),
   update: vi.fn(),
 }
@@ -841,11 +842,28 @@ describe('CampaignTasksService', () => {
         ],
       })
 
-      await service.generateDefaultTasks(campaignWithFutureElection(), TODAY)
+      await service.generateDefaultTasks(
+        makeCampaign({
+          isPro: true,
+          details: { electionDate: '2026-11-03' },
+        }),
+        TODAY,
+      )
 
       expect(mockTransaction).toHaveBeenCalled()
       expect(mockTxModel.createMany).toHaveBeenCalled()
       expect(mockSlackService.message).toHaveBeenCalled()
+    })
+
+    it('does not send Slack when campaign is not Pro', async () => {
+      mockTxModel.count.mockResolvedValueOnce(0)
+      mockTxModel.deleteMany.mockResolvedValue({ count: 0 })
+      mockTxModel.createMany.mockResolvedValue({ count: 1 })
+
+      await service.generateDefaultTasks(campaignWithFutureElection(), TODAY)
+
+      expect(mockTxModel.createMany).toHaveBeenCalled()
+      expect(mockSlackService.message).not.toHaveBeenCalled()
     })
 
     it('sends Slack with correct outreach task details', async () => {
@@ -875,7 +893,13 @@ describe('CampaignTasksService', () => {
         ],
       })
 
-      await service.generateDefaultTasks(campaignWithFutureElection(), TODAY)
+      await service.generateDefaultTasks(
+        makeCampaign({
+          isPro: true,
+          details: { electionDate: '2026-11-03' },
+        }),
+        TODAY,
+      )
 
       const messageMock = vi.mocked(mockSlackService.message!)
       const slackCall = messageMock.mock.calls[0]
@@ -897,7 +921,13 @@ describe('CampaignTasksService', () => {
       )
 
       await expect(
-        service.generateDefaultTasks(campaignWithFutureElection(), TODAY),
+        service.generateDefaultTasks(
+          makeCampaign({
+            isPro: true,
+            details: { electionDate: '2026-11-03' },
+          }),
+          TODAY,
+        ),
       ).resolves.not.toThrow()
       expect(mockTxModel.createMany).toHaveBeenCalled()
     })
@@ -918,6 +948,105 @@ describe('CampaignTasksService', () => {
       expect(mockTransaction).not.toHaveBeenCalled()
       expect(mockTxModel.createMany).not.toHaveBeenCalled()
       expect(mockSlackService.message).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('notifySlackOnProUpgrade', () => {
+    const candidateMock = {
+      id: 1,
+      data: { name: 'Test Candidate', hubspotId: '12345' },
+      user: { firstName: 'Jane', lastName: 'Doe' },
+      campaignTasks: [
+        {
+          flowType: CampaignTaskType.text,
+          title: 'Introduction Text',
+          date: new Date('2025-06-15'),
+        },
+      ],
+    }
+
+    it('sends slack and persists the notified-at flag when default tasks exist', async () => {
+      mockCampaignModel.findUnique = vi.fn().mockResolvedValue({ details: {} })
+      mockModel.count.mockResolvedValueOnce(1)
+      mockCampaignModel.findUniqueOrThrow.mockResolvedValue(candidateMock)
+      mockCampaignModel.update.mockResolvedValue({})
+
+      await service.notifySlackOnProUpgrade(1)
+
+      expect(mockSlackService.message).toHaveBeenCalledTimes(1)
+      expect(mockCampaignModel.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: {
+          details: expect.objectContaining({
+            proUpgradeSlackNotifiedAt: expect.any(Number),
+          }),
+        },
+      })
+    })
+
+    it('does nothing if proUpgradeSlackNotifiedAt is already set', async () => {
+      mockCampaignModel.findUnique = vi
+        .fn()
+        .mockResolvedValue({ details: { proUpgradeSlackNotifiedAt: 1 } })
+
+      await service.notifySlackOnProUpgrade(1)
+
+      expect(mockModel.count).not.toHaveBeenCalled()
+      expect(mockSlackService.message).not.toHaveBeenCalled()
+      expect(mockCampaignModel.update).not.toHaveBeenCalled()
+    })
+
+    it('does not send Slack if no default tasks exist', async () => {
+      mockCampaignModel.findUnique = vi.fn().mockResolvedValue({ details: {} })
+      mockModel.count.mockResolvedValueOnce(0)
+
+      await service.notifySlackOnProUpgrade(1)
+
+      expect(mockSlackService.message).not.toHaveBeenCalled()
+      expect(mockCampaignModel.update).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when the campaign has no details', async () => {
+      mockCampaignModel.findUnique = vi.fn().mockResolvedValue(null)
+
+      await service.notifySlackOnProUpgrade(1)
+
+      expect(mockModel.count).not.toHaveBeenCalled()
+      expect(mockSlackService.message).not.toHaveBeenCalled()
+    })
+
+    it('retries the slack send up to 3 times then succeeds', async () => {
+      mockCampaignModel.findUnique = vi.fn().mockResolvedValue({ details: {} })
+      mockModel.count.mockResolvedValueOnce(1)
+      mockCampaignModel.findUniqueOrThrow.mockResolvedValue(candidateMock)
+      mockCampaignModel.update.mockResolvedValue({})
+
+      const messageMock = vi.mocked(mockSlackService.message!)
+      messageMock.mockReset()
+      messageMock
+        .mockRejectedValueOnce(new Error('boom1'))
+        .mockRejectedValueOnce(new Error('boom2'))
+        .mockResolvedValueOnce(undefined)
+
+      await service.notifySlackOnProUpgrade(1)
+
+      expect(messageMock).toHaveBeenCalledTimes(3)
+      expect(mockCampaignModel.update).toHaveBeenCalled()
+    })
+
+    it('swallows errors when slack fails on all 3 attempts', async () => {
+      mockCampaignModel.findUnique = vi.fn().mockResolvedValue({ details: {} })
+      mockModel.count.mockResolvedValueOnce(1)
+      mockCampaignModel.findUniqueOrThrow.mockResolvedValue(candidateMock)
+      mockCampaignModel.update.mockClear()
+
+      const messageMock = vi.mocked(mockSlackService.message!)
+      messageMock.mockReset()
+      messageMock.mockRejectedValue(new Error('boom'))
+
+      await expect(service.notifySlackOnProUpgrade(1)).resolves.not.toThrow()
+      expect(messageMock).toHaveBeenCalledTimes(3)
+      expect(mockCampaignModel.update).not.toHaveBeenCalled()
     })
   })
 

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, MessageEvent, NotFoundException } from '@nestjs/common'
+import {
+  forwardRef,
+  Inject,
+  Injectable,
+  MessageEvent,
+  NotFoundException,
+} from '@nestjs/common'
 import { Campaign, Prisma } from '@prisma/client'
 import {
   addDays,
@@ -23,6 +29,7 @@ import {
   parseIsoDateString,
 } from 'src/shared/util/date.util'
 import { sleep } from 'src/shared/util/sleep.util'
+import { WrapperType } from 'src/shared/types/utility.types'
 import { SlackService } from 'src/vendors/slack/services/slack.service'
 import {
   SlackChannel,
@@ -49,6 +56,7 @@ import { generalDefaultTasks } from '../fixtures/defaultTasks'
 import { primaryDefaultTasks } from '../fixtures/defaultTasksForPrimary'
 import { CompleteTaskBodySchema } from '../schemas/completeTaskBody.schema'
 import { AiGenerationService } from './aiGeneration.service'
+import { CampaignsService } from '../../services/campaigns.service'
 
 const CAMPAIGN_DEFAULT_TASKS_ADVISORY_LOCK_KEY = 918_273
 const VOTER_GOALS_ADVISORY_LOCK_KEY = 918_274
@@ -65,6 +73,8 @@ export class CampaignTasksService extends createPrismaBase(
   constructor(
     private readonly aiGenerationService: AiGenerationService,
     private readonly slackService: SlackService,
+    @Inject(forwardRef(() => CampaignsService))
+    private readonly campaignsService: WrapperType<CampaignsService>,
   ) {
     super()
   }
@@ -390,14 +400,8 @@ export class CampaignTasksService extends createPrismaBase(
 
       await this.sendCampaignPlanSlackMessage(campaignId)
 
-      await this.client.campaign.update({
-        where: { id: campaignId },
-        data: {
-          details: {
-            ...campaign.details,
-            proUpgradeSlackNotifiedAt: Date.now(),
-          },
-        },
+      await this.campaignsService.patchCampaignDetails(campaignId, {
+        proUpgradeSlackNotifiedAt: Date.now(),
       })
     } catch (error) {
       this.logger.error(

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -480,21 +480,25 @@ export class CampaignTasksService extends createPrismaBase(
     channel: SlackChannel,
     maxAttempts = 3,
   ) {
+    // SlackService.message() swallows axios errors and returns undefined on
+    // failure, so we have to treat a falsy return as a failure ourselves —
+    // a thrown error here would only happen for misconfiguration.
     let lastError: unknown
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        await this.slackService.message(message, channel)
-        return
+        const result = await this.slackService.message(message, channel)
+        if (result) return
+        lastError = new Error('Slack message returned no data')
       } catch (error) {
         lastError = error
-        if (attempt === maxAttempts) break
-        const delayMs = 2 ** (attempt - 1) * SLACK_RETRY_BASE_DELAY_MS
-        this.logger.warn(
-          { error, attempt, channel, delayMs },
-          'Slack send failed, retrying',
-        )
-        await sleep(delayMs)
       }
+      if (attempt === maxAttempts) break
+      const delayMs = 2 ** (attempt - 1) * SLACK_RETRY_BASE_DELAY_MS
+      this.logger.warn(
+        { error: lastError, attempt, channel, delayMs },
+        'Slack send failed, retrying',
+      )
+      await sleep(delayMs)
     }
     throw lastError
   }

--- a/src/campaigns/tasks/services/campaignTasks.service.ts
+++ b/src/campaigns/tasks/services/campaignTasks.service.ts
@@ -56,6 +56,7 @@ const MAX_TASK_WINDOW_DAYS = 49
 const SHORTENED_WINDOW_BUFFER_DAYS = 7
 const FULL_WINDOW_THRESHOLD_DAYS = 56
 const SIGNUP_AWARENESS_MIN_DAYS_TO_ELECTION = 42
+const SLACK_RETRY_BASE_DELAY_MS = 500
 
 @Injectable()
 export class CampaignTasksService extends createPrismaBase(
@@ -365,69 +366,133 @@ export class CampaignTasksService extends createPrismaBase(
       created = true
     })
 
-    if (created) {
+    if (created && campaign.isPro) {
       void this.notifySlackDefaultTasksCreated(campaign.id)
+    }
+  }
+
+  async notifySlackOnProUpgrade(campaignId: number) {
+    try {
+      const campaign = await this.client.campaign.findUnique({
+        where: { id: campaignId },
+        select: { details: true },
+      })
+      if (!campaign?.details) return
+
+      if (campaign.details.proUpgradeSlackNotifiedAt) {
+        return
+      }
+
+      const defaultTasksCount = await this.model.count({
+        where: { campaignId, isDefaultTask: true },
+      })
+      if (defaultTasksCount === 0) return
+
+      await this.sendCampaignPlanSlackMessage(campaignId)
+
+      await this.client.campaign.update({
+        where: { id: campaignId },
+        data: {
+          details: {
+            ...campaign.details,
+            proUpgradeSlackNotifiedAt: Date.now(),
+          },
+        },
+      })
+    } catch (error) {
+      this.logger.error(
+        { error, campaignId },
+        'Failed to send Slack notification on Pro upgrade',
+      )
     }
   }
 
   async notifySlackDefaultTasksCreated(campaignId: number) {
     try {
-      const campaign = await this.client.campaign.findUniqueOrThrow({
-        where: { id: campaignId },
-        include: { user: true, campaignTasks: true },
-      })
-
-      const candidateName =
-        [campaign.user?.firstName, campaign.user?.lastName]
-          .filter((value): value is string => Boolean(value))
-          .join(' ') ||
-        campaign.data.name ||
-        'Unknown'
-
-      const outreachTasks = campaign.campaignTasks.filter(
-        (task) =>
-          task.flowType === CampaignTaskType.text ||
-          task.flowType === CampaignTaskType.robocall,
-      )
-
-      const taskLines = outreachTasks.map((task) => {
-        const dueDate = task.date
-          ? format(task.date, 'MMM d, yyyy')
-          : 'No date set'
-        return `- ${task.flowType!.toUpperCase()}: ${task.title} (Due: ${dueDate})`
-      })
-
-      const { hubspotId } = campaign.data
-
-      const slackBody = [
-        ':white_check_mark: *AI Campaign Plan Created*',
-        `Candidate: ${candidateName}`,
-        `HubSpot ID: ${hubspotId ?? 'N/A'}`,
-        '',
-        `*Outreach Tasks (${outreachTasks.length}):*`,
-        ...(taskLines.length > 0 ? taskLines : ['None']),
-      ].join('\n')
-
-      await this.slackService.message(
-        {
-          blocks: [
-            {
-              type: SlackMessageType.SECTION,
-              text: {
-                type: SlackMessageType.MRKDWN,
-                text: slackBody,
-              },
-            },
-          ],
-        },
-        SlackChannel.casClickupTasks,
-      )
+      await this.sendCampaignPlanSlackMessage(campaignId)
     } catch (error) {
       this.logger.error(
         { error, campaignId },
         'Failed to send Slack notification for default tasks',
       )
     }
+  }
+
+  private async sendCampaignPlanSlackMessage(campaignId: number) {
+    const campaign = await this.client.campaign.findUniqueOrThrow({
+      where: { id: campaignId },
+      include: { user: true, campaignTasks: true },
+    })
+
+    const candidateName =
+      [campaign.user?.firstName, campaign.user?.lastName]
+        .filter((value): value is string => Boolean(value))
+        .join(' ') ||
+      campaign.data.name ||
+      'Unknown'
+
+    const outreachTasks = campaign.campaignTasks.filter(
+      (task) =>
+        task.flowType === CampaignTaskType.text ||
+        task.flowType === CampaignTaskType.robocall,
+    )
+
+    const taskLines = outreachTasks.map((task) => {
+      const dueDate = task.date
+        ? format(task.date, 'MMM d, yyyy')
+        : 'No date set'
+      return `- ${task.flowType!.toUpperCase()}: ${task.title} (Due: ${dueDate})`
+    })
+
+    const { hubspotId } = campaign.data
+
+    const slackBody = [
+      ':white_check_mark: *AI Campaign Plan Created*',
+      `Candidate: ${candidateName}`,
+      `HubSpot ID: ${hubspotId ?? 'N/A'}`,
+      '',
+      `*Outreach Tasks (${outreachTasks.length}):*`,
+      ...(taskLines.length > 0 ? taskLines : ['None']),
+    ].join('\n')
+
+    await this.sendSlackWithRetry(
+      {
+        blocks: [
+          {
+            type: SlackMessageType.SECTION,
+            text: {
+              type: SlackMessageType.MRKDWN,
+              text: slackBody,
+            },
+          },
+        ],
+      },
+      SlackChannel.casClickupTasks,
+    )
+  }
+
+  private async sendSlackWithRetry(
+    message: Parameters<SlackService['message']>[0],
+    channel: SlackChannel,
+    maxAttempts = 3,
+  ) {
+    let lastError: unknown
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await this.slackService.message(message, channel)
+        return
+      } catch (error) {
+        lastError = error
+        if (attempt === maxAttempts) break
+        const delayMs = 2 ** (attempt - 1) * SLACK_RETRY_BASE_DELAY_MS
+        this.logger.warn(
+          { error, attempt, channel, delayMs },
+          'Slack send failed, retrying',
+        )
+        await sleep(delayMs)
+      }
+    }
+    throw lastError
   }
 
   private orderDefaultTasksForCampaign(


### PR DESCRIPTION
## ENG-7494: Send campaign-plan Slack message ONLY when a candidate upgrades to Pro

[ClickUp ticket](https://app.clickup.com/t/86ah1q6pe)

### Problem
The `#cas-clickup-tasks` Slack message was firing at plan generation time for all candidates regardless of tier. Free candidates who later upgraded to Pro were never re-surfaced, so their voter outreach never got executed.

### Solution
- **Plan generation:** Slack only fires when the campaign is already Pro at the time tasks are created.
- **Pro upgrade:** When a free candidate upgrades, Slack fires if they already have a plan.
- **Dedupe:** A `proUpgradeSlackNotifiedAt` timestamp is persisted in `campaign.details` so a downgrade + re-upgrade doesn't double-post. The write goes through `patchCampaignDetails` (Serializable transaction) to avoid a concurrent-write race.
- **Retry:** Slack sends retry up to 3 times with exponential backoff (500ms / 1s / 2s), then fail silently so a Slack outage can't break the upgrade flow.

### Files changed
- `prisma/schema/campaign.jsonTypes.d.ts` + `updateCampaign.schema.ts` — added `proUpgradeSlackNotifiedAt` to the `CampaignDetails` type and Zod schema.
- `campaignTasks.service.ts` — gated plan-gen notification on `isPro`; added `notifySlackOnProUpgrade` with dedupe + retry; extracted shared `sendCampaignPlanSlackMessage` helper.
- `campaigns.service.ts` — injected `CampaignTasksService` and calls `notifySlackOnProUpgrade` on the free→Pro transition.
- Tests updated to cover all new paths (113/113 passing).

### No migration needed
`proUpgradeSlackNotifiedAt` is stored inside the existing `details` JSON column — no DDL changes.