### PR TITLE
feat(mcp): introduce general MCP server

### DIFF
--- a/contracts/src/campaigns/CampaignWithLiveContext.schema.ts
+++ b/contracts/src/campaigns/CampaignWithLiveContext.schema.ts
@@ -1,10 +1,15 @@
 import { z } from 'zod'
 import { CampaignWithPositionNameSchema } from './CampaignWithPositionName.schema'
+import { OrganizationSchema } from './Organization.schema'
 import { RaceTargetMetricsSchema } from './RaceTargetMetrics.schema'
 
 /**
  * The full single-campaign read shape (e.g. `GET /v1/campaigns/:id` over
  * M2M), enriched with both `positionName` and live race-target metrics.
+ *
+ * `organization` is optional because some endpoints (e.g. `GET /v1/campaigns/:id`)
+ * strip it from the response while others (e.g. `GET /v1/campaigns/mine`)
+ * include it for downstream consumers that need `organization.positionId`.
  *
  * For list endpoints, prefer `CampaignWithPositionNameSchema` to avoid the
  * expensive per-row metrics lookup.
@@ -12,6 +17,7 @@ import { RaceTargetMetricsSchema } from './RaceTargetMetrics.schema'
 export const CampaignWithLiveContextSchema =
   CampaignWithPositionNameSchema.extend({
     raceTargetMetrics: RaceTargetMetricsSchema.nullable(),
+    organization: OrganizationSchema.optional(),
   })
 
 export type CampaignWithLiveContext = z.infer<

--- a/contracts/src/campaigns/Organization.schema.ts
+++ b/contracts/src/campaigns/Organization.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+export const OrganizationSchema = z.object({
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+  slug: z.string(),
+  ownerId: z.number(),
+  positionId: z.string().nullable(),
+  overrideDistrictId: z.string().nullable(),
+  customPositionName: z.string().nullable(),
+})
+
+export type Organization = z.infer<typeof OrganizationSchema>

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -152,9 +152,7 @@ export {
   type ReadCampaignOutput,
 } from './campaigns/Campaign.schema'
 
-export {
-  ReadCampaignOutputSchema,
-} from './campaigns/ReadCampaignOutput.schema'
+export { ReadCampaignOutputSchema } from './campaigns/ReadCampaignOutput.schema'
 
 export {
   SetDistrictOutputSchema,
@@ -175,6 +173,11 @@ export {
   CampaignWithLiveContextSchema,
   type CampaignWithLiveContext,
 } from './campaigns/CampaignWithLiveContext.schema'
+
+export {
+  OrganizationSchema,
+  type Organization,
+} from './campaigns/Organization.schema'
 
 export {
   CAMPAIGN_SORT_KEYS,

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@langchain/community": "0.3.59",
         "@langchain/core": "0.3.80",
         "@langchain/openai": "0.4.9",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@nestjs/axios": "^4.0.0",
         "@nestjs/common": "^11.0.8",
         "@nestjs/core": "^11.0.8",
@@ -120,7 +121,8 @@
         "vitest": "^4.0.15",
         "yargs": "^18.0.0",
         "zipcodes": "^8.0.0",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.25.2"
       },
       "devDependencies": {
         "@contentful/rich-text-types": "^17.0.0",
@@ -6735,9 +6737,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.8.tgz",
-      "integrity": "sha512-0/g2lIOPzX8f3vzW1ggQgvG5mjtFBDBHFAzI5SFAi2DzSqS9luJwqg9T6O/gKYLi+inS7eNxBeIFkkghIPvrMA==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -8300,12 +8302,12 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
-      "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.7",
+        "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -8313,14 +8315,15 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "jose": "^6.1.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
         "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
@@ -22220,10 +22223,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
+      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -23797,6 +23803,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/hono": {
+      "version": "4.12.17",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
+      "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
@@ -24179,7 +24194,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -33222,12 +33236,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@langchain/community": "0.3.59",
     "@langchain/core": "0.3.80",
     "@langchain/openai": "0.4.9",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@nestjs/axios": "^4.0.0",
     "@nestjs/common": "^11.0.8",
     "@nestjs/core": "^11.0.8",
@@ -158,7 +159,8 @@
     "vitest": "^4.0.15",
     "yargs": "^18.0.0",
     "zipcodes": "^8.0.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@contentful/rich-text-types": "^17.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,5 @@
 import { AgentExperimentsModule } from '@/agentExperiments/agentExperiments.module'
+import { McpModule } from '@/mcp/mcp.module'
 import { AdminModule } from '@/admin/admin.module'
 import { AnalyticsModule } from '@/analytics/analytics.module'
 import { AuthenticationModule } from '@/authentication/authentication.module'
@@ -60,6 +61,7 @@ import { loggerModule } from './observability/logging/logger-module'
     TopIssuesModule,
     AdminModule,
     AgentExperimentsModule,
+    McpModule,
     SharedModule,
     PaymentsModule,
     VotersModule,

--- a/src/campaigns/campaigns.controller.ts
+++ b/src/campaigns/campaigns.controller.ts
@@ -1,4 +1,5 @@
 import { M2MOnly } from '@/authentication/guards/M2MOnly.guard'
+import { McpTool } from '@/mcp/decorators/McpTool.decorator'
 import { OrganizationsService } from '@/organizations/services/organizations.service'
 import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
 import { ZodResponseInterceptor } from '@/shared/interceptors/ZodResponse.interceptor'
@@ -71,6 +72,13 @@ export class CampaignsController {
   }
 
   @Get('mine')
+  @ResponseSchema(CampaignWithLiveContextSchema)
+  @McpTool({
+    description:
+      "Read the calling user's active campaign, including organization and live status. " +
+      'Use this on startup to understand who the user is, what office they are running for, ' +
+      'and what state the campaign is in.',
+  })
   @UseCampaign({ include: { organization: true } })
   async findMine(
     @ReqCampaign()

--- a/src/mcp/CLAUDE.md
+++ b/src/mcp/CLAUDE.md
@@ -1,0 +1,125 @@
+# MCP Module
+
+Exposes gp-api as a Model Context Protocol server. Any controller route can opt in as an agent-callable tool by adding `@McpTool({ description })` next to its existing decorators; calls land at `POST /v1/mcp` (JSON-RPC over HTTP) and are dispatched into the host's normal request pipeline via `fastify.inject` — auth, validation, interceptors, and business logic all unchanged.
+
+The module is deliberately host-agnostic: it does not know who is calling, why, or whether the caller is an agent. `/v1/mcp` runs behind the global `SessionGuard` and is callable by any authenticated user. Narrower auth (e.g., locking the endpoint to a specific actor identity) belongs on top of this module, not inside it.
+
+## Opting a route in
+
+Add `@McpTool({ description })` alongside the existing decorators on the handler. Description is what the calling agent reads to decide whether to call the tool — write it for an LLM, not a human reviewer.
+
+```ts
+@Get('mine')
+@ResponseSchema(CampaignWithLiveContextSchema)
+@McpTool({
+  description:
+    "Read the calling user's active campaign, including organization " +
+    'and live status. Use this on startup to understand who the user is, ' +
+    'what office they are running for, and what state the campaign is in.',
+})
+@UseCampaign({ include: { organization: true } })
+async findMine(@ReqCampaign() campaign: ...) { ... }
+```
+
+That's the entire dev-facing surface. Method, path, input/output schemas, and tool name are reflected from existing decorators at request time. Tool name = `${HTTP_METHOD}_${slug(controllerPath + methodPath)}` (e.g. `GET_campaigns_mine`) — the slug step is forced by Anthropic's tool-name regex `^[a-zA-Z0-9_-]{1,64}$`.
+
+## Constraints
+
+`gatherTools()` enforces these at request time and throws with a list of every violation. The live integration test boots the app and triggers the walk, so a CI run catches misconfigured tools before merge.
+
+- `@McpTool` must be on a route handler with an HTTP method decorator (`@Get`, `@Post`, ...).
+- `@ResponseSchema(...)` is required.
+- If `@Body`/`@Query`/`@Param` is declared, it must use a `createZodDto` class. Untyped params (e.g. `@Body() x: object`) are rejected.
+- If the route path contains `:placeholder`, `@Param() ... : SomeDto` is required — catches "forgot to read the path param" mistakes.
+- Tool names must be unique across the registry (the slug rule means `/users/me` and `/users-me` would collide; not realistic today but worth knowing).
+
+## Request flow
+
+```
+POST /v1/mcp                          (Accept: application/json, text/event-stream)
+   │
+   ▼
+McpController.handle
+   │  mcp.createServer()                    ← fresh Server per request
+   │  StreamableHTTPServerTransport         ← enableJsonResponse=true, stateless
+   ▼
+SDK dispatches { tools/list | tools/call }
+   │
+   ├── tools/list:  gatherTools() → toMcpTool(...) → JSON-RPC response
+   │
+   └── tools/call:  gatherTools() → resolve by name → fastify.inject({
+                       method, url=`${globalPrefix}${tool.path}`,
+                       headers=<inbound, denylist hop-by-hop>,
+                       payload=arguments.body,
+                     })
+                   → wrap as { content: [{type:'text', text:<body>}], isError: status>=400 }
+```
+
+The inner `fastify.inject` re-enters the host's full request pipeline: global guards (`SessionGuard`, `RolesGuard`), pipes, interceptors (`ZodResponseInterceptor`), the actual handler. A tool call is, behaviorally, an internal proxy of an HTTP request.
+
+### Why a fresh `Server` per request
+
+The MCP SDK's `Server.connect(transport)` throws on a re-attached transport. A singleton Server would fail on the second concurrent request (race on `_transport`). `new Server` is cheap and idiomatic for stateless Streamable HTTP — the SDK examples do the same.
+
+### Header forwarding
+
+The MCP SDK surfaces the inbound HTTP request's headers via `extra.requestInfo` in each handler. The call_tool handler forwards almost everything onto `fastify.inject` so the inner handler sees the same auth and context the outer caller sent (`Authorization` for `SessionGuard`, `x-organization-slug` for `UseCampaign`, correlation IDs, etc.). A small denylist (`host`, `content-length`, `transfer-encoding`, `accept-encoding`, ...) drops HTTP-machinery headers that fastify.inject will set itself.
+
+### Tool name → URL
+
+`gatherTools()` records each tool's `path` as `controllerPath + methodPath` — **without** the global prefix. The host's global prefix (`v1`) is applied at dispatch time via `ApplicationConfig.getGlobalPrefix()`. Keeps the registry decoupled from how the app is mounted (and keeps the unit tests simple — they don't need to know the prefix).
+
+## Calling `/v1/mcp`
+
+Standard MCP JSON-RPC over HTTP. Two non-obvious things:
+
+- `Accept: application/json, text/event-stream` is **required** by the MCP Streamable HTTP transport spec. Without it the server returns `406 Not Acceptable`.
+- `tools/call` takes `arguments: { body?, query?, params? }` — each maps to the matching `@Body`/`@Query`/`@Param` on the underlying route. Zero-arg routes pass `arguments: {}`.
+
+```http
+POST /v1/mcp
+Authorization: Bearer <session-jwt>
+Accept: application/json, text/event-stream
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "GET_campaigns_mine",
+    "arguments": {}
+  }
+}
+```
+
+## Files
+
+| File                                      | Purpose                                                                                                                         |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `mcp.module.ts`                           | Nest module — provides `McpServerService`, exposes `McpController` at `/mcp`                                                    |
+| `mcp.controller.ts`                       | `@All()` handler — builds a per-request `Server` + transport, delegates to `transport.handleRequest`                            |
+| `services/mcpServer.service.ts`           | `createServer()`, `gatherTools()` (walk + validate), `getTools()` (test seam), `buildUrl()`                                     |
+| `services/mcpServer.service.live.test.ts` | CI gate — boots the real app via `useTestService()`, POSTs JSON-RPC to `/v1/mcp`, asserts list + call work end-to-end           |
+| `services/mcpServer.service.test.ts`      | Unit tests against synthetic controller fixtures via `Test.createTestingModule` — fast, exercise gather/validate/dispatch logic |
+| `decorators/McpTool.decorator.ts`         | `@McpTool({ description })` — only dev-facing decorator                                                                         |
+| `util/toolName.util.ts`                   | `deriveToolName(method, path)` — slugs the path to fit Anthropic's regex                                                        |
+| `util/schemaReflect.util.ts`              | Walks `ROUTE_ARGS_METADATA` + `design:paramtypes` to pull Zod schemas off `@Body/@Query/@Param` DTOs and `@ResponseSchema(...)` |
+| `util/inputSchema.util.ts`                | Merges declared body/query/params Zod schemas into one object for the MCP tool's `inputSchema`                                  |
+| `mcp.types.ts`                            | `RegisteredMcpTool`, `InputDeclaration`                                                                                         |
+
+## Testing
+
+`mcpServer.service.live.test.ts` is the canonical integration test and the schema-completeness CI gate in one. It boots the full AppModule via `useTestService()`, POSTs JSON-RPC to `/v1/mcp` with a real axios client, and asserts both `tools/list` and `tools/call` round-trip correctly. If a misconfigured `@McpTool` exists anywhere in the app, this test fails on the first `tools/list` call with a clear list of every violation.
+
+Unit tests in `mcpServer.service.test.ts` use synthetic controller fixtures via `Test.createTestingModule` — fast, exercise the gather/validate/dispatch logic against controlled inputs without spinning up Postgres.
+
+```bash
+npx vitest run src/mcp
+```
+
+## Known design choices
+
+- **`gatherTools()` runs on every request.** With one opted-in tool the cost is unmeasurable; if tool count grows to dozens, this is where to add caching with proper invalidation (the registry is pure-functional over controller metadata, so the cache key is "until the process restarts").
+- **No `@McpTool`-specific OpenAPI surface.** The module's only HTTP entry point is `/v1/mcp` (JSON-RPC). The MCP tool list is discovered via the protocol, not via OpenAPI introspection.
+- **Per-route opt-in, not whole-controller.** Decorating a controller would surface routes the dev didn't intend (admin endpoints, internal M2M routes). Opt-in is per-handler so each tool is a deliberate choice.

--- a/src/mcp/decorators/McpTool.decorator.test.ts
+++ b/src/mcp/decorators/McpTool.decorator.test.ts
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+// Test fixtures define decorated controller stubs whose method bodies don't matter.
+import { describe, expect, it } from 'vitest'
+import { Reflector } from '@nestjs/core'
+import { McpTool, MCP_TOOL_KEY, McpToolMetadata } from './McpTool.decorator'
+
+describe('McpTool decorator', () => {
+  it('attaches metadata under MCP_TOOL_KEY', () => {
+    class Example {
+      @McpTool({
+        description: "Update fields on the calling user's active campaign.",
+      })
+      handler() {}
+    }
+
+    const reflector = new Reflector()
+    const meta = reflector.get<McpToolMetadata>(
+      MCP_TOOL_KEY,
+      Example.prototype.handler,
+    )
+    expect(meta).toEqual({
+      description: "Update fields on the calling user's active campaign.",
+    })
+  })
+
+  it('rejects empty description at runtime', () => {
+    expect(() => McpTool({ description: '' })).toThrow(/description/i)
+    expect(() => McpTool({ description: '   ' })).toThrow(/description/i)
+  })
+})

--- a/src/mcp/decorators/McpTool.decorator.ts
+++ b/src/mcp/decorators/McpTool.decorator.ts
@@ -1,0 +1,17 @@
+import { SetMetadata } from '@nestjs/common'
+
+export const MCP_TOOL_KEY = 'mcp_tool'
+
+export type McpToolMetadata = {
+  description: string
+}
+
+export const McpTool = ({ description }: { description: string }) => {
+  if (!description || !description.trim()) {
+    throw new Error(
+      '@McpTool: description is required and must be non-empty. ' +
+        'The description is what the agent reads to decide whether to call this tool.',
+    )
+  }
+  return SetMetadata(MCP_TOOL_KEY, { description } as McpToolMetadata)
+}

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, All, Req, Res } from '@nestjs/common'
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { McpServerService } from './services/mcpServer.service'
+
+@Controller('mcp')
+export class McpController {
+  constructor(private readonly mcp: McpServerService) {}
+
+  @All()
+  async handle(@Req() req: FastifyRequest, @Res() reply: FastifyReply) {
+    const server = this.mcp.createServer()
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    })
+    await server.connect(transport)
+    await transport.handleRequest(req.raw, reply.raw, req.body)
+  }
+}

--- a/src/mcp/mcp.module.ts
+++ b/src/mcp/mcp.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common'
+import { DiscoveryModule } from '@nestjs/core'
+import { McpServerService } from './services/mcpServer.service'
+import { McpController } from './mcp.controller'
+
+@Module({
+  imports: [DiscoveryModule],
+  providers: [McpServerService],
+  exports: [McpServerService],
+  controllers: [McpController],
+})
+export class McpModule {}

--- a/src/mcp/mcp.types.ts
+++ b/src/mcp/mcp.types.ts
@@ -1,0 +1,21 @@
+import type { ZodSchema } from 'zod'
+
+export type InputDeclaration = {
+  declared: boolean
+  schema: ZodSchema | null
+}
+
+export type RegisteredMcpTool = {
+  toolName: string
+  description: string
+  method: string
+  path: string
+  inputDeclarations: {
+    body: InputDeclaration
+    query: InputDeclaration
+    params: InputDeclaration
+  }
+  outputSchema: ZodSchema | null
+  controllerClassName: string
+  handlerName: string
+}

--- a/src/mcp/services/mcpServer.service.live.test.ts
+++ b/src/mcp/services/mcpServer.service.live.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { useTestService } from '@/test-service'
+
+const service = useTestService()
+
+const MCP_ACCEPT = 'application/json, text/event-stream'
+
+describe('POST /v1/mcp (JSON-RPC over HTTP)', () => {
+  it('lists registered MCP tools', async () => {
+    const res = await service.client.post(
+      '/v1/mcp',
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: {},
+      },
+      { headers: { Accept: MCP_ACCEPT } },
+    )
+
+    expect(res.status).toBe(200)
+
+    expect(res.data).toStrictEqual({
+      id: 1,
+      jsonrpc: '2.0',
+      result: {
+        tools: expect.arrayContaining([
+          {
+            name: 'GET_campaigns_mine',
+            description:
+              "Read the calling user's active campaign, including organization and live status. Use this on startup to understand who the user is, what office they are running for, and what state the campaign is in.",
+            inputSchema: {
+              properties: {},
+              type: 'object',
+            },
+          },
+        ]),
+      },
+    })
+  })
+
+  it('invokes a tool via tools/call as the calling user', async () => {
+    const org = await service.prisma.organization.create({
+      data: { slug: 'mcp-test-org', ownerId: service.user.id },
+    })
+    await service.prisma.campaign.create({
+      data: {
+        userId: service.user.id,
+        slug: 'mcp-test-campaign',
+        details: {},
+        organizationSlug: org.slug,
+      },
+    })
+
+    const res = await service.client.post(
+      '/v1/mcp',
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'GET_campaigns_mine', arguments: {} },
+      },
+      { headers: { Accept: MCP_ACCEPT, 'x-organization-slug': org.slug } },
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.data.result.isError).toBe(false)
+
+    expect(res.data).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: {
+        isError: false,
+        content: [{ type: 'text', text: expect.any(String) }],
+      },
+    })
+    const toolResult = JSON.parse(res.data.result.content[0].text)
+
+    expect(toolResult).toMatchObject({
+      id: 1,
+      isPro: false,
+      slug: 'mcp-test-campaign',
+    })
+  })
+
+  it('rejects unauthenticated requests', async () => {
+    const res = await service.client.post(
+      '/v1/mcp',
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/list',
+        params: {},
+      },
+      { headers: { Accept: MCP_ACCEPT, Authorization: 'Bearer invalid' } },
+    )
+
+    expect(res.status).toBe(401)
+    expect(res.data).toStrictEqual({
+      statusCode: 401,
+      message: 'Unauthorized',
+    })
+  })
+})

--- a/src/mcp/services/mcpServer.service.test.ts
+++ b/src/mcp/services/mcpServer.service.test.ts
@@ -1,0 +1,404 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+// Test fixtures define decorated controller stubs whose method bodies don't matter.
+import { describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { Body, Controller, Get, Param, Patch, Module } from '@nestjs/common'
+import { DiscoveryModule, HttpAdapterHost } from '@nestjs/core'
+import { PinoLogger } from 'nestjs-pino'
+import { z } from 'zod'
+import { createZodDto } from 'nestjs-zod'
+import { McpTool } from '../decorators/McpTool.decorator'
+import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { McpServerService } from './mcpServer.service'
+
+type InjectOpts = {
+  method: string
+  url: string
+  headers?: Record<string, string>
+  payload?: unknown
+}
+
+type InjectFn = (opts: InjectOpts) => Promise<{
+  statusCode: number
+  body: string
+  headers: Record<string, string>
+}>
+
+const buildAppModule = (controllers: unknown[], inject: InjectFn) => {
+  const mockHost = {
+    httpAdapter: { getInstance: () => ({ inject }) },
+  } as unknown as HttpAdapterHost
+
+  @Module({
+    imports: [DiscoveryModule],
+    controllers: controllers as never[],
+    providers: [
+      McpServerService,
+      { provide: HttpAdapterHost, useValue: mockHost },
+      { provide: PinoLogger, useValue: createMockLogger() },
+    ],
+    exports: [McpServerService],
+  })
+  class TestApp {}
+
+  return Test.createTestingModule({ imports: [TestApp] })
+}
+
+const InSchema = z.object({ slogan: z.string() })
+class InDto extends createZodDto(InSchema) {}
+const ParamSchema = z.object({ id: z.string() })
+class ParamDto extends createZodDto(ParamSchema) {}
+const OutSchema = z.object({ ok: z.boolean() })
+
+@Controller('campaigns')
+class FakeController {
+  @Get('mine')
+  @ResponseSchema(OutSchema)
+  @McpTool({ description: "Read the calling user's campaign." })
+  read() {}
+
+  @Patch('mine')
+  @McpTool({ description: "Update the calling user's campaign." })
+  @ResponseSchema(OutSchema)
+  update(@Body() _b: InDto) {}
+
+  @Get('untagged')
+  notATool() {}
+
+  @Get(':id')
+  @ResponseSchema(OutSchema)
+  @McpTool({ description: 'Read by id with @Param Zod DTO.' })
+  readById(@Param() _p: ParamDto) {}
+}
+
+const noopInject: InjectFn = async () => ({
+  statusCode: 200,
+  body: '{}',
+  headers: {},
+})
+
+describe('McpServerService.gatherTools', () => {
+  it('discovers @McpTool-decorated handlers and builds tool entries', async () => {
+    const moduleRef = await buildAppModule(
+      [FakeController],
+      noopInject,
+    ).compile()
+    await moduleRef.init()
+
+    const tools = moduleRef.get(McpServerService).getTools()
+
+    const read = tools.find((t) => t.toolName === 'GET_campaigns_mine')!
+    expect(read).toBeDefined()
+    expect(read.description).toBe("Read the calling user's campaign.")
+    expect(read.outputSchema).toBe(OutSchema)
+    expect(read.inputDeclarations.body.declared).toBe(false)
+    expect(read.inputDeclarations.body.schema).toBeNull()
+    expect(read.inputDeclarations.query.declared).toBe(false)
+    expect(read.inputDeclarations.params.declared).toBe(false)
+
+    const update = tools.find((t) => t.toolName === 'PATCH_campaigns_mine')!
+    expect(update).toBeDefined()
+    expect(update.outputSchema).toBe(OutSchema)
+    expect(update.inputDeclarations.body.declared).toBe(true)
+    expect(update.inputDeclarations.body.schema).toBe(InSchema)
+    expect(update.inputDeclarations.params.declared).toBe(false)
+  })
+
+  it('marks params declared from path :placeholder and binds the @Param Zod DTO', async () => {
+    const moduleRef = await buildAppModule(
+      [FakeController],
+      noopInject,
+    ).compile()
+    await moduleRef.init()
+
+    const tools = moduleRef.get(McpServerService).getTools()
+    const readById = tools.find((t) => t.handlerName === 'readById')!
+    expect(readById).toBeDefined()
+    expect(readById.inputDeclarations.params.declared).toBe(true)
+    expect(readById.inputDeclarations.params.schema).toBe(ParamSchema)
+  })
+
+  it('does not include handlers without @McpTool', async () => {
+    const moduleRef = await buildAppModule(
+      [FakeController],
+      noopInject,
+    ).compile()
+    await moduleRef.init()
+
+    const tools = moduleRef.get(McpServerService).getTools()
+    expect(tools.find((t) => t.handlerName === 'notATool')).toBeUndefined()
+  })
+
+  it('throws when an @McpTool handler is missing @ResponseSchema', async () => {
+    @Controller('campaigns')
+    class NoOutputController {
+      @Get('no-output')
+      @McpTool({ description: 'no @ResponseSchema' })
+      noOutput() {}
+    }
+
+    const moduleRef = await buildAppModule(
+      [NoOutputController],
+      noopInject,
+    ).compile()
+    await moduleRef.init()
+
+    expect(() => moduleRef.get(McpServerService).getTools()).toThrow(
+      /Invalid @McpTool configuration/,
+    )
+    expect(() => moduleRef.get(McpServerService).getTools()).toThrow(
+      /missing @ResponseSchema/,
+    )
+  })
+
+  it('throws when an @McpTool handler declares @Body without a Zod DTO', async () => {
+    @Controller('bad')
+    class BadBodyController {
+      @Patch('thing')
+      @ResponseSchema(OutSchema)
+      @McpTool({ description: 'body declared without a Zod DTO' })
+      bad(@Body() _b: object) {}
+    }
+
+    const moduleRef = await buildAppModule(
+      [BadBodyController],
+      noopInject,
+    ).compile()
+    await moduleRef.init()
+
+    expect(() => moduleRef.get(McpServerService).getTools()).toThrow(
+      /@Body declared but is not a nestjs-zod createZodDto class/,
+    )
+  })
+
+  it('throws when path :placeholder lacks a @Param Zod DTO', async () => {
+    @Controller('bad')
+    class BadParamController {
+      @Get(':id')
+      @ResponseSchema(OutSchema)
+      @McpTool({ description: 'path placeholder without @Param Zod DTO' })
+      badParam() {}
+    }
+
+    const moduleRef = await buildAppModule(
+      [BadParamController],
+      noopInject,
+    ).compile()
+    await moduleRef.init()
+
+    expect(() => moduleRef.get(McpServerService).getTools()).toThrow(
+      /@Param or path :placeholder is present but no nestjs-zod createZodDto provides a Zod schema/,
+    )
+  })
+
+  it('throws when @McpTool is applied to a handler with no HTTP method decorator', async () => {
+    @Controller('campaigns')
+    class NoHttpController {
+      @McpTool({ description: 'helper, not a route' })
+      helper() {}
+    }
+
+    const moduleRef = await buildAppModule(
+      [NoHttpController],
+      noopInject,
+    ).compile()
+    await moduleRef.init()
+
+    expect(() => moduleRef.get(McpServerService).getTools()).toThrow(
+      /has no HTTP method decorator/,
+    )
+  })
+
+  it('throws when two handlers map to the same tool name', async () => {
+    @Controller('campaigns')
+    class DupController {
+      @Get('mine')
+      @McpTool({ description: 'First handler.' })
+      first() {}
+
+      @Get('mine')
+      @McpTool({ description: 'Duplicate handler.' })
+      second() {}
+    }
+
+    const moduleRef = await buildAppModule(
+      [DupController],
+      noopInject,
+    ).compile()
+    await moduleRef.init()
+
+    expect(() => moduleRef.get(McpServerService).getTools()).toThrow(
+      /Duplicate MCP tool name/,
+    )
+  })
+})
+
+@Controller('v1')
+class FooController {
+  @Get('foo')
+  @ResponseSchema(z.object({ ok: z.boolean() }))
+  @McpTool({ description: 'read foo' })
+  read() {}
+
+  @Patch('foo')
+  @ResponseSchema(z.object({ ok: z.boolean() }))
+  @McpTool({ description: 'write foo' })
+  write(@Body() _b: InDto) {}
+}
+
+describe('McpServerService MCP request handlers', () => {
+  it('exposes list_tools that returns tool entries with JSON Schema input shapes', async () => {
+    const moduleRef = await buildAppModule(
+      [FooController],
+      noopInject,
+    ).compile()
+    await moduleRef.init()
+
+    const svc = moduleRef.get(McpServerService)
+    const server = svc.createServer() as unknown as {
+      _requestHandlers: Map<
+        string,
+        (req: unknown, extra?: unknown) => Promise<unknown>
+      >
+    }
+    const listHandler = server._requestHandlers.get('tools/list')
+    expect(listHandler).toBeDefined()
+    const result = (await listHandler!({
+      method: 'tools/list',
+      params: {},
+    })) as {
+      tools: Array<{
+        name: string
+        description: string
+        inputSchema: { type: string; properties?: Record<string, unknown> }
+      }>
+    }
+    expect(result.tools).toHaveLength(2)
+
+    const get = result.tools.find((t) => t.name === 'GET_v1_foo')!
+    expect(get.inputSchema.type).toBe('object')
+    expect(get.inputSchema.properties).toEqual({})
+
+    const post = result.tools.find((t) => t.name === 'PATCH_v1_foo')!
+    expect(post.description).toBe('write foo')
+    expect(post.inputSchema.type).toBe('object')
+    expect(post.inputSchema.properties).toBeDefined()
+    expect(Object.keys(post.inputSchema.properties!)).toContain('body')
+  })
+
+  it('routes call_tool through fastify.inject with method + path and forwards Authorization', async () => {
+    const calls: InjectOpts[] = []
+    const inject = vi.fn(async (opts: InjectOpts) => {
+      calls.push(opts)
+      return {
+        statusCode: 200,
+        body: '{"ok":true}',
+        headers: { 'content-type': 'application/json' },
+      }
+    })
+    const moduleRef = await buildAppModule([FooController], inject).compile()
+    await moduleRef.init()
+
+    const svc = moduleRef.get(McpServerService)
+    const server = svc.createServer() as unknown as {
+      _requestHandlers: Map<
+        string,
+        (req: unknown, extra?: unknown) => Promise<unknown>
+      >
+    }
+    const callHandler = server._requestHandlers.get('tools/call')!
+    const result = (await callHandler(
+      {
+        method: 'tools/call',
+        params: { name: 'PATCH_v1_foo', arguments: { body: { slogan: 'x' } } },
+      },
+      {
+        requestInfo: {
+          headers: { authorization: 'Bearer test-jwt' },
+        },
+      },
+    )) as { isError: boolean; content: Array<{ text: string }> }
+    expect(result.isError).toBe(false)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].method).toBe('PATCH')
+    expect(calls[0].url).toBe('/v1/foo')
+    expect(calls[0].payload).toEqual({ slogan: 'x' })
+    expect(calls[0].headers?.authorization).toBe('Bearer test-jwt')
+    expect(result.content[0].text).toBe('{"ok":true}')
+  })
+
+  it('still calls fastify.inject when no Authorization header is present', async () => {
+    const calls: InjectOpts[] = []
+    const inject = vi.fn(async (opts: InjectOpts) => {
+      calls.push(opts)
+      return {
+        statusCode: 401,
+        body: '{"error":"unauthorized"}',
+        headers: { 'content-type': 'application/json' },
+      }
+    })
+    const moduleRef = await buildAppModule([FooController], inject).compile()
+    await moduleRef.init()
+
+    const svc = moduleRef.get(McpServerService)
+    const server = svc.createServer() as unknown as {
+      _requestHandlers: Map<
+        string,
+        (req: unknown, extra?: unknown) => Promise<unknown>
+      >
+    }
+    const callHandler = server._requestHandlers.get('tools/call')!
+    await callHandler({
+      method: 'tools/call',
+      params: { name: 'PATCH_v1_foo', arguments: { body: { slogan: 'x' } } },
+    })
+    expect(calls).toHaveLength(1)
+    expect(calls[0].headers?.authorization).toBeUndefined()
+  })
+
+  it('returns isError when the upstream returns 4xx', async () => {
+    const moduleRef = await buildAppModule([FooController], async () => ({
+      statusCode: 400,
+      body: '{"error":"bad"}',
+      headers: { 'content-type': 'application/json' },
+    })).compile()
+    await moduleRef.init()
+
+    const svc = moduleRef.get(McpServerService)
+    const server = svc.createServer() as unknown as {
+      _requestHandlers: Map<
+        string,
+        (req: unknown, extra?: unknown) => Promise<unknown>
+      >
+    }
+    const callHandler = server._requestHandlers.get('tools/call')!
+    const result = (await callHandler({
+      method: 'tools/call',
+      params: { name: 'GET_v1_foo', arguments: {} },
+    })) as { isError: boolean }
+    expect(result.isError).toBe(true)
+  })
+
+  it('returns isError for unknown tool', async () => {
+    const moduleRef = await buildAppModule(
+      [FooController],
+      noopInject,
+    ).compile()
+    await moduleRef.init()
+
+    const svc = moduleRef.get(McpServerService)
+    const server = svc.createServer() as unknown as {
+      _requestHandlers: Map<
+        string,
+        (req: unknown, extra?: unknown) => Promise<unknown>
+      >
+    }
+    const callHandler = server._requestHandlers.get('tools/call')!
+    const result = (await callHandler({
+      method: 'tools/call',
+      params: { name: 'DOES_NOT_EXIST', arguments: {} },
+    })) as { isError: boolean }
+    expect(result.isError).toBe(true)
+  })
+})

--- a/src/mcp/services/mcpServer.service.ts
+++ b/src/mcp/services/mcpServer.service.ts
@@ -1,0 +1,314 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion */
+// zod-to-json-schema returns a JSONSchema-shaped object that the MCP SDK accepts as
+// Tool['inputSchema'], but its return type is broader than the SDK's tighter declaration.
+// The fastify adapter is loosely typed via HttpAdapterHost, so member access on the
+// underlying instance triggers unsafe-* lints. NestJS DiscoveryService surfaces controller
+// wrappers with `instance` and `metatype` typed as `any`, and the Reflect API by definition
+// returns `any`. The casts here are deliberate adapters to known runtime shapes (fastify's
+// inject API, MCP SDK's Tool inputSchema, NestJS metadata layer). Behavior is covered by
+// mcpServer.service.test.ts.
+import { Injectable, RequestMethod } from '@nestjs/common'
+import {
+  ApplicationConfig,
+  DiscoveryService,
+  HttpAdapterHost,
+  MetadataScanner,
+  Reflector,
+} from '@nestjs/core'
+import { PATH_METADATA, METHOD_METADATA } from '@nestjs/common/constants'
+import { PinoLogger } from 'nestjs-pino'
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  Tool,
+} from '@modelcontextprotocol/sdk/types.js'
+import { zodToJsonSchema } from 'zod-to-json-schema'
+import { MCP_TOOL_KEY, McpToolMetadata } from '../decorators/McpTool.decorator'
+import {
+  reflectInputDeclarations,
+  reflectOutputSchema,
+} from '../util/schemaReflect.util'
+import { deriveToolName } from '../util/toolName.util'
+import { RegisteredMcpTool } from '../mcp.types'
+import { buildCombinedInputSchema } from '../util/inputSchema.util'
+
+type FastifyInjectResponse = {
+  statusCode: number
+  body: string
+  headers: Record<string, string>
+}
+
+type FastifyAdapter = {
+  getInstance: () => {
+    inject: (opts: {
+      method: string
+      url: string
+      headers?: Record<string, string>
+      payload?: unknown
+    }) => Promise<FastifyInjectResponse>
+  }
+}
+
+const HTTP_METHOD_NAME: Record<number, string> = {
+  [RequestMethod.GET]: 'GET',
+  [RequestMethod.POST]: 'POST',
+  [RequestMethod.PUT]: 'PUT',
+  [RequestMethod.DELETE]: 'DELETE',
+  [RequestMethod.PATCH]: 'PATCH',
+  [RequestMethod.OPTIONS]: 'OPTIONS',
+  [RequestMethod.HEAD]: 'HEAD',
+  [RequestMethod.ALL]: 'ALL',
+}
+
+const joinPath = (controllerPath: string, methodPath: string): string => {
+  const c = controllerPath.startsWith('/')
+    ? controllerPath
+    : `/${controllerPath}`
+  const m = methodPath.startsWith('/')
+    ? methodPath
+    : methodPath
+      ? `/${methodPath}`
+      : ''
+  return `${c}${m}`.replace(/\/+/g, '/')
+}
+
+const DROPPED_REQUEST_HEADERS = new Set([
+  'host',
+  'connection',
+  'content-length',
+  'content-encoding',
+  'transfer-encoding',
+  'accept-encoding',
+  'expect',
+  'te',
+  'upgrade',
+])
+
+@Injectable()
+export class McpServerService {
+  constructor(
+    private readonly discovery: DiscoveryService,
+    private readonly metadataScanner: MetadataScanner,
+    private readonly reflector: Reflector,
+    private readonly httpAdapterHost: HttpAdapterHost,
+    private readonly applicationConfig: ApplicationConfig,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(McpServerService.name)
+  }
+
+  createServer(): Server {
+    const server = new Server(
+      { name: 'gp-api', version: '1.0.0' },
+      { capabilities: { tools: {} } },
+    )
+
+    server.setRequestHandler(ListToolsRequestSchema, () => ({
+      tools: this.gatherTools().map((t) => this.toMcpTool(t)),
+    }))
+
+    server.setRequestHandler(CallToolRequestSchema, async (req, extra) => {
+      const tools = this.gatherTools()
+      const tool = tools.find((t) => t.toolName === req.params.name)
+      if (!tool) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `Unknown tool: ${req.params.name}` }],
+        }
+      }
+
+      const args = (req.params.arguments ?? {}) as {
+        body?: unknown
+        query?: Record<string, string>
+        params?: Record<string, string>
+      }
+
+      const prefix = this.applicationConfig.getGlobalPrefix()
+      const url = this.buildUrl(prefix, tool.path, args.params, args.query)
+      const adapter = this.httpAdapterHost
+        .httpAdapter as unknown as FastifyAdapter
+      const fastify = adapter.getInstance()
+
+      // Forward most originating HTTP headers so the inner injected request
+      // sees the same auth and context (e.g. authorization for SessionGuard,
+      // x-organization-slug for UseCampaign). Drop hop-by-hop and HTTP-framing
+      // headers that fastify.inject will set itself. The MCP SDK exposes the
+      // originating headers via `extra.requestInfo` since 1.x.
+      const inboundHeaders = extra?.requestInfo?.headers ?? {}
+      const forwardHeaders: Record<string, string> = {}
+      for (const [name, value] of Object.entries(inboundHeaders)) {
+        if (DROPPED_REQUEST_HEADERS.has(name.toLowerCase())) continue
+        const v = Array.isArray(value) ? value[0] : value
+        if (typeof v === 'string') forwardHeaders[name] = v
+      }
+
+      const response = await fastify.inject({
+        method: tool.method,
+        url,
+        headers: forwardHeaders,
+        payload: args.body,
+      })
+
+      if (response.statusCode >= 400) {
+        this.logger.warn(
+          {
+            toolName: tool.toolName,
+            method: tool.method,
+            statusCode: response.statusCode,
+          },
+          'MCP tool invocation returned non-2xx',
+        )
+      }
+
+      return {
+        content: [{ type: 'text', text: response.body }],
+        isError: response.statusCode >= 400,
+      }
+    })
+
+    return server
+  }
+
+  getTools(): RegisteredMcpTool[] {
+    return this.gatherTools()
+  }
+
+  private gatherTools(): RegisteredMcpTool[] {
+    const controllers = this.discovery.getControllers()
+    const collected: RegisteredMcpTool[] = []
+
+    for (const wrapper of controllers) {
+      const { instance, metatype } = wrapper
+      if (!instance || !metatype) continue
+
+      const controllerPath: string =
+        Reflect.getMetadata(PATH_METADATA, metatype) ?? ''
+
+      const proto = Object.getPrototypeOf(instance)
+      const methodNames = this.metadataScanner.getAllMethodNames(proto)
+
+      for (const methodName of methodNames) {
+        const handler = proto[methodName]
+        const meta = this.reflector.get<McpToolMetadata>(MCP_TOOL_KEY, handler)
+        if (!meta) continue
+
+        const httpMethodNum: number | undefined = Reflect.getMetadata(
+          METHOD_METADATA,
+          handler,
+        )
+        const methodPath: string =
+          Reflect.getMetadata(PATH_METADATA, handler) ?? ''
+
+        if (httpMethodNum === undefined) {
+          throw new Error(
+            `@McpTool applied to ${metatype.name}.${methodName}, which has no HTTP method decorator. ` +
+              `@McpTool can only be used on controller route handlers (@Get/@Post/@Put/@Patch/@Delete).`,
+          )
+        }
+
+        const method = HTTP_METHOD_NAME[httpMethodNum] ?? 'UNKNOWN'
+        const path = joinPath(controllerPath, methodPath)
+        const toolName = deriveToolName(method, path)
+
+        collected.push({
+          toolName,
+          description: meta.description,
+          method,
+          path,
+          inputDeclarations: reflectInputDeclarations(proto, methodName, path),
+          outputSchema: reflectOutputSchema(handler),
+          controllerClassName: metatype.name,
+          handlerName: methodName,
+        })
+      }
+    }
+
+    const byName = new Map<string, RegisteredMcpTool>()
+    for (const t of collected) {
+      if (byName.has(t.toolName)) {
+        const existing = byName.get(t.toolName)!
+        throw new Error(
+          `Duplicate MCP tool name "${t.toolName}" — registered by ${existing.controllerClassName}.${existing.handlerName} and ${t.controllerClassName}.${t.handlerName}`,
+        )
+      }
+      byName.set(t.toolName, t)
+    }
+
+    const violations: string[] = []
+    for (const t of collected) {
+      if (!t.outputSchema) {
+        violations.push(`${t.toolName}: missing @ResponseSchema(...)`)
+      }
+      if (
+        t.inputDeclarations.body.declared &&
+        !t.inputDeclarations.body.schema
+      ) {
+        violations.push(
+          `${t.toolName}: @Body declared but is not a nestjs-zod createZodDto class`,
+        )
+      }
+      if (
+        t.inputDeclarations.query.declared &&
+        !t.inputDeclarations.query.schema
+      ) {
+        violations.push(
+          `${t.toolName}: @Query declared but is not a nestjs-zod createZodDto class`,
+        )
+      }
+      if (
+        t.inputDeclarations.params.declared &&
+        !t.inputDeclarations.params.schema
+      ) {
+        violations.push(
+          `${t.toolName}: @Param or path :placeholder is present but no nestjs-zod createZodDto provides a Zod schema`,
+        )
+      }
+    }
+    if (violations.length > 0) {
+      throw new Error(
+        `Invalid @McpTool configuration:\n  ${violations.join('\n  ')}`,
+      )
+    }
+
+    this.logger.debug({ toolCount: collected.length }, 'gathered MCP tools')
+
+    return collected
+  }
+
+  private toMcpTool(t: RegisteredMcpTool): Tool {
+    const combined = buildCombinedInputSchema(t.inputDeclarations)
+    const inputSchema = combined
+      ? (zodToJsonSchema(combined) as unknown as Tool['inputSchema'])
+      : ({ type: 'object', properties: {} } as Tool['inputSchema'])
+
+    return {
+      name: t.toolName,
+      description: t.description,
+      inputSchema,
+    }
+  }
+
+  private buildUrl(
+    globalPrefix: string,
+    path: string,
+    params?: Record<string, string>,
+    query?: Record<string, string>,
+  ): string {
+    const cleanPrefix = globalPrefix
+      ? `/${globalPrefix.replace(/^\/+|\/+$/g, '')}`
+      : ''
+    let url = `${cleanPrefix}${path}`
+    if (params) {
+      for (const [k, v] of Object.entries(params)) {
+        url = url.replace(`:${k}`, encodeURIComponent(v))
+      }
+    }
+    if (query && Object.keys(query).length > 0) {
+      const qs = new URLSearchParams(query).toString()
+      url += `?${qs}`
+    }
+    return url
+  }
+}

