### PR TITLE
dev -> qa

### DIFF
--- a/src/contacts/contacts.types.ts
+++ b/src/contacts/contacts.types.ts
@@ -4,20 +4,18 @@ export type DistrictStatsBucket = {
   percent: number
 }
 
-export type DistrictStatSummary = {
-  buckets: DistrictStatsBucket[]
-}
+export type DistrictStatCategory = DistrictStatsBucket[]
 
 export type StatsResponse = {
   districtId: string
-  computedAt: string
+  computedAt?: string
   totalConstituents: number
   totalConstituentsWithCellPhone: number
   buckets: {
-    age: DistrictStatSummary
-    homeowner: DistrictStatSummary
-    education: DistrictStatSummary
-    presenceOfChildren: DistrictStatSummary
-    estimatedIncomeRange: DistrictStatSummary
+    age: DistrictStatCategory
+    homeowner: DistrictStatCategory
+    education: DistrictStatCategory
+    presenceOfChildren: DistrictStatCategory
+    estimatedIncomeRange: DistrictStatCategory
   }
 }

--- a/src/contacts/tests/contacts.e2e.ts
+++ b/src/contacts/tests/contacts.e2e.ts
@@ -197,9 +197,9 @@ test.describe('Contacts and Segments', () => {
       totalConstituents: number
       totalConstituentsWithCellPhone?: number
       buckets: Record<string, unknown> & {
-        age?: { buckets?: unknown[] }
-        homeowner?: { buckets?: unknown[] }
-        education?: { buckets?: unknown[] }
+        age?: unknown[]
+        homeowner?: unknown[]
+        education?: unknown[]
       }
     }
     // District id comes from election-api for CONTACTS_TEST_POSITION_ID, not the legacy People seed id.
@@ -217,8 +217,8 @@ test.describe('Contacts and Segments', () => {
     expect(stats.buckets).toHaveProperty('age')
     expect(stats.buckets).toHaveProperty('homeowner')
     expect(stats.buckets).toHaveProperty('education')
-    if (stats.buckets.age?.buckets) {
-      expect(stats.buckets.age.buckets.length).toBeGreaterThan(0)
+    if (stats.buckets.age) {
+      expect(stats.buckets.age.length).toBeGreaterThan(0)
     }
   })
 

--- a/src/onboarding/schemas/getOnboardingStats.schema.ts
+++ b/src/onboarding/schemas/getOnboardingStats.schema.ts
@@ -21,20 +21,18 @@ const districtStatsBucketSchema = z.object({
   percent: z.number(),
 })
 
-const districtStatSummarySchema = z.object({
-  buckets: z.array(districtStatsBucketSchema),
-})
+const districtStatCategorySchema = z.array(districtStatsBucketSchema)
 
 export const onboardingStatsResponseSchema = z.object({
   districtId: z.string(),
-  computedAt: z.string(),
+  computedAt: z.string().optional(),
   totalConstituents: z.number(),
   totalConstituentsWithCellPhone: z.number(),
   buckets: z.object({
-    age: districtStatSummarySchema,
-    homeowner: districtStatSummarySchema,
-    education: districtStatSummarySchema,
-    presenceOfChildren: districtStatSummarySchema,
-    estimatedIncomeRange: districtStatSummarySchema,
+    age: districtStatCategorySchema,
+    homeowner: districtStatCategorySchema,
+    education: districtStatCategorySchema,
+    presenceOfChildren: districtStatCategorySchema,
+    estimatedIncomeRange: districtStatCategorySchema,
   }),
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `contacts`/`onboarding` stats response contract (bucket categories are now raw arrays and `computedAt` can be omitted), which may break downstream consumers expecting the previous nested `{ buckets: ... }` shape.
> 
> **Overview**
> Updates district stats typings and validation to match a simplified payload: each stats category (`age`, `homeowner`, etc.) is now a `DistrictStatsBucket[]` (instead of an object containing `buckets`), and `computedAt` is now optional.
> 
> Adjusts the contacts e2e test assertions for `/v1/contacts/stats` to reflect the new bucket array shape and optional fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e8b4bb8378d43cb01878cf6aa47f66a287fb0a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->