### PR TITLE
ENG-7541 - Domain search endpoint with pattern + price cap

### DIFF
--- a/src/shared/util/date.util.test.ts
+++ b/src/shared/util/date.util.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { parseIsoDateAsUTC } from './date.util'
+
+describe('parseIsoDateAsUTC', () => {
+  // Asserting against Date.UTC(...) makes these checks TZ-independent —
+  // they fail in *any* non-UTC test runner if the parser drifts to local
+  // time. (Asserting only `getUTCMonth` etc. would falsely pass on a UTC
+  // host even if the parser were broken, defeating the regression guard.)
+
+  it('parses date-only "YYYY-MM-DD" as UTC midnight', () => {
+    const d = parseIsoDateAsUTC('2026-11-03')
+    expect(d.getTime()).toBe(Date.UTC(2026, 10, 3))
+  })
+
+  it('preserves the calendar month at the month boundary (Nov 1)', () => {
+    const d = parseIsoDateAsUTC('2026-11-01')
+    expect(d.getTime()).toBe(Date.UTC(2026, 10, 1))
+  })
+
+  it('preserves the calendar year at the year boundary (Jan 1)', () => {
+    const d = parseIsoDateAsUTC('2026-01-01')
+    expect(d.getTime()).toBe(Date.UTC(2026, 0, 1))
+  })
+
+  it('passes through strings that already carry a TZ offset', () => {
+    const d = parseIsoDateAsUTC('2026-11-03T10:30:00Z')
+    expect(d.getTime()).toBe(Date.UTC(2026, 10, 3, 10, 30, 0))
+  })
+})

--- a/src/shared/util/date.util.ts
+++ b/src/shared/util/date.util.ts
@@ -5,9 +5,12 @@ import {
   isBefore,
   isValid,
   parse,
+  parseISO,
   startOfDay,
   subDays,
 } from 'date-fns'
+
+const ISO_DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/
 
 export const toDateOnlyString = (d?: Date | null) => {
   return d ? d.toISOString().slice(0, 10) : undefined
@@ -34,6 +37,20 @@ export const getMidnightForDate = (date: Date) =>
 
 export const parseIsoDateString = (dateString: string) =>
   parse(dateString, DateFormats.isoDate, new Date())
+
+/**
+ * Parses 'YYYY-MM-DD' as UTC midnight. Use this when downstream code reads
+ * the Date with `getUTCMonth()` / `getUTCFullYear()` and the source value
+ * is a calendar date with no wall-clock-time intent — `parseIsoDateString`
+ * (and `parseISO` directly) interpret bare 'YYYY-MM-DD' as LOCAL midnight,
+ * which causes month/year wrap-around on servers east of UTC (e.g. local
+ * 2026-01-01 → UTC 2025-12-31). Inputs that already carry a TZ offset are
+ * passed through unchanged.
+ */
+export const parseIsoDateAsUTC = (dateString: string): Date =>
+  ISO_DATE_ONLY_RE.test(dateString)
+    ? parseISO(`${dateString}T00:00:00Z`)
+    : parseISO(dateString)
 
 export const isDateTodayOrFuture = (
   dateString: string | undefined | null,

--- a/src/websites/controllers/domains.controller.test.ts
+++ b/src/websites/controllers/domains.controller.test.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { Reflector } from '@nestjs/core'
+import { RequestMethod } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DomainsController } from './domains.controller'
+import { DomainsService } from '../services/domains.service'
+import { WebsitesService } from '../services/websites.service'
+import { UseCampaignGuard } from 'src/campaigns/guards/UseCampaign.guard'
+import { REQUIRE_CAMPAIGN_META_KEY } from 'src/campaigns/decorators/UseCampaign.decorator'
+import {
+  createMockCampaign,
+  createMockUser,
+} from '@/shared/test-utils/mockData.util'
+
+describe('DomainsController.searchDomains', () => {
+  let controller: DomainsController
+  let mockDomains: { searchDomainsForCampaign: ReturnType<typeof vi.fn> }
+
+  beforeEach(async () => {
+    mockDomains = {
+      searchDomainsForCampaign: vi.fn().mockResolvedValue({
+        candidates: [{ domain: 'vote-oneill.run', price: 8 }],
+      }),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DomainsController],
+      providers: [
+        { provide: DomainsService, useValue: mockDomains },
+        { provide: WebsitesService, useValue: {} },
+      ],
+    })
+      .overrideGuard(UseCampaignGuard)
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    controller = module.get<DomainsController>(DomainsController)
+  })
+
+  it('delegates to DomainsService.searchDomainsForCampaign and returns its result', async () => {
+    const campaign = {
+      ...createMockCampaign({ details: { electionDate: '2026-11-03' } }),
+      user: createMockUser({ firstName: 'Mary', lastName: "O'Neill" }),
+    }
+
+    const result = await controller.searchDomains(campaign, {
+      patterns: ['vote-{last_name}.run'],
+      maxPrice: 10,
+    })
+
+    expect(mockDomains.searchDomainsForCampaign).toHaveBeenCalledWith(
+      campaign,
+      ['vote-{last_name}.run'],
+      10,
+    )
+    expect(result).toEqual({
+      candidates: [{ domain: 'vote-oneill.run', price: 8 }],
+    })
+  })
+
+  it('handler is registered for POST /search with @UseCampaign() including user', () => {
+    const reflector = new Reflector()
+
+    const path = Reflect.getMetadata('path', controller.searchDomains)
+    const method = Reflect.getMetadata('method', controller.searchDomains)
+    expect(path).toBe('search')
+    expect(method).toBe(RequestMethod.POST)
+
+    const meta = reflector.get(
+      REQUIRE_CAMPAIGN_META_KEY,
+      controller.searchDomains,
+    )
+    expect(meta).toBeDefined()
+    expect(meta.include).toEqual({ user: true })
+  })
+})

--- a/src/websites/controllers/domains.controller.ts
+++ b/src/websites/controllers/domains.controller.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  Body,
   Controller,
   Delete,
   Get,
@@ -14,16 +15,22 @@ import { DomainsService } from '../services/domains.service'
 import { PaymentStatus } from 'src/payments/payments.types'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { SearchDomainSchema } from '../schemas/SearchDomain.schema'
+import {
+  SearchDomainsBodySchema,
+  SearchDomainsResponseSchema,
+} from '../schemas/SearchDomains.schema'
 import { UseCampaign } from 'src/campaigns/decorators/UseCampaign.decorator'
 import { ReqCampaign } from 'src/campaigns/decorators/ReqCampaign.decorator'
-import { Campaign, DomainStatus, UserRole } from '@prisma/client'
+import { Campaign, DomainStatus, User, UserRole } from '@prisma/client'
 import { Roles } from 'src/authentication/decorators/Roles.decorator'
 import { WebsitesService } from '../services/websites.service'
 import {
   DomainOperationStatus,
   DomainOperationType,
   DomainStatusResponse,
+  PatternedDomainSearchResult,
 } from '../domains.types'
