### PR TITLE
ENG-10204: fire pro_upgrade_complete from Stripe subscription webhook so the event tracks reliably regardless of client-side success page render

### DIFF
--- a/src/payments/services/paymentEventsService.test.ts
+++ b/src/payments/services/paymentEventsService.test.ts
@@ -1,0 +1,123 @@
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { Campaign, User } from '@prisma/client'
+import Stripe from 'stripe'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EVENTS } from 'src/vendors/segment/segment.types'
+import { CheckoutSessionMode, WebhookEventType } from '../payments.types'
+import { PaymentEventsService } from './paymentEventsService'
+
+describe('PaymentEventsService', () => {
+  let service: PaymentEventsService
+  const logger = createMockLogger()
+
+  const usersService = {
+    findUser: vi.fn(),
+    patchUserMetaData: vi.fn(),
+  }
+  const campaignsService = {
+    findByUserId: vi.fn(),
+    patchCampaignDetails: vi.fn(),
+    setIsPro: vi.fn(),
+  }
+  const analytics = {
+    trackProPayment: vi.fn(),
+    track: vi.fn(),
+  }
+  const slackService = { message: vi.fn() }
+  const voterFileDownloadAccess = { downloadAccessAlert: vi.fn() }
+  const organizationsService = {
+    getDistrictForOrgSlug: vi.fn(),
+    resolvePositionNameByOrganizationSlug: vi.fn(),
+  }
+  const crm = { getCrmCompanyOwnerName: vi.fn() }
+
+  const mockUser = { id: 1, email: 'test@example.com' } as User
+  const mockCampaign = {
+    id: 111,
+    organizationSlug: null,
+    details: {
+      electionDate: new Date(Date.now() + 365 * 86_400_000).toISOString(),
+    },
+    data: {},
+  } as unknown as Campaign
+
+  const subscriptionEvent = {
+    type: WebhookEventType.CheckoutSessionCompleted,
+    data: {
+      object: {
+        id: 'cs_test',
+        mode: CheckoutSessionMode.SUBSCRIPTION,
+        customer: 'cus_test',
+        subscription: 'sub_test',
+        metadata: { userId: '1' },
+      },
+    },
+  } as unknown as Stripe.CheckoutSessionCompletedEvent
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    usersService.findUser.mockResolvedValue(mockUser)
+    usersService.patchUserMetaData.mockResolvedValue(undefined)
+    campaignsService.findByUserId.mockResolvedValue(mockCampaign)
+    campaignsService.patchCampaignDetails.mockResolvedValue(undefined)
+    campaignsService.setIsPro.mockResolvedValue(undefined)
+    analytics.trackProPayment.mockResolvedValue(undefined)
+    analytics.track.mockResolvedValue(undefined)
+    slackService.message.mockResolvedValue(undefined)
+    voterFileDownloadAccess.downloadAccessAlert.mockResolvedValue(undefined)
+
+    service = new PaymentEventsService(
+      usersService as never,
+      campaignsService as never,
+      slackService as never,
+      {} as never,
+      crm as never,
+      voterFileDownloadAccess as never,
+      organizationsService as never,
+      {} as never,
+      analytics as never,
+      {} as never,
+      logger,
+    )
+  })
+
+  describe('handleEvent — checkout.session.completed (subscription)', () => {
+    it('fires pro_upgrade_complete with the correct user id and payload', async () => {
+      await service.handleEvent(subscriptionEvent)
+
+      expect(analytics.track).toHaveBeenCalledExactlyOnceWith(
+        mockUser.id,
+        EVENTS.Account.ProUpgradeComplete,
+        { pro: true },
+      )
+      expect(usersService.patchUserMetaData).toHaveBeenCalled()
+    })
+
+    it('swallows analytics.track errors and continues the flow', async () => {
+      const trackError = new Error('segment down')
+      analytics.track.mockRejectedValueOnce(trackError)
+
+      await expect(
+        service.handleEvent(subscriptionEvent),
+      ).resolves.not.toThrow()
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ error: trackError }),
+        expect.stringContaining('pro_upgrade_complete'),
+      )
+      expect(usersService.patchUserMetaData).toHaveBeenCalled()
+    })
+
+    it('fires pro_upgrade_complete even when trackProPayment throws', async () => {
+      analytics.trackProPayment.mockRejectedValueOnce(new Error('boom'))
+
+      await service.handleEvent(subscriptionEvent)
+
+      expect(analytics.track).toHaveBeenCalledWith(
+        mockUser.id,
+        EVENTS.Account.ProUpgradeComplete,
+        { pro: true },
+      )
+    })
+  })
+})

