### PR TITLE
feat(onboarding): add /v1/onboarding/voter-issues endpoint

### DIFF
--- a/src/elections/services/elections.service.test.ts
+++ b/src/elections/services/elections.service.test.ts
@@ -407,4 +407,29 @@ describe('ElectionsService', () => {
       expect(service.cleanDistrictName('## ##')).toBe('## ##')
     })
   })
+
+  describe('getVoterIssues', () => {
+    it('returns the issues array from the API and forwards districtId', async () => {
+      const issues = [
+        { label: 'Education', score: 88, priority: 'high' as const },
+      ]
+      mockHttpGet.mockReturnValue(of({ data: issues, status: 200 }))
+
+      const result = await service.getVoterIssues({ districtId: 'd-1' })
+
+      expect(result).toEqual(issues)
+      expect(mockHttpGet).toHaveBeenCalledWith(
+        expect.stringContaining('voter-issues'),
+        expect.objectContaining({ params: { districtId: 'd-1' } }),
+      )
+    })
+
+    it('returns null when the API returns null', async () => {
+      mockHttpGet.mockReturnValue(of({ data: null, status: 200 }))
+
+      const result = await service.getVoterIssues({ districtId: 'd-1' })
+
+      expect(result).toBeNull()
+    })
+  })
 })

--- a/src/elections/services/elections.service.ts
+++ b/src/elections/services/elections.service.ts
@@ -20,6 +20,7 @@ import {
   ProjectedTurnout,
   RaceTargetDetailsResult,
   RaceTargetMetrics,
+  VoterIssue,
 } from '../types/elections.types'
 
 @Injectable()