--- a/src/mcp/util/inputSchema.util.ts
+++ b/src/mcp/util/inputSchema.util.ts
@@ -1,0 +1,13 @@
+import { z, ZodSchema } from 'zod'
+import type { RegisteredMcpTool } from '../mcp.types'
+
+export const buildCombinedInputSchema = (
+  decls: RegisteredMcpTool['inputDeclarations'],
+): ZodSchema | null => {
+  const obj: Record<string, ZodSchema> = {}
+  if (decls.body.schema) obj.body = decls.body.schema
+  if (decls.query.schema) obj.query = decls.query.schema
+  if (decls.params.schema) obj.params = decls.params.schema
+  if (Object.keys(obj).length === 0) return null
+  return z.object(obj)
+}

--- a/src/mcp/util/schemaReflect.util.test.ts
+++ b/src/mcp/util/schemaReflect.util.test.ts
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+// Test fixtures define decorated controller stubs whose method bodies don't matter.
+import 'reflect-metadata'
+import { describe, expect, it } from 'vitest'
+import { Body, Param, Query } from '@nestjs/common'
+import { z } from 'zod'
+import { createZodDto } from 'nestjs-zod'
+import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import {
+  reflectInputDeclarations,
+  reflectOutputSchema,
+} from './schemaReflect.util'
+
+const BodySchema = z.object({ slogan: z.string().max(255) })
+class BodyDto extends createZodDto(BodySchema) {}
+
+const ParamsSchema = z.object({ id: z.string() })
+class ParamsDto extends createZodDto(ParamsSchema) {}
+
+const OutputSchema = z.object({ id: z.string(), updated: z.boolean() })
+
+describe('reflectOutputSchema', () => {
+  it('returns the Zod schema set by @ResponseSchema', () => {
+    class C {
+      @ResponseSchema(OutputSchema)
+      handler() {}
+    }
+    expect(reflectOutputSchema(C.prototype.handler)).toBe(OutputSchema)
+  })
+
+  it('returns null when no @ResponseSchema is present', () => {
+    class C {
+      handler() {}
+    }
+    expect(reflectOutputSchema(C.prototype.handler)).toBeNull()
+  })
+})
+
+describe('reflectInputDeclarations', () => {
+  it('marks body declared and captures its schema when @Body is present', () => {
+    class C {
+      handler(@Body() _b: BodyDto) {}
+    }
+    const decls = reflectInputDeclarations(C.prototype, 'handler', '/foo')
+    expect(decls.body.declared).toBe(true)
+    expect(decls.body.schema).toBe(BodySchema)
+    expect(decls.query.declared).toBe(false)
+    expect(decls.params.declared).toBe(false)
+  })
+
+  it('returns all-undeclared when handler has no params and path has no placeholder', () => {
+    class C {
+      handler() {}
+    }
+    const decls = reflectInputDeclarations(C.prototype, 'handler', '/foo')
+    expect(decls.body.declared).toBe(false)
+    expect(decls.body.schema).toBeNull()
+    expect(decls.query.declared).toBe(false)
+    expect(decls.query.schema).toBeNull()
+    expect(decls.params.declared).toBe(false)
+    expect(decls.params.schema).toBeNull()
+  })
+
+  it('marks params declared (schema=null) when path contains :placeholder but @Param is missing', () => {
+    class C {
+      handler() {}
+    }
+    const decls = reflectInputDeclarations(C.prototype, 'handler', '/foo/:id')
+    expect(decls.params.declared).toBe(true)
+    expect(decls.params.schema).toBeNull()
+  })
+
+  it('marks params declared and captures schema when @Param Zod DTO is present alongside :placeholder', () => {
+    class C {
+      handler(@Param() _p: ParamsDto) {}
+    }
+    const decls = reflectInputDeclarations(C.prototype, 'handler', '/foo/:id')
+    expect(decls.params.declared).toBe(true)
+    expect(decls.params.schema).toBe(ParamsSchema)
+  })
+
+  it('marks query declared without a schema when @Query has no Zod DTO', () => {
+    class C {
+      handler(@Query() _q: object) {}
+    }
+    const decls = reflectInputDeclarations(C.prototype, 'handler', '/foo')
+    expect(decls.query.declared).toBe(true)
+    expect(decls.query.schema).toBeNull()
+  })
+})

