### PR TITLE
ENG-7351 - Fixes a 500 Error When Searching Users

### DIFF
--- a/src/authentication/guards/Session.guard.ts
+++ b/src/authentication/guards/Session.guard.ts
@@ -98,10 +98,10 @@ export class SessionGuard implements CanActivate {
       return clerkFields
         ? {
             ...rawUser,
-            email: clerkFields.email,
-            firstName: clerkFields.firstName,
-            lastName: clerkFields.lastName,
-            name: clerkFields.name,
+            email: clerkFields.email ?? rawUser.email,
+            firstName: clerkFields.firstName ?? rawUser.firstName,
+            lastName: clerkFields.lastName ?? rawUser.lastName,
+            name: clerkFields.name ?? rawUser.name,
             avatar: clerkFields.avatar,
           }
         : rawUser

--- a/src/authentication/guards/Session.guard.ts
+++ b/src/authentication/guards/Session.guard.ts
@@ -95,13 +95,18 @@ export class SessionGuard implements CanActivate {
     ])
 
     if (rawUser) {
+      // Use `||` (not `??`) so empty strings from Clerk also fall back to the
+      // DB value, matching the truthiness check in
+      // ClerkUserEnricherService.applyFields. `??` would only catch
+      // null/undefined and let `''` through, which can fail downstream
+      // schema validation (e.g. EmailSchema, firstName.min(2)).
       return clerkFields
         ? {
             ...rawUser,
-            email: clerkFields.email ?? rawUser.email,
-            firstName: clerkFields.firstName ?? rawUser.firstName,
-            lastName: clerkFields.lastName ?? rawUser.lastName,
-            name: clerkFields.name ?? rawUser.name,
+            email: clerkFields.email || rawUser.email,
+            firstName: clerkFields.firstName || rawUser.firstName,
+            lastName: clerkFields.lastName || rawUser.lastName,
+            name: clerkFields.name || rawUser.name,
             avatar: clerkFields.avatar,
           }
         : rawUser

--- a/src/vendors/clerk/services/clerk-user-enricher.service.test.ts
+++ b/src/vendors/clerk/services/clerk-user-enricher.service.test.ts
@@ -15,7 +15,9 @@ type ClerkUserShape = {
   imageUrl: string
 }
 
-const buildClerkUser = (overrides: Partial<ClerkUserShape> = {}): ClerkUserShape => ({
+const buildClerkUser = (
+  overrides: Partial<ClerkUserShape> = {},
+): ClerkUserShape => ({
   id: 'clerk_default',
   primaryEmailAddress: { emailAddress: 'clerk@goodparty.org' },
   emailAddresses: [{ emailAddress: 'clerk@goodparty.org' }],

--- a/src/vendors/clerk/services/clerk-user-enricher.service.test.ts
+++ b/src/vendors/clerk/services/clerk-user-enricher.service.test.ts
@@ -1,0 +1,239 @@
+import { Test } from '@nestjs/testing'
+import { LoggerModule } from 'nestjs-pino'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CLERK_CLIENT_PROVIDER_TOKEN } from '@/vendors/clerk/providers/clerk-client.provider'
+import { ClerkUserEnricherService } from './clerk-user-enricher.service'
+
+type ClerkUserShape = {
+  id: string
+  primaryEmailAddress?: { emailAddress: string } | null
+  emailAddresses?: { emailAddress: string }[]
+  firstName: string | null
+  lastName: string | null
+  fullName: string | null
+  hasImage: boolean
+  imageUrl: string
+}
+
+const buildClerkUser = (overrides: Partial<ClerkUserShape> = {}): ClerkUserShape => ({
+  id: 'clerk_default',
+  primaryEmailAddress: { emailAddress: 'clerk@goodparty.org' },
+  emailAddresses: [{ emailAddress: 'clerk@goodparty.org' }],
+  firstName: 'Clerk',
+  lastName: 'User',
+  fullName: 'Clerk User',
+  hasImage: false,
+  imageUrl: '',
+  ...overrides,
+})
+
+describe('ClerkUserEnricherService', () => {
+  let enricher: ClerkUserEnricherService
+  let getUser: ReturnType<typeof vi.fn>
+  let getUserList: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    getUser = vi.fn()
+    getUserList = vi.fn()
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [LoggerModule.forRoot({ pinoHttp: { enabled: false } })],
+      providers: [
+        ClerkUserEnricherService,
+        {
+          provide: CLERK_CLIENT_PROVIDER_TOKEN,
+          useValue: {
+            users: { getUser, getUserList },
+          },
+        },
+      ],
+    }).compile()
+
+    enricher = moduleRef.get(ClerkUserEnricherService)
+  })
+
+  describe('enrichUsers (bulk)', () => {
+    it('overwrites DB fields with Clerk values when Clerk has them', async () => {
+      getUserList.mockResolvedValue({
+        data: [
+          buildClerkUser({
+            id: 'clerk_a',
+            primaryEmailAddress: { emailAddress: 'newer@goodparty.org' },
+            firstName: 'Newer',
+            lastName: 'Name',
+            fullName: 'Newer Name',
+          }),
+        ],
+      })
+
+      const dbUser = {
+        id: 1,
+        clerkId: 'clerk_a',
+        email: 'older@goodparty.org',
+        firstName: 'Older',
+        lastName: 'Name',
+        name: 'Older Name',
+        avatar: null,
+      }
+
+      const [enriched] = await enricher.enrichUsers([dbUser])
+
+      expect(enriched).toMatchObject({
+        email: 'newer@goodparty.org',
+        firstName: 'Newer',
+        lastName: 'Name',
+        name: 'Newer Name',
+      })
+    })
+
+    it('keeps the DB email when Clerk has no primary email (regression: search with "+" character)', async () => {
+      // Simulates a Clerk user that exists but has no primaryEmailAddress and
+      // no emailAddresses entry. Previously the enricher overwrote the DB
+      // email with '' which then failed `EmailSchema` in
+      // ZodResponseInterceptor, returning a 500 to the admin search UI.
+      getUserList.mockResolvedValue({
+        data: [
+          buildClerkUser({
+            id: 'clerk_no_email',
+            primaryEmailAddress: null,
+            emailAddresses: [],
+            firstName: 'Matthew',
+            lastName: 'Tester',
+          }),
+        ],
+      })
+
+      const dbUser = {
+        id: 42,
+        clerkId: 'clerk_no_email',
+        email: 'matthew+dev-clerk-1@goodparty.org',
+        firstName: 'Matthew',
+        lastName: 'Tester',
+        name: 'Matthew Tester',
+        avatar: null,
+      }
+
+      const [enriched] = await enricher.enrichUsers([dbUser])
+
+      expect(enriched.email).toBe('matthew+dev-clerk-1@goodparty.org')
+    })
+
+    it('keeps DB firstName/lastName/name when Clerk has empty values', async () => {
+      getUserList.mockResolvedValue({
+        data: [
+          buildClerkUser({
+            id: 'clerk_blank_names',
+            firstName: null,
+            lastName: '',
+            fullName: null,
+          }),
+        ],
+      })
+
+      const dbUser = {
+        id: 7,
+        clerkId: 'clerk_blank_names',
+        email: 'someone@goodparty.org',
+        firstName: 'Real',
+        lastName: 'Name',
+        name: 'Real Name',
+        avatar: null,
+      }
+
+      const [enriched] = await enricher.enrichUsers([dbUser])
+
+      expect(enriched).toMatchObject({
+        firstName: 'Real',
+        lastName: 'Name',
+        name: 'Real Name',
+      })
+    })
+
+    it('falls back to emailAddresses[0] when primary is missing', async () => {
+      getUserList.mockResolvedValue({
+        data: [
+          buildClerkUser({
+            id: 'clerk_secondary',
+            primaryEmailAddress: null,
+            emailAddresses: [{ emailAddress: 'secondary@goodparty.org' }],
+          }),
+        ],
+      })
+
+      const dbUser = {
+        id: 8,
+        clerkId: 'clerk_secondary',
+        email: 'db@goodparty.org',
+        firstName: 'X',
+        lastName: 'Y',
+        name: 'X Y',
+        avatar: null,
+      }
+
+      const [enriched] = await enricher.enrichUsers([dbUser])
+
+      expect(enriched.email).toBe('secondary@goodparty.org')
+    })
+
+    it('returns user untouched when Clerk lookup fails', async () => {
+      getUserList.mockRejectedValue(new Error('boom'))
+
+      const dbUser = {
+        id: 9,
+        clerkId: 'clerk_missing',
+        email: 'unchanged@goodparty.org',
+        firstName: 'Un',
+        lastName: 'Changed',
+        name: 'Un Changed',
+        avatar: null,
+      }
+
+      const [enriched] = await enricher.enrichUsers([dbUser])
+
+      expect(enriched).toEqual(dbUser)
+    })
+  })
+
+  describe('enrichUser (single)', () => {
+    it('keeps DB email when Clerk has no email', async () => {
+      getUser.mockResolvedValue(
+        buildClerkUser({
+          id: 'clerk_single',
+          primaryEmailAddress: null,
+          emailAddresses: [],
+        }),
+      )
+
+      const dbUser = {
+        id: 100,
+        clerkId: 'clerk_single',
+        email: 'kept@goodparty.org',
+        firstName: 'Kept',
+        lastName: 'Email',
+        name: 'Kept Email',
+        avatar: null,
+      }
+
+      const enriched = await enricher.enrichUser(dbUser)
+
+      expect(enriched.email).toBe('kept@goodparty.org')
+    })
+
+    it('returns the user unchanged when clerkId is null', async () => {
+      const dbUser = {
+        id: 200,
+        clerkId: null,
+        email: 'noclerk@goodparty.org',
+        firstName: 'No',
+        lastName: 'Clerk',
+        name: 'No Clerk',
+        avatar: null,
+      }
+
+      const enriched = await enricher.enrichUser(dbUser)
+
+      expect(enriched).toEqual(dbUser)
+      expect(getUser).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/vendors/clerk/services/clerk-user-enricher.service.ts
+++ b/src/vendors/clerk/services/clerk-user-enricher.service.ts
@@ -168,7 +168,8 @@ export class ClerkUserEnricherService {
     const firstName = clerkUser.firstName ?? null
     const lastName = clerkUser.lastName ?? null
     const fallbackName = [firstName, lastName].filter(Boolean).join(' ').trim()
-    const name = clerkUser.fullName ?? (fallbackName.length > 0 ? fallbackName : null)
+    const name =
+      clerkUser.fullName ?? (fallbackName.length > 0 ? fallbackName : null)
 
     return {
       email,

--- a/src/vendors/clerk/services/clerk-user-enricher.service.ts
+++ b/src/vendors/clerk/services/clerk-user-enricher.service.ts
@@ -4,10 +4,10 @@ import { PinoLogger } from 'nestjs-pino'
 import { CLERK_CLIENT_PROVIDER_TOKEN } from '@/vendors/clerk/providers/clerk-client.provider'
 
 export interface ClerkUserFields {
-  email: string
-  firstName: string
-  lastName: string
-  name: string
+  email: string | null
+  firstName: string | null
+  lastName: string | null
+  name: string | null
   avatar: string | null
 }
 
@@ -45,20 +45,7 @@ export class ClerkUserEnricherService {
 
     try {
       const clerkUser = await this.clerkClient.users.getUser(clerkId)
-      const email =
-        clerkUser.primaryEmailAddress?.emailAddress ??
-        clerkUser.emailAddresses?.[0]?.emailAddress
-
-      const firstName = clerkUser.firstName ?? ''
-      const lastName = clerkUser.lastName ?? ''
-
-      const fields: ClerkUserFields = {
-        email: email ?? '',
-        firstName,
-        lastName,
-        name: clerkUser.fullName ?? `${firstName} ${lastName}`.trim(),
-        avatar: clerkUser.hasImage ? clerkUser.imageUrl : null,
-      }
+      const fields = this.buildFields(clerkUser)
 
       this.fieldsCache.set(clerkId, {
         fields,
@@ -125,20 +112,7 @@ export class ClerkUserEnricherService {
       })
 
       for (const clerkUser of clerkUsers.data) {
-        const email =
-          clerkUser.primaryEmailAddress?.emailAddress ??
-          clerkUser.emailAddresses?.[0]?.emailAddress
-
-        const firstName = clerkUser.firstName ?? ''
-        const lastName = clerkUser.lastName ?? ''
-
-        const fields: ClerkUserFields = {
-          email: email ?? '',
-          firstName,
-          lastName,
-          name: clerkUser.fullName ?? `${firstName} ${lastName}`.trim(),
-          avatar: clerkUser.hasImage ? clerkUser.imageUrl : null,
-        }
+        const fields = this.buildFields(clerkUser)
 
         result.set(clerkUser.id, fields)
         this.fieldsCache.set(clerkUser.id, {
@@ -160,13 +134,48 @@ export class ClerkUserEnricherService {
     user: T,
     fields: ClerkUserFields,
   ): T {
+    // Only overwrite a field when Clerk has a non-empty value. Otherwise
+    // keep the database value so downstream response-schema validation
+    // (e.g. EmailSchema, firstName.min(2)) doesn't reject the user.
     return {
       ...user,
-      ...('email' in user ? { email: fields.email } : {}),
-      ...('firstName' in user ? { firstName: fields.firstName } : {}),
-      ...('lastName' in user ? { lastName: fields.lastName } : {}),
-      ...('name' in user ? { name: fields.name } : {}),
+      ...('email' in user && fields.email ? { email: fields.email } : {}),
+      ...('firstName' in user && fields.firstName
+        ? { firstName: fields.firstName }
+        : {}),
+      ...('lastName' in user && fields.lastName
+        ? { lastName: fields.lastName }
+        : {}),
+      ...('name' in user && fields.name ? { name: fields.name } : {}),
       ...('avatar' in user ? { avatar: fields.avatar } : {}),
+    }
+  }
+
+  private buildFields(clerkUser: {
+    primaryEmailAddress?: { emailAddress: string } | null
+    emailAddresses?: { emailAddress: string }[]
+    firstName: string | null
+    lastName: string | null
+    fullName: string | null
+    hasImage: boolean
+    imageUrl: string
+  }): ClerkUserFields {
+    const email =
+      clerkUser.primaryEmailAddress?.emailAddress ??
+      clerkUser.emailAddresses?.[0]?.emailAddress ??
+      null
+
+    const firstName = clerkUser.firstName ?? null
+    const lastName = clerkUser.lastName ?? null
+    const fallbackName = [firstName, lastName].filter(Boolean).join(' ').trim()
+    const name = clerkUser.fullName ?? (fallbackName.length > 0 ? fallbackName : null)
+
+    return {
+      email,
+      firstName,
+      lastName,
+      name,
+      avatar: clerkUser.hasImage ? clerkUser.imageUrl : null,
     }
   }
 }


### PR DESCRIPTION
applyFields() blindly overwrote the DB user's values, even when Clerk returned empty strings.

The enriched response then hit ZodResponseInterceptor validating against ReadUserOutputSchema, which requires:

email: EmailSchema (z.string().email()) — rejects ''
firstName: z.string().min(2) — rejects ''
lastName: z.string().min(2) — rejects ''
So if any user in the result page had a Clerk record missing a primary email or a name, the entire response failed validation, the interceptor threw InternalServerErrorException, and the admin saw a 500.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session/user enrichment paths used on authenticated requests; while behavior is a narrow fallback change, incorrect merging could impact identity data shown to clients.
> 
> **Overview**
> Prevents Clerk enrichment from overwriting persisted user `email`/`firstName`/`lastName`/`name` with empty or missing values, keeping DB values when Clerk doesn’t provide a non-empty replacement (fixing response-schema validation 500s).
> 
> Refactors Clerk field extraction into `buildFields()` and makes `ClerkUserFields` nullable, updates `SessionGuard` to use nullish fallbacks when merging Clerk fields, and adds comprehensive unit tests covering missing/blank email and name scenarios plus failure handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 972404e20452777d18fbfc0bba215851edf8eddd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->