+import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
 
 @Controller('domains')
 @UsePipes(ZodValidationPipe)
@@ -42,6 +49,17 @@ export class DomainsController {
   @Get('search')
   async searchDomain(@Query() { domain }: SearchDomainSchema) {
     return this.domains.searchForDomain(domain)
+  }
+
+  @Post('search')
+  @UseCampaign({ include: { user: true } })
+  @HttpCode(HttpStatus.OK)
+  @ResponseSchema(SearchDomainsResponseSchema)
+  async searchDomains(
+    @ReqCampaign() campaign: Campaign & { user: User },
+    @Body() { patterns, maxPrice }: SearchDomainsBodySchema,
+  ): Promise<PatternedDomainSearchResult> {
+    return this.domains.searchDomainsForCampaign(campaign, patterns, maxPrice)
   }
 
   @Get('status')

--- a/src/websites/domains.types.ts
+++ b/src/websites/domains.types.ts
@@ -21,6 +21,15 @@ export interface DomainSearchResult extends DomainSuggestion {
   price: number | undefined
 }
 
+export interface PatternedDomainCandidate {
+  domain: string
+  price: number
+}
+
+export interface PatternedDomainSearchResult {
+  candidates: PatternedDomainCandidate[]
+}
+
 // Enum for domain operation statuses
 export enum DomainOperationStatus {
   SUBMITTED = 'SUBMITTED',

--- a/src/websites/schemas/SearchDomains.schema.ts
+++ b/src/websites/schemas/SearchDomains.schema.ts
@@ -1,0 +1,18 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+export const SearchDomainsResponseSchema = z.object({
+  candidates: z.array(
+    z.object({
+      domain: z.string(),
+      price: z.number(),
+    }),
+  ),
+})
+
+export class SearchDomainsBodySchema extends createZodDto(
+  z.object({
+    patterns: z.array(z.string().min(1)).min(1).max(20),
+    maxPrice: z.number().positive(),
+  }),
+) {}

--- a/src/websites/schemas/SearchDomains.schema.ts
+++ b/src/websites/schemas/SearchDomains.schema.ts
@@ -12,7 +12,7 @@ export const SearchDomainsResponseSchema = z.object({
 
 export class SearchDomainsBodySchema extends createZodDto(
   z.object({
-    patterns: z.array(z.string().min(1)).min(1).max(20),
+    patterns: z.array(z.string().min(1).max(200)).min(1).max(20),
     maxPrice: z.number().positive(),
   }),
 ) {}

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -388,5 +388,20 @@ describe('DomainsService', () => {
       ).rejects.toBeInstanceOf(BadRequestException)
       expect(mockRoute53.checkDomainAvailability).not.toHaveBeenCalled()
     })
+
+    it('propagates BadRequest from Route53 (e.g. UnsupportedTLD) instead of silencing it', async () => {
+      mockRoute53.checkDomainAvailability.mockImplementation(() => {
+        throw new BadRequestException('UnsupportedTLD')
+      })
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 5 })
+
+      await expect(
+        service.searchDomainsForCampaign(
+          campaignWithUser,
+          ['vote-{last_name}.xyz'],
+          10,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException)
+    })
   })
 })

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -16,7 +16,12 @@ import { DomainsService } from './domains.service'
 import { createMockClerkEnricher } from '@/shared/test-utils/mockClerkEnricher.util'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
 import { ClerkUserEnricherService } from '@/vendors/clerk/services/clerk-user-enricher.service'
-import { createMockUser } from '@/shared/test-utils/mockData.util'
+import {
+  createMockCampaign,
+  createMockUser,
+} from '@/shared/test-utils/mockData.util'
+import { BadRequestException } from '@nestjs/common'
+import { DomainAvailability } from '@aws-sdk/client-route-53-domains'
 
 const mockUser = createMockUser()
 