--- a/src/mcp/util/schemaReflect.util.ts
+++ b/src/mcp/util/schemaReflect.util.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-type-assertion */
+// Reflection-driven schema extraction: Reflect.getMetadata returns `any`, so casting to the
+// expected metadata shape (ROUTE_ARGS_METADATA, design:paramtypes) is unavoidable here.
+import 'reflect-metadata'
+import { ZodSchema } from 'zod'
+import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants'
+import { RouteParamtypes } from '@nestjs/common/enums/route-paramtypes.enum'
+import { RESPONSE_SCHEMA_KEY } from '@/shared/decorators/ResponseSchema.decorator'
+import { RegisteredMcpTool } from '../mcp.types'
+
+type ZodDtoClass = { schema?: ZodSchema } & (new (
+  ...args: unknown[]
+) => unknown)
+
+const PARAM_TYPE_TO_INPUT_KEY: Record<number, 'body' | 'query' | 'params'> = {
+  [RouteParamtypes.BODY]: 'body',
+  [RouteParamtypes.QUERY]: 'query',
+  [RouteParamtypes.PARAM]: 'params',
+}
+
+export const reflectOutputSchema = (
+  handler: (...args: unknown[]) => unknown,
+): ZodSchema | null => {
+  const schema = Reflect.getMetadata(RESPONSE_SCHEMA_KEY, handler)
+  return (schema as ZodSchema | undefined) ?? null
+}
+
+export const reflectInputDeclarations = (
+  controllerProto: object,
+  methodName: string,
+  routePath: string,
+): RegisteredMcpTool['inputDeclarations'] => {
+  const result: RegisteredMcpTool['inputDeclarations'] = {
+    body: { declared: false, schema: null },
+    query: { declared: false, schema: null },
+    params: { declared: false, schema: null },
+  }
+
+  if (/[/](:)[a-zA-Z]/.test(routePath)) {
+    result.params.declared = true
+  }
+
+  const paramMeta = Reflect.getMetadata(
+    ROUTE_ARGS_METADATA,
+    controllerProto.constructor,
+    methodName,
+  ) as Record<string, { index: number; pipes?: unknown[] }> | undefined
+
+  if (!paramMeta) return result
+
+  const paramTypes = (Reflect.getMetadata(
+    'design:paramtypes',
+    controllerProto,
+    methodName,
+  ) ?? []) as ZodDtoClass[]
+
+  for (const key of Object.keys(paramMeta)) {
+    const [paramTypeStr] = key.split(':')
+    const paramType = Number(paramTypeStr)
+    const inputKey = PARAM_TYPE_TO_INPUT_KEY[paramType]
+    if (!inputKey) continue
+
+    result[inputKey].declared = true
+
+    const { index } = paramMeta[key]
+    const dto = paramTypes[index]
+    if (dto?.schema) {
+      result[inputKey].schema = dto.schema
+    }
+  }
+
+  return result
+}

