### PR TITLE
chore: disable controller p95 latency alerts

### DIFF
--- a/deploy/components/alerting/alerts.types.ts
+++ b/deploy/components/alerting/alerts.types.ts
@@ -48,8 +48,3 @@ export type Alert = {
   /** Whether the alert is disabled. */
   disabled?: boolean
 }
-
-export type EndpointOverride = {
-  /** Override for p95 latency threshold (ms). */
-  p95LatencyMs?: number
-}

--- a/deploy/components/alerting/controller-alerts.ts
+++ b/deploy/components/alerting/controller-alerts.ts
@@ -1,11 +1,6 @@
 import { ControllerName, ROUTE_MAP } from '../../../src/generated/route-types'
 import { Alert, SlackGroup } from './alerts.types'
-import {
-  ALERT_OWNERSHIP,
-  DEFAULT_P95_READ_LATENCY_MS,
-  DEFAULT_P95_WRITE_LATENCY_MS,
-  ENDPOINT_OVERRIDES,
-} from '../alerts'
+import { ALERT_OWNERSHIP } from '../alerts'
 
 const EXCLUDED_STATUS_CODES = [401, 403, 404, 409, 498]
 const statusCodeFilter = [
@@ -19,52 +14,25 @@ export const controllerAlerts = (controller: ControllerName): Alert[] => {
   )?.[0]
   const routes = ROUTE_MAP[controller]
 
-  return routes.flatMap((route) => {
-    const overrides =
-      // Route endpoint is a string that may match ENDPOINT_OVERRIDES keys — validated by optional chaining below
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      ENDPOINT_OVERRIDES[route.endpoint as keyof typeof ENDPOINT_OVERRIDES]
-    const p95LatencyMs =
-      overrides?.p95LatencyMs ??
-      (route.method === 'GET'
-        ? DEFAULT_P95_READ_LATENCY_MS
-        : DEFAULT_P95_WRITE_LATENCY_MS)
-
+  return routes.map((route) => {
     const routeBase = `{service_name="gp-api", deployment_environment_name="$ENV"} |= "Request completed" | json | request_endpoint = "${route.endpoint}"`
     const slug = route.endpoint.replace(/[/:]/g, '-').replace(' ', '-')
 
-    return [
-      {
-        slug: `${slug}-error-count`,
-        name: `[${controller}] ${route.endpoint} - Errors detected`,
-        type: 'log' as const,
-        expr: `sum(count_over_time(${routeBase} | ${statusCodeFilter} [1h]))`,
-        threshold: 0,
-        for: '1m',
-        message: [
-          `\`${route.endpoint}\` returned unexpected error responses in the last hour (status ≥ 400, excluding 401/403/404/409/498).`,
-          'Click *View in Grafana* to find the failing requests, then examine their logs and stack traces to understand why errors are occurring and ship fixes.',
-        ].join('\n\n'),
-        // slackGroupName comes from Object.entries find — disabled flag guards undefined case
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        notify: slackGroupName as SlackGroup,
-        disabled: !slackGroupName,
-      } satisfies Alert,
-      {
-        slug: `${slug}-p95-latency`,
-        name: `[${controller}] ${route.endpoint} - High p95 latency`,
-        type: 'log' as const,
-        expr: `quantile_over_time(0.95, ${routeBase} | keep responseTimeMs | unwrap responseTimeMs [1h])`,
-        threshold: p95LatencyMs,
-        for: '1m',
-        message: [
-          `\`${route.endpoint}\` p95 latency has exceeded ${p95LatencyMs}ms over the last hour.`,
-          'Click *View in Grafana* to find the slow requests, then examine their traces to identify the bottleneck (slow DB queries, external API calls, etc.). If this endpoint is expected to be this slow, <https://github.com/thegoodparty/gp-api/blob/develop/ALERTING.md#how-to-override-thresholds|raise the threshold>.',
-        ].join('\n\n'),
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        notify: slackGroupName as SlackGroup,
-        disabled: !slackGroupName,
-      } satisfies Alert,
-    ]
+    return {
+      slug: `${slug}-error-count`,
+      name: `[${controller}] ${route.endpoint} - Errors detected`,
+      type: 'log' as const,
+      expr: `sum(count_over_time(${routeBase} | ${statusCodeFilter} [1h]))`,
+      threshold: 0,
+      for: '1m',
+      message: [
+        `\`${route.endpoint}\` returned unexpected error responses in the last hour (status ≥ 400, excluding 401/403/404/409/498).`,
+        'Click *View in Grafana* to find the failing requests, then examine their logs and stack traces to understand why errors are occurring and ship fixes.',
+      ].join('\n\n'),
+      // slackGroupName comes from Object.entries find — disabled flag guards undefined case
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      notify: slackGroupName as SlackGroup,
+      disabled: !slackGroupName,
+    } satisfies Alert
   })
 }

--- a/deploy/components/alerts.ts
+++ b/deploy/components/alerts.ts
@@ -1,8 +1,5 @@
-import { ControllerName, Endpoint } from '../../src/generated/route-types'
-import { Alert, EndpointOverride, SlackGroup } from './alerting/alerts.types'
-
-export const DEFAULT_P95_READ_LATENCY_MS = 1000
-export const DEFAULT_P95_WRITE_LATENCY_MS = 3000
+import { ControllerName } from '../../src/generated/route-types'
+import { Alert, SlackGroup } from './alerting/alerts.types'
 
 /** Map of slack group to controllers */
 export const ALERT_OWNERSHIP: Record<SlackGroup, ControllerName[]> = {
@@ -14,18 +11,6 @@ export const ALERT_OWNERSHIP: Record<SlackGroup, ControllerName[]> = {
     'organizations',
   ],
   'win-bugs': [],
-}
-
-export const ENDPOINT_OVERRIDES: Partial<Record<Endpoint, EndpointOverride>> = {
-  'GET /v1/contacts': {
-    p95LatencyMs: 999_999,
-  },
-  'GET /v1/contacts/download': {
-    p95LatencyMs: 999_999,
-  },
-  'POST /v1/polls/analyze-bias': {
-    p95LatencyMs: 999_999,
-  },
 }
 
 export const GLOBAL_ALERTS: Alert[] = [

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -8,10 +8,9 @@ There are two categories of alerts:
 
 ### Controller Alerts (auto-generated)
 
-Every controller endpoint automatically gets two alerts:
+Every controller endpoint automatically gets one alert:
 
 - **Error count**: Fires when any requests return error status codes (≥ 400, excluding 401/403/404/409/498) within a 1-hour window.
-- **P95 latency**: Fires when the 95th percentile response time exceeds 2000ms for GET requests or 3000ms for writes (POST/PUT/DELETE/PATCH) over a 1-hour window.
 
 These are generated automatically from the controllers in the codebase -- you don't write them by hand. **All controller alerts are disabled by default** and require explicit opt-in via the ownership mapping (see [Ownership](#ownership) below).
 
@@ -59,12 +58,12 @@ Controllers that aren't assigned to either group still get alerts generated, but
 
 All alerting configuration lives in `deploy/`:
 
-| File                                              | Purpose                                                                          |
-| ------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `deploy/components/alerts.ts`                     | Ownership mapping, default thresholds, per-endpoint overrides, and global alerts |
-| `deploy/components/alerting/controller-alerts.ts` | Generates error count + latency alerts for each controller endpoint              |
-| `deploy/components/alerting/alerts.types.ts`      | Type definitions for `Alert`, `EndpointOverride`, `SlackGroup`                   |
-| `deploy/components/grafana.ts`                    | Converts alerts into Grafana rule groups via Pulumi                              |
+| File                                              | Purpose                                                   |
+| ------------------------------------------------- | --------------------------------------------------------- |
+| `deploy/components/alerts.ts`                     | Ownership mapping and global alerts                       |
+| `deploy/components/alerting/controller-alerts.ts` | Generates error count alerts for each controller endpoint |
+| `deploy/components/alerting/alerts.types.ts`      | Type definitions for `Alert` and `SlackGroup`             |
+| `deploy/components/grafana.ts`                    | Converts alerts into Grafana rule groups via Pulumi       |
 
 ## How to opt in a controller
 
@@ -75,18 +74,6 @@ All of that controller's endpoint alerts become active on the next deploy.
 ## How to override thresholds
 
 Error alerts always fire on any unexpected error and cannot be overridden -- if an endpoint is returning errors, you should know about it.
-
-Latency thresholds can be overridden per-endpoint by adding an entry to `ENDPOINT_OVERRIDES` in `deploy/components/alerts.ts`:
-
-```typescript
-export const ENDPOINT_OVERRIDES: Partial<Record<Endpoint, EndpointOverride>> = {
-  'GET /v1/contacts': {
-    p95LatencyMs: 5000,
-  },
-}
-```
-
-Endpoint strings are in the format `METHOD /v1/controller/path` and are type-safe -- your editor will autocomplete them.
 
 ## How to add a new global alert
 


### PR DESCRIPTION
## Summary

The auto-generated p95 latency alerts on every controller endpoint produced more noise than signal — slow requests on a route are usually a known characteristic of that route (large CSV exports, AI calls, etc.) rather than a regression worth paging on. Error-count alerts already catch the failure modes we actually care about, so the latency rules were mostly being silenced via per-endpoint overrides.

This removes the latency alert generator entirely along with the configuration that existed only to feed it (`DEFAULT_P95_READ_LATENCY_MS`, `DEFAULT_P95_WRITE_LATENCY_MS`, `ENDPOINT_OVERRIDES`, the `EndpointOverride` type) and trims the observability doc to match.

Controller alerting now covers error counts only. Global alerts (CPU, memory, health probe, Peerly errors, impersonation fallback, Serve background-job failures) are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes alerting behavior by removing per-endpoint p95 latency rules, which could reduce detection of performance regressions until other signals catch them. No runtime application logic changes, but monitoring coverage is intentionally reduced.
> 
> **Overview**
> Stops generating controller *p95 latency* alerts and leaves controller auto-alerting as **error-count only**.
> 
> Removes the latency-threshold configuration surface (`DEFAULT_P95_*`, `ENDPOINT_OVERRIDES`, and `EndpointOverride`) and updates `docs/observability.md` to reflect the simplified controller alert model and key-file responsibilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1d22a8959ddfb26d6b794bbeaea833b124e8606. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->