@@ -41,6 +46,8 @@ describe('DomainsService', () => {
     getValidatedSessionUser: ReturnType<typeof vi.fn>
     retrievePayment: ReturnType<typeof vi.fn>
   }
+  let mockRoute53: { checkDomainAvailability: ReturnType<typeof vi.fn> }
+  let mockVercel: { checkDomainPrice: ReturnType<typeof vi.fn> }
   let mockPrisma: {
     domain: {
       findMany: ReturnType<typeof vi.fn>
@@ -50,6 +57,8 @@ describe('DomainsService', () => {
   }
 
   beforeEach(async () => {
+    mockRoute53 = { checkDomainAvailability: vi.fn() }
+    mockVercel = { checkDomainPrice: vi.fn() }
     mockAnalytics = {
       track: vi.fn().mockResolvedValue(undefined),
     }
@@ -81,8 +90,8 @@ describe('DomainsService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         { provide: PrismaService, useValue: mockPrisma },
-        { provide: AwsRoute53Service, useValue: {} },
-        { provide: VercelService, useValue: {} },
+        { provide: AwsRoute53Service, useValue: mockRoute53 },
+        { provide: VercelService, useValue: mockVercel },
         { provide: PaymentsService, useValue: mockPayments },
         { provide: StripeService, useValue: mockStripe },
         { provide: ForwardEmailService, useValue: {} },
@@ -181,6 +190,178 @@ describe('DomainsService', () => {
 
       expect(result).toHaveProperty('domain')
       expect(result).toHaveProperty('message')
+    })
+  })
+
+  describe('searchDomainsForCampaign', () => {
+    const campaignWithUser = {
+      ...createMockCampaign({
+        details: { electionDate: '2026-11-03' },
+      }),
+      user: createMockUser({ firstName: 'Mary', lastName: "O'Neill" }),
+    }
+
+    it('expands patterns, queries registrar, returns available + under cap', async () => {
+      mockRoute53.checkDomainAvailability.mockImplementation(
+        (domain: string) => ({
+          Availability:
+            domain === 'vote-oneill-nov-2026.bio'
+              ? DomainAvailability.UNAVAILABLE
+              : DomainAvailability.AVAILABLE,
+        }),
+      )
+      mockVercel.checkDomainPrice.mockImplementation((domain: string) => ({
+        price: domain === 'vote-oneill-nov-2026.win' ? 25 : 8,
+      }))
+
+      const result = await service.searchDomainsForCampaign(
+        campaignWithUser,
+        ['vote-{last_name}-{month_abbreviation}-{yyyy}.(run|bio|win)'],
+        10,
+      )
+
+      expect(result.candidates.map((c) => c.domain).sort()).toEqual(
+        ['vote-oneill-nov-2026.run'].sort(),
+      )
+      expect(result.candidates[0]).toEqual({
+        domain: 'vote-oneill-nov-2026.run',
+        price: 8,
+      })
+    })
+
+    it('normalizes the candidate last name (handles apostrophes)', async () => {
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 5 })
+
+      const result = await service.searchDomainsForCampaign(
+        campaignWithUser,
+        ['vote-{last_name}.run'],
+        10,
+      )
+
+      expect(mockRoute53.checkDomainAvailability).toHaveBeenCalledWith(
+        'vote-oneill.run',
+      )
+      expect(result.candidates).toHaveLength(1)
+    })
+
+    it('deduplicates identical expansions across patterns', async () => {
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 5 })
+
+      await service.searchDomainsForCampaign(
+        campaignWithUser,
+        ['vote-{last_name}.run', 'vote-{last_name}.(run|bio)'],
+        10,
+      )
+
+      expect(mockRoute53.checkDomainAvailability).toHaveBeenCalledTimes(2)
+    })
+
+    it('excludes domains over the price cap', async () => {
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockImplementation((domain: string) => ({
+        price: domain.endsWith('.bio') ? 50 : 7,
+      }))
+
+      const result = await service.searchDomainsForCampaign(
+        campaignWithUser,
+        ['vote-{last_name}.(run|bio)'],
+        10,
+      )
+
+      expect(result.candidates.map((c) => c.domain)).toEqual([
+        'vote-oneill.run',
+      ])
+    })
+
+    it('returns empty list when no candidates expanded', async () => {
+      const result = await service.searchDomainsForCampaign(
+        campaignWithUser,
+        [],
+        10,
+      )
+
+      expect(result.candidates).toEqual([])
+      expect(mockRoute53.checkDomainAvailability).not.toHaveBeenCalled()
+    })
+
+    it('falls back to current date when campaign has no electionDate', async () => {
+      const campaignNoDate = {
+        ...createMockCampaign({ details: {} }),
+        user: createMockUser({ firstName: 'Mary', lastName: "O'Neill" }),
+      }
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 5 })
+
+      const result = await service.searchDomainsForCampaign(
+        campaignNoDate,
+        ['vote-{last_name}-{yyyy}.run'],
+        10,
+      )
+
+      expect(result.candidates).toHaveLength(1)
+      expect(result.candidates[0].domain).toMatch(/^vote-oneill-\d{4}\.run$/)
+    })
+
+    it('skips (does not fail the whole request) when one availability call fails', async () => {
+      mockRoute53.checkDomainAvailability.mockImplementation(
+        (domain: string) => {
+          if (domain.endsWith('.bio')) {
+            throw new Error('route53 boom')
+          }
+          return { Availability: DomainAvailability.AVAILABLE }
+        },
+      )
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 5 })
+
+      const result = await service.searchDomainsForCampaign(
+        campaignWithUser,
+        ['vote-{last_name}.(run|bio)'],
+        10,
+      )
+
+      expect(result.candidates.map((c) => c.domain)).toEqual([
+        'vote-oneill.run',
+      ])
+    })
+
+    it('skips a candidate whose price lookup fails (does not fail the whole request)', async () => {
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockImplementation((domain: string) => {
+        if (domain.endsWith('.bio')) throw new Error('vercel boom')
+        return { price: 7 }
+      })
+
+      const result = await service.searchDomainsForCampaign(
+        campaignWithUser,
+        ['vote-{last_name}.(run|bio)'],
+        10,
+      )
+
+      expect(result.candidates.map((c) => c.domain)).toEqual([
+        'vote-oneill.run',
+      ])
+    })
+
+    it('rejects with BadRequest when patterns expand past the candidate cap', async () => {
+      const huge =
+        '(a|b|c|d|e|f|g|h|i|j)(a|b|c|d|e|f|g|h|i|j){last_name}.(run|bio)'
+
+      await expect(
+        service.searchDomainsForCampaign(campaignWithUser, [huge], 10),
+      ).rejects.toBeInstanceOf(BadRequestException)
+      expect(mockRoute53.checkDomainAvailability).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -292,6 +292,31 @@ describe('DomainsService', () => {
       expect(mockRoute53.checkDomainAvailability).not.toHaveBeenCalled()
     })
 
+    it('uses UTC-anchored date components for boundary date-only strings', async () => {
+      // Jan 1 is the worst case: a TZ-naive parser would render local
+      // 2026-01-01 as Dec 31, 2025 in UTC, producing 'dec-2025' instead
+      // of 'jan-2026'. This test fails on any TZ-east-of-UTC server
+      // unless the parser anchors to UTC midnight.
+      const campaignBoundary = {
+        ...createMockCampaign({ details: { electionDate: '2026-01-01' } }),
+        user: createMockUser({ firstName: 'Mary', lastName: "O'Neill" }),
+      }
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 5 })
+
+      const result = await service.searchDomainsForCampaign(
+        campaignBoundary,
+        ['vote-{last_name}-{month_abbreviation}-{yyyy}.run'],
+        10,
+      )
+
+      expect(result.candidates.map((c) => c.domain)).toEqual([
+        'vote-oneill-jan-2026.run',
+      ])
+    })
+
     it('falls back to current date when campaign has no electionDate', async () => {
       const campaignNoDate = {
         ...createMockCampaign({ details: {} }),

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -389,19 +389,20 @@ describe('DomainsService', () => {
       expect(mockRoute53.checkDomainAvailability).not.toHaveBeenCalled()
     })
 
-    it('propagates BadRequest from Route53 (e.g. UnsupportedTLD) instead of silencing it', async () => {
+    it('skips candidate when Route53 throws BadRequest (e.g. UnsupportedTLD)', async () => {
       mockRoute53.checkDomainAvailability.mockImplementation(() => {
         throw new BadRequestException('UnsupportedTLD')
       })
       mockVercel.checkDomainPrice.mockResolvedValue({ price: 5 })
 
-      await expect(
-        service.searchDomainsForCampaign(
-          campaignWithUser,
-          ['vote-{last_name}.xyz'],
-          10,
-        ),
-      ).rejects.toBeInstanceOf(BadRequestException)
+      const result = await service.searchDomainsForCampaign(
+        campaignWithUser,
+        ['vote-{last_name}.xyz'],
+        10,
+      )
+
+      expect(result).toEqual({ candidates: [] })
+    })
     })
   })
 })

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -403,6 +403,5 @@ describe('DomainsService', () => {
 
       expect(result).toEqual({ candidates: [] })
     })