--- a/src/mcp/util/toolName.util.test.ts
+++ b/src/mcp/util/toolName.util.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { deriveToolName } from './toolName.util'
+
+describe('deriveToolName', () => {
+  it.each([
+    ['GET', '/v1/campaigns/mine', 'GET_v1_campaigns_mine'],
+    ['POST', '/v1/campaigns/mine', 'POST_v1_campaigns_mine'],
+    ['PATCH', '/v1/users/:id', 'PATCH_v1_users_id'],
+    ['DELETE', '/v1/files/:id', 'DELETE_v1_files_id'],
+  ])('derives "%s %s" → "%s"', (method, path, expected) => {
+    expect(deriveToolName(method, path)).toBe(expected)
+  })
+
+  it('uppercases lowercase methods', () => {
+    expect(deriveToolName('get', '/v1/foo')).toBe('GET_v1_foo')
+  })
+
+  it('throws on empty path', () => {
+    expect(() => deriveToolName('GET', '')).toThrow(/path/i)
+  })
+})

--- a/src/mcp/util/toolName.util.ts
+++ b/src/mcp/util/toolName.util.ts
@@ -1,0 +1,7 @@
+export const deriveToolName = (method: string, path: string): string => {
+  if (!path) {
+    throw new Error('deriveToolName: path is required')
+  }
+  const slug = path.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+  return `${method.toUpperCase()}_${slug}`
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json-summary', 'json'],
     },
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
     env: dotenv.parse(readFileSync(`${__dirname}/.env.test`)),
     clearMocks: true,
   },


