### PR TITLE
QA <- Dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,25 @@ npm run infra deploy <env>     # deploy via Pulumi
 | Why a thing is the way it is | `docs/adr/`                                      |
 | AI rule-by-rule code review  | `ai-rules/` (git submodule)                      |
 
+## Module pointers
+
+Per-area `CLAUDE.md` files cover purpose, key files, patterns, and gotchas for the dirs you'll touch most:
+
+| Working in                        | Read                                        |
+| --------------------------------- | ------------------------------------------- |
+| Campaigns / plans / tasks         | `src/campaigns/CLAUDE.md`                   |
+| Voter file / L2 lookups           | `src/voters/CLAUDE.md`                      |
+| Stripe payments / pro upgrades    | `src/payments/CLAUDE.md`                    |
+| Campaign websites / domains       | `src/websites/CLAUDE.md`                    |
+| SQS producer/consumer / async     | `src/queue/CLAUDE.md`                       |
+| Auth, JWT, Clerk M2M, roles       | `src/authentication/CLAUDE.md`              |
+| Agent experiments                 | `src/agentExperiments/CLAUDE.md`            |
+| Schema / migrations               | `prisma/CLAUDE.md`                          |
+| `@goodparty_org/contracts`        | `contracts/CLAUDE.md` + `docs/contracts.md` |
+| Pulumi / Docker / Grafana         | `deploy/CLAUDE.md`                          |
+| One-off / build scripts           | `scripts/CLAUDE.md`                         |
+| Seed data / factories / scenarios | `seed/CLAUDE.md`                            |
+
 ## Code style
 
 - **No semicolons**, single quotes, trailing commas (`.prettierrc`)
