### PR TITLE
ENG-7570 fix Pro renewal checkout

### DIFF
--- a/src/payments/payments.controller.ts
+++ b/src/payments/payments.controller.ts
@@ -10,9 +10,11 @@ import {
   Post,
   RawBodyRequest,
   Req,
+  UseGuards,
 } from '@nestjs/common'
 import { UserRole } from '@prisma/client'
 import { Roles } from 'src/authentication/decorators/Roles.decorator'
+import { AdminOrM2MGuard } from 'src/authentication/guards/AdminOrM2M.guard'
 import { Stripe } from 'stripe'
 import { PublicAccess } from '../authentication/decorators/PublicAccess.decorator'
 import { CampaignsService } from '../campaigns/services/campaigns.service'
@@ -82,7 +84,7 @@ export class PaymentsController {
    * See ENG-7570.
    */
   @Post('recover-pending-subscription')
-  @Roles(UserRole.admin)
+  @UseGuards(AdminOrM2MGuard)
   @HttpCode(HttpStatus.OK)
   async recoverPendingSubscription(@Body() body: { userId: number }) {
     const userId = Number(body?.userId)

--- a/src/payments/payments.controller.ts
+++ b/src/payments/payments.controller.ts
@@ -10,11 +10,9 @@ import {
   Post,
   RawBodyRequest,
   Req,
-  UseGuards,
 } from '@nestjs/common'
 import { UserRole } from '@prisma/client'
 import { Roles } from 'src/authentication/decorators/Roles.decorator'
-import { AdminOrM2MGuard } from 'src/authentication/guards/AdminOrM2M.guard'
 import { Stripe } from 'stripe'
 import { PublicAccess } from '../authentication/decorators/PublicAccess.decorator'
 import { CampaignsService } from '../campaigns/services/campaigns.service'
@@ -84,7 +82,7 @@ export class PaymentsController {
    * See ENG-7570.
    */
   @Post('recover-pending-subscription')
-  @UseGuards(AdminOrM2MGuard)
+  @Roles(UserRole.admin)
   @HttpCode(HttpStatus.OK)
   async recoverPendingSubscription(@Body() body: { userId: number }) {
     const userId = Number(body?.userId)

--- a/src/payments/payments.controller.ts
+++ b/src/payments/payments.controller.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  Body,
   Controller,
   Headers,
   HttpCode,
@@ -73,5 +74,21 @@ export class PaymentsController {
   @HttpCode(HttpStatus.OK)
   async fixMissingCustomerIds() {
     return this.paymentsService.fixMissingCustomerIds()
+  }
+
+  /**
+   * Replays the Stripe subscription-checkout success path for a user whose
+   * webhook originally failed and is now stuck on "Subscription Pending".
+   * See ENG-7570.
+   */
+  @Post('recover-pending-subscription')
+  @Roles(UserRole.admin)
+  @HttpCode(HttpStatus.OK)
+  async recoverPendingSubscription(@Body() body: { userId: number }) {
+    const userId = Number(body?.userId)
+    if (!Number.isInteger(userId) || userId <= 0) {
+      throw new BadRequestException('userId is required and must be a number')
+    }
+    return this.stripeEvents.replayPendingProCheckoutForUser(userId)
   }
 }

--- a/src/payments/purchase.controller.test.ts
+++ b/src/payments/purchase.controller.test.ts
@@ -1,0 +1,141 @@
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import {
+  createMockCampaign,
+  createMockUser,
+} from '@/shared/test-utils/mockData.util'
+import { BadRequestException } from '@nestjs/common'
+import { Campaign } from '@prisma/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CampaignsService } from '../campaigns/services/campaigns.service'
+import { UsersService } from '../users/services/users.service'
+import { StripeService } from '../vendors/stripe/services/stripe.service'
+import { PurchaseController } from './purchase.controller'
+import { PurchaseService } from './services/purchase.service'
+
+describe('PurchaseController.createProCheckoutSession', () => {
+  let controller: PurchaseController
+  let stripeService: { createCheckoutSession: ReturnType<typeof vi.fn> }
+  let usersService: { patchUserMetaData: ReturnType<typeof vi.fn> }
+  let campaignsService: { findByUserId: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    stripeService = {
+      createCheckoutSession: vi.fn().mockResolvedValue({
+        redirectUrl: 'https://stripe.test/checkout',
+        checkoutSessionId: 'cs_test_123',
+      }),
+    }
+    usersService = { patchUserMetaData: vi.fn().mockResolvedValue(undefined) }
+    campaignsService = { findByUserId: vi.fn() }
+
+    controller = new PurchaseController(
+      stripeService as unknown as StripeService,
+      usersService as unknown as UsersService,
+      campaignsService as unknown as CampaignsService,
+      {} as PurchaseService,
+      createMockLogger(),
+    )
+  })
+
+  const formatYmd = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  const futureDate = () => {
+    const d = new Date()
+    d.setFullYear(d.getFullYear() + 1)
+    return formatYmd(d)
+  }
+  const pastDate = () => {
+    const d = new Date()
+    d.setFullYear(d.getFullYear() - 1)
+    return formatYmd(d)
+  }
+  const today = () => formatYmd(new Date())
+
+  it('creates a checkout session when election date is in the future', async () => {
+    const campaign: Campaign = createMockCampaign({
+      details: { electionDate: futureDate() },
+    })
+    campaignsService.findByUserId.mockResolvedValue(campaign)
+    const user = createMockUser()
+
+    const result = await controller.createProCheckoutSession(user)
+
+    expect(result).toEqual({ redirectUrl: 'https://stripe.test/checkout' })
+    expect(stripeService.createCheckoutSession).toHaveBeenCalledWith(
+      user.id,
+      user.email,
+    )
+    expect(usersService.patchUserMetaData).toHaveBeenCalledWith(user.id, {
+      checkoutSessionId: 'cs_test_123',
+    })
+  })
+
+  it('creates a checkout session when election date is today', async () => {
+    const campaign: Campaign = createMockCampaign({
+      details: { electionDate: today() },
+    })
+    campaignsService.findByUserId.mockResolvedValue(campaign)
+    const user = createMockUser()
+
+    await controller.createProCheckoutSession(user)
+
+    expect(stripeService.createCheckoutSession).toHaveBeenCalledWith(
+      user.id,
+      user.email,
+    )
+  })
+
+  it('throws CAMPAIGN_NOT_FOUND when user has no campaign', async () => {
+    campaignsService.findByUserId.mockResolvedValue(null)
+    const user = createMockUser()
+
+    await expect(controller.createProCheckoutSession(user)).rejects.toThrow(
+      BadRequestException,
+    )
+    try {
+      await controller.createProCheckoutSession(user)
+    } catch (e) {
+      expect((e as BadRequestException).getResponse()).toMatchObject({
+        errorCode: 'CAMPAIGN_NOT_FOUND',
+      })
+    }
+    expect(stripeService.createCheckoutSession).not.toHaveBeenCalled()
+  })
+
+  it('throws CAMPAIGN_ELECTION_DATE_INVALID when electionDate is missing', async () => {
+    campaignsService.findByUserId.mockResolvedValue(
+      createMockCampaign({ details: {} }),
+    )
+    const user = createMockUser()
+
+    try {
+      await controller.createProCheckoutSession(user)
+      expect.fail('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(BadRequestException)
+      expect((e as BadRequestException).getResponse()).toMatchObject({
+        errorCode: 'CAMPAIGN_ELECTION_DATE_INVALID',
+      })
+    }
+    expect(stripeService.createCheckoutSession).not.toHaveBeenCalled()
+  })
+
+  it('throws CAMPAIGN_ELECTION_DATE_INVALID when electionDate is in the past', async () => {
+    campaignsService.findByUserId.mockResolvedValue(
+      createMockCampaign({ details: { electionDate: pastDate() } }),
+    )
+    const user = createMockUser()
+
+    try {
+      await controller.createProCheckoutSession(user)
+      expect.fail('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(BadRequestException)
+      expect((e as BadRequestException).getResponse()).toMatchObject({
+        errorCode: 'CAMPAIGN_ELECTION_DATE_INVALID',
+      })
+    }
+    expect(stripeService.createCheckoutSession).not.toHaveBeenCalled()
+    expect(usersService.patchUserMetaData).not.toHaveBeenCalled()
+  })
+})

--- a/src/payments/purchase.controller.ts
+++ b/src/payments/purchase.controller.ts
@@ -5,6 +5,8 @@ import { Campaign, Organization, User } from '@prisma/client'
 import { PinoLogger } from 'nestjs-pino'
 import { serializeError } from 'serialize-error'
 import { ReqUser } from '../authentication/decorators/ReqUser.decorator'
+import { CampaignsService } from '../campaigns/services/campaigns.service'
+import { isDateTodayOrFuture } from '../shared/util/date.util'
 import { UsersService } from '../users/services/users.service'
 import { StripeService } from '../vendors/stripe/services/stripe.service'
 import {
@@ -21,6 +23,7 @@ export class PurchaseController {
   constructor(
     private readonly stripeService: StripeService,
     private readonly usersService: UsersService,
+    private readonly campaignsService: CampaignsService,
     private readonly purchaseService: PurchaseService,
     private readonly logger: PinoLogger,
   ) {
@@ -30,6 +33,25 @@ export class PurchaseController {
   @Post('checkout-session')
   async createProCheckoutSession(@ReqUser() user: User) {
     const { email } = user
+
+    // Block checkout up front when normal Pro activation cannot proceed cleanly,
+    // rather than letting Stripe charge the customer and forcing webhook recovery
+    // for a subscription that needs manual triage (ENG-7570).
+    const campaign = await this.campaignsService.findByUserId(user.id)
+    if (!campaign) {
+      throw new BadRequestException({
+        message: 'No campaign found for user',
+        errorCode: 'CAMPAIGN_NOT_FOUND',
+      })
+    }
+    if (!isDateTodayOrFuture(campaign.details?.electionDate)) {
+      throw new BadRequestException({
+        message:
+          'Campaign election date is missing or in the past. Update your election date before renewing Pro.',
+        errorCode: 'CAMPAIGN_ELECTION_DATE_INVALID',
+      })
+    }
+
     const { redirectUrl, checkoutSessionId } =
       await this.stripeService.createCheckoutSession(user.id, email)
 

--- a/src/payments/services/paymentEventsService.test.ts
+++ b/src/payments/services/paymentEventsService.test.ts
@@ -1,0 +1,268 @@
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import {
+  createMockCampaign,
+  createMockUser,
+} from '@/shared/test-utils/mockData.util'
+import { Campaign, User } from '@prisma/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AnalyticsService } from 'src/analytics/analytics.service'
+import { CampaignsService } from '../../campaigns/services/campaigns.service'
+import { CrmCampaignsService } from '../../campaigns/services/crmCampaigns.service'
+import { EmailService } from '../../email/email.service'
+import { OrganizationsService } from '../../organizations/services/organizations.service'
+import { VoterFileDownloadAccessService } from '../../shared/services/voterFileDownloadAccess.service'
+import { UsersService } from '../../users/services/users.service'
+import { SlackService } from '../../vendors/slack/services/slack.service'
+import { StripeService } from '../../vendors/stripe/services/stripe.service'
+import { CheckoutSessionMode } from '../payments.types'
+import { PaymentEventsService } from './paymentEventsService'
+import type { PurchaseService } from './purchase.service'
+import type Stripe from 'stripe'
+
+const formatYmd = (d: Date) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+const futureIso = () => {
+  const d = new Date()
+  d.setFullYear(d.getFullYear() + 1)
+  return formatYmd(d)
+}
+const pastIso = () => {
+  const d = new Date()
+  d.setFullYear(d.getFullYear() - 1)
+  return formatYmd(d)
+}
+
+const buildSubscriptionSession = (
+  overrides: Partial<Stripe.Checkout.Session> = {},
+): Stripe.Checkout.Session =>
+  ({
+    id: 'cs_test_123',
+    mode: CheckoutSessionMode.SUBSCRIPTION,
+    customer: 'cus_test_abc',
+    subscription: 'sub_test_xyz',
+    payment_status: 'paid',
+    metadata: { userId: '7' },
+    ...overrides,
+  }) as unknown as Stripe.Checkout.Session
+
+describe('PaymentEventsService', () => {
+  let service: PaymentEventsService
+  let usersService: {
+    findUser: ReturnType<typeof vi.fn>
+    patchUserMetaData: ReturnType<typeof vi.fn>
+  }
+  let campaignsService: {
+    findByUserId: ReturnType<typeof vi.fn>
+    patchCampaignDetails: ReturnType<typeof vi.fn>
+    setIsPro: ReturnType<typeof vi.fn>
+  }
+  let slackService: { message: ReturnType<typeof vi.fn> }
+  let voterFileDownloadAccess: { downloadAccessAlert: ReturnType<typeof vi.fn> }
+  let organizationsService: {
+    getDistrictForOrgSlug: ReturnType<typeof vi.fn>
+    resolvePositionNameByOrganizationSlug: ReturnType<typeof vi.fn>
+  }
+  let stripeService: { retrieveCheckoutSession: ReturnType<typeof vi.fn> }
+  let analytics: { trackProPayment: ReturnType<typeof vi.fn> }
+  let crm: { getCrmCompanyOwnerName: ReturnType<typeof vi.fn> }
+
+  const mockUser: User = createMockUser({ id: 7, email: 'allie@example.com' })
+
+  beforeEach(() => {
+    usersService = {
+      findUser: vi.fn().mockResolvedValue(mockUser),
+      patchUserMetaData: vi.fn().mockResolvedValue(undefined),
+    }
+    campaignsService = {
+      findByUserId: vi.fn(),
+      patchCampaignDetails: vi.fn().mockResolvedValue(undefined),
+      setIsPro: vi.fn().mockResolvedValue(undefined),
+    }
+    slackService = { message: vi.fn().mockResolvedValue(undefined) }
+    voterFileDownloadAccess = {
+      downloadAccessAlert: vi.fn().mockResolvedValue(undefined),
+    }
+    organizationsService = {
+      getDistrictForOrgSlug: vi.fn().mockResolvedValue(null),
+      resolvePositionNameByOrganizationSlug: vi.fn().mockResolvedValue(null),
+    }
+    stripeService = { retrieveCheckoutSession: vi.fn() }
+    analytics = { trackProPayment: vi.fn().mockResolvedValue(undefined) }
+    crm = { getCrmCompanyOwnerName: vi.fn().mockResolvedValue('PA Name') }
+
+    service = new PaymentEventsService(
+      usersService as unknown as UsersService,
+      campaignsService as unknown as CampaignsService,
+      slackService as unknown as SlackService,
+      {} as EmailService,
+      crm as unknown as CrmCampaignsService,
+      voterFileDownloadAccess as unknown as VoterFileDownloadAccessService,
+      organizationsService as unknown as OrganizationsService,
+      stripeService as unknown as StripeService,
+      analytics as unknown as AnalyticsService,
+      {} as PurchaseService,
+      createMockLogger(),
+    )
+  })
+
+  describe('checkoutSessionCompletedHandler — subscription mode', () => {
+    it('grants Pro and clears checkoutSessionId on the happy path', async () => {
+      const campaign: Campaign = createMockCampaign({
+        details: { electionDate: futureIso() },
+      })
+      campaignsService.findByUserId.mockResolvedValue(campaign)
+
+      const event = {
+        type: 'checkout.session.completed',
+        data: { object: buildSubscriptionSession() },
+      } as unknown as Stripe.CheckoutSessionCompletedEvent
+
+      await service.checkoutSessionCompletedHandler(event)
+
+      expect(campaignsService.patchCampaignDetails).toHaveBeenCalledWith(
+        campaign.id,
+        { subscriptionId: 'sub_test_xyz' },
+      )
+      expect(campaignsService.setIsPro).toHaveBeenCalledWith(campaign.id)
+      expect(usersService.patchUserMetaData).toHaveBeenCalledWith(mockUser.id, {
+        customerId: 'cus_test_abc',
+        checkoutSessionId: null,
+      })
+      expect(voterFileDownloadAccess.downloadAccessAlert).toHaveBeenCalledTimes(
+        1,
+      )
+    })
+
+    it('still grants Pro when electionDate is in the past, alerts via Slack, and skips voter-file alert', async () => {
+      const campaign: Campaign = createMockCampaign({
+        details: { electionDate: pastIso() },
+      })
+      campaignsService.findByUserId.mockResolvedValue(campaign)
+
+      const event = {
+        type: 'checkout.session.completed',
+        data: { object: buildSubscriptionSession() },
+      } as unknown as Stripe.CheckoutSessionCompletedEvent
+
+      await expect(
+        service.checkoutSessionCompletedHandler(event),
+      ).resolves.toBeUndefined()
+
+      expect(campaignsService.patchCampaignDetails).toHaveBeenCalledWith(
+        campaign.id,
+        { subscriptionId: 'sub_test_xyz' },
+      )
+      expect(campaignsService.setIsPro).toHaveBeenCalledWith(campaign.id)
+      expect(usersService.patchUserMetaData).toHaveBeenCalledWith(mockUser.id, {
+        customerId: 'cus_test_abc',
+        checkoutSessionId: null,
+      })
+      // Triage alert was sent
+      expect(slackService.message).toHaveBeenCalled()
+      const alertCall = slackService.message.mock.calls.find(([msg]) =>
+        String((msg as { text?: string })?.text ?? '').includes(
+          'missing/past electionDate',
+        ),
+      )
+      expect(alertCall).toBeDefined()
+      // voter file alert is skipped when election date is invalid
+      expect(voterFileDownloadAccess.downloadAccessAlert).not.toHaveBeenCalled()
+    })
+
+    it('still grants Pro when electionDate is missing entirely', async () => {
+      const campaign: Campaign = createMockCampaign({ details: {} })
+      campaignsService.findByUserId.mockResolvedValue(campaign)
+
+      const event = {
+        type: 'checkout.session.completed',
+        data: { object: buildSubscriptionSession() },
+      } as unknown as Stripe.CheckoutSessionCompletedEvent
+
+      await service.checkoutSessionCompletedHandler(event)
+
+      expect(campaignsService.setIsPro).toHaveBeenCalledWith(campaign.id)
+      expect(usersService.patchUserMetaData).toHaveBeenCalledWith(mockUser.id, {
+        customerId: 'cus_test_abc',
+        checkoutSessionId: null,
+      })
+    })
+  })
+
+  describe('replayPendingProCheckoutForUser', () => {
+    it('replays the success path using the user’s stored checkoutSessionId', async () => {
+      const userWithSession = createMockUser({
+        id: 7,
+        metaData: { checkoutSessionId: 'cs_pending_111' },
+      })
+      usersService.findUser.mockResolvedValueOnce(userWithSession)
+      // The replay then re-enters handleSubscriptionCheckoutCompleted, which
+      // calls findUser again via metadata.userId
+      usersService.findUser.mockResolvedValue(userWithSession)
+      stripeService.retrieveCheckoutSession.mockResolvedValue(
+        buildSubscriptionSession({ id: 'cs_pending_111' }),
+      )
+      campaignsService.findByUserId.mockResolvedValue(
+        createMockCampaign({ details: { electionDate: futureIso() } }),
+      )
+
+      const result = await service.replayPendingProCheckoutForUser(7)
+
+      expect(stripeService.retrieveCheckoutSession).toHaveBeenCalledWith(
+        'cs_pending_111',
+      )
+      expect(campaignsService.setIsPro).toHaveBeenCalled()
+      expect(result).toEqual({
+        userId: 7,
+        checkoutSessionId: 'cs_pending_111',
+        replayed: true,
+      })
+    })
+
+    it('throws when the user has no checkoutSessionId', async () => {
+      usersService.findUser.mockResolvedValue(
+        createMockUser({ id: 7, metaData: null }),
+      )
+      await expect(service.replayPendingProCheckoutForUser(7)).rejects.toThrow(
+        /no checkoutSessionId/,
+      )
+    })
+
+    it('throws when the session payment_status is not paid', async () => {
+      usersService.findUser.mockResolvedValue(
+        createMockUser({
+          id: 7,
+          metaData: { checkoutSessionId: 'cs_unpaid_222' },
+        }),
+      )
+      stripeService.retrieveCheckoutSession.mockResolvedValue(
+        buildSubscriptionSession({
+          id: 'cs_unpaid_222',
+          payment_status: 'unpaid',
+        }),
+      )
+      await expect(service.replayPendingProCheckoutForUser(7)).rejects.toThrow(
+        /payment_status/,
+      )
+    })
+
+    it('throws when the stored checkout session belongs to another user', async () => {
+      usersService.findUser.mockResolvedValue(
+        createMockUser({
+          id: 7,
+          metaData: { checkoutSessionId: 'cs_wrong_user_333' },
+        }),
+      )
+      stripeService.retrieveCheckoutSession.mockResolvedValue(
+        buildSubscriptionSession({
+          id: 'cs_wrong_user_333',
+          metadata: { userId: '99' },
+        }),
+      )
+
+      await expect(service.replayPendingProCheckoutForUser(7)).rejects.toThrow(
+        /does not belong to user/,
+      )
+      expect(campaignsService.setIsPro).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/payments/services/paymentEventsService.ts
+++ b/src/payments/services/paymentEventsService.ts
@@ -13,7 +13,11 @@ import { CampaignsService } from '../../campaigns/services/campaigns.service'
 import { UsersService } from '../../users/services/users.service'
 import { SlackService } from '../../vendors/slack/services/slack.service'
 import { Campaign, User } from '@prisma/client'
-import { DateFormats, formatDate } from '../../shared/util/date.util'
+import {
+  DateFormats,
+  formatDate,
+  isDateTodayOrFuture,
+} from '../../shared/util/date.util'
 import { getUserFullName } from '../../users/util/users.util'
 import { EmailService } from '../../email/email.service'
 import { SlackChannel } from '../../vendors/slack/slackService.types'
@@ -21,7 +25,6 @@ import { IS_PROD } from 'src/shared/util/appEnvironment.util'
 import { CrmCampaignsService } from '../../campaigns/services/crmCampaigns.service'
 import { OrganizationsService } from '../../organizations/services/organizations.service'
 import { VoterFileDownloadAccessService } from '../../shared/services/voterFileDownloadAccess.service'
-import { parseCampaignElectionDate } from '../../campaigns/util/parseCampaignElectionDate.util'
 import { AnalyticsService } from 'src/analytics/analytics.service'
 import { WrapperType } from 'src/shared/types/utility.types'
 import { PurchaseService } from './purchase.service'
@@ -208,6 +211,44 @@ export class PaymentEventsService {
   }
 
   /**
+   * Replays the post-payment success path for a checkout session.
+   * Used by the admin recovery endpoint to unstick users whose webhook
+   * originally failed (e.g. past electionDate; see ENG-7570).
+   */
+  async replayPendingProCheckoutForUser(userId: number) {
+    const user = await this.usersService.findUser({ id: userId })
+    if (!user) {
+      throw new BadRequestException(`No user found with id ${userId}`)
+    }
+    const checkoutSessionId = user.metaData?.checkoutSessionId
+    if (!checkoutSessionId) {
+      throw new BadRequestException(
+        `User ${userId} has no checkoutSessionId to replay`,
+      )
+    }
+    const session =
+      await this.stripeService.retrieveCheckoutSession(checkoutSessionId)
+    if (session.mode !== CheckoutSessionMode.SUBSCRIPTION) {
+      throw new BadRequestException(
+        `Checkout session ${checkoutSessionId} is not a subscription checkout`,
+      )
+    }
+    if (session.payment_status !== 'paid') {
+      throw new BadRequestException(
+        `Checkout session ${checkoutSessionId} payment_status is ${session.payment_status}; cannot replay`,
+      )
+    }
+    const sessionUserId = Number(session.metadata?.userId)
+    if (!Number.isInteger(sessionUserId) || sessionUserId !== userId) {
+      throw new BadRequestException(
+        `Checkout session ${checkoutSessionId} does not belong to user ${userId}`,
+      )
+    }
+    await this.handleSubscriptionCheckoutCompleted(session)
+    return { userId, checkoutSessionId, replayed: true }
+  }
+
+  /**
    * Handles checkout.session.completed events for subscription checkouts (Pro plan).
    */
   private async handleSubscriptionCheckoutCompleted(
@@ -240,11 +281,38 @@ export class PaymentEventsService {
     }
 
     const { id: campaignId } = campaign
-    const electionDate = parseCampaignElectionDate(campaign)
-    if (!electionDate || electionDate < new Date()) {
-      throw new BadGatewayException(
-        'No electionDate or electionDate is in the past',
+    const hasValidElectionDate = isDateTodayOrFuture(
+      campaign.details?.electionDate,
+    )
+
+    // The customer has already been charged by Stripe at this point, so we must
+    // grant Pro access regardless of election-date validity — otherwise the user
+    // is stuck on "Subscription Pending" forever (ENG-7570). When the date is
+    // invalid we still complete the entitlement, then alert ops to follow up.
+    if (!hasValidElectionDate) {
+      this.logger.error(
+        {
+          userId: user.id,
+          campaignId,
+          customerId,
+          subscriptionId,
+          electionDate: campaign.details?.electionDate,
+        },
+        '[WEBHOOK] Granting Pro despite missing/past electionDate — campaign needs manual triage',
       )
+      try {
+        await this.slackService.message(
+          {
+            text: `:warning: Pro subscription completed but campaign has missing/past electionDate. Manual triage needed.\nUser: \`${getUserFullName(user)}\` (${user.email})\nCampaign slug: \`${campaign.slug}\`\nelectionDate: \`${campaign.details?.electionDate ?? 'null'}\`\nsubscriptionId: \`${String(subscriptionId)}\``,
+          },
+          IS_PROD ? SlackChannel.botPolitics : SlackChannel.botDev,
+        )
+      } catch (error) {
+        this.logger.error(
+          { error },
+          '[WEBHOOK] Failed to send election-date triage Slack alert',
+        )
+      }
     }
 
     // These have to happen in serial since setIsPro also mutates the JSONP details column
@@ -274,31 +342,47 @@ export class PaymentEventsService {
       checkoutSessionId: null,
     })
 
-    // Non-critical: Send notifications - log failures but don't fail webhook
-    const results = await Promise.allSettled([
-      this.sendProSignUpSlackMessage(user, campaign),
-      (async () => {
-        const district = campaign.organizationSlug
-          ? await this.organizationsService.getDistrictForOrgSlug(
-              campaign.organizationSlug,
-            )
-          : null
-        await this.voterFileDownloadAccess.downloadAccessAlert(
-          campaign,
-          user,
-          district,
-        )
-      })(),
-    ])
+    // Non-critical: Send notifications - log failures but don't fail webhook.
+    // Skip the voter-file alert when the election date is invalid since the
+    // downstream district lookup assumes a current race.
+    const notificationTasks: Array<{
+      label: string
+      run: () => Promise<unknown>
+    }> = [
+      {
+        label: 'send Slack message',
+        run: () => this.sendProSignUpSlackMessage(user, campaign),
+      },
+    ]
+    if (hasValidElectionDate) {
+      notificationTasks.push({
+        label: 'send voter file alert',
+        run: async () => {
+          const district = campaign.organizationSlug
+            ? await this.organizationsService.getDistrictForOrgSlug(
+                campaign.organizationSlug,
+              )
+            : null
+          await this.voterFileDownloadAccess.downloadAccessAlert(
+            campaign,
+            user,
+            district,
+          )
+        },
+      })
+    }
 
-    // Log any notification failures
+    const results = await Promise.allSettled(
+      notificationTasks.map(({ run }) => run()),
+    )
+
     results.forEach((result, index) => {
       if (result.status === 'rejected') {
-        const action = ['send Slack message', 'send voter file alert'][index]
+        const { label } = notificationTasks[index]!
         this.logger.error(
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           { reason: result.reason },
-          `[WEBHOOK] Failed to ${action} - User: ${user.id}, CustomerId: ${customerId}`,
+          `[WEBHOOK] Failed to ${label} - User: ${user.id}, CustomerId: ${customerId}`,
         )
       }
     })


### PR DESCRIPTION
## Summary
- Block Pro checkout creation when the campaign election date is missing or in the past so users are not sent to Stripe for a subscription that cannot activate cleanly.
- Let paid Stripe subscription checkout webhooks complete Pro activation even when the election date is stale, preventing users from remaining stuck in Subscription Pending after money changes hands.
- Add an admin-only recovery endpoint for already-stuck users and focused tests for checkout validation, webhook behavior, and replay safety.

## Root Cause
The subscription checkout webhook previously threw after payment when the campaign election date was missing or in the past. That prevented `subscriptionId`, `isPro`, and `checkoutSessionId` cleanup from being persisted.

## Validation
- `npm test -- src/payments/purchase.controller.test.ts src/payments/services/paymentEventsService.test.ts`
- `npx eslint src/payments/payments.controller.ts` (existing max-params warning only)
