### PR TITLE
Prod <- QA

### DIFF
--- a/deploy/components/alerts.ts
+++ b/deploy/components/alerts.ts
@@ -106,4 +106,21 @@ export const GLOBAL_ALERTS: Alert[] = [
     ].join('\n\n'),
     notify: 'win-bugs',
   },
+  {
+    slug: 'admin-impersonation-email-fallback-spike',
+    name: '[Admin] Impersonation falling back to email actor',
+    type: 'log',
+    expr: 'sum(count_over_time({service_name="gp-api", deployment_environment_name="$ENV"} |= "Actor has no gp-api Clerk account" [15m]))',
+    threshold: 5,
+    for: '5m',
+    message: [
+      'More than 5 admin impersonations have used the email-as-actor.sub fallback in the last 15 minutes.',
+      "This means actorEmail lookups against gp-api's Clerk instance returned no match for those impersonation requests. Possible causes:",
+      '  • Admins without a gp-api Clerk account are impersonating (a routine baseline may exist; we have not yet measured it)',
+      '  • Email casing/format regression in gp-admin → SDK → controller',
+      '  • Clerk lookup degraded or rate-limited',
+      '  • Clerk has begun rejecting non-user_ actor.sub values',
+      'Click *View in Grafana* to see the warn log lines (search "Actor has no gp-api Clerk account") and inspect the affected actorEmail values, then verify whether those admins exist in the gp-api Clerk instance.',
+    ].join('\n\n'),
+  },
 ]

