### PR TITLE
fix: align onboarding contacts stats schema with people-api response

### DIFF
--- a/src/contacts/contacts.types.ts
+++ b/src/contacts/contacts.types.ts
@@ -4,20 +4,18 @@ export type DistrictStatsBucket = {
   percent: number
 }
 
-export type DistrictStatSummary = {
-  buckets: DistrictStatsBucket[]
-}
+export type DistrictStatCategory = DistrictStatsBucket[]
 
 export type StatsResponse = {
   districtId: string
-  computedAt: string
+  computedAt?: string
   totalConstituents: number
   totalConstituentsWithCellPhone: number
   buckets: {
-    age: DistrictStatSummary
-    homeowner: DistrictStatSummary
-    education: DistrictStatSummary
-    presenceOfChildren: DistrictStatSummary
-    estimatedIncomeRange: DistrictStatSummary
+    age: DistrictStatCategory
+    homeowner: DistrictStatCategory
+    education: DistrictStatCategory
+    presenceOfChildren: DistrictStatCategory
+    estimatedIncomeRange: DistrictStatCategory
   }
 }

--- a/src/contacts/tests/contacts.e2e.ts
+++ b/src/contacts/tests/contacts.e2e.ts
@@ -197,9 +197,9 @@ test.describe('Contacts and Segments', () => {
       totalConstituents: number
       totalConstituentsWithCellPhone?: number
       buckets: Record<string, unknown> & {
-        age?: { buckets?: unknown[] }
-        homeowner?: { buckets?: unknown[] }
-        education?: { buckets?: unknown[] }
+        age?: unknown[]
+        homeowner?: unknown[]
+        education?: unknown[]
       }
     }
     // District id comes from election-api for CONTACTS_TEST_POSITION_ID, not the legacy People seed id.
@@ -217,8 +217,8 @@ test.describe('Contacts and Segments', () => {
     expect(stats.buckets).toHaveProperty('age')
     expect(stats.buckets).toHaveProperty('homeowner')
     expect(stats.buckets).toHaveProperty('education')
-    if (stats.buckets.age?.buckets) {
-      expect(stats.buckets.age.buckets.length).toBeGreaterThan(0)
+    if (stats.buckets.age) {
+      expect(stats.buckets.age.length).toBeGreaterThan(0)
     }
   })
 

--- a/src/onboarding/schemas/getOnboardingStats.schema.ts
+++ b/src/onboarding/schemas/getOnboardingStats.schema.ts
@@ -21,20 +21,18 @@ const districtStatsBucketSchema = z.object({
   percent: z.number(),
 })
 
-const districtStatSummarySchema = z.object({
-  buckets: z.array(districtStatsBucketSchema),
-})
+const districtStatCategorySchema = z.array(districtStatsBucketSchema)
 
 export const onboardingStatsResponseSchema = z.object({
   districtId: z.string(),
-  computedAt: z.string(),
+  computedAt: z.string().optional(),
   totalConstituents: z.number(),
   totalConstituentsWithCellPhone: z.number(),
   buckets: z.object({
-    age: districtStatSummarySchema,
-    homeowner: districtStatSummarySchema,
-    education: districtStatSummarySchema,
-    presenceOfChildren: districtStatSummarySchema,
-    estimatedIncomeRange: districtStatSummarySchema,
+    age: districtStatCategorySchema,
+    homeowner: districtStatCategorySchema,
+    education: districtStatCategorySchema,
+    presenceOfChildren: districtStatCategorySchema,
+    estimatedIncomeRange: districtStatCategorySchema,
   }),
 })


### PR DESCRIPTION
The /v1/onboarding/contacts/stats endpoint was returning 500 for some districts because the response Zod schema expected:
  - computedAt as required
  - each bucket category wrapped as { buckets: [...] }

But people-api returns each category as a bare array, and computedAt is not always present. Update the schema and TS types to match.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the validated/typed shape of the onboarding contacts stats response (optional `computedAt` and bucket arrays), which could affect downstream consumers if they relied on the previous wrapper object.
> 
> **Overview**
> Aligns the `/v1/onboarding/contacts/stats` (and related contacts stats typing) response contract with people-api by making `computedAt` optional and representing each bucket category as a bare array of `DistrictStatsBucket` rather than `{ buckets: [...] }`.
> 
> Updates the contacts E2E assertions to match the new bucket shape (array length checks instead of nested `buckets`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89799033efbd0ae5a9ed3d1bd02cb9ef83e7d10e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->