@@ -86,7 +105,7 @@ Provides `this.model`, `this.client`, `this.logger`, bound passthroughs (`findMa
 Three global guards run in order:
 
 1. `ClerkM2MAuthGuard` — accepts `mt_*` tokens via Clerk M2M
-2. `JwtAuthGuard` — accepts user JWTs from cookies
+2. `SessionGuard` — accepts user JWTs from cookies
 3. `RolesGuard` — enforces `@Roles(...)`
 
 Decorators: `@PublicAccess()`, `@Roles(UserRole.X)`, `@ReqUser()`. Route-level guards: `AdminOrM2MGuard`, `M2MOnly`. ADR: `docs/adr/0004-clerk-m2m-auth.md`.

--- a/contracts/CLAUDE.md
+++ b/contracts/CLAUDE.md
@@ -1,0 +1,35 @@
+# Contracts (`@goodparty_org/contracts`)
+
+Public npm package: shared Zod schemas and TypeScript types consumed by `gp-api`, `@goodparty_org/sdk`, and `gp-admin`. Lives **inside** the `gp-api` repo and is built as part of the API build, but is published independently.
+
+Anything that crosses a service boundary (request/response shapes, public enums) belongs here. ADR / detailed guide: `docs/contracts.md`.
+
+## Key files
+
+| Path                        | Purpose                                                                       |
+| --------------------------- | ----------------------------------------------------------------------------- |
+| `package.json`              | npm metadata; `name: "@goodparty_org/contracts"`, dual CJS/ESM build via tsup |
+| `tsup.config.ts`            | Build config — emits `dist/index.{js,mjs,d.ts}`                               |
+| `src/index.ts`              | Public surface; everything reachable from here is exported                    |
+| `src/<feature>/`            | Per-domain schemas (`campaigns/`, `users/`, `elections/`, `ecanvasser/`)      |
+| `src/shared/`               | Cross-domain primitives (pagination, enums, util types)                       |
+| `src/generated/`            | Output of `scripts/generate-enums.ts` (Prisma → Zod enum mirrors)             |
+| `scripts/generate-enums.ts` | Generates Zod enums from Prisma enums to keep them in sync                    |
+| `CHANGELOG.md`              | Human-edited changelog (manually maintained per release)                      |
+| `dist/`                     | Build output, committed only via npm publish workflow                         |
+
+## Patterns
+
+- **Build pipeline is two stages**: `npm run generate-enums` → `tsup`. Both run via `npm run build`. `scripts/build-contracts.ts` at the repo root short-circuits when the source is older than `dist/index.js`.
+- **Prisma enums are the source of truth for enum values** — never hand-write a Zod enum that mirrors a Prisma one; let `generate-enums.ts` do it. Add the Prisma enum first, then regenerate.
+- **Adding a public schema**: create the Zod schema in `src/<feature>/`, export from `src/<feature>/index.ts`, then re-export from `src/index.ts`. If it isn't reachable from the root index, it doesn't ship.
+- **Versioning is manual.** Bump `package.json` version + write a `CHANGELOG.md` entry in the same PR that changes the public surface.
+- The contracts build runs automatically on `npm run start:dev`, `npm run build`, and `npm test` — you generally don't run `cd contracts && npm run build` by hand.
+
+## Gotchas
+
+- **Never bypass `@goodparty_org/contracts` for cross-service shapes** (root `CLAUDE.md`, "Never" list). Don't redeclare a schema in `gp-api/src/` if it's already in contracts.
+- **Don't use `.passthrough()` on input schemas** (Rule from root `CLAUDE.md`). Use `.strict()` or the default behaviour.
+- The published `dist/` should never be edited by hand — it's regenerated on every build.
+- `gp-sdk` and `gp-admin` import from this package over npm, not via a path alias. A breaking change here ripples across repos — coordinate via Changesets and bump the version intentionally.
+- `provenance: true` is set in `publishConfig`; the publish workflow needs OIDC creds to succeed.

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -1,0 +1,35 @@
+# Deploy
+
+Pulumi (TypeScript) infrastructure-as-code, the production Dockerfile, and the `infra-cli.ts` wrapper used by the `npm run infra` commands. Targets four environments: `preview` (per-PR), `dev` (`develop` branch), `qa`, `prod`.
+
+## Key files
+
+| Path                                 | Purpose                                                                    |
+| ------------------------------------ | -------------------------------------------------------------------------- | --------------------------------- |
+| `index.ts`                           | Pulumi program entry — wires VPC, service, asset bucket, Grafana resources |
+| `Pulumi.yaml`                        | Stack metadata (`name: gp-api`, `runtime: nodejs`)                         |
+| `infra-cli.ts`                       | yargs-based CLI wrapping `pulumi`; `npm run infra <diff                    | deploy> <env>` shells out to this |
+| `Dockerfile`                         | Production image build (Node 22 Alpine, multi-copy with prebuilt `dist/`)  |
+| `docker-entrypoint.sh`               | Container bootstrap (env validation, migration check, app start)           |
+| `components/service.ts`              | ECS Fargate service + ALB target group                                     |
+| `components/vpc.ts`                  | VPC selection (existing VPC, hardcoded subnets/SGs)                        |
+| `components/assets-bucket.ts`        | S3 bucket for user uploads                                                 |
+| `components/assets-router.ts`        | CloudFront fronting the assets bucket                                      |
+| `components/grafana.ts`              | Grafana data sources, dashboards, contact points                           |
+| `components/alerting/` + `alerts.ts` | Grafana alert rules and routing                                            |
+| `pulumi/`                            | `node_modules` for Pulumi's runtime (separate dependency tree)             |
+
+## Patterns
+
+- **Environment is a literal union** (`'preview' \| 'dev' \| 'qa' \| 'prod'`) narrowed from `pulumi.Config().require('environment')`. The `select<T>(values)` helper in `index.ts` is the canonical way to choose per-env values — use it instead of `if/else` chains.
+- **Preview stacks are ephemeral**: `prNumber` is required for `preview`, and stack name is `pr-${prNumber}`. `find-stale-preview-stacks.ts` cleans up dangling ones.
+- **Pulumi config secrets** come from SSM via `infra-cli.ts` (`PULUMI_CONFIG_PASSPHRASE`, `GRAFANA_AUTH`, `GRAFANA_SM_ACCESS_TOKEN`). The CLI fetches them per-run; nothing is committed.
+- **Docker image is tagged with `imageUri`** passed in from CI; `index.ts` reads it via `pulumi.Config()`. Local builds aren't deployable — push through the workflow.
+- **Observability lives here, not just in app code.** Grafana dashboards/alerts are defined in `components/grafana.ts` and `components/alerting/`. App-side metric naming must line up with these.
+
+## Gotchas
+
+- VPC ID, subnet IDs, security group IDs, and the hosted zone are **hardcoded** in `index.ts`. They reference the existing AWS account and aren't created by Pulumi. Don't try to make them dynamic.
+- `pulumi/` has its own `node_modules` — don't `npm install` inside `deploy/`. Pulumi resolves from there at runtime.
+- `Dockerfile` copies `node_modules/.prisma` from the build host. CI must run `prisma generate` before the docker build, or the image will fail at runtime with missing native engines.
+- `infra deploy preview` requires `prNumber`; running it without one will throw on `config.require`.

--- a/prisma/CLAUDE.md
+++ b/prisma/CLAUDE.md
@@ -1,0 +1,29 @@
+# Prisma
+
+Postgres schema, migrations, and the Prisma client surface. Schema is split per-model under `schema/` (Prisma's multi-file schema feature). Migrations are immutable once applied.
+
+## Key files
+
+| Path                                    | Purpose                                                                             |
+| --------------------------------------- | ----------------------------------------------------------------------------------- |
+| `schema/schema.prisma`                  | Generators (`prisma-client-js`, `prisma-json-types-generator`) and datasource       |
+| `schema/<model>.prisma`                 | One file per model (`campaign.prisma`, `organization.prisma`, etc.)                 |
+| `schema/migrations/<timestamp>_<name>/` | Applied migrations — **never edit, never delete**                                   |
+| `schema/migrations/migration_lock.toml` | Prisma's lock — committed                                                           |
+| `schema/<model>.jsonTypes.d.ts`         | Hand-maintained TS types for `Json` columns (avoid creating new ones — see Rule 25) |
+
+## Patterns
+
+- **One model per file.** When adding a model, create `schema/<modelName>.prisma`. Don't append to `schema.prisma`.
+- **The PrismaBase pattern is mandatory** for services backed by a model — see root `CLAUDE.md` and `docs/adr/0001-prisma-base-pattern.md`.
+- **Migrations**: `npm run migrate:dev` creates and applies one locally. `npm run migrate:reset` wipes the local DB and re-seeds. Never run reset against a non-local database.
+- **Pending-migration check** runs on every `npm run start:dev` via `scripts/check-pending-migrations.ts`. If you see the yellow warning banner, run `migrate:dev` before continuing.
+- **`prisma-json-types-generator`** turns `Json` columns into typed fields if you have a matching `<model>.jsonTypes.d.ts` and a `///` comment annotation in the `.prisma` file (e.g. `/// [CampaignData]`). The generator is run as part of `npm run generate`.
+
+## Gotchas
+
+- **Migrations are immutable.** Editing a file in `schema/migrations/<timestamp>/` after it's been applied will desync prod from dev. If you need to fix a bad migration, write a new one.
+- **`map:` and snake_case** — DB columns are `snake_case`, Prisma fields are `camelCase`, joined by `@map()`. Match the existing style on adjacent fields when adding columns.
+- **`Json` columns are an anti-pattern** for known-shape data (Rule 25). Several legacy models (`Campaign.data`, `Campaign.details`, `Campaign.aiContent`) use them — don't replicate that for new models. Prefer proper columns or relations.
+- **Don't bypass `npm run generate`.** `prisma generate` alone misses the route-types step (`scripts/generate-route-types.ts`) that the `generate` script also runs.
+- `binaryTargets = ["native", "linux-musl-openssl-3.0.x"]` is set so the same `node_modules/.prisma` works in the Alpine Docker image — keep it.

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,40 @@
+# Scripts
+
+One-off and recurring TypeScript scripts run via `tsx` or `npm run` aliases. Two flavours:
+
+1. **Build / dev-loop scripts** wired into `package.json` (`build-contracts`, `check-pending-migrations`, `generate-route-types`).
+2. **Operational / one-shot scripts** (backfills, drift reports, manual triggers) run on demand by engineers.
+
+If logic only runs once and lives elsewhere, it doesn't belong here. If it's reusable and called from app code, it belongs in `src/`.
+
+## Key files
+
+| Path                                                              | Purpose                                                                                        |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `build-contracts.ts`                                              | Skips contract rebuild when `dist/` is fresher than `src/`; runs on `start:dev`, `build`, etc. |
+| `check-pending-migrations.ts`                                     | Boots-time warning banner if `prisma migrate status` reports unapplied migrations              |
+| `generate-route-types.ts`                                         | Walks `src/**/*.controller.ts` and emits a route-name → method/path map                        |
+| `generate-agent-job-types.ts`                                     | Syncs `agent-experiment-metadata-dev` S3 bucket → `src/generated/agent-job-contracts.ts`       |
+| `migrate-clean.ts` / `migrate-logger.ts`                          | Custom Prisma migrate wrappers used by `npm run migrate:*`                                     |
+| `aws-setup.sh` / `setup-readonly-role.sh`                         | Bash helpers for first-time AWS setup; not used in CI                                          |
+| `10dlc-status-drift-report.ts`                                    | Compares Peerly TCR state against our DB; one-shot operational                                 |
+| `backfill-voter-file-filter-orgs.ts`                              | Migration helper for the org-scoping change on `VoterFileFilter`                               |
+| `find-stale-preview-stacks.ts`                                    | Lists Pulumi preview stacks with no matching open PR                                           |
+| `dispatch-experiment.ts` / `trigger-poll.ts` / `complete-poll.ts` | Manual queue producers for testing async flows                                                 |
+| `test-weekly-tasks-digest-event.ts`                               | Locally fires the weekly tasks digest handler                                                  |
+| `output/`                                                         | Generated artefacts (e.g. agent metadata sync); gitignored content                             |
+| `*.sql`                                                           | Read-only diagnostic queries (run via `psql`, not from app code)                               |
+
+## Patterns
+
+- **Run with `tsx`**: `npx tsx scripts/<name>.ts` (or via the matching `npm run` alias). Don't compile to `dist/` first.
+- **Operational scripts must be safe to run twice.** Idempotency or an explicit `--dry-run` flag is the convention — see `backfill-voter-file-filter-orgs.ts`.
+- **`scripts/output/`** is the agreed-upon dump path for generated artefacts. Add new outputs there, not at the repo root.
+- **Don't import controllers/services from `src/`** unless you genuinely need the Nest container. Most scripts construct a `PrismaClient` directly.
+
+## Gotchas
+
+- `check-pending-migrations.ts` swallows non-pending errors silently — that's intentional (no DB locally is fine), don't "fix" it to throw.
+- `build-contracts.ts` skips when `dist/` is newer; if you've edited contracts and the build appears stale, delete `contracts/dist/` to force a rebuild.
+- `generate-agent-job-types.ts` requires AWS creds with read on `agent-experiment-metadata-dev`. It is **not** run in CI; output must be committed.
+- One-off backfills accumulate. Move clearly-dead scripts out (or delete) when their migration is complete — Rule 20 (Remove Code Completely) applies here too.

--- a/seed/CLAUDE.md
+++ b/seed/CLAUDE.md
@@ -1,0 +1,42 @@
+# Seed
+
+Development and CSV seed data. Two distinct flows:
+
+1. **Factory seeds** — generated via `@faker-js/faker`-style factories under `factories/`. Local dev only (`development` `NODE_ENV` with `SKIP_MTFCC_SEED`).
+2. **CSV seeds** — reference data (MTFCC codes, offices) loaded from `data/*.csv`. Run in dev / qa / prod.
+
+Entry point is `seed/seed.ts`. `npm run migrate:reset` invokes it after wiping the DB.
+
+## Key files
+
+| Path                    | Purpose                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------ |
+| `seed.ts`               | Orchestrator; chooses CSV-only vs. CSV-and-factory based on `NODE_ENV` + flags |
+| `users.ts`              | Factory seed for `User` rows; exports `ADMIN_USER`, `SERVE_USER` constants     |
+| `campaigns.ts`          | Factory seed for campaigns + linked org                                        |
+| `topIssues.ts`          | Static list of top issues                                                      |
+| `websiteData.ts`        | Per-campaign website seed data                                                 |
+| `mtfcc.ts`              | Loads `data/mtfcc.csv` (Census MAF/TIGER feature class codes)                  |
+| `offices.ts`            | Loads office reference data                                                    |
+| `contentful.ts`         | Mirrors a snapshot of Contentful entries into the DB                           |
+| `fixedCampaigns.json`   | Pinned campaigns used by integration tests for stable IDs                      |
+| `scenarios.ts`          | One-off scenario scripts: `npx tsx seed/scenarios.ts pro\|demo\|freeTexts`     |
+| `factories/`            | Per-model factories (`campaign.factory.ts`, `user.factory.ts`, etc.)           |
+| `factories/generate.ts` | Faker wrapper / per-factory shared helpers                                     |
+| `data/`                 | CSV reference data (MTFCC, election types, geo entities)                       |
+| `util/`                 | Helpers (e.g. `seedEcanvasserDemoAccount.util.ts`)                             |
+
+## Patterns
+
+- **CSV seeds run unconditionally in dev/qa/prod**; factory seeds run only with `NODE_ENV=development` and `SKIP_MTFCC_SEED=true`. This prevents fake users from leaking into hosted envs.
+- **Factories return Prisma create input**, not saved rows. The caller decides whether to `create` or batch.
+- **`fixedCampaigns.json`** holds known IDs/slugs used by tests and demo flows — treat it as a contract, not a sample. Adding a campaign here is a code change, not a data change.
+- **Scenarios are CLI-arg driven**: `seed/scenarios.ts <name>`. Add a new branch in the `switch` instead of adding a new file when possible.
+
+## Gotchas
+
+- **`IS_PREVIEW=true`** flips the seed path: factory seeds run even in production-mode containers so PR preview envs have data. Don't put expensive seeds in the factory path without checking the preview impact.
+- **`getTypeArg()` parses `process.argv`** — running `seed.ts` programmatically from another script needs to set `argv` carefully or call helpers directly.
+- **Contentful seed depends on live API access.** It'll silently no-op if creds are missing; check the logs if your local DB is missing CMS-derived rows.
+- **CSV files in `data/` are large** and committed to git — don't regenerate them casually. They're authoritative reference data, not derived.
+- `hashPasswordSync` is used in seed for speed; production code uses the async variant. Don't copy the sync version into `src/`.

--- a/src/authentication/CLAUDE.md
+++ b/src/authentication/CLAUDE.md
@@ -1,0 +1,41 @@
+# Authentication Module
+
+JWT + Clerk M2M auth, role enforcement, and user-facing auth flows (set/reset password). The actual directory name is `src/authentication/` (not `src/auth/`).
+
+Auth state is enforced globally via three guards registered in order. Most routes are protected by default; opt-out is explicit via `@PublicAccess()`.
+
+## Key files
+
+| Path                                     | Purpose                                                                           |
+| ---------------------------------------- | --------------------------------------------------------------------------------- |
+| `authentication.module.ts`               | Registers global guards as `APP_GUARD`, requires `AUTH_SECRET` at boot            |
+| `authentication.controller.ts`           | `POST /authentication/set-password-email`, `/reset-password`, `/recover-password` |
+| `authentication.service.ts`              | JWT sign/verify, password reset token issuance, bcrypt compare                    |
+| `authentication.consts.ts`               | `M2M_TOKEN_PREFIX = 'mt_'`                                                        |
+| `decorators/PublicAccess.decorator.ts`   | Skip auth on a controller or route                                                |
+| `decorators/Roles.decorator.ts`          | `@Roles(UserRole.ADMIN, ...)` — role gate via `RolesGuard`                        |
+| `decorators/ReqUser.decorator.ts`        | Inject the authed `User`                                                          |
+| `guards/ClerkM2MAuth.guard.ts`           | `ClerkM2MAuthGuard` — accepts `mt_*` Clerk machine tokens (global)                |
+| `guards/Session.guard.ts`                | `SessionGuard` — accepts user JWTs from cookies (global)                          |
+| `guards/Roles.guard.ts`                  | `RolesGuard` — reads `@Roles()` metadata and enforces                             |
+| `guards/AdminOrM2M.guard.ts`             | Route-level: admin user OR M2M token                                              |
+| `guards/M2MOnly.guard.ts`                | Route-level: M2M only                                                             |
+| `interceptors/AdminAudit.interceptor.ts` | Logs admin actions for the audit trail                                            |
+| `util/setTokenCookie.util.ts`            | Cookie writer used after login/refresh                                            |
+| `util/effectiveUser.util.ts`             | Resolves the "acting as" user when admins impersonate                             |
+| `providers/clerk-client.provider.ts`     | Constructs the Clerk SDK client                                                   |
+
+## Patterns
+
+- **Global guards run in order**: `ClerkM2MAuthGuard` → `SessionGuard` → `RolesGuard`, all wired as `APP_GUARD` from `authentication.module.ts`. New guards belong route-level, not global, unless they're truly cross-cutting.
+- **`@PublicAccess()` is the only escape hatch.** Don't conditionally skip auth inside a guard — opt out at the route level.
+- **Absence of `@Roles()` = "any authenticated user".** `routeIsPublicAndNoRoles.util.ts` is what makes that work; don't rely on the decorator being present to imply auth.
+- Password resets issue a **short-lived JWT**, not a DB-stored token. Side effects after consumption must be done in the same request.
+
+## Gotchas
+
+- `AUTH_SECRET` must be set at boot — module throws otherwise. No fallback path.
+- ADR for the M2M flow is `docs/adr/0004-clerk-m2m-auth.md` — read before adding new M2M-callable endpoints.
+- `effectiveUser.util.ts` returns the **impersonated** user, not the admin doing the impersonation. Audit logging needs both — pull the real admin from the request, not from `effectiveUser`.
+- `AdminAudit.interceptor.ts` only fires when explicitly applied — it is **not** global. Routes that mutate user data should opt in.
+- The `services/` directory exists but is empty. Don't be surprised; the only service lives at the module root for historical reasons.

--- a/src/campaigns/CLAUDE.md
+++ b/src/campaigns/CLAUDE.md
@@ -1,0 +1,37 @@
+# Campaigns Module
+
+The core domain entity. A `Campaign` is the per-candidate workspace that hangs off an `Organization` (1:1) and owns plans, tasks, positions, AI-generated content, TCR/SMS compliance, and update history. Most other modules (websites, voters, payments, outreach) reference a campaign as their unit of work.
+
+This module is `@Global` — `CampaignsService` is available without re-importing.
+
+## Key files
+
+| Path                                       | Purpose                                                         |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `campaigns.module.ts`                      | `@Global()`, wires submodule services and re-exports            |
+| `campaigns.controller.ts`                  | HTTP for campaigns + nested route groups under `/campaigns/*`   |
+| `services/campaigns.service.ts`            | Core CRUD on `Campaign`, slug build, list/pagination            |
+| `services/campaignPlanVersions.service.ts` | Append-only history of campaign plan JSON snapshots             |
+| `services/crmCampaigns.service.ts`         | Sync staff-managed campaigns to/from HubSpot                    |
+| `ai/`                                      | LLM-driven plan/copy generation (`campaignsAi.module.ts`)       |
+| `tasks/`                                   | Weekly tasks digest, task generation, legacy task controllers   |
+| `tcrCompliance/`                           | TCR brand/campaign registration for Peerly SMS sending          |
+| `positions/`                               | Race positions a campaign is running for                        |
+| `updateHistory/`                           | User-facing `CampaignUpdateHistory` (per-field audit log)       |
+| `decorators/`                              | `@ReqCampaign()`, `@UseCampaign()` — load campaign onto request |
+| `guards/`                                  | Campaign-scoped access guards                                   |
+| `campaigns.types.ts`                       | `CampaignWith<...>` helpers for Prisma includes                 |
+
+## Patterns
+
+- **Sub-feature directories own their own controller/service/schemas** (`tasks/`, `tcrCompliance/`, `positions/`, `updateHistory/`). They are wired into `CampaignsModule`, not registered as separate Nest modules — keep them inside this module unless they grow third-party deps.
+- **`@UseCampaign()` + `@ReqCampaign()`** is the standard way to scope a route to "the current user's campaign". Don't pull `campaignId` out of the body — read the campaign off the request.
+- **Plan versions are append-only.** Treat `campaignPlanVersions` as event-sourced; never UPDATE an existing row, always INSERT a new version.
+- The `Campaign.data`, `details`, and `aiContent` columns are `Json` with typed `.jsonTypes.d.ts` shadows. New fields belong in **proper columns**, not these blobs (Rule 25 in `.cursor/rules/rules.mdc`).
+
+## Gotchas
+
+- Module is `@Global` — adding a service here exposes it app-wide. Don't re-export from another module.
+- `WebsitesModule` uses `forwardRef(() => CampaignsModule)` to break a cycle (campaigns imports `WebsitesModule` directly). Adding new cross-edges risks a circular-import surprise; prefer routing the dependency through `payments` or `organizations` if possible.
+- `organizationSlug` is the foreign key, not `organizationId`. Cascade-delete is on the slug.
+- Several services here import from `@goodparty_org/contracts` (e.g. `CampaignLaunchStatus`). When changing those enums, follow `docs/contracts.md` — the SDK and `gp-admin` consume them.

--- a/src/payments/CLAUDE.md
+++ b/src/payments/CLAUDE.md
@@ -1,0 +1,37 @@
+# Payments Module
+
+Stripe-backed payments. Two controllers, both mounted under `/payments`:
+
+- `payments.controller.ts` — `POST /payments/events` (Stripe webhook receiver) and `PATCH /payments/fix-missing-customer-id` (admin maintenance).
+- `purchase.controller.ts` — checkout flows under `/payments/purchase/*`: create/complete Stripe Custom Checkout sessions, billing-portal redirects, and free-purchase fast paths. This is the entry point external callers (websites, outreach, polls) use.
+
+`PurchaseService` orchestrates a typed purchase → checkout session → fulfillment flow. `PaymentsService` is a thinner Stripe wrapper used internally; rarely the right place to start.
+
+## Key files
+
+| Path                               | Purpose                                                                                                                                        |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `payments.module.ts`               | Wires controllers + services; `forwardRef(() => CampaignsModule)`, depends on `StripeModule`, `UsersModule`                                    |
+| `payments.controller.ts`           | Stripe webhook + admin `fix-missing-customer-id` endpoint                                                                                      |
+| `purchase.controller.ts`           | `POST /payments/purchase/checkout-session`, `portal-session`, `create-checkout-session`, `complete-checkout-session`, `complete-free-purchase` |
+| `services/payments.service.ts`     | `createPayment`/`retrievePayment` over Stripe PaymentIntents; customer-id backfill (`@Timeout(0)` on boot + admin endpoint)                    |
+| `services/purchase.service.ts`     | Per-`PurchaseType` validation, amount calc, post-purchase handlers                                                                             |
+| `services/paymentEventsService.ts` | Stripe webhook event dispatcher (subscriptions, invoices, charges)                                                                             |
+| `payments.types.ts`                | `PaymentType`, `PaymentIntentPayload<T>`                                                                                                       |
+| `purchase.types.ts`                | `PurchaseType` enum (`DOMAIN_REGISTRATION`, `TEXT`, `POLL`) and per-type DTOs                                                                  |
+
+Filename note: `paymentEventsService.ts` intentionally lacks the `.service` suffix — historical, leave it.
+
+## Patterns
+
+- **Stripe webhook events flow through `PaymentEventsService`**, not the controllers. To react to a new event type, add the handler there — that's where business effects fire.
+- **`PurchaseType` is the typed extension point.** Adding a new purchase kind: add to the enum, add a metadata type, register a `PurchaseHandler<Metadata>` (`validatePurchase` / `calculateAmount` / optional `getProductName` / `getProductDescription`) in `PurchaseService`. Don't add ad-hoc payment paths outside this module.
+- **External calls are wrapped in try/catch and throw `BadGatewayException`** (`.cursor/rules/rules.mdc` Rule 3). DB writes are not wrapped — let `PrismaExceptionFilter` handle them.
+- `forwardRef(() => CampaignsModule)` because purchase fulfillment touches campaign state.
+
+## Gotchas
+
+- Stripe webhooks must be idempotent — events can replay. Preserve dedupe in `PaymentEventsService` when adding handlers.
+- The webhook route is `@PublicAccess()` and verifies the `stripe-signature` header — never bypass that check.
+- `PaymentsService.backfillMissingCustomerIdsOnBoot` runs at startup via `@Timeout(0)`. Be mindful of side effects when adding work to `PaymentsService` constructor or boot path.
+- Test fixtures use Stripe test-mode IDs prefixed `pi_test_…`. Don't compare against literal IDs in assertions; assert on side effects (DB row, user metadata) instead.

--- a/src/queue/CLAUDE.md
+++ b/src/queue/CLAUDE.md
@@ -1,0 +1,34 @@
+# Queue Module
+
+Single FIFO SQS queue with a strict producer/consumer split. Anything that needs async work goes through here.
+
+The architecture is fixed: **one queue, switch on `QueueType` enum.** Don't create a new queue for a new message type — add a `QueueType` enum value and a handler. ADR: `docs/adr/0003-fifo-sqs-single-queue.md`.
+
+A short overview also lives in `README.md`.
+
+## Key files
+
+| Path                                   | Purpose                                                                              |
+| -------------------------------------- | ------------------------------------------------------------------------------------ |
+| `queue.types.ts`                       | `QueueType` enum + per-type message data shapes (`QueueMessage` discriminated union) |
+| `queue.config.ts`                      | SQS client config (region, queue URL resolution)                                     |
+| `producer/queueProducer.module.ts`     | Module imported by anyone enqueuing messages                                         |
+| `producer/queueProducer.service.ts`    | `enqueue(message: QueueMessage)` — single entry point for sending                    |
+| `producer/queueProducer.controller.ts` | Internal-only endpoint for re-driving messages                                       |
+| `consumer/queueConsumer.module.ts`     | Excluded when `NODE_ENV === 'test'`                                                  |
+| `consumer/queueConsumer.service.ts`    | Polls SQS, switches on `QueueType` to dispatch handlers                              |
+| `consumer/fixtures/`                   | Sample SQS payloads for tests                                                        |
+
+## Patterns
+
+- **Adding a new async job** = three steps: (1) add a `QueueType` enum value + data shape in `queue.types.ts`, (2) call `queueProducer.enqueue({ type, data })` from the originating module, (3) add a case in `queueConsumer.service.ts` that calls a handler defined in the owning feature module (e.g. `CampaignsService.handleWeeklyTasksDigest`). The consumer should not contain business logic — it dispatches.
+- **`MessageGroupId` enforces FIFO ordering** per logical key (e.g. `agent-dispatch-{organizationSlug}`). Pick a group that gives you the ordering you actually need; over-broad groups serialize the queue.
+- **Idempotency is the producer/handler's job.** SQS can redeliver. Consumer handlers use `optimisticLockingUpdate` or status guards to drop duplicates (see `agentExperiments` module for the canonical pattern).
+- **Import `QueueProducerModule` wherever you enqueue.** Feature modules should depend on the producer side only; never import `QueueConsumerModule` from feature code.
+
+## Gotchas
+
+- `QueueConsumerModule` is excluded under `NODE_ENV === 'test'` — integration tests that need consumer behaviour must call `handle*` methods directly, not through SQS.
+- The consumer file is intentionally large and switch-based; future refactor will split per-handler. Don't restructure it as part of an unrelated change (Rule 5).
+- AWS credentials are required even in dev (the producer constructor throws otherwise). Set `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in `.env` for local work.
+- Preview environments do **not** set `AGENT_DISPATCH_QUEUE_NAME` — agent dispatch fails fast on PR branches by design.

--- a/src/voters/CLAUDE.md
+++ b/src/voters/CLAUDE.md
@@ -1,0 +1,33 @@
+# Voters Module
+
+Voter data layer. Talks to L2 (commercial voter file vendor) for live counts/filtering and persists per-campaign voter file filters used by outreach. Owns the `VoterFileFilter` model and the voter-file download access flow.
+
+This module does not store the voter file itself — L2 is the source of truth. We persist filters, derived counts, and audit metadata.
+
+## Key files
+
+| Path                                  | Purpose                                                                                                      |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `voters.module.ts`                    | Module wiring; exports `VoterFileService`, `VotersService`, `VoterFileFilterService`, `VoterDatabaseService` |
+| `voterFile/voterFile.controller.ts`   | HTTP: list/create/update/delete `VoterFileFilter`, request downloads                                         |
+| `voterFile/voterFile.service.ts`      | CRUD on `VoterFileFilter`, download URL signing                                                              |
+| `services/voters.service.ts`          | L2 API client (counts, demographic breakdowns)                                                               |
+| `services/voterDatabase.service.ts`   | Direct queries against the in-house voter database                                                           |
+| `services/voterFileFilter.service.ts` | Filter persistence + per-campaign filter listing                                                             |
+| `services/voterOutreach.service.ts`   | Bridges voter filters to outreach campaigns                                                                  |
+| `schemas/`                            | Zod input schemas for filter create/update                                                                   |
+| `voters.types.ts`                     | `VoterCounts`, `EthnicityCounts`, `GenderCounts`, `PartisanCounts`, `VoterHistoryColumn`                     |
+
+## Patterns
+
+- **L2 is the system of record for voters.** Treat `VotersService` as a thin axios wrapper — never cache L2 responses in our DB beyond the explicit count snapshots on `VoterFileFilter`.
+- **`L2_DATA_KEY` is required at boot** (`voters.service.ts` throws on missing env). Don't add lazy fallbacks.
+- **Voter file downloads are gated** through `VoterFileDownloadAccessService` (in `src/shared/services/`) — it checks campaign tier + entitlement. Don't bypass it from new endpoints.
+- Filters are scoped to a campaign via `@UseCampaign()` + `@ReqCampaign()` — same pattern as the rest of the campaign-scoped surface.
+
+## Gotchas
+
+- `VoterDatabaseService` and `VotersService` look similar but query different sources: the former hits our Postgres, the latter hits L2's HTTP API. Pick deliberately.
+- The L2 API has its own rate limits and timeouts; wrap new calls in `try/catch` and throw `BadGatewayException` per `.cursor/rules/rules.mdc` Rule 3.
+- Counts surfaced to the UI come from L2 in real time and may shift between page loads — don't rely on them for billing or quota math.
+- `VotersModule` imports `OutreachModule` (one-way). If you find yourself wanting `OutreachModule` to import voters too, route the dependency through an existing service instead — adding a back-edge will require `forwardRef` and is a smell.

--- a/src/websites/CLAUDE.md
+++ b/src/websites/CLAUDE.md
@@ -1,0 +1,34 @@
+# Websites Module
+
+Backend for campaign websites — public-facing static sites generated per campaign with optional custom domains, contact-form intake, and view tracking. Vercel hosts the rendered output; this module owns the database side and the domain-registration flow through Route 53.
+
+A longer narrative lives in `README.md` (data model, endpoint catalogue). This file is the navigation pointer.
+
+## Key files
+
+| Path                                  | Purpose                                                                                                      |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `websites.module.ts`                  | Wires controllers + services; depends on `VercelModule`, `AwsModule`, `PaymentsModule`, `ForwardEmailModule` |
+| `controllers/websites.controller.ts`  | CRUD on `Website`, contact form submission, view tracking                                                    |
+| `controllers/domains.controller.ts`   | Custom domain registration, status polling, suggestions                                                      |
+| `services/websites.service.ts`        | Website CRUD, default content generation, publish/unpublish                                                  |
+| `services/domains.service.ts`         | Route 53 + Vercel domain orchestration                                                                       |
+| `services/websiteContacts.service.ts` | Inbound contact form persistence                                                                             |
+| `services/websiteViews.service.ts`    | UUID-keyed visitor view counter                                                                              |
+| `schemas/`                            | Zod schemas for create/update website, contact form, list filters                                            |
+| `domains.types.ts`                    | `DomainRegistrationStatus`, payload shapes                                                                   |
+| `README.md`                           | DB models + endpoint reference                                                                               |
+
+## Patterns
+
+- **Domain registration is a multi-step async flow** (Stripe charge → Route 53 op → polling → Vercel attach). State lives on the `Domain` row; never short-circuit by reading from Route 53 ad hoc.
+- **Forward Email is the inbound mail provider** for custom-domain campaign emails. New email-related domain features go through `ForwardEmailModule`, not direct DNS edits.
+- Website creation auto-seeds content from the campaign's positions and user data — see `WebsitesService.createForCampaign`.
+- `WebsitesModule` has a non-trivial constructor that wires `PurchaseService` for the domain purchase flow — uncommon for a Nest module class; if you're adding logic here, prefer pushing it into a service.
+
+## Gotchas
+
+- `forwardRef(() => CampaignsModule)` — circular with campaigns. Keep new edges to the campaigns side as forwardRefs to avoid breaking module init.
+- `WebsiteView` uses a localStorage-issued visitor UUID; treat it as advisory, not authoritative analytics.
+- Public-facing endpoints use `@PublicAccess()` and `@UseCampaign()` together — don't drop one when refactoring or you'll either expose admin data or 401 the public site.
+- Contact form submissions are write-only from the public site; the admin-side read goes through a separate authenticated endpoint with `GetWebsiteContactsSchema`.


### PR DESCRIPTION
This PR releases gp-api to QA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime behavior or API surface is modified.
> 
> **Overview**
> Adds a **module navigation layer** by introducing per-area `CLAUDE.md` docs (e.g. `src/campaigns/`, `src/authentication/`, `deploy/`, `prisma/`, `contracts/`, `scripts/`, `seed/`) that capture key files, patterns, and gotchas for common workstreams.
> 
> Updates the root `CLAUDE.md` to link to these module pointers and corrects the documented global auth guard chain to reference `SessionGuard` (replacing `JwtAuthGuard`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf1e35a76dc1a792ec5fc094ff08cd0adf13e2f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->