### PR TITLE
fix(meetings): allow null description in fullAgenda items

### DIFF
--- a/src/meetings/types/briefing.schema.ts
+++ b/src/meetings/types/briefing.schema.ts
@@ -16,7 +16,8 @@ const PriorityIssueAnalysisSchema = z.object({
   actionItem: z.string(),
   askThis: z.string(),
   tryThis: z.string().nullable(),
-  whoIsPresenting: z.string(),
+  // The pipeline emits null when no presenter is named on the agenda.
+  whoIsPresenting: z.string().nullable(),
   supportingContext: z.string().nullable(),
   supportingDocuments: z.array(z.object({ name: z.string(), url: z.string() })),
 })
@@ -33,7 +34,11 @@ const PriorityIssueSchema = z.object({
 const FullAgendaItemSchema = z.object({
   number: z.string(),
   title: z.string(),
-  description: z.string(),
+  // The pipeline emits `null` for procedural items (Call to Order, Roll
+  // Call, etc.) where there's no agenda description to give. A non-nullable
+  // string here causes Zod to throw on every real briefing, which
+  // listBriefings silently swallows — and the UI shows nothing.
+  description: z.string().nullable(),
   category: z.string(),
   isPriority: z.boolean().optional(),
   priorityNumber: z.number().optional(),

--- a/src/meetings/types/briefing.types.ts
+++ b/src/meetings/types/briefing.types.ts
@@ -19,7 +19,7 @@ export type PriorityIssueAnalysis = {
   actionItem: string
   askThis: string
   tryThis: string | null
-  whoIsPresenting: string
+  whoIsPresenting: string | null
   supportingContext: string | null
   supportingDocuments: { name: string; url: string }[]
 }
@@ -38,7 +38,7 @@ export type PriorityIssue = {
 export type FullAgendaItem = {
   number: string
   title: string
-  description: string
+  description: string | null
   category: string
   isPriority?: boolean
   priorityNumber?: number


### PR DESCRIPTION
The pipeline emits description: null for procedural agenda items (Call to Order, Roll Call, etc.) where there's no agenda content to describe. The non-nullable z.string() in FullAgendaItemSchema caused Zod to throw on every real briefing — which listBriefings silently swallows in its per-key try/catch. Net effect: every briefing parsed in S3 was being dropped, so the meetings UI showed nothing even though the briefings were present.

Verified against la-habra-CA_2026-05-04 and surprise-AZ_2026-04-21 briefings in meeting-pipeline-dev. After this fix both parse cleanly. Mirror the schema change in briefing.types.ts so the static type matches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema/type loosening that only broadens accepted briefing JSON to match pipeline output; main impact is that previously dropped S3 briefings will now parse and appear in the UI.
> 
> **Overview**
> Fixes briefing parsing by allowing `fullAgenda[].description` to be `null` in both the Zod `FullAgendaItemSchema` and the corresponding `FullAgendaItem` TypeScript type.
> 
> This prevents `BriefingSchema.parse` failures in `listBriefings`/`getBriefing` when the pipeline emits `null` descriptions for procedural agenda items, so briefings are no longer silently skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b6585b9ecfcaac09f7c2b2b6abc7cd59f9626ac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->