### PR TITLE
dev -> qa

### DIFF
--- a/src/meetings/types/briefing.schema.ts
+++ b/src/meetings/types/briefing.schema.ts
@@ -16,7 +16,8 @@ const PriorityIssueAnalysisSchema = z.object({
   actionItem: z.string(),
   askThis: z.string(),
   tryThis: z.string().nullable(),
-  whoIsPresenting: z.string(),
+  // The pipeline emits null when no presenter is named on the agenda.
+  whoIsPresenting: z.string().nullable(),
   supportingContext: z.string().nullable(),
   supportingDocuments: z.array(z.object({ name: z.string(), url: z.string() })),
 })
@@ -33,7 +34,11 @@ const PriorityIssueSchema = z.object({
 const FullAgendaItemSchema = z.object({
   number: z.string(),
   title: z.string(),
-  description: z.string(),
+  // The pipeline emits `null` for procedural items (Call to Order, Roll
+  // Call, etc.) where there's no agenda description to give. A non-nullable
+  // string here causes Zod to throw on every real briefing, which
+  // listBriefings silently swallows — and the UI shows nothing.
+  description: z.string().nullable(),
   category: z.string(),
   isPriority: z.boolean().optional(),
   priorityNumber: z.number().optional(),

--- a/src/meetings/types/briefing.types.ts
+++ b/src/meetings/types/briefing.types.ts
@@ -19,7 +19,7 @@ export type PriorityIssueAnalysis = {
   actionItem: string
   askThis: string
   tryThis: string | null
-  whoIsPresenting: string
+  whoIsPresenting: string | null
   supportingContext: string | null
   supportingDocuments: { name: string; url: string }[]
 }
@@ -38,7 +38,7 @@ export type PriorityIssue = {
 export type FullAgendaItem = {
   number: string
   title: string
-  description: string
+  description: string | null
   category: string
   isPriority?: boolean
   priorityNumber?: number


### PR DESCRIPTION
dev -> qa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type/schema loosening to match pipeline output; main impact is allowing previously-invalid briefings to parse and display rather than being dropped.
> 
> **Overview**
> Updates the briefing Zod schema and TS types to accept `null` for `PriorityIssueAnalysis.whoIsPresenting` and `FullAgendaItem.description`, matching meeting pipeline output.
> 
> This prevents Zod parsing failures (notably during `listBriefings`) when agenda items are procedural or a presenter isn’t specified, so briefings are no longer silently skipped and the UI can render them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb6636e3ad28fcb66faf60591d85b4ef88d389d1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->