### PR TITLE
Bug Fixes - ENG-7596 | ENG-7469 | ENG-7468 | ENG-7466 (#1539)

### DIFF
--- a/src/authentication/guards/Session.guard.ts
+++ b/src/authentication/guards/Session.guard.ts
@@ -119,16 +119,21 @@ export class SessionGuard implements CanActivate {
     ])
 
     if (rawUser) {
-      return clerkFields
-        ? {
-            ...rawUser,
-            email: clerkFields.email,
-            firstName: clerkFields.firstName,
-            lastName: clerkFields.lastName,
-            name: clerkFields.name,
-            avatar: clerkFields.avatar,
-          }
-        : rawUser
+      if (!clerkFields) {
+        // Clerk unreachable: keep DB identity fields but never serve a stale
+        // local avatar as if it were Clerk's (see ClerkUserEnricherService).
+        return { ...rawUser, avatar: null }
+      }
+      // Use `||` (not `??`) so empty strings from Clerk also fall back to the
+      // DB value, matching ClerkUserEnricherService.applyFields.
+      return {
+        ...rawUser,
+        email: clerkFields.email || rawUser.email,
+        firstName: clerkFields.firstName || rawUser.firstName,
+        lastName: clerkFields.lastName || rawUser.lastName,
+        name: clerkFields.name || rawUser.name,
+        avatar: clerkFields.avatar,
+      }
     }
 
     if (role === 'actor') {

--- a/src/vendors/clerk/services/clerk-user-enricher.service.test.ts
+++ b/src/vendors/clerk/services/clerk-user-enricher.service.test.ts
@@ -1,0 +1,373 @@
+import { Test } from '@nestjs/testing'
+import { LoggerModule } from 'nestjs-pino'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CLERK_CLIENT_PROVIDER_TOKEN } from '@/vendors/clerk/providers/clerk-client.provider'
+import { PrismaService } from '@/prisma/prisma.service'
+import { ClerkUserEnricherService } from './clerk-user-enricher.service'
+
+vi.mock('@/vendors/clerk/util/clerkThrottle.util', () => ({
+  clerkThrottle: <T>(fn: () => Promise<T>) => fn(),
+}))
+
+type ClerkUserShape = {
+  id: string
+  primaryEmailAddress?: { emailAddress: string } | null
+  emailAddresses?: { emailAddress: string }[]
+  firstName: string | null
+  lastName: string | null
+  fullName: string | null
+  hasImage: boolean
+  imageUrl: string
+}
+
+const buildClerkUser = (
+  overrides: Partial<ClerkUserShape> = {},
+): ClerkUserShape => ({
+  id: 'clerk_default',
+  primaryEmailAddress: { emailAddress: 'clerk@goodparty.org' },
+  emailAddresses: [{ emailAddress: 'clerk@goodparty.org' }],
+  firstName: 'Clerk',
+  lastName: 'User',
+  fullName: 'Clerk User',
+  hasImage: false,
+  imageUrl: '',
+  ...overrides,
+})
+
+describe('ClerkUserEnricherService', () => {
+  let enricher: ClerkUserEnricherService
+  let getUser: ReturnType<typeof vi.fn>
+  let getUserList: ReturnType<typeof vi.fn>
+  let userUpdate: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    getUser = vi.fn()
+    getUserList = vi.fn()
+    userUpdate = vi.fn().mockResolvedValue({})
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [LoggerModule.forRoot({ pinoHttp: { enabled: false } })],
+      providers: [
+        ClerkUserEnricherService,
+        {
+          provide: CLERK_CLIENT_PROVIDER_TOKEN,
+          useValue: {
+            users: { getUser, getUserList },
+          },
+        },
+        {
+          provide: PrismaService,
+          useValue: {
+            user: { update: userUpdate },
+          },
+        },
+      ],
+    }).compile()
+
+    enricher = moduleRef.get(ClerkUserEnricherService)
+  })
+
+  describe('enrichUsers (bulk)', () => {
+    it('overwrites DB fields with Clerk values when Clerk has them', async () => {
+      getUserList.mockResolvedValue({
+        data: [
+          buildClerkUser({
+            id: 'clerk_a',
+            primaryEmailAddress: { emailAddress: 'newer@goodparty.org' },
+            firstName: 'Newer',
+            lastName: 'Name',
+            fullName: 'Newer Name',
+            hasImage: true,
+            imageUrl: 'https://img.clerk/new.png',
+          }),
+        ],
+      })
+
+      const dbUser = {
+        id: 1,
+        clerkId: 'clerk_a',
+        email: 'older@goodparty.org',
+        firstName: 'Older',
+        lastName: 'Name',
+        name: 'Older Name',
+        avatar: null,
+      }
+
+      const [enriched] = await enricher.enrichUsers([dbUser])
+
+      expect(enriched).toMatchObject({
+        email: 'newer@goodparty.org',
+        firstName: 'Newer',
+        lastName: 'Name',
+        name: 'Newer Name',
+        avatar: 'https://img.clerk/new.png',
+      })
+    })
+
+    it('keeps the DB email when Clerk has no primary email (regression: search with "+" character)', async () => {
+      getUserList.mockResolvedValue({
+        data: [
+          buildClerkUser({
+            id: 'clerk_no_email',
+            primaryEmailAddress: null,
+            emailAddresses: [],
+            firstName: 'Matthew',
+            lastName: 'Tester',
+          }),
+        ],
+      })
+
+      const dbUser = {
+        id: 42,
+        clerkId: 'clerk_no_email',
+        email: 'matthew+dev-clerk-1@goodparty.org',
+        firstName: 'Matthew',
+        lastName: 'Tester',
+        name: 'Matthew Tester',
+        avatar: null,
+      }
+
+      const [enriched] = await enricher.enrichUsers([dbUser])
+
+      expect(enriched.email).toBe('matthew+dev-clerk-1@goodparty.org')
+    })
+
+    it('keeps DB firstName/lastName/name when Clerk has empty values', async () => {
+      getUserList.mockResolvedValue({
+        data: [
+          buildClerkUser({
+            id: 'clerk_blank_names',
+            firstName: null,
+            lastName: '',
+            fullName: null,
+          }),
+        ],
+      })
+
+      const dbUser = {
+        id: 7,
+        clerkId: 'clerk_blank_names',
+        email: 'someone@goodparty.org',
+        firstName: 'Real',
+        lastName: 'Name',
+        name: 'Real Name',
+        avatar: null,
+      }
+
+      const [enriched] = await enricher.enrichUsers([dbUser])
+
+      expect(enriched).toMatchObject({
+        firstName: 'Real',
+        lastName: 'Name',
+        name: 'Real Name',
+      })
+    })
+
+    it('falls back to emailAddresses[0] when primary is missing', async () => {
+      getUserList.mockResolvedValue({
+        data: [
+          buildClerkUser({
+            id: 'clerk_secondary',
+            primaryEmailAddress: null,
+            emailAddresses: [{ emailAddress: 'secondary@goodparty.org' }],
+          }),
+        ],
+      })
+
+      const dbUser = {
+        id: 8,
+        clerkId: 'clerk_secondary',
+        email: 'db@goodparty.org',
+        firstName: 'X',
+        lastName: 'Y',
+        name: 'X Y',
+        avatar: null,
+      }
+
+      const [enriched] = await enricher.enrichUsers([dbUser])
+
+      expect(enriched.email).toBe('secondary@goodparty.org')
+    })
+
+    it('returns user untouched when Clerk lookup fails', async () => {
+      getUserList.mockRejectedValue(new Error('boom'))
+
+      const dbUser = {
+        id: 9,
+        clerkId: 'clerk_missing',
+        email: 'unchanged@goodparty.org',
+        firstName: 'Un',
+        lastName: 'Changed',
+        name: 'Un Changed',
+        avatar: 'https://legacy/upload.png',
+      }
+
+      const [enriched] = await enricher.enrichUsers([dbUser])
+
+      expect(enriched.firstName).toBe('Un')
+      expect(enriched.avatar).toBe(null)
+    })
+
+    it('strips avatar when user has no clerkId', async () => {
+      const dbUser = {
+        id: 10,
+        clerkId: null as string | null,
+        email: 'legacy@goodparty.org',
+        firstName: 'Leg',
+        lastName: 'acy',
+        avatar: 'https://legacy/old.png',
+      }
+
+      const [enriched] = await enricher.enrichUsers([dbUser])
+
+      expect(enriched.avatar).toBe(null)
+      expect(getUserList).not.toHaveBeenCalled()
+    })
+
+    it('sets avatar to null when Clerk has no profile image', async () => {
+      getUserList.mockResolvedValue({
+        data: [
+          buildClerkUser({
+            id: 'clerk_no_img',
+            hasImage: false,
+            imageUrl: '',
+          }),
+        ],
+      })
+
+      const dbUser = {
+        id: 11,
+        clerkId: 'clerk_no_img',
+        email: 'u@goodparty.org',
+        firstName: 'U',
+        lastName: 'Ser',
+        avatar: 'https://cdn/stale-upload.png',
+      }
+
+      const [enriched] = await enricher.enrichUsers([dbUser])
+
+      expect(enriched.avatar).toBe(null)
+    })
+  })
+
+  describe('enrichUser (single)', () => {
+    it('keeps DB email when Clerk has no email', async () => {
+      getUser.mockResolvedValue(
+        buildClerkUser({
+          id: 'clerk_single',
+          primaryEmailAddress: null,
+          emailAddresses: [],
+        }),
+      )
+
+      const dbUser = {
+        id: 100,
+        clerkId: 'clerk_single',
+        email: 'kept@goodparty.org',
+        firstName: 'Kept',
+        lastName: 'Email',
+        name: 'Kept Email',
+        avatar: null,
+      }
+
+      const enriched = await enricher.enrichUser(dbUser)
+
+      expect(enriched.email).toBe('kept@goodparty.org')
+    })
+
+    it('returns avatar null when clerkId is null and lazy link finds no Clerk user', async () => {
+      getUserList.mockResolvedValue({ data: [] })
+
+      const dbUser = {
+        id: 200,
+        clerkId: null,
+        email: 'noclerk@goodparty.org',
+        firstName: 'No',
+        lastName: 'Clerk',
+        name: 'No Clerk',
+        avatar: 'https://legacy/x.png',
+      }
+
+      const enriched = await enricher.enrichUser(dbUser)
+
+      expect(enriched).toMatchObject({
+        clerkId: null,
+        avatar: null,
+        firstName: 'No',
+      })
+      expect(userUpdate).not.toHaveBeenCalled()
+    })
+
+    it('lazy-links clerkId by email then applies Clerk avatar', async () => {
+      getUserList.mockResolvedValueOnce({
+        data: [
+          buildClerkUser({
+            id: 'user_lazy_1',
+            primaryEmailAddress: { emailAddress: 'lazy@goodparty.org' },
+            firstName: 'Lazy',
+            lastName: 'Linked',
+            fullName: 'Lazy Linked',
+            hasImage: true,
+            imageUrl: 'https://img.clerk/lazy.png',
+          }),
+        ],
+      })
+
+      const dbUser = {
+        id: 300,
+        clerkId: null,
+        email: 'lazy@goodparty.org',
+        firstName: 'Old',
+        lastName: 'Db',
+        name: 'Old Db',
+        avatar: 'https://legacy/db.png',
+      }
+
+      const enriched = await enricher.enrichUser(dbUser)
+
+      expect(userUpdate).toHaveBeenCalledWith({
+        where: { id: 300 },
+        data: { clerkId: 'user_lazy_1' },
+      })
+      expect(enriched).toMatchObject({
+        clerkId: 'user_lazy_1',
+        firstName: 'Lazy',
+        lastName: 'Linked',
+        avatar: 'https://img.clerk/lazy.png',
+      })
+      expect(getUser).not.toHaveBeenCalled()
+    })
+
+    it('nulls avatar on single-user Clerk fetch failure when clerkId is set', async () => {
+      getUser.mockRejectedValue(new Error('clerk down'))
+
+      const dbUser = {
+        id: 400,
+        clerkId: 'user_err',
+        email: 'e@goodparty.org',
+        firstName: 'Keep',
+        lastName: 'Me',
+        avatar: 'https://legacy/z.png',
+      }
+
+      const enriched = await enricher.enrichUser(dbUser)
+
+      expect(enriched.firstName).toBe('Keep')
+      expect(enriched.avatar).toBe(null)
+    })
+
+    it('returns the user unchanged when clerkId is null and no email (no avatar key)', async () => {
+      const dbUser = {
+        id: 500,
+        clerkId: null,
+        firstName: 'X',
+        lastName: 'Y',
+      }
+
+      const enriched = await enricher.enrichUser(dbUser)
+
+      expect(enriched).toEqual(dbUser)
+      expect(getUser).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/vendors/clerk/services/clerk-user-enricher.service.ts
+++ b/src/vendors/clerk/services/clerk-user-enricher.service.ts
@@ -1,17 +1,21 @@
 import { Inject, Injectable } from '@nestjs/common'
 import { ClerkClient } from '@clerk/backend'
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import { PinoLogger } from 'nestjs-pino'
+import { PrismaService } from '@/prisma/prisma.service'
 import { CLERK_CLIENT_PROVIDER_TOKEN } from '@/vendors/clerk/providers/clerk-client.provider'
+import { clerkThrottle } from '@/vendors/clerk/util/clerkThrottle.util'
 
 export interface ClerkUserFields {
-  email: string
-  firstName: string
-  lastName: string
-  name: string
+  email: string | null
+  firstName: string | null
+  lastName: string | null
+  name: string | null
   avatar: string | null
 }
 
 type Enrichable = {
+  id?: number
   clerkId: string | null
   email?: string | null
   firstName?: string | null
@@ -25,6 +29,7 @@ export class ClerkUserEnricherService {
   constructor(
     @Inject(CLERK_CLIENT_PROVIDER_TOKEN)
     private readonly clerkClient: ClerkClient,
+    private readonly prisma: PrismaService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(ClerkUserEnricherService.name)
@@ -34,6 +39,9 @@ export class ClerkUserEnricherService {
     string,
     { fields: ClerkUserFields; expiresAt: number }
   >()
+
+  /** Negative cache for lazy email→Clerk lookups (same TTL as Clerk field cache). */
+  private readonly emailMissCache = new Map<string, number>()
 
   private readonly cacheTtlMs = 30_000
 
@@ -45,20 +53,7 @@ export class ClerkUserEnricherService {
 
     try {
       const clerkUser = await this.clerkClient.users.getUser(clerkId)
-      const email =
-        clerkUser.primaryEmailAddress?.emailAddress ??
-        clerkUser.emailAddresses?.[0]?.emailAddress
-
-      const firstName = clerkUser.firstName ?? ''
-      const lastName = clerkUser.lastName ?? ''
-
-      const fields: ClerkUserFields = {
-        email: email ?? '',
-        firstName,
-        lastName,
-        name: clerkUser.fullName ?? `${firstName} ${lastName}`.trim(),
-        avatar: clerkUser.hasImage ? clerkUser.imageUrl : null,
-      }
+      const fields = this.buildFields(clerkUser)
 
       this.fieldsCache.set(clerkId, {
         fields,
@@ -76,12 +71,28 @@ export class ClerkUserEnricherService {
   }
 
   async enrichUser<T extends Enrichable>(user: T): Promise<T> {
-    if (!user.clerkId) return user
+    let effective = { ...user } as T
 
-    const fields = await this.fetchClerkFields(user.clerkId)
-    if (!fields) return user
+    if (!effective.clerkId) {
+      const linkedId = await this.tryResolveAndPersistClerkId(effective)
+      if (linkedId) {
+        effective = { ...effective, clerkId: linkedId }
+      } else {
+        return this.stripStaleAvatarWhenNoClerk(effective)
+      }
+    }
 
-    return this.applyFields(user, fields)
+    const clerkIdForFetch = effective.clerkId
+    if (!clerkIdForFetch) {
+      return this.stripStaleAvatarWhenNoClerk(effective)
+    }
+
+    const fields = await this.fetchClerkFields(clerkIdForFetch)
+    if (!fields) {
+      return this.stripAvatarOnClerkFetchFailure(effective)
+    }
+
+    return this.applyFields(effective, fields)
   }
 
   async enrichUsers<T extends Enrichable>(users: T[]): Promise<T[]> {
@@ -89,14 +100,21 @@ export class ClerkUserEnricherService {
       .map((u) => u.clerkId)
       .filter((id): id is string => id != null)
 
-    if (clerkIds.length === 0) return users
+    if (clerkIds.length === 0) {
+      return users.map((u) => this.stripStaleAvatarWhenNoClerk(u))
+    }
 
     const fieldsByClerkId = await this.fetchClerkFieldsBulk(clerkIds)
 
     return users.map((user) => {
-      if (!user.clerkId) return user
+      if (!user.clerkId) {
+        return this.stripStaleAvatarWhenNoClerk(user)
+      }
       const fields = fieldsByClerkId.get(user.clerkId)
-      return fields ? this.applyFields(user, fields) : user
+      if (!fields) {
+        return this.stripAvatarOnClerkFetchFailure(user)
+      }
+      return this.applyFields(user, fields)
     })
   }
 
@@ -125,20 +143,7 @@ export class ClerkUserEnricherService {
       })
 
       for (const clerkUser of clerkUsers.data) {
-        const email =
-          clerkUser.primaryEmailAddress?.emailAddress ??
-          clerkUser.emailAddresses?.[0]?.emailAddress
-
-        const firstName = clerkUser.firstName ?? ''
-        const lastName = clerkUser.lastName ?? ''
-
-        const fields: ClerkUserFields = {
-          email: email ?? '',
-          firstName,
-          lastName,
-          name: clerkUser.fullName ?? `${firstName} ${lastName}`.trim(),
-          avatar: clerkUser.hasImage ? clerkUser.imageUrl : null,
-        }
+        const fields = this.buildFields(clerkUser)
 
         result.set(clerkUser.id, fields)
         this.fieldsCache.set(clerkUser.id, {
@@ -160,13 +165,119 @@ export class ClerkUserEnricherService {
     user: T,
     fields: ClerkUserFields,
   ): T {
+    // Only overwrite identity fields when Clerk has a non-empty value.
+    // Avatar always follows Clerk (including null when hasImage is false).
     return {
       ...user,
-      ...('email' in user ? { email: fields.email } : {}),
-      ...('firstName' in user ? { firstName: fields.firstName } : {}),
-      ...('lastName' in user ? { lastName: fields.lastName } : {}),
-      ...('name' in user ? { name: fields.name } : {}),
+      ...('email' in user && fields.email ? { email: fields.email } : {}),
+      ...('firstName' in user && fields.firstName
+        ? { firstName: fields.firstName }
+        : {}),
+      ...('lastName' in user && fields.lastName
+        ? { lastName: fields.lastName }
+        : {}),
+      ...('name' in user && fields.name ? { name: fields.name } : {}),
       ...('avatar' in user ? { avatar: fields.avatar } : {}),
+    }
+  }
+
+  private buildFields(clerkUser: {
+    primaryEmailAddress?: { emailAddress: string } | null
+    emailAddresses?: { emailAddress: string }[]
+    firstName: string | null
+    lastName: string | null
+    fullName: string | null
+    hasImage: boolean
+    imageUrl: string
+  }): ClerkUserFields {
+    const email =
+      clerkUser.primaryEmailAddress?.emailAddress ??
+      clerkUser.emailAddresses?.[0]?.emailAddress ??
+      null
+
+    const firstName = clerkUser.firstName ?? null
+    const lastName = clerkUser.lastName ?? null
+    const fallbackName = [firstName, lastName].filter(Boolean).join(' ').trim()
+    const name =
+      clerkUser.fullName ?? (fallbackName.length > 0 ? fallbackName : null)
+
+    return {
+      email,
+      firstName,
+      lastName,
+      name,
+      avatar: clerkUser.hasImage ? clerkUser.imageUrl : null,
+    }
+  }
+
+  /** No Clerk id (or lazy link failed): never expose legacy DB avatar as “truth”. */
+  private stripStaleAvatarWhenNoClerk<T extends Enrichable>(user: T): T {
+    if (!('avatar' in user)) return user
+    return { ...user, avatar: null }
+  }
+
+  /** Clerk id present but API fetch failed: keep DB name/email, drop stale avatar. */
+  private stripAvatarOnClerkFetchFailure<T extends Enrichable>(user: T): T {
+    if (!('avatar' in user)) return user
+    return { ...user, avatar: null }
+  }
+
+  private async tryResolveAndPersistClerkId<T extends Enrichable>(
+    user: T,
+  ): Promise<string | null> {
+    const id = typeof user.id === 'number' ? user.id : null
+    const email =
+      typeof user.email === 'string' && user.email.trim().length > 0
+        ? user.email.trim()
+        : null
+    if (!id || !email) return null
+
+    const key = email.toLowerCase()
+    const missUntil = this.emailMissCache.get(key)
+    if (missUntil != null && missUntil > Date.now()) return null
+
+    try {
+      const { data } = await clerkThrottle(() =>
+        this.clerkClient.users.getUserList({
+          emailAddress: [email],
+          limit: 1,
+        }),
+      )
+      const clerkUser = data[0]
+      if (!clerkUser?.id) {
+        this.emailMissCache.set(key, Date.now() + this.cacheTtlMs)
+        return null
+      }
+
+      await this.prisma.user.update({
+        where: { id },
+        data: { clerkId: clerkUser.id },
+      })
+      // Reuse the Clerk payload we already have: enrichUser() calls fetchClerkFields() next,
+      // which would otherwise hit getUser() for the same id (extra latency + quota).
+      const fields = this.buildFields(clerkUser)
+      this.fieldsCache.set(clerkUser.id, {
+        fields,
+        expiresAt: Date.now() + this.cacheTtlMs,
+      })
+      return clerkUser.id
+    } catch (err) {
+      if (
+        err instanceof PrismaClientKnownRequestError &&
+        err.code === 'P2002'
+      ) {
+        this.logger.warn(
+          { email, userId: id },
+          'Lazy Clerk link skipped: clerkId already taken',
+        )
+      } else {
+        this.logger.warn(
+          { err, email, userId: id },
+          'Lazy Clerk link by email failed',
+        )
+      }
+      this.emailMissCache.set(key, Date.now() + this.cacheTtlMs)
+      return null
     }
   }
 }


### PR DESCRIPTION
* .

* Remove useless backfill scripts

* Address bugbot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user identity enrichment paths used during request authentication and campaign flows, including lazy-linking `clerkId` updates in the DB and new fallback rules; mistakes could surface wrong profile data or cause unexpected DB writes.
> 
> **Overview**
> Tightens how user profile fields are merged from Clerk vs the DB: identity fields now only override when Clerk provides non-empty values, while `avatar` is always sourced from Clerk and is explicitly nulled when Clerk is unreachable or a user lacks a `clerkId` (preventing stale legacy avatars from being served).
> 
> Extends `ClerkUserEnricherService` to optionally *lazy-link* users missing a `clerkId` by looking up Clerk by email (with throttling + negative caching) and persisting the discovered `clerkId`, handling uniqueness conflicts.
> 
> Adds a comprehensive test suite covering bulk/single enrichment, missing emails (including `+` cases), empty-name regressions, avatar stripping on failures, and lazy-link behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7df35d42f6af5cf24b81600946f66671b41a440f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->