-    })
   })
 })

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -420,7 +420,11 @@ export class DomainsService
       )
     } else if (isNaN(electionDate.getTime())) {
       this.logger.warn(
-        { campaignId: campaign.id, electionDateStr, fn: 'searchDomainsForCampaign' },
+        {
+          campaignId: campaign.id,
+          electionDateStr,
+          fn: 'searchDomainsForCampaign',
+        },
         'invalid electionDate stored on campaign; falling back to current date',
       )
       electionDate = new Date()

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -457,9 +457,12 @@ export class DomainsService
       if (r.status === 'fulfilled' && r.value !== null) {
         found.push(r.value)
       } else if (r.status === 'rejected') {
-        if (r.reason instanceof BadRequestException) {
-          throw r.reason
-        }
+        const err =
+          r.reason instanceof Error ? r.reason : new Error(String(r.reason))
+        this.logger.warn(
+          { err, fn: 'searchDomainsForCampaign' },
+          'candidate availability check failed; skipping',
+        )
         const err =
           r.reason instanceof Error ? r.reason : new Error(String(r.reason))
         this.logger.warn(

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -50,6 +50,8 @@ import {
 } from '../util/domainPatterns.util'
 import { parseISO } from 'date-fns'
 
+const ISO_DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/
+
 const MAX_PATTERN_CANDIDATES = 50
 
 const { ENABLE_DOMAIN_SETUP } = process.env
@@ -410,8 +412,16 @@ export class DomainsService
     maxPrice: number,
   ): Promise<PatternedDomainSearchResult> {
     const electionDateStr = campaign.details?.electionDate
+    // Anchor date-only strings to UTC midnight — bare 'YYYY-MM-DD' would
+    // otherwise be parsed as LOCAL midnight by parseISO, causing
+    // getUTCMonth/getUTCFullYear in the pattern util to wrap on servers
+    // east of UTC (e.g. local 2026-01-01 → UTC 2025-12-31).
     const electionDate = electionDateStr
-      ? parseISO(electionDateStr)
+      ? parseISO(
+          ISO_DATE_ONLY_RE.test(electionDateStr)
+            ? `${electionDateStr}T00:00:00Z`
+            : electionDateStr,
+        )
       : new Date()
     if (!electionDateStr) {
       this.logger.warn(

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -44,7 +44,10 @@ import {
 } from '../domains.types'
 import { RegisterDomainSchema } from '../schemas/RegisterDomain.schema'
 import { ClerkUserEnricherService } from '@/vendors/clerk/services/clerk-user-enricher.service'
-import { expandDomainPatterns } from '../util/domainPatterns.util'
+import {
+  expandDomainPatterns,
+  PatternExpansionLimitError,
+} from '../util/domainPatterns.util'
 import { parseISO } from 'date-fns'
 
 const MAX_PATTERN_CANDIDATES = 50
@@ -417,17 +420,24 @@ export class DomainsService
       )
     }
 
-    const candidates = expandDomainPatterns(patterns, {
-      firstName: campaign.user.firstName ?? '',
-      lastName: campaign.user.lastName ?? '',
-      electionDate,
-    })
-
-    if (candidates.length > MAX_PATTERN_CANDIDATES) {
-      throw new BadRequestException(
-        `Patterns expand to ${candidates.length} candidates ` +
-          `(max ${MAX_PATTERN_CANDIDATES})`,
+    let candidates: string[]
+    try {
+      candidates = expandDomainPatterns(
+        patterns,
+        {
+          firstName: campaign.user.firstName ?? '',
+          lastName: campaign.user.lastName ?? '',
+          electionDate,
+        },
+        { maxCandidates: MAX_PATTERN_CANDIDATES },
       )
+    } catch (error) {
+      if (error instanceof PatternExpansionLimitError) {
+        throw new BadRequestException(
+          `Patterns expand to more than ${MAX_PATTERN_CANDIDATES} candidates`,
+        )
+      }
+      throw error
     }
 
     const checked = await Promise.allSettled(

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -7,7 +7,7 @@ import {
   Injectable,
 } from '@nestjs/common'
 import { Timeout } from '@nestjs/schedule'
-import { Domain, DomainStatus, User } from '@prisma/client'
+import { Campaign, Domain, DomainStatus, User } from '@prisma/client'
 import { AddProjectDomainResponseBody } from '@vercel/sdk/models/addprojectdomainop'
 import { BuySingleDomainResponseBody } from '@vercel/sdk/models/buysingledomainop'
 import { GetDomainResponseBody } from '@vercel/sdk/models/getdomainop'
@@ -36,9 +36,18 @@ import { ForwardEmailDomainResponse } from '../../vendors/forwardEmail/forwardEm
 import { ForwardEmailService } from '../../vendors/forwardEmail/services/forwardEmail.service'
 import { AnalyticsService } from 'src/analytics/analytics.service'
 import { EVENTS } from 'src/vendors/segment/segment.types'
-import { DomainPurchaseMetadata, DomainSearchResult } from '../domains.types'
+import {
+  DomainPurchaseMetadata,
+  DomainSearchResult,
+  PatternedDomainCandidate,
+  PatternedDomainSearchResult,
+} from '../domains.types'
 import { RegisterDomainSchema } from '../schemas/RegisterDomain.schema'
 import { ClerkUserEnricherService } from '@/vendors/clerk/services/clerk-user-enricher.service'
+import { expandDomainPatterns } from '../util/domainPatterns.util'
+import { parseISO } from 'date-fns'
+
+const MAX_PATTERN_CANDIDATES = 50
 
 const { ENABLE_DOMAIN_SETUP } = process.env
 
@@ -390,6 +399,96 @@ export class DomainsService
 
   async getDomainDetails(domainName: string) {
     return this.vercel.getDomainDetails(domainName)
+  }
+
+  async searchDomainsForCampaign(
+    campaign: Campaign & { user: User },
+    patterns: string[],
+    maxPrice: number,
+  ): Promise<PatternedDomainSearchResult> {
+    const electionDateStr = campaign.details?.electionDate
+    const electionDate = electionDateStr
+      ? parseISO(electionDateStr)
+      : new Date()
+    if (!electionDateStr) {
+      this.logger.warn(
+        { campaignId: campaign.id, fn: 'searchDomainsForCampaign' },
+        'no electionDate on campaign; falling back to current date',
+      )
+    }
+
+    const candidates = expandDomainPatterns(patterns, {
+      firstName: campaign.user.firstName ?? '',
+      lastName: campaign.user.lastName ?? '',
+      electionDate,
+    })
+
+    if (candidates.length > MAX_PATTERN_CANDIDATES) {
+      throw new BadRequestException(
+        `Patterns expand to ${candidates.length} candidates ` +
+          `(max ${MAX_PATTERN_CANDIDATES})`,
+      )
+    }
+
+    const checked = await Promise.allSettled(
+      candidates.map((domain) =>
+        this.checkPatternedCandidate(domain, maxPrice),
+      ),
+    )
+
+    const found = checked.flatMap((r) => {
+      if (r.status === 'fulfilled' && r.value !== null) return [r.value]
+      if (r.status === 'rejected') {
+        const err =
+          r.reason instanceof Error ? r.reason : new Error(String(r.reason))
+        this.logger.warn(
+          { err, fn: 'searchDomainsForCampaign' },
+          'candidate availability check failed; skipping',
+        )
+      }
+      return []
+    })
+
+    return { candidates: found }
+  }
+
+  private async checkPatternedCandidate(
+    domain: string,
+    maxPrice: number,
+  ): Promise<PatternedDomainCandidate | null> {
+    let availability: DomainAvailability | undefined
+    try {
+      const resp = await this.route53.checkDomainAvailability(domain)
+      availability = resp.Availability
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error
+      }
+      throw new BadGatewayException('Route53 availability check failed', {
+        cause: error instanceof Error ? error : new Error(String(error)),
+      })
+    }
+
+    if (availability !== DomainAvailability.AVAILABLE) {
+      return null
+    }
+
+    let price: number
+    try {
+      const resp = await this.vercel.checkDomainPrice(domain)
+      price = resp.price
+    } catch (error) {
+      this.logger.warn(
+        { err: error, domain },
+        'Vercel price lookup failed; skipping candidate',
+      )
+      return null
+    }
+
+    if (price > maxPrice) {
+      return null
+    }
+    return { domain, price }
   }
 
   async searchForDomain(domainName: string): Promise<DomainSearchResult> {

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -475,12 +475,11 @@ export class DomainsService
       const resp = await this.route53.checkDomainAvailability(domain)
       availability = resp.Availability
     } catch (error) {
-      if (error instanceof BadRequestException) {
-        throw error
-      }
-      throw new BadGatewayException('Route53 availability check failed', {
-        cause: error instanceof Error ? error : new Error(String(error)),
-      })
+      this.logger.warn(
+        { err: error, domain, fn: 'checkPatternedCandidate' },
+        'Route53 availability check failed; skipping candidate',
+      )
+      return null
     }
 
     if (availability !== DomainAvailability.AVAILABLE) {

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -446,9 +446,14 @@ export class DomainsService
       ),
     )
 
-    const found = checked.flatMap((r) => {
-      if (r.status === 'fulfilled' && r.value !== null) return [r.value]
-      if (r.status === 'rejected') {
+    const found: PatternedDomainCandidate[] = []
+    for (const r of checked) {
+      if (r.status === 'fulfilled' && r.value !== null) {
+        found.push(r.value)
+      } else if (r.status === 'rejected') {
+        if (r.reason instanceof BadRequestException) {
+          throw r.reason
+        }
         const err =
           r.reason instanceof Error ? r.reason : new Error(String(r.reason))
         this.logger.warn(
@@ -456,8 +461,7 @@ export class DomainsService
           'candidate availability check failed; skipping',
         )
       }
-      return []
-    })
+    }
 
     return { candidates: found }
   }

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -48,9 +48,7 @@ import {
   expandDomainPatterns,
   PatternExpansionLimitError,
 } from '../util/domainPatterns.util'
-import { parseISO } from 'date-fns'
-
-const ISO_DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/
+import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 
 const MAX_PATTERN_CANDIDATES = 50
 
@@ -412,16 +410,8 @@ export class DomainsService
     maxPrice: number,
   ): Promise<PatternedDomainSearchResult> {
     const electionDateStr = campaign.details?.electionDate
-    // Anchor date-only strings to UTC midnight — bare 'YYYY-MM-DD' would
-    // otherwise be parsed as LOCAL midnight by parseISO, causing
-    // getUTCMonth/getUTCFullYear in the pattern util to wrap on servers
-    // east of UTC (e.g. local 2026-01-01 → UTC 2025-12-31).
     const electionDate = electionDateStr
-      ? parseISO(
-          ISO_DATE_ONLY_RE.test(electionDateStr)
-            ? `${electionDateStr}T00:00:00Z`
-            : electionDateStr,
-        )
+      ? parseIsoDateAsUTC(electionDateStr)
       : new Date()
     if (!electionDateStr) {
       this.logger.warn(

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -410,7 +410,7 @@ export class DomainsService
     maxPrice: number,
   ): Promise<PatternedDomainSearchResult> {
     const electionDateStr = campaign.details?.electionDate
-    const electionDate = electionDateStr
+    let electionDate = electionDateStr
       ? parseIsoDateAsUTC(electionDateStr)
       : new Date()
     if (!electionDateStr) {
@@ -418,6 +418,12 @@ export class DomainsService
         { campaignId: campaign.id, fn: 'searchDomainsForCampaign' },
         'no electionDate on campaign; falling back to current date',
       )
+    } else if (isNaN(electionDate.getTime())) {
+      this.logger.warn(
+        { campaignId: campaign.id, electionDateStr, fn: 'searchDomainsForCampaign' },
+        'invalid electionDate stored on campaign; falling back to current date',
+      )
+      electionDate = new Date()
     }
 
     let candidates: string[]

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -467,12 +467,6 @@ export class DomainsService
           { err, fn: 'searchDomainsForCampaign' },
           'candidate availability check failed; skipping',
         )
-        const err =
-          r.reason instanceof Error ? r.reason : new Error(String(r.reason))
-        this.logger.warn(
-          { err, fn: 'searchDomainsForCampaign' },
-          'candidate availability check failed; skipping',
-        )
       }
     }
 

--- a/src/websites/util/domainPatterns.util.test.ts
+++ b/src/websites/util/domainPatterns.util.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DomainPatternContext,
+  expandDomainPattern,
+  expandDomainPatterns,
+  normalizeName,
+} from './domainPatterns.util'
+
+describe('normalizeName', () => {
+  it("strips apostrophes (handles O'Neill)", () => {
+    expect(normalizeName("O'Neill")).toBe('oneill')
+  })
+
+  it('lowercases input', () => {
+    expect(normalizeName('SMITH')).toBe('smith')
+  })
+
+  it('strips spaces and hyphens', () => {
+    expect(normalizeName('De-La Cruz')).toBe('delacruz')
+  })
+
+  it('preserves digits', () => {
+    expect(normalizeName('Smith2nd')).toBe('smith2nd')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(normalizeName('')).toBe('')
+  })
+})
+
+describe('expandDomainPattern', () => {
+  const context: DomainPatternContext = {
+    firstName: 'Mary',
+    lastName: "O'Neill",
+    electionDate: new Date('2026-11-03T00:00:00Z'),
+  }
+
+  it('substitutes {last_name} with the normalized form', () => {
+    expect(expandDomainPattern('{last_name}.run', context)).toEqual([
+      'oneill.run',
+    ])
+  })
+
+  it('substitutes {month_abbreviation} as lowercase 3-letter month', () => {
+    expect(expandDomainPattern('x-{month_abbreviation}.run', context)).toEqual([
+      'x-nov.run',
+    ])
+  })
+
+  it('substitutes {yyyy} and {mm}', () => {
+    expect(expandDomainPattern('{mm}{yyyy}.run', context)).toEqual([
+      '112026.run',
+    ])
+  })
+
+  it('substitutes {first_initial} and {last_initial} from normalized name', () => {
+    expect(
+      expandDomainPattern(
+        'vote-{first_initial}{last_initial}-{mm}{yyyy}.run',
+        context,
+      ),
+    ).toEqual(['vote-mo-112026.run'])
+  })
+
+  it('expands a single TLD alternation', () => {
+    expect(expandDomainPattern('vote-{last_name}.(run|bio)', context)).toEqual([
+      'vote-oneill.run',
+      'vote-oneill.bio',
+    ])
+  })
+
+  it('expands the cross-product of multiple alternations', () => {
+    const result = expandDomainPattern(
+      'vote-(4|for)-{last_name}.(run|win)',
+      context,
+    )
+    expect(result.sort()).toEqual(
+      [
+        'vote-4-oneill.run',
+        'vote-4-oneill.win',
+        'vote-for-oneill.run',
+        'vote-for-oneill.win',
+      ].sort(),
+    )
+  })
+
+  it('expands the full six-TLD × (4|for) cross-product (12 candidates)', () => {
+    const result = expandDomainPattern(
+      'vote(4|for){last_name}{month_abbreviation}{yyyy}.(run|bio|fyi|win|digital|site)',
+      context,
+    )
+    expect(result).toHaveLength(12)
+    expect(result).toContain('vote4oneillnov2026.run')
+    expect(result).toContain('voteforoneillnov2026.digital')
+  })
+
+  it('returns empty when {last_name} resolves to empty', () => {
+    expect(
+      expandDomainPattern('{last_name}.run', {
+        firstName: 'Mary',
+        lastName: '',
+        electionDate: new Date('2026-11-03'),
+      }),
+    ).toEqual([])
+  })
+
+  it('returns empty when {first_initial} resolves to empty', () => {
+    expect(
+      expandDomainPattern('{first_initial}{last_initial}.run', {
+        firstName: '',
+        lastName: 'Smith',
+        electionDate: new Date('2026-11-03'),
+      }),
+    ).toEqual([])
+  })
+
+  it('returns empty when an unknown placeholder is present', () => {
+    expect(expandDomainPattern('{wat}.run', context)).toEqual([])
+  })
+
+  it('pads single-digit month to two digits in {mm}', () => {
+    expect(
+      expandDomainPattern('x-{mm}.run', {
+        ...context,
+        electionDate: new Date('2026-01-15T00:00:00Z'),
+      }),
+    ).toEqual(['x-01.run'])
+  })
+})
+
+describe('expandDomainPatterns', () => {
+  const context: DomainPatternContext = {
+    firstName: 'Mary',
+    lastName: "O'Neill",
+    electionDate: new Date('2026-11-03T00:00:00Z'),
+  }
+
+  it('expands and deduplicates across multiple patterns', () => {
+    const result = expandDomainPatterns(
+      [
+        'vote-{last_name}.run',
+        'vote-{last_name}.run',
+        'vote-{last_name}.(run|bio)',
+      ],
+      context,
+    )
+    expect(result.sort()).toEqual(['vote-oneill.bio', 'vote-oneill.run'])
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(expandDomainPatterns([], context)).toEqual([])
+  })
+})

--- a/src/websites/util/domainPatterns.util.test.ts
+++ b/src/websites/util/domainPatterns.util.test.ts
@@ -4,6 +4,7 @@ import {
   expandDomainPattern,
   expandDomainPatterns,
   normalizeName,
+  PatternExpansionLimitError,
 } from './domainPatterns.util'
 
 describe('normalizeName', () => {
@@ -126,6 +127,36 @@ describe('expandDomainPattern', () => {
       }),
     ).toEqual(['x-01.run'])
   })
+
+  it('returns input unchanged for unmatched parens (no ReDoS on "(((...")', () => {
+    const adversarial = '('.repeat(10_000)
+    const start = performance.now()
+    const result = expandDomainPattern(adversarial, context)
+    const elapsed = performance.now() - start
+    expect(result).toEqual([adversarial])
+    expect(elapsed).toBeLessThan(50)
+  })
+
+  it('returns empty for unmatched braces (no ReDoS on "{{{...")', () => {
+    const adversarial = '{'.repeat(10_000)
+    const start = performance.now()
+    const result = expandDomainPattern(adversarial, context)
+    const elapsed = performance.now() - start
+    expect(result).toEqual([adversarial])
+    expect(elapsed).toBeLessThan(50)
+  })
+
+  it('treats empty parens "()" as a literal (no expansion)', () => {
+    expect(expandDomainPattern('a().run', context)).toEqual(['a().run'])
+  })
+
+  it('treats empty braces "{}" as a literal (does not trigger bail-out)', () => {
+    expect(expandDomainPattern('a{}.run', context)).toEqual(['a{}.run'])
+  })
+
+  it('returns empty when an unresolved placeholder follows an empty "{}"', () => {
+    expect(expandDomainPattern('a{}{wat}.run', context)).toEqual([])
+  })
 })
 
 describe('expandDomainPatterns', () => {
@@ -149,5 +180,27 @@ describe('expandDomainPatterns', () => {
 
   it('returns empty array for empty input', () => {
     expect(expandDomainPatterns([], context)).toEqual([])
+  })
+
+  it('aborts early instead of materializing 1M intermediate candidates', () => {
+    const opts = '(a|b|c|d|e|f|g|h|i|j)'
+    // 6 groups of 10 options = 1,000,000 candidates without a cap.
+    const huge = `${opts}${opts}${opts}${opts}${opts}${opts}.run`
+
+    const start = performance.now()
+    expect(() =>
+      expandDomainPatterns([huge], context, { maxCandidates: 50 }),
+    ).toThrowError(PatternExpansionLimitError)
+    const elapsed = performance.now() - start
+
+    expect(elapsed).toBeLessThan(50)
+  })
+
+  it('caps the total across patterns, not per-pattern', () => {
+    // Each pattern alone (5 options) fits under the cap; the sum exceeds it.
+    const p = '(a|b|c|d|e).run'
+    expect(() =>
+      expandDomainPatterns([p, p, p], context, { maxCandidates: 10 }),
+    ).toThrowError(PatternExpansionLimitError)
   })
 })

--- a/src/websites/util/domainPatterns.util.test.ts
+++ b/src/websites/util/domainPatterns.util.test.ts
@@ -182,14 +182,32 @@ describe('expandDomainPatterns', () => {
     expect(expandDomainPatterns([], context)).toEqual([])
   })
 
-  it('aborts early instead of materializing 1M intermediate candidates', () => {
+  it('aborts early instead of materializing 10^7 intermediate candidates', () => {
     const opts = '(a|b|c|d|e|f|g|h|i|j)'
-    // 6 groups of 10 options = 1,000,000 candidates without a cap.
-    const huge = `${opts}${opts}${opts}${opts}${opts}${opts}.run`
+    // 7 groups of 10 options = 10,000,000 candidates without a cap —
+    // the worst-case scenario flagged by static analysis.
+    const huge = `${opts.repeat(7)}.run`
 
     const start = performance.now()
     expect(() =>
       expandDomainPatterns([huge], context, { maxCandidates: 50 }),
+    ).toThrowError(PatternExpansionLimitError)
+    const elapsed = performance.now() - start
+
+    // If the cross-product had actually materialized this would take
+    // multiple seconds and likely OOM. < 50ms proves early abort.
+    expect(elapsed).toBeLessThan(50)
+  })
+
+  it('aborts early on 20 max-explosive patterns (schema upper bound)', () => {
+    // 20 patterns × 10^7 candidates each = 2 * 10^8 leaves uncapped.
+    const opts = '(a|b|c|d|e|f|g|h|i|j)'
+    const huge = `${opts.repeat(7)}.run`
+    const patterns = Array.from({ length: 20 }, () => huge)
+
+    const start = performance.now()
+    expect(() =>
+      expandDomainPatterns(patterns, context, { maxCandidates: 50 }),
     ).toThrowError(PatternExpansionLimitError)
     const elapsed = performance.now() - start
 

--- a/src/websites/util/domainPatterns.util.ts
+++ b/src/websites/util/domainPatterns.util.ts
@@ -83,8 +83,12 @@ const expandAlternations = (input: string, budget: Budget): string[] => {
   // strings before any post-hoc check could fire).
   return group
     .split('|')
-    .flatMap((opt) => expandAlternations(input.replace(whole, opt), budget))
-}
+    .flatMap((opt) =>
+      expandAlternations(
+        input.slice(0, open) + opt + input.slice(close + 1),
+        budget,
+      ),
+    )
 
 const substituteAndExpand = (
   pattern: string,

--- a/src/websites/util/domainPatterns.util.ts
+++ b/src/websites/util/domainPatterns.util.ts
@@ -102,7 +102,7 @@ const substituteAndExpand = (
     if (value === undefined || value === '') {
       return []
     }
-    substituted = substituted.replace(m[0], value)
+    substituted = substituted.replaceAll(m[0], value)
   }
   if (hasUnresolvedPlaceholder(substituted)) {
     return []

--- a/src/websites/util/domainPatterns.util.ts
+++ b/src/websites/util/domainPatterns.util.ts
@@ -75,7 +75,6 @@ const expandAlternations = (input: string, budget: Budget): string[] => {
   if (open === -1) return consumeOne(input, budget)
   const close = input.indexOf(')', open + 1)
   if (close === -1 || close === open + 1) return consumeOne(input, budget)
-  const whole = input.slice(open, close + 1)
   const group = input.slice(open + 1, close)
   // Budget is decremented at each leaf, so the recursion aborts the moment
   // the cap is hit — preventing the cross-product from materializing
@@ -89,6 +88,7 @@ const expandAlternations = (input: string, budget: Budget): string[] => {
         budget,
       ),
     )
+}
 
 const substituteAndExpand = (
   pattern: string,

--- a/src/websites/util/domainPatterns.util.ts
+++ b/src/websites/util/domainPatterns.util.ts
@@ -1,0 +1,79 @@
+export type DomainPatternContext = {
+  firstName: string
+  lastName: string
+  electionDate: Date
+}
+
+export const normalizeName = (name: string): string =>
+  name.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+const MONTH_ABBREVIATIONS = [
+  'jan',
+  'feb',
+  'mar',
+  'apr',
+  'may',
+  'jun',
+  'jul',
+  'aug',
+  'sep',
+  'oct',
+  'nov',
+  'dec',
+]
+
+const buildSubstitutions = (
+  ctx: DomainPatternContext,
+): Record<string, string> => {
+  const normalizedLast = normalizeName(ctx.lastName)
+  const normalizedFirst = normalizeName(ctx.firstName)
+  // Election dates are stored as ISO date-only strings (UTC midnight). Use
+  // UTC getters here so the rendered domain is independent of server TZ —
+  // date-fns `format` defaults to local TZ and would render Nov 3 UTC as
+  // Nov 2 in any TZ west of UTC.
+  const monthIndex = ctx.electionDate.getUTCMonth()
+  return {
+    last_name: normalizedLast,
+    first_initial: normalizedFirst.charAt(0),
+    last_initial: normalizedLast.charAt(0),
+    mm: String(monthIndex + 1).padStart(2, '0'),
+    yyyy: String(ctx.electionDate.getUTCFullYear()),
+    month_abbreviation: MONTH_ABBREVIATIONS[monthIndex],
+  }
+}
+
+const expandAlternations = (input: string): string[] => {
+  const match = input.match(/\(([^)]+)\)/)
+  if (!match) return [input]
+  const [whole, group] = match
+  return group
+    .split('|')
+    .flatMap((opt) => expandAlternations(input.replace(whole, opt)))
+}
+
+export const expandDomainPattern = (
+  pattern: string,
+  ctx: DomainPatternContext,
+): string[] => {
+  const subs = buildSubstitutions(ctx)
+  let substituted = pattern
+  for (const m of pattern.matchAll(/\{([a-z_]+)\}/g)) {
+    const value = subs[m[1]]
+    if (value === undefined || value === '') {
+      return []
+    }
+    substituted = substituted.replace(m[0], value)
+  }
+  if (/\{[^}]+\}/.test(substituted)) {
+    return []
+  }
+  return expandAlternations(substituted)
+}
+
+export const expandDomainPatterns = (
+  patterns: string[],
+  ctx: DomainPatternContext,
+): string[] => {
+  const all = patterns.flatMap((p) => expandDomainPattern(p, ctx))
+  return Array.from(new Set(all))
+}

--- a/src/websites/util/domainPatterns.util.ts
+++ b/src/websites/util/domainPatterns.util.ts
@@ -122,14 +122,21 @@ const hasUnresolvedPlaceholder = (s: string): boolean => {
   return false
 }
 
+/**
+ * Invariant: at most `options.maxCandidates` candidate strings are ever
+ * materialized in memory across the entire call, regardless of how
+ * "explosive" the input patterns are (e.g. `(a|b|...|j){7}` would yield
+ * 10^7 candidates uncapped). The shared `Budget` is decremented at every
+ * leaf inside `expandAlternations`; the recursion throws
+ * `PatternExpansionLimitError` the moment the (limit + 1)-th leaf is
+ * about to be emitted, so the cross-product never fully materializes.
+ */
 export const expandDomainPatterns = (
   patterns: string[],
   ctx: DomainPatternContext,
   options?: { maxCandidates?: number },
 ): string[] => {
   const limit = options?.maxCandidates ?? Number.POSITIVE_INFINITY
-  // One shared budget across patterns so the *total* candidate count caps,
-  // not the per-pattern count.
   const budget: Budget = { left: limit, limit }
   const all = patterns.flatMap((p) => substituteAndExpand(p, ctx, budget))
   return Array.from(new Set(all))

--- a/src/websites/util/domainPatterns.util.ts
+++ b/src/websites/util/domainPatterns.util.ts
@@ -1,6 +1,15 @@
 export type DomainPatternContext = {
   firstName: string
   lastName: string
+  /**
+   * Must be a Date whose UTC components (year/month/day) represent the
+   * intended calendar date. The substitution code reads
+   * `getUTCFullYear()` / `getUTCMonth()` to render `{yyyy}` / `{mm}` /
+   * `{month_abbreviation}`, so a Date constructed in local time would
+   * wrap month/year on servers east of UTC. Use
+   * `parseIsoDateAsUTC` (in `shared/util/date.util.ts`) to parse
+   * 'YYYY-MM-DD' strings safely.
+   */
   electionDate: Date
 }
 

--- a/src/websites/util/domainPatterns.util.ts
+++ b/src/websites/util/domainPatterns.util.ts
@@ -42,18 +42,45 @@ const buildSubstitutions = (
   }
 }
 
-const expandAlternations = (input: string): string[] => {
-  const match = input.match(/\(([^)]+)\)/)
-  if (!match) return [input]
-  const [whole, group] = match
-  return group
-    .split('|')
-    .flatMap((opt) => expandAlternations(input.replace(whole, opt)))
+export class PatternExpansionLimitError extends Error {
+  constructor(public readonly limit: number) {
+    super(`pattern expansion exceeded ${limit} candidate(s)`)
+    this.name = 'PatternExpansionLimitError'
+  }
 }
 
-export const expandDomainPattern = (
+type Budget = { left: number; limit: number }
+
+const consumeOne = (input: string, budget: Budget): string[] => {
+  budget.left -= 1
+  if (budget.left < 0) {
+    throw new PatternExpansionLimitError(budget.limit)
+  }
+  return [input]
+}
+
+const expandAlternations = (input: string, budget: Budget): string[] => {
+  // Linear-time scan instead of /\(([^)]+)\)/ — the regex form has
+  // O(n^2) backtracking on adversarial inputs like '(((((' (CodeQL ReDoS).
+  const open = input.indexOf('(')
+  if (open === -1) return consumeOne(input, budget)
+  const close = input.indexOf(')', open + 1)
+  if (close === -1 || close === open + 1) return consumeOne(input, budget)
+  const whole = input.slice(open, close + 1)
+  const group = input.slice(open + 1, close)
+  // Budget is decremented at each leaf, so the recursion aborts the moment
+  // the cap is hit — preventing the cross-product from materializing
+  // (e.g. 6 groups of 10 options would otherwise yield 1M intermediate
+  // strings before any post-hoc check could fire).
+  return group
+    .split('|')
+    .flatMap((opt) => expandAlternations(input.replace(whole, opt), budget))
+}
+
+const substituteAndExpand = (
   pattern: string,
   ctx: DomainPatternContext,
+  budget: Budget,
 ): string[] => {
   const subs = buildSubstitutions(ctx)
   let substituted = pattern
@@ -64,16 +91,46 @@ export const expandDomainPattern = (
     }
     substituted = substituted.replace(m[0], value)
   }
-  if (/\{[^}]+\}/.test(substituted)) {
+  if (hasUnresolvedPlaceholder(substituted)) {
     return []
   }
-  return expandAlternations(substituted)
+  return expandAlternations(substituted, budget)
+}
+
+export const expandDomainPattern = (
+  pattern: string,
+  ctx: DomainPatternContext,
+  options?: { maxCandidates?: number },
+): string[] => {
+  const limit = options?.maxCandidates ?? Number.POSITIVE_INFINITY
+  return substituteAndExpand(pattern, ctx, { left: limit, limit })
+}
+
+// Linear-time check for any '{...}' group with ≥1 char inside. Avoids the
+// O(n^2) backtracking of /\{[^}]+\}/.test() on adversarial inputs like
+// '{{{{{' (CodeQL ReDoS).
+const hasUnresolvedPlaceholder = (s: string): boolean => {
+  let from = 0
+  while (from < s.length) {
+    const open = s.indexOf('{', from)
+    if (open === -1) return false
+    const close = s.indexOf('}', open + 1)
+    if (close === -1) return false
+    if (close > open + 1) return true
+    from = close + 1
+  }
+  return false
 }
 
 export const expandDomainPatterns = (
   patterns: string[],
   ctx: DomainPatternContext,
+  options?: { maxCandidates?: number },
 ): string[] => {
-  const all = patterns.flatMap((p) => expandDomainPattern(p, ctx))
+  const limit = options?.maxCandidates ?? Number.POSITIVE_INFINITY
+  // One shared budget across patterns so the *total* candidate count caps,
+  // not the per-pattern count.
+  const budget: Budget = { left: limit, limit }
+  const all = patterns.flatMap((p) => substituteAndExpand(p, ctx, budget))
   return Array.from(new Set(all))
 }


### PR DESCRIPTION
… add related types

- Added PatternedDomainCandidate and PatternedDomainSearchResult interfaces to domains.types.ts.
- Implemented searchDomainsForCampaign method in DomainsService to handle domain search based on campaign details and patterns.
- Updated DomainsController to include a new endpoint for searching domains.
- Enhanced unit tests for DomainsService to cover the new search functionality and edge cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated `POST /domains/search` endpoint that fans out to Route53/Vercel and introduces new pattern-expansion logic, so regressions could affect domain search behavior and external-call load. Date parsing semantics also change for `YYYY-MM-DD` inputs, which could shift downstream UTC-derived month/year formatting.
> 
> **Overview**
> Adds `POST /domains/search` (campaign-scoped via `@UseCampaign({ include: { user: true } })`) that accepts domain `patterns` plus a `maxPrice` and returns candidate domains with prices, validated by new Zod request/response schemas.
> 
> Implements `DomainsService.searchDomainsForCampaign` to expand placeholders/alternations into a capped, deduped candidate set, then checks Route53 availability and Vercel pricing, skipping failed lookups and rejecting overly-explosive patterns.
> 
> Introduces `expandDomainPatterns` utilities with explicit ReDoS/oom safeguards and adds `parseIsoDateAsUTC` (with tests) to ensure date-only election dates don’t wrap month/year across server timezones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db14d9504e21b20b523fa324f2d05f247771fabb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->