### PR TITLE
feat(experiments): include clerk_user_id in agent dispatch SQS payload

### DIFF
--- a/src/agentExperiments/services/experimentRuns.service.test.ts
+++ b/src/agentExperiments/services/experimentRuns.service.test.ts
@@ -57,6 +57,7 @@ describe('ExperimentRunsService', () => {
       const result = await service.dispatchRun({
         type: 'district_issue_pulse',
         organizationSlug: 'org-1',
+        clerkUserId: 'user_test_dispatch',
         params: {
           state: 'CA',
           city: 'San Francisco',
@@ -116,6 +117,7 @@ describe('ExperimentRunsService', () => {
       await service.dispatchRun({
         type: 'district_issue_pulse',
         organizationSlug: 'org-1',
+        clerkUserId: 'user_test_dispatch',
         params: {
           state: 'CA',
           city: 'San Francisco',
@@ -128,8 +130,10 @@ describe('ExperimentRunsService', () => {
       const [call] = sqsMock.commandCalls(SendMessageCommand)
       const body = JSON.parse(call.args[0].input.MessageBody as string) as {
         run_id: string
+        clerk_user_id: string
       }
       expect(body.run_id).toBe(dbRunId)
+      expect(body.clerk_user_id).toBe('user_test_dispatch')
     })
 
     it('namespaces FIFO group per organization so runs for one org serialize', async () => {
@@ -138,6 +142,7 @@ describe('ExperimentRunsService', () => {
       await service.dispatchRun({
         type: 'district_issue_pulse',
         organizationSlug: 'org-alpha',
+        clerkUserId: 'user_test_dispatch',
         params: {
           state: 'CA',
           city: 'San Francisco',
@@ -148,6 +153,7 @@ describe('ExperimentRunsService', () => {
       await service.dispatchRun({
         type: 'district_issue_pulse',
         organizationSlug: 'org-beta',
+        clerkUserId: 'user_test_dispatch',
         params: {
           state: 'CA',
           city: 'San Francisco',
@@ -172,6 +178,7 @@ describe('ExperimentRunsService', () => {
         service.dispatchRun({
           type: 'district_issue_pulse',
           organizationSlug: 'org-1',
+          clerkUserId: 'user_test_dispatch',
           params: {
             state: 'CA',
             city: 'San Francisco',
@@ -195,6 +202,7 @@ describe('ExperimentRunsService', () => {
         service.dispatchRun({
           type: 'district_issue_pulse',
           organizationSlug: 'org-1',
+          clerkUserId: 'user_test_dispatch',
           params: {
             state: 'CA',
             city: 'San Francisco',
@@ -213,6 +221,7 @@ describe('ExperimentRunsService', () => {
       await service.dispatchRun({
         type: 'district_issue_pulse',
         organizationSlug: 'org-1',
+        clerkUserId: 'user_test_dispatch',
         params: {
           state: 'CA',
           city: 'San Francisco',
@@ -223,6 +232,7 @@ describe('ExperimentRunsService', () => {
       await service.dispatchRun({
         type: 'district_issue_pulse',
         organizationSlug: 'org-1',
+        clerkUserId: 'user_test_dispatch',
         params: {
           state: 'CA',
           city: 'San Francisco',

--- a/src/agentExperiments/services/experimentRuns.service.ts
+++ b/src/agentExperiments/services/experimentRuns.service.ts
@@ -14,6 +14,7 @@ export type ExperimentRunDispatchInput<
 > = {
   type: ExperimentType
   organizationSlug: string
+  clerkUserId: string
   params: AgentJobContracts[ExperimentType]['Input']
 }
 
@@ -62,6 +63,7 @@ export class ExperimentRunsService extends createPrismaBase(
       params: input.params,
       organization_slug: input.organizationSlug,
       experiment_type: input.type,
+      clerk_user_id: input.clerkUserId,
     }
 
     const deduplicationId = randomUUID()


### PR DESCRIPTION
## Why

The broker (`gp-ai-projects`) needs to know which end-user an agent run acts as, so it can mint a Clerk actor token for that user when the run dispatches:

```ts
clerkClient.actorTokens.create({
  user_id: <clerk_user_id>,                       // ← from this SQS field
  actor: { sub: AGENT_FLEET_CLERK_ID },
})
```

gp-api owns the user/run association, so the broker has to learn it from the dispatch event. Adding `clerk_user_id` to the SQS payload, and a matching required `clerkUserId` on `ExperimentRunDispatchInput`.

Companion PR (broker): thegoodparty/gp-ai-projects#81 — uses this field on `/internal/mint-run-token`.

## What it adds

- `clerkUserId: string` on `ExperimentRunDispatchInput` (required).
- `clerk_user_id` in the SQS message body produced by `ExperimentRunsService.dispatchRun`.
- Test assertions for the new field on the SQS body.

Not stored on the `experiment_run` row — the broker is the only consumer; gp-api doesn't need to query by it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `dispatchRun` input contract (new required field) and alters the SQS message schema, which can break existing callers/consumers if not updated in lockstep.
> 
> **Overview**
> `ExperimentRunsService.dispatchRun` now requires a `clerkUserId` and forwards it as `clerk_user_id` in the agent-dispatch SQS `MessageBody`.
> 
> Tests were updated to pass the new field and assert it is present alongside `run_id` in the dispatched payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a490674644eaf7b2efb44ec0510510986c91787. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->