### PR TITLE
Add prototype pollution protection to AI content schemas

### DIFF
--- a/src/campaigns/ai/content/aiContent.controller.test.ts
+++ b/src/campaigns/ai/content/aiContent.controller.test.ts
@@ -23,9 +23,9 @@ describe('AiContentController.delete', () => {
   it.each(['__proto__', 'constructor', 'prototype'])(
     'rejects forbidden key: %s',
     async (key) => {
-      await expect(
-        controller.delete(campaignWith({}), key),
-      ).rejects.toThrow(BadRequestException)
+      await expect(controller.delete(campaignWith({}), key)).rejects.toThrow(
+        BadRequestException,
+      )
     },
   )
 
@@ -43,7 +43,9 @@ describe('AiContentController.delete', () => {
 
     expect(mockCampaigns.update).toHaveBeenCalledWith({
       where: { id: 1 },
-      data: { aiContent: expect.not.objectContaining({ bio: expect.anything() }) },
+      data: {
+        aiContent: expect.not.objectContaining({ bio: expect.anything() }),
+      },
     })
   })
 })

--- a/src/campaigns/ai/content/aiContent.controller.test.ts
+++ b/src/campaigns/ai/content/aiContent.controller.test.ts
@@ -1,0 +1,49 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common'
+import { Campaign } from '@prisma/client'
+import { describe, expect, it, vi } from 'vitest'
+import { AiContentController } from './aiContent.controller'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+
+const mockCampaigns = { update: vi.fn() }
+
+const controller = new AiContentController(
+  {} as never,
+  {} as never,
+  mockCampaigns as never,
+  {} as never,
+  {} as never,
+  {} as never,
+  createMockLogger(),
+)
+
+const campaignWith = (aiContent: Record<string, unknown>) =>
+  ({ id: 1, aiContent }) as unknown as Campaign
+
+describe('AiContentController.delete', () => {
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'rejects forbidden key: %s',
+    async (key) => {
+      await expect(
+        controller.delete(campaignWith({}), key),
+      ).rejects.toThrow(BadRequestException)
+    },
+  )
+
+  it('throws NotFoundException when key is not in aiContent', async () => {
+    await expect(
+      controller.delete(campaignWith({}), 'missing'),
+    ).rejects.toThrow(NotFoundException)
+  })
+
+  it('deletes a valid key from aiContent', async () => {
+    const campaign = campaignWith({ bio: { name: 'Bio' } })
+    mockCampaigns.update.mockResolvedValue(campaign)
+
+    await controller.delete(campaign, 'bio')
+
+    expect(mockCampaigns.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { aiContent: expect.not.objectContaining({ bio: expect.anything() }) },
+    })
+  })
+})

--- a/src/campaigns/ai/content/aiContent.controller.ts
+++ b/src/campaigns/ai/content/aiContent.controller.ts
@@ -33,6 +33,7 @@ import { AnalyticsService } from 'src/analytics/analytics.service'
 import { EVENTS } from '../../../vendors/segment/segment.types'
 import { PinoLogger } from 'nestjs-pino'
 import { ClerkUserEnricherService } from '@/vendors/clerk/services/clerk-user-enricher.service'
+import { FORBIDDEN_KEYS } from '../schemas/forbiddenKeys'
 
 @Controller('campaigns/ai')
 @UseCampaign()