--- a/src/payments/services/paymentEventsService.ts
+++ b/src/payments/services/paymentEventsService.ts
@@ -23,6 +23,7 @@ import { OrganizationsService } from '../../organizations/services/organizations
 import { VoterFileDownloadAccessService } from '../../shared/services/voterFileDownloadAccess.service'
 import { parseCampaignElectionDate } from '../../campaigns/util/parseCampaignElectionDate.util'
 import { AnalyticsService } from 'src/analytics/analytics.service'
+import { EVENTS } from 'src/vendors/segment/segment.types'
 import { WrapperType } from 'src/shared/types/utility.types'
 import { PurchaseService } from './purchase.service'
 import { PinoLogger } from 'nestjs-pino'
@@ -264,6 +265,17 @@ export class PaymentEventsService {
         `[WEBHOOK] Failed to track pro payment analytics - User: ${user.id}, Session: ${session.id}`,
       )
       // Don't throw - we don't want to fail the webhook for analytics issues
+    }
+
+    try {
+      await this.analytics.track(user.id, EVENTS.Account.ProUpgradeComplete, {
+        pro: true,
+      })
+    } catch (error) {
+      this.logger.error(
+        { error },
+        `[WEBHOOK] Failed to track pro_upgrade_complete - User: ${user.id}, Session: ${session.id}`,
+      )
     }
 
     // Critical: Update user metadata with customerId - must succeed

--- a/src/vendors/segment/segment.types.ts
+++ b/src/vendors/segment/segment.types.ts
@@ -17,6 +17,7 @@ export const EVENTS = {
   Account: {
     PasswordResetRequested: 'Account - Password Reset Requested',
     ProSubscriptionConfirmed: 'Account - Pro Subscription Confirmed',
+    ProUpgradeComplete: 'pro_upgrade_complete',
     UserDeleted: 'Account - User Deleted',
   },
   Onboarding: {


### PR DESCRIPTION
The pro_upgrade_complete event is currently fired from a useEffect on the /dashboard/pro-sign-up/success page in gp-webapp, which makes it lossy: it only fires if the user actually lands on that page with JavaScript executing and Segment unblocked — meaning ad blockers, slow networks, closed tabs after Stripe redirect, or any server-side redirect from candidateAccess() will silently drop the event (this is what caused the regression observed on March 11, 2025). This PR moves the source of truth server-side by firing pro_upgrade_complete from handleSubscriptionCheckoutCompleted in paymentEventsService.ts, alongside the existing Account - Pro Subscription Confirmed event. The Stripe webhook is the canonical "user actually upgraded to Pro" moment — it runs whenever setIsPro(campaignId) runs, which is what truly defines a Pro upgrade — so the event is now guaranteed to fire exactly when the upgrade is real, regardless of the client's browser state. The new track call is wrapped in its own try/catch so a failure in trackProPayment (which does richer Stripe data extraction) cannot suppress it. The client-side fire in PurchaseSuccessPage.tsx is now redundant and should be removed in a follow-up gp-webapp PR once events are confirmed flowing from this change in prod.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Segment event emitted from the Stripe subscription webhook path; incorrect event naming or webhook execution edge cases could impact downstream analytics/HubSpot workflows, but failures are caught and should not break the upgrade flow.
> 
> **Overview**
> Moves the `pro_upgrade_complete` Segment tracking to the server-side Stripe `checkout.session.completed` subscription webhook by adding a dedicated `analytics.track` call after `setIsPro`, with its own try/catch so analytics failures don’t fail the webhook.
> 
> Extends `EVENTS` with `Account.ProUpgradeComplete` and adds a focused `PaymentEventsService` test suite to assert the event payload/userId and that analytics errors are logged and swallowed while critical metadata updates continue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af74dab5e6fda5e7fb95acc22bbcf49c598e09d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->