### PR DESCRIPTION
## Why

First of two PRs that bring an MCP server to gp-api. This one establishes a **general-purpose** MCP server: any controller route can opt in as an agent-callable tool via `@McpTool`, and the `/v1/mcp` endpoint dispatches MCP requests back into the host's normal request pipeline (auth, validation, business logic, response interceptors — all unchanged). No agent-specific concepts in this PR.

The companion PR adds an agent-actor authentication layer on top (Clerk actor tokens, agent-fleet identity) so we can lock `/v1/mcp` down to known agent runs.

Design doc: https://goodparty.clickup.com/90132012119/v/dc/2ky4jq2q-20493/2ky4jq2q-69013

## What it adds

- **`@McpTool({ description })` decorator** on controller route handlers. Description is the only thing developers must write; method, path, and schemas come from the existing decorators (`@Get`/`@Post`/etc., `nestjs-zod` DTOs, `@ResponseSchema`).
- **`McpServerService`** with a per-request `createServer()` factory — fresh MCP `Server` per request avoids the SDK's `connect()` throwing on a re-attached transport under concurrency. `gatherTools()` walks NestJS DiscoveryService each request, builds tool definitions, and validates schema completeness — throws on misconfigured tools so a CI run that boots the app catches bad config.
- **`/v1/mcp` controller** mounting the MCP Streamable HTTP transport. Gated by the global `SessionGuard`. Forwards most inbound headers (Authorization, x-organization-slug, etc.) into the inner `fastify.inject` call so the tool call re-runs through the host's normal request pipeline.
- **Live integration test** that boots a real app via `useTestService`, POSTs JSON-RPC `tools/list` and `tools/call` over real HTTP, and asserts a real campaign payload comes back.
- **Worked example**: `GET /campaigns/mine` is the first opted-in tool.
- **Contracts**: new `OrganizationSchema` + `organization` field on `CampaignWithLiveContextSchema` (the response includes organization; the schema needed to reflect it).

## Key design choices

- **Tool name = slug, not URL path verbatim.** Path with slashes (`GET /v1/campaigns/mine`) is human-friendly but Anthropic's tool-name regex is `^[a-zA-Z0-9_-]{1,64}$`. Slugged form satisfies the constraint with zero developer choice.
- **Schema completeness is enforced inline in `gatherTools()`.** No separate validator script — same reflection that builds the registry validates it. Smart rule: input schema required only when the route declares `@Body`/`@Query`/`@Param` OR has `:placeholder` in the path; zero-arg session reads (like `findMine`) are legal with no input.
- **Broad header forwarding into `fastify.inject`.** Denylist of HTTP-machinery headers (host, content-length, etc.); everything else passes through so the inner handler sees the same auth and context the outer caller sent.
- **`SessionGuard` is the only auth on `/v1/mcp` in this PR.** That's intentional — this PR is the general server, no agent-specific lock. The follow-up adds Clerk actor-token gating.