--- a/src/admin/users/adminUsers.controller.test.ts
+++ b/src/admin/users/adminUsers.controller.test.ts
@@ -55,6 +55,8 @@ describe('AdminUsersController', () => {
     const usersServiceMock: Partial<UsersService> = {
       findMany: vi.fn(),
       findUniqueOrThrow: vi.fn(),
+      findUserByEmail: vi.fn(),
+      resolveClerkIdByEmail: vi.fn(),
       createUser: vi.fn(),
       deleteUser: vi.fn(),
       impersonateUser: vi.fn(),
@@ -83,6 +85,36 @@ describe('AdminUsersController', () => {
       const guards = getGuards('impersonate')
       expect(guards).toContain(AdminOrM2MGuard)
     })
+
+    it('protects searchByEmail with AdminOrM2MGuard', () => {
+      const guards = getGuards('searchByEmail')
+      expect(guards).toContain(AdminOrM2MGuard)
+    })
+  })
+
+  describe('searchByEmail', () => {
+    it('returns users whose email contains the search term', async () => {
+      vi.spyOn(usersService, 'findMany').mockResolvedValue([mockTargetUser])
+
+      const result = await controller.searchByEmail('candidate')
+
+      expect(usersService.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            email: expect.objectContaining({ contains: 'candidate' }),
+          },
+        }),
+      )
+      expect(result).toEqual([mockTargetUser])
+    })
+
+    it('returns empty array when no users match', async () => {
+      vi.spyOn(usersService, 'findMany').mockResolvedValue([])
+
+      const result = await controller.searchByEmail('nobody')
+
+      expect(result).toEqual([])
+    })
   })
 
   describe('impersonate', () => {
@@ -107,51 +139,58 @@ describe('AdminUsersController', () => {
       expect(result).toEqual({ token: 'actor_token_123' })
     })
 
-    it('falls back to body.actorClerkId when req.user has no clerkId', async () => {
-      const adminWithoutClerkId = { ...mockUser, clerkId: null }
+    it('uses actorSub from request when swapping in an impersonating session', async () => {
       vi.spyOn(usersService, 'findUniqueOrThrow').mockResolvedValue(
         mockTargetUser,
       )
       vi.spyOn(usersService, 'impersonateUser').mockResolvedValue({
-        token: 'actor_token_456',
+        token: 'swap_token',
       })
 
-      const req = { user: adminWithoutClerkId } as unknown as IncomingRequest
-      const result = await controller.impersonate(42, req, {
-        actorClerkId: 'm2m_actor_clerk_id',
-      })
+      const candidateUser = { ...mockTargetUser, impersonating: true }
+      const req = {
+        user: candidateUser,
+        actorSub: mockUser.clerkId,
+      } as IncomingRequest
+      const result = await controller.impersonate(42, req, {})
 
+      expect(usersService.resolveClerkIdByEmail).not.toHaveBeenCalled()
       expect(usersService.impersonateUser).toHaveBeenCalledWith(
         mockTargetUser.id,
-        'm2m_actor_clerk_id',
+        mockUser.clerkId,
       )
-      expect(result).toEqual({ token: 'actor_token_456' })
+      expect(result).toEqual({ token: 'swap_token' })
     })
 
-    it('uses body.actorClerkId when called via M2M (no req.user)', async () => {
+    it('resolves actorEmail via resolveClerkIdByEmail when called via M2M', async () => {
       vi.spyOn(usersService, 'findUniqueOrThrow').mockResolvedValue(
         mockTargetUser,
       )
+      vi.spyOn(usersService, 'resolveClerkIdByEmail').mockResolvedValue({
+        source: 'clerk',
+        clerkId: mockUser.clerkId!,
+      })
       vi.spyOn(usersService, 'impersonateUser').mockResolvedValue({
         token: 'm2m_token',
       })
 
       const req = { user: undefined } as IncomingRequest
       const result = await controller.impersonate(42, req, {
-        actorClerkId: 'svc_clerk_id',
+        actorEmail: mockUser.email,
       })
 
+      expect(usersService.resolveClerkIdByEmail).toHaveBeenCalledWith(
+        mockUser.email,
+      )
       expect(usersService.impersonateUser).toHaveBeenCalledWith(
         mockTargetUser.id,
-        'svc_clerk_id',
+        mockUser.clerkId,
       )
       expect(result).toEqual({ token: 'm2m_token' })
     })
 
-    it('throws BadRequestException when no actorClerkId can be resolved', async () => {
-      const req = {
-        user: { ...mockUser, clerkId: null },
-      } as unknown as IncomingRequest
+    it('throws BadRequestException when M2M call omits actorEmail', async () => {
+      const req = { user: undefined } as IncomingRequest
 
       await expect(controller.impersonate(42, req, {})).rejects.toThrow(
         BadRequestException,
@@ -161,12 +200,37 @@ describe('AdminUsersController', () => {
       expect(usersService.impersonateUser).not.toHaveBeenCalled()
     })
 
-    it('throws BadRequestException with descriptive message when actorClerkId is missing', async () => {
+    it('throws BadRequestException with descriptive message when actorEmail is missing', async () => {
       const req = { user: undefined } as IncomingRequest
 
       await expect(controller.impersonate(42, req, {})).rejects.toThrow(
-        'actorClerkId is required when using M2M auth',
+        'actorEmail is required when using M2M auth',
       )
+    })
+
+    it('uses email directly as actor identity when no Clerk account exists in this environment', async () => {
+      const unknownEmail = 'unknown@example.com'
+      vi.spyOn(usersService, 'findUniqueOrThrow').mockResolvedValue(
+        mockTargetUser,
+      )
+      vi.spyOn(usersService, 'resolveClerkIdByEmail').mockResolvedValue({
+        source: 'email-fallback',
+        email: unknownEmail,
+      })
+      vi.spyOn(usersService, 'impersonateUser').mockResolvedValue({
+        token: 'fallback_token',
+      })
+
+      const req = { user: undefined } as IncomingRequest
+      const result = await controller.impersonate(42, req, {
+        actorEmail: unknownEmail,
+      })
+
+      expect(usersService.impersonateUser).toHaveBeenCalledWith(
+        mockTargetUser.id,
+        unknownEmail,
+      )
+      expect(result).toEqual({ token: 'fallback_token' })
     })
 
     it('looks up target user by the path param id before impersonating', async () => {

--- a/src/admin/users/adminUsers.controller.ts
+++ b/src/admin/users/adminUsers.controller.ts
@@ -1,4 +1,5 @@
 import { IncomingRequest } from '@/authentication/authentication.types'
+import { ReqUser } from '@/authentication/decorators/ReqUser.decorator'
 import { AdminOrM2MGuard } from '@/authentication/guards/AdminOrM2M.guard'
 import {
   BadRequestException,
@@ -16,11 +17,10 @@ import {
   UseGuards,
   UsePipes,
 } from '@nestjs/common'
-import { UserRole } from '@prisma/client'
+import { Prisma, UserRole } from '@prisma/client'
 import { subDays, subMonths } from 'date-fns'
 import { PinoLogger } from 'nestjs-pino'
 import { ZodValidationPipe } from 'nestjs-zod'
-import { ReqUser } from '@/authentication/decorators/ReqUser.decorator'
 import { Roles } from 'src/authentication/decorators/Roles.decorator'
 import { UsersService } from 'src/users/services/users.service'
 import { SlackService } from 'src/vendors/slack/services/slack.service'
@@ -62,6 +62,16 @@ export class AdminUsersController {
     return this.usersService.findMany({ where: { createdAt: { gt: date } } })
   }
 
+  @Get('search')
+  @UseGuards(AdminOrM2MGuard)
+  async searchByEmail(@Query('email') email: string) {
+    return this.usersService.findMany({
+      where: { email: { contains: email, mode: Prisma.QueryMode.insensitive } },
+      take: 10,
+      select: { id: true, email: true, name: true },
+    })
+  }
+
   @Get(':id')
   @Roles(UserRole.admin)
   async get(@Param('id', ParseIntPipe) id: number) {
@@ -79,15 +89,9 @@ export class AdminUsersController {
   async impersonate(
     @Param('id', ParseIntPipe) id: number,
     @Req() req: IncomingRequest,
-    @Body() body: { actorClerkId?: string },
+    @Body() body: { actorEmail?: string },
   ) {
-    const actorClerkId = req.user?.clerkId ?? body.actorClerkId
-
-    if (!actorClerkId) {
-      throw new BadRequestException(
-        'actorClerkId is required when using M2M auth',
-      )
-    }
+    const actorClerkId = await this.resolveActorClerkId(req, body.actorEmail)
 
     this.logger.info(
       { targetUserId: id, actorClerkId, authSource: req.user ? 'user' : 'm2m' },
@@ -96,6 +100,49 @@ export class AdminUsersController {
 
     const user = await this.usersService.findUniqueOrThrow({ where: { id } })
     return this.usersService.impersonateUser(user.id, actorClerkId)
+  }
+
+  // Resolves which Clerk ID to embed as actor.sub in the impersonation token.
+  //
+  // gp-admin and gp-api/gp-webapp run on separate Clerk instances, so an admin's
+  // Clerk ID from gp-admin is never valid here. We accept actorEmail instead and
+  // resolve it against gp-api's Clerk instance. If the admin has no account in
+  // this instance (common — they may have never logged into the webapp), we fall
+  // back to the email string itself. Clerk does not validate actor.sub at token
+  // creation time, so this works in practice; SessionGuard's startsWith('user_')
+  // check prevents the downstream 404 latency on every subsequent request.
+  // If Clerk ever starts validating actor.sub, admins will need gp-api accounts.
+  private async resolveActorClerkId(
+    req: IncomingRequest,
+    actorEmail?: string,
+  ): Promise<string> {
+    // Happy path: actor resolved from the JWT (admin has a gp-api Clerk account)
+    if (req.actorUser?.clerkId) return req.actorUser.clerkId
+
+    // Direct admin session (not currently impersonating someone)
+    if (req.user && !req.user.impersonating && req.user.clerkId) {
+      return req.user.clerkId
+    }
+
+    // Swap path: actor.sub is already embedded in the current JWT — carry it forward
+    // without re-resolving so the actor identity stays consistent for the session
+    if (req.actorSub) return req.actorSub
+
+    // M2M initial impersonation from gp-admin: resolve email → gp-api Clerk ID,
+    // falling back to the email string if the admin has no gp-api account
+    if (actorEmail) {
+      const identity = await this.usersService.resolveClerkIdByEmail(actorEmail)
+      if (identity.source === 'email-fallback') {
+        this.logger.warn(
+          { actorEmail },
+          'Actor has no gp-api Clerk account — using email as actor.sub fallback',
+        )
+        return identity.email
+      }
+      return identity.clerkId
+    }
+
+    throw new BadRequestException('actorEmail is required when using M2M auth')
   }
 
   @Delete(':id')

--- a/src/authentication/authentication.types.ts
+++ b/src/authentication/authentication.types.ts
@@ -4,5 +4,7 @@ import { VerifiedM2MToken } from '@/authentication/interfaces/auth-provider.inte
 export interface IncomingRequest extends Request {
   headers: Headers & { authorization?: string }
   user?: User & { impersonating?: boolean }
+  actorUser?: User
+  actorSub?: string
   m2mToken?: VerifiedM2MToken
 }

--- a/src/authentication/guards/AdminOrM2M.guard.test.ts
+++ b/src/authentication/guards/AdminOrM2M.guard.test.ts
@@ -46,4 +46,22 @@ describe('AdminOrM2MGuard', () => {
     const result = guard.canActivate(mockContext({ user: { roles: [] } }))
     expect(result).toBe(false)
   })
+
+  it('allows impersonating sessions (actor claim present)', () => {
+    const result = guard.canActivate(
+      mockContext({
+        user: { roles: [UserRole.candidate], impersonating: true },
+      }),
+    )
+    expect(result).toBe(true)
+  })
+
+  it('rejects non-impersonating candidate sessions', () => {
+    const result = guard.canActivate(
+      mockContext({
+        user: { roles: [UserRole.candidate], impersonating: false },
+      }),
+    )
+    expect(result).toBe(false)
+  })
 })

--- a/src/authentication/guards/AdminOrM2M.guard.ts
+++ b/src/authentication/guards/AdminOrM2M.guard.ts
@@ -1,15 +1,17 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common'
 import { UserRole } from '@prisma/client'
-import { VerifiedM2MToken } from '@/authentication/interfaces/auth-provider.interface'
+import { IncomingRequest } from '@/authentication/authentication.types'
+import { effectiveUser } from '@/authentication/util/effectiveUser.util'
 
 // TODO: remove after we sunset the existing admin ENG-6732
 @Injectable()
 export class AdminOrM2MGuard implements CanActivate {
   canActivate(context: ExecutionContext) {
-    const { user, m2mToken } = context.switchToHttp().getRequest<{
-      user?: { roles: UserRole[] }
-      m2mToken?: VerifiedM2MToken
-    }>()
-    return Boolean(m2mToken || user?.roles.includes(UserRole.admin))
+    const req = context.switchToHttp().getRequest<IncomingRequest>()
+    return Boolean(
+      req.m2mToken ||
+        effectiveUser(req)?.roles.includes(UserRole.admin) ||
+        req.user?.impersonating,
+    )
   }
 }

--- a/src/authentication/guards/Roles.guard.ts
+++ b/src/authentication/guards/Roles.guard.ts
@@ -2,6 +2,8 @@ import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { UserRole } from '@prisma/client'
 import { ROLES_KEY } from '../decorators/Roles.decorator'
+import { IncomingRequest } from '@/authentication/authentication.types'
+import { effectiveUser } from '@/authentication/util/effectiveUser.util'
 
 @Injectable()
 export class RolesGuard implements CanActivate {
@@ -14,9 +16,9 @@ export class RolesGuard implements CanActivate {
     if (!requiredRoles) {
       return true
     }
-    const { user } = context.switchToHttp().getRequest<{
-      user: { roles?: UserRole[] }
-    }>()
-    return requiredRoles.some((role) => user.roles?.includes(role))
+    const req = context.switchToHttp().getRequest<IncomingRequest>()
+    return requiredRoles.some((role) =>
+      effectiveUser(req)?.roles?.includes(role),
+    )
   }
 }

--- a/src/authentication/guards/Session.guard.ts
+++ b/src/authentication/guards/Session.guard.ts
@@ -54,7 +54,14 @@ export class SessionGuard implements CanActivate {
       const { externalUserId, actor } =
         await this.authProvider.verifySessionToken(token)
 
-      const user = await this.resolveUser(externalUserId)
+      if (actor?.sub) {
+        request.actorSub = actor.sub
+      }
+
+      const [user, actorUser] = await Promise.all([
+        this.resolveUser(externalUserId, 'subject'),
+        actor ? this.resolveUser(actor.sub, 'actor') : Promise.resolve(null),
+      ])
 
       if (!user) {
         this.logger.warn(
@@ -63,9 +70,19 @@ export class SessionGuard implements CanActivate {
         return this.allowPublicOrThrow(context)
       }
 
+      if (actor && !actorUser) {
+        this.logger.warn(
+          { actorSub: actor.sub },
+          'Actor claim present but actor could not be resolved — continuing without actor privileges',
+        )
+      }
+
       request.user = {
         ...user,
         impersonating: actor != null,
+      }
+      if (actorUser) {
+        request.actorUser = actorUser
       }
       this.sessions.trackSession(user)
     } catch (err) {
@@ -86,7 +103,14 @@ export class SessionGuard implements CanActivate {
     throw new UnauthorizedException()
   }
 
-  private async resolveUser(externalUserId: string): Promise<User | null> {
+  private async resolveUser(
+    externalUserId: string,
+    role: 'subject' | 'actor' = 'subject',
+  ): Promise<User | null> {
+    if (!externalUserId.startsWith('user_')) {
+      return null
+    }
+
     const [rawUser, clerkFields] = await Promise.all([
       this.usersService.model.findUnique({
         where: { clerkId: externalUserId },
@@ -107,11 +131,15 @@ export class SessionGuard implements CanActivate {
         : rawUser
     }
 
+    if (role === 'actor') {
+      return null
+    }
+
     try {
       const providerUser = await this.authProvider.getUser(externalUserId)
       if (!providerUser?.email) {
         this.logger.warn(
-          { externalUserId },
+          { clerkId: externalUserId, role },
           'Auth provider user has no email address, cannot provision',
         )
         return null
@@ -125,7 +153,7 @@ export class SessionGuard implements CanActivate {
       })
     } catch (err) {
       this.logger.error(
-        { err, externalUserId },
+        { err, clerkId: externalUserId, role },
         'Failed to provision user from auth provider',
       )
       return null

--- a/src/authentication/util/effectiveUser.util.ts
+++ b/src/authentication/util/effectiveUser.util.ts
@@ -1,0 +1,3 @@
+import { IncomingRequest } from '@/authentication/authentication.types'
+
+export const effectiveUser = (req: IncomingRequest) => req.actorUser ?? req.user

--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -3,7 +3,7 @@ import { CLERK_CLIENT_PROVIDER_TOKEN } from '@/vendors/clerk/providers/clerk-cli
 import { ClerkClient } from '@clerk/backend'
 import { BadGatewayException, BadRequestException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { UsersService } from './users.service'
+import { UsersService, type ResolvedActorIdentity } from './users.service'
 import { AnalyticsService } from '@/analytics/analytics.service'
 import { StripeService } from '@/vendors/stripe/services/stripe.service'
 
@@ -286,6 +286,48 @@ describe('UsersService', () => {
       await expect(
         usersService.findUserByResetToken('tests@goodparty.org', 'wrong-token'),
       ).rejects.toThrow()
+    })
+  })
+
+  describe('resolveClerkIdByEmail', () => {
+    let clerkClient: ClerkClient
+
+    beforeEach(() => {
+      clerkClient = service.app.get<ClerkClient>(CLERK_CLIENT_PROVIDER_TOKEN)
+    })
+
+    it('returns clerk source when Clerk returns a user for the email', async () => {
+      vi.spyOn(clerkClient.users, 'getUserList').mockResolvedValue({
+        data: [{ id: 'user_from_clerk_lookup' } as never],
+        totalCount: 1,
+      } as Awaited<ReturnType<typeof clerkClient.users.getUserList>>)
+
+      const result: ResolvedActorIdentity =
+        await usersService.resolveClerkIdByEmail('anyone@example.com')
+
+      expect(result).toEqual({
+        source: 'clerk',
+        clerkId: 'user_from_clerk_lookup',
+      })
+      expect(clerkClient.users.getUserList).toHaveBeenCalledWith({
+        emailAddress: ['anyone@example.com'],
+        limit: 1,
+      })
+    })
+
+    it('returns email-fallback source when Clerk returns no users', async () => {
+      vi.spyOn(clerkClient.users, 'getUserList').mockResolvedValue({
+        data: [],
+        totalCount: 0,
+      } as Awaited<ReturnType<typeof clerkClient.users.getUserList>>)
+
+      const result =
+        await usersService.resolveClerkIdByEmail('nobody@example.com')
+
+      expect(result).toEqual({
+        source: 'email-fallback',
+        email: 'nobody@example.com',
+      })
     })
   })
 

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -40,6 +40,11 @@ import { hashPassword } from '../util/passwords.util'
 import { CrmUsersService } from './crmUsers.service'
 import { clerkThrottle } from '@/vendors/clerk/util/clerkThrottle.util'
 
+/** Result of resolving a gp-api Clerk user by email for impersonation actor.sub. */
+export type ResolvedActorIdentity =
+  | { source: 'clerk'; clerkId: string }
+  | { source: 'email-fallback'; email: string }
+
 const REGISTER_USER_CRM_FORM_ID = '37d98f01-7062-405f-b0d1-c95179057db1'
 
 const TEST_USER_DOMAIN = '@test.goodparty.org'
@@ -406,6 +411,18 @@ export class UsersService extends createPrismaBase(MODELS.User) {
         'Failed to track user deletion event',
       )
     }
+  }
+
+  /** Resolves gp-api Clerk user id by email, or signals email fallback when no user exists. */
+  async resolveClerkIdByEmail(email: string): Promise<ResolvedActorIdentity> {
+    const result = await this.clerkClient.users.getUserList({
+      emailAddress: [email],
+      limit: 1,
+    })
+    const clerkId = result.data[0]?.id
+    return clerkId
+      ? { source: 'clerk', clerkId }
+      : { source: 'email-fallback', email }
   }
 
   async impersonateUser(userId: number, actorClerkId: string) {

--- a/src/vendors/clerk/util/clerkThrottle.util.ts
+++ b/src/vendors/clerk/util/clerkThrottle.util.ts
@@ -10,5 +10,5 @@ export const clerkThrottle = throttleRequestsWithRetry({
   workerCount: 1,
   safetyFactor: 0.5,
   maxRetries: 3,
-  label: 'clerk-seed',
+  label: 'clerk-api',
 })


### PR DESCRIPTION
This PR releases gp-api to Prod.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes impersonation token actor identity resolution and relaxes guard behavior for impersonating sessions, which impacts authentication/authorization flows. Also adds new admin search endpoint and Clerk lookups, so misconfiguration could affect admin access or auditing.
> 
> **Overview**
> Improves admin impersonation by **resolving the token actor identity more robustly**: the `/admin/users/impersonate/:id` API now accepts `actorEmail` (instead of `actorClerkId`) for M2M calls, looks up the gp-api Clerk user by email, and *falls back to using the email string as `actor.sub`* when no Clerk account exists; it also preserves `actorSub` during impersonation “swap” flows.
> 
> Extends session/role handling to support this: `SessionGuard` now captures actor claims (`actorSub`) and separately resolves/stores an `actorUser`, `RolesGuard`/`AdminOrM2MGuard` use `effectiveUser(req)` (actor user when present) and `AdminOrM2MGuard` explicitly allows `req.user.impersonating`. Adds a guarded `/admin/users/search?email=` endpoint (case-insensitive, limited fields/results) plus tests, introduces `UsersService.resolveClerkIdByEmail`, updates Clerk throttle label, and adds a Grafana alert for spikes in the email-fallback impersonation path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b3c5516a9a35e518ac86ed0110ee39014cc577. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->