@@ -174,6 +175,23 @@ export class ElectionsService {
 
   async getDistrict(id: string): Promise<District | null> {
     return this.electionApiGet<District, object>(`districts/${id}`, {})
+  }
+
+  async getVoterIssues(params: {
+    districtId?: string
+    ballotReadyPositionId?: string
+    state?: string
+    city?: string
+  }): Promise<VoterIssue[] | null> {
+    return this.electionApiGet<
+      VoterIssue[],
+      {
+        districtId?: string
+        ballotReadyPositionId?: string
+        state?: string
+        city?: string
+      }
+    >('voter-issues', params)
   }
 
   async getDistrictId(

--- a/src/elections/services/elections.service.ts
+++ b/src/elections/services/elections.service.ts
@@ -178,20 +178,12 @@ export class ElectionsService {
   }
 
   async getVoterIssues(params: {
-    districtId?: string
-    ballotReadyPositionId?: string
-    state?: string
-    city?: string
+    districtId: string
   }): Promise<VoterIssue[] | null> {
-    return this.electionApiGet<
-      VoterIssue[],
-      {
-        districtId?: string
-        ballotReadyPositionId?: string
-        state?: string
-        city?: string
-      }
-    >('voter-issues', params)
+    return this.electionApiGet<VoterIssue[], { districtId: string }>(
+      'voter-issues',
+      params,
+    )
   }
 
   async getDistrictId(

--- a/src/elections/types/elections.types.ts
+++ b/src/elections/types/elections.types.ts
@@ -68,6 +68,12 @@ export type RaceTargetMetrics = {
 
 export type RaceTargetDetailsResult = RaceTargetMetrics
 
+export type VoterIssue = {
+  label: string
+  score: number
+  priority: 'high' | 'medium' | 'low'
+}
+
 export enum ProjectedTurnoutSourceColumns {
   id = 'id',
   createdAt = 'createdAt',

--- a/src/onboarding/onboarding.module.ts
+++ b/src/onboarding/onboarding.module.ts
@@ -1,13 +1,19 @@
 import { Module } from '@nestjs/common'
 import { AiModule } from '@/ai/ai.module'
 import { ContactsModule } from '@/contacts/contacts.module'
+import { ElectionsModule } from '@/elections/elections.module'
 import { OnboardingContactsController } from './onboardingContacts.controller'
 import { OnboardingLocalNewsController } from './onboardingLocalNews.controller'
+import { OnboardingVoterIssuesController } from './onboardingVoterIssues.controller'
 import { OnboardingLocalNewsService } from './services/localNews.service'
 
 @Module({
-  imports: [AiModule, ContactsModule],
-  controllers: [OnboardingContactsController, OnboardingLocalNewsController],
+  imports: [AiModule, ContactsModule, ElectionsModule],
+  controllers: [
+    OnboardingContactsController,
+    OnboardingLocalNewsController,
+    OnboardingVoterIssuesController,
+  ],
   providers: [OnboardingLocalNewsService],
 })
 export class OnboardingModule {}

--- a/src/onboarding/onboarding.module.ts
+++ b/src/onboarding/onboarding.module.ts
@@ -2,13 +2,14 @@ import { Module } from '@nestjs/common'
 import { AiModule } from '@/ai/ai.module'
 import { ContactsModule } from '@/contacts/contacts.module'
 import { ElectionsModule } from '@/elections/elections.module'
+import { OrganizationsModule } from '@/organizations/organizations.module'
 import { OnboardingContactsController } from './onboardingContacts.controller'
 import { OnboardingLocalNewsController } from './onboardingLocalNews.controller'
 import { OnboardingVoterIssuesController } from './onboardingVoterIssues.controller'
 import { OnboardingLocalNewsService } from './services/localNews.service'
 
 @Module({
-  imports: [AiModule, ContactsModule, ElectionsModule],
+  imports: [AiModule, ContactsModule, ElectionsModule, OrganizationsModule],
   controllers: [
     OnboardingContactsController,
     OnboardingLocalNewsController,

--- a/src/onboarding/onboardingVoterIssues.controller.test.ts
+++ b/src/onboarding/onboardingVoterIssues.controller.test.ts
@@ -1,0 +1,65 @@
+import { NotFoundException } from '@nestjs/common'
+import { Organization } from '@prisma/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElectionsService } from '@/elections/services/elections.service'
+import { OrganizationsService } from '@/organizations/services/organizations.service'
+import { OnboardingVoterIssuesController } from './onboardingVoterIssues.controller'
+
+describe('OnboardingVoterIssuesController', () => {
+  let controller: OnboardingVoterIssuesController
+  let getVoterIssues: ReturnType<typeof vi.fn>
+  let getDistrictForOrgSlug: ReturnType<typeof vi.fn>
+
+  const organization = { slug: 'org-slug' } as Organization
+
+  beforeEach(() => {
+    getVoterIssues = vi.fn()
+    getDistrictForOrgSlug = vi.fn()
+    controller = new OnboardingVoterIssuesController(
+      { getVoterIssues } as unknown as ElectionsService,
+      { getDistrictForOrgSlug } as unknown as OrganizationsService,
+    )
+  })
+
+  it('resolves the district from the organization and forwards to elections service', async () => {
+    getDistrictForOrgSlug.mockResolvedValue({
+      id: 'd-1',
+      l2Type: 'City',
+      l2Name: 'Los Angeles',
+    })
+    const issues = [
+      { label: 'Education', score: 88, priority: 'high' as const },
+    ]
+    getVoterIssues.mockResolvedValue(issues)
+
+    const result = await controller.getVoterIssues(organization)
+
+    expect(getDistrictForOrgSlug).toHaveBeenCalledWith('org-slug')
+    expect(getVoterIssues).toHaveBeenCalledWith({ districtId: 'd-1' })
+    expect(result).toEqual({ issues })
+  })
+
+  it('coerces a null upstream response to an empty issues array', async () => {
+    getDistrictForOrgSlug.mockResolvedValue({
+      id: 'd-1',
+      l2Type: 'City',
+      l2Name: 'Los Angeles',
+    })
+    getVoterIssues.mockResolvedValue(null)
+
+    const result = await controller.getVoterIssues(organization)
+
+    expect(result).toEqual({ issues: [] })
+  })
+
+  it('throws NotFoundException when the organization has no district', async () => {
+    getDistrictForOrgSlug.mockResolvedValue(null)
+
+    await expect(controller.getVoterIssues(organization)).rejects.toThrow(
+      new NotFoundException(
+        'No district associated with organization "org-slug"',
+      ),
+    )
+    expect(getVoterIssues).not.toHaveBeenCalled()
+  })
+})

--- a/src/onboarding/onboardingVoterIssues.controller.ts
+++ b/src/onboarding/onboardingVoterIssues.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Query, UsePipes } from '@nestjs/common'
+import { ZodValidationPipe } from 'nestjs-zod'
+import { ElectionsService } from '@/elections/services/elections.service'
+import {
+  GetVoterIssuesQueryDTO,
+  VoterIssuesResponse,
+} from './schemas/getVoterIssues.schema'
+
+@Controller('onboarding/voter-issues')
+@UsePipes(ZodValidationPipe)
+export class OnboardingVoterIssuesController {
+  constructor(private readonly elections: ElectionsService) {}
+
+  @Get()
+  async getVoterIssues(
+    @Query() query: GetVoterIssuesQueryDTO,
+  ): Promise<VoterIssuesResponse> {
+    const issues = await this.elections.getVoterIssues({
+      districtId: query.districtId,
+      ballotReadyPositionId: query.ballotReadyPositionId,
+      state: query.state,
+      city: query.city,
+    })
+    return { issues: issues ?? [] }
+  }
+}

--- a/src/onboarding/onboardingVoterIssues.controller.ts
+++ b/src/onboarding/onboardingVoterIssues.controller.ts
@@ -17,9 +17,6 @@ export class OnboardingVoterIssuesController {
   ): Promise<VoterIssuesResponse> {
     const issues = await this.elections.getVoterIssues({
       districtId: query.districtId,
-      ballotReadyPositionId: query.ballotReadyPositionId,
-      state: query.state,
-      city: query.city,
     })
     return { issues: issues ?? [] }
   }

--- a/src/onboarding/onboardingVoterIssues.controller.ts
+++ b/src/onboarding/onboardingVoterIssues.controller.ts
@@ -1,22 +1,48 @@
-import { Controller, Get, Query, UsePipes } from '@nestjs/common'
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  UseInterceptors,
+  UsePipes,
+} from '@nestjs/common'
+import { Organization } from '@prisma/client'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { ElectionsService } from '@/elections/services/elections.service'
+import { ReqOrganization } from '@/organizations/decorators/ReqOrganization.decorator'
+import { UseOrganization } from '@/organizations/decorators/UseOrganization.decorator'
+import { OrganizationsService } from '@/organizations/services/organizations.service'
+import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import { ZodResponseInterceptor } from '@/shared/interceptors/ZodResponse.interceptor'
 import {
-  GetVoterIssuesQueryDTO,
   VoterIssuesResponse,
+  voterIssuesResponseSchema,
 } from './schemas/getVoterIssues.schema'
 
 @Controller('onboarding/voter-issues')
 @UsePipes(ZodValidationPipe)
+@UseInterceptors(ZodResponseInterceptor)
 export class OnboardingVoterIssuesController {
-  constructor(private readonly elections: ElectionsService) {}
+  constructor(
+    private readonly elections: ElectionsService,
+    private readonly organizations: OrganizationsService,
+  ) {}
 
   @Get()
+  @UseOrganization()
+  @ResponseSchema(voterIssuesResponseSchema)
   async getVoterIssues(
-    @Query() query: GetVoterIssuesQueryDTO,
+    @ReqOrganization() organization: Organization,
   ): Promise<VoterIssuesResponse> {
+    const district = await this.organizations.getDistrictForOrgSlug(
+      organization.slug,
+    )
+    if (!district) {
+      throw new NotFoundException(
+        `No district associated with organization "${organization.slug}"`,
+      )
+    }
     const issues = await this.elections.getVoterIssues({
-      districtId: query.districtId,
+      districtId: district.id,
     })
     return { issues: issues ?? [] }
   }

--- a/src/onboarding/schemas/getVoterIssues.schema.ts
+++ b/src/onboarding/schemas/getVoterIssues.schema.ts
@@ -1,0 +1,35 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+const getVoterIssuesQuerySchema = z
+  .object({
+    districtId: z.string().min(1).optional(),
+    ballotReadyPositionId: z.string().min(1).optional(),
+    state: z.string().min(2).max(2).optional(),
+    city: z.string().min(1).optional(),
+  })
+  .refine(
+    (v) =>
+      Boolean(v.districtId || v.ballotReadyPositionId || v.state || v.city),
+    {
+      message:
+        'At least one of districtId, ballotReadyPositionId, state, or city is required',
+    },
+  )
+
+export class GetVoterIssuesQueryDTO extends createZodDto(
+  getVoterIssuesQuerySchema,
+) {}
+
+export const voterIssueSchema = z.object({
+  label: z.string(),
+  score: z.number().min(0).max(100),
+  priority: z.enum(['high', 'medium', 'low']),
+})
+
+export const voterIssuesResponseSchema = z.object({
+  issues: z.array(voterIssueSchema),
+})
+
+export type VoterIssueOutput = z.infer<typeof voterIssueSchema>
+export type VoterIssuesResponse = z.infer<typeof voterIssuesResponseSchema>

--- a/src/onboarding/schemas/getVoterIssues.schema.ts
+++ b/src/onboarding/schemas/getVoterIssues.schema.ts
@@ -1,13 +1,4 @@
-import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
-
-const getVoterIssuesQuerySchema = z.object({
-  districtId: z.string().min(1),
-})
-
-export class GetVoterIssuesQueryDTO extends createZodDto(
-  getVoterIssuesQuerySchema,
-) {}
 
 export const voterIssueSchema = z.object({
   label: z.string(),

--- a/src/onboarding/schemas/getVoterIssues.schema.ts
+++ b/src/onboarding/schemas/getVoterIssues.schema.ts
@@ -1,16 +1,9 @@
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
-const getVoterIssuesQuerySchema = z
-  .object({
-    districtId: z.string().min(1).optional(),
-    ballotReadyPositionId: z.string().min(1).optional(),
-    state: z.string().min(2).max(2).optional(),
-    city: z.string().min(1).optional(),
-  })
-  .refine((v) => Boolean(v.districtId || v.ballotReadyPositionId), {
-    message: 'At least one of districtId or ballotReadyPositionId is required',
-  })
+const getVoterIssuesQuerySchema = z.object({
+  districtId: z.string().min(1),
+})
 
 export class GetVoterIssuesQueryDTO extends createZodDto(
   getVoterIssuesQuerySchema,

--- a/src/onboarding/schemas/getVoterIssues.schema.ts
+++ b/src/onboarding/schemas/getVoterIssues.schema.ts
@@ -8,14 +8,9 @@ const getVoterIssuesQuerySchema = z
     state: z.string().min(2).max(2).optional(),
     city: z.string().min(1).optional(),
   })
-  .refine(
-    (v) =>
-      Boolean(v.districtId || v.ballotReadyPositionId || v.state || v.city),
-    {
-      message:
-        'At least one of districtId, ballotReadyPositionId, state, or city is required',
-    },
-  )
+  .refine((v) => Boolean(v.districtId || v.ballotReadyPositionId), {
+    message: 'At least one of districtId or ballotReadyPositionId is required',
+  })
 
 export class GetVoterIssuesQueryDTO extends createZodDto(
   getVoterIssuesQuerySchema,


### PR DESCRIPTION
## Why

Pairs with [election-api PR](https://github.com/thegoodparty/election-api/pulls?q=is%3Apr+head%3Afeat%2Fvoter-issues-endpoint) which exposes `GET /voter-issues` backed by the new `DistrictTopIssue` table (election-api#147). gp-api needs a thin proxy so the webapp can render top voter issues during onboarding.

## What

Adds `GET /v1/onboarding/voter-issues`.

- Accepts `districtId` | `ballotReadyPositionId` | `state` | `city` (at least one required).
- Forwards to election-api's `GET /voter-issues` via `ElectionsService.getVoterIssues()`.
- Returns `{ issues: VoterIssue[] }` where `VoterIssue = { label, score, priority: 'high'|'medium'|'low' }`.
- Response validated by `voterIssuesResponseSchema` (Zod).

## Files

- `src/onboarding/onboardingVoterIssues.controller.ts` (new)
- `src/onboarding/schemas/getVoterIssues.schema.ts` (new)
- `src/onboarding/onboarding.module.ts` — register controller, import `ElectionsModule`
- `src/elections/services/elections.service.ts` — `getVoterIssues()` HTTP wrapper
- `src/elections/types/elections.types.ts` — `VoterIssue` type

## Notes

- election-api currently resolves district only via `districtId` or `ballotReadyPositionId`. `state` / `city` are forwarded but ignored downstream — endpoint returns `[]` if neither key is provided. Webapp must pass one of them.
- No DB / migration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new onboarding API endpoint that proxies to the external election API; main risk is behavior/availability coupling to that upstream service and potential auth/response-validation inconsistency versus other onboarding endpoints.
> 
> **Overview**
> Adds `GET /onboarding/voter-issues` to support showing top voter issues during onboarding, validating query params with a new Zod DTO and requiring at least one of `districtId`, `ballotReadyPositionId`, `state`, or `city`.
> 
> Wires the endpoint into `OnboardingModule` (including importing `ElectionsModule`) and extends `ElectionsService` with `getVoterIssues()` plus a shared `VoterIssue` type to proxy `GET /voter-issues` from the election API and return `{ issues: [...] }` (defaulting to an empty list on null).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cdadeb965e1fbe496193e2e9e2b365497a81dfe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->