@@ -108,7 +109,7 @@ export class AiContentController {
   @Delete(':key')
   @HttpCode(HttpStatus.NO_CONTENT)
   async delete(@ReqCampaign() campaign: Campaign, @Param('key') key: string) {
-    if (['__proto__', 'constructor', 'prototype'].includes(key)) {
+    if (FORBIDDEN_KEYS.has(key)) {
       throw new BadRequestException('Invalid key')
     }
 

--- a/src/campaigns/ai/content/aiContent.controller.ts
+++ b/src/campaigns/ai/content/aiContent.controller.ts
@@ -108,6 +108,10 @@ export class AiContentController {
   @Delete(':key')
   @HttpCode(HttpStatus.NO_CONTENT)
   async delete(@ReqCampaign() campaign: Campaign, @Param('key') key: string) {
+    if (['__proto__', 'constructor', 'prototype'].includes(key)) {
+      throw new BadRequestException('Invalid key')
+    }
+
     const aiContent = campaign.aiContent
 
     if (!aiContent?.[key]) {

--- a/src/campaigns/ai/schemas/CreateAiContent.schema.test.ts
+++ b/src/campaigns/ai/schemas/CreateAiContent.schema.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { CreateAiContentSchema } from './CreateAiContent.schema'
+
+describe('CreateAiContentSchema', () => {
+  const schema = CreateAiContentSchema.schema
+
+  it('accepts a valid key', () => {
+    const result = schema.safeParse({ key: 'bio' })
+    expect(result.success).toBe(true)
+  })
+
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'rejects forbidden key: %s',
+    (key) => {
+      const result = schema.safeParse({ key })
+      expect(result.success).toBe(false)
+    },
+  )
+})

--- a/src/campaigns/ai/schemas/CreateAiContent.schema.ts
+++ b/src/campaigns/ai/schemas/CreateAiContent.schema.ts
@@ -1,7 +1,6 @@
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
-
-const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+import { FORBIDDEN_KEYS } from './forbiddenKeys'
 
 export class CreateAiContentSchema extends createZodDto(
   z.object({

--- a/src/campaigns/ai/schemas/CreateAiContent.schema.ts
+++ b/src/campaigns/ai/schemas/CreateAiContent.schema.ts
@@ -1,9 +1,13 @@
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
 export class CreateAiContentSchema extends createZodDto(
   z.object({
-    key: z.string(),
+    key: z
+      .string()
+      .refine((k) => !FORBIDDEN_KEYS.has(k), { message: 'Invalid key' }),
     regenerate: z.boolean().optional(),
     editMode: z.boolean().optional(),
     // TODO: more exact types for the below inputs

--- a/src/campaigns/ai/schemas/RenameAiContent.schema.test.ts
+++ b/src/campaigns/ai/schemas/RenameAiContent.schema.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { RenameAiContentSchema } from './RenameAiContent.schema'
+
+describe('RenameAiContentSchema', () => {
+  const schema = RenameAiContentSchema.schema
+
+  it('accepts a valid key and name', () => {
+    const result = schema.safeParse({ key: 'intro', name: 'Introduction' })
+    expect(result.success).toBe(true)
+  })
+
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'rejects forbidden key: %s',
+    (key) => {
+      const result = schema.safeParse({ key, name: 'anything' })
+      expect(result.success).toBe(false)
+    },
+  )
+})

--- a/src/campaigns/ai/schemas/RenameAiContent.schema.ts
+++ b/src/campaigns/ai/schemas/RenameAiContent.schema.ts
@@ -1,7 +1,6 @@
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
-
-const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+import { FORBIDDEN_KEYS } from './forbiddenKeys'
 
 export class RenameAiContentSchema extends createZodDto(
   z.object({

--- a/src/campaigns/ai/schemas/RenameAiContent.schema.ts
+++ b/src/campaigns/ai/schemas/RenameAiContent.schema.ts
@@ -1,9 +1,13 @@
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
 export class RenameAiContentSchema extends createZodDto(
   z.object({
-    key: z.string(),
+    key: z
+      .string()
+      .refine((k) => !FORBIDDEN_KEYS.has(k), { message: 'Invalid key' }),
     name: z.string(),
   }),
 ) {}

--- a/src/campaigns/ai/schemas/forbiddenKeys.ts
+++ b/src/campaigns/ai/schemas/forbiddenKeys.ts
@@ -1,0 +1,1 @@
+export const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])


### PR DESCRIPTION
## Summary
This PR adds security validation to prevent prototype pollution attacks by blocking dangerous object property names (`__proto__`, `constructor`, `prototype`) from being used as keys in AI content operations.

## Key Changes
- **CreateAiContentSchema**: Added validation to reject forbidden keys using Zod's `refine()` method
- **RenameAiContentSchema**: Added the same validation to prevent renaming content to forbidden keys
- **AiContentController**: Added runtime validation in the `delete()` endpoint to block deletion attempts using forbidden keys

## Implementation Details
- A `FORBIDDEN_KEYS` Set is defined in both schema files containing the three dangerous property names
- Schema validation uses Zod's `refine()` to check keys at the DTO level with a custom error message
- Controller-level validation provides an additional safety check in the delete endpoint
- All three dangerous keys are consistently blocked across create, rename, and delete operations

https://claude.ai/code/session_015r2pSkKFNefS5Z64RkiM9L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds simple validation to reject dangerous keys (`__proto__`, `constructor`, `prototype`) in AI content create/rename/delete flows, only affecting requests using those keys.
> 
> **Overview**
> Adds prototype-pollution protection for AI content keys by rejecting `__proto__`, `constructor`, and `prototype`.
> 
> `CreateAiContentSchema` and `RenameAiContentSchema` now validate `key` via Zod `refine()`, and `AiContentController.delete()` adds a runtime guard that returns `400 Bad Request` for these keys before mutating `aiContent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd2ca12b8ced28bc57d945603194fe4c33becb89. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->