### PR TITLE
ENG-7571 Sort the selected tasks for the digest email by date asc.

### DIFF
--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.test.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.test.ts
@@ -183,6 +183,83 @@ describe('WeeklyTasksDigestHandlerService', () => {
     expect(userIds).toEqual([100, 200])
   })
 
+  it('orders the selected tasks by date ascending in the emitted event', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeDigestRow({
+        slot: 1,
+        title: 'Outreach late',
+        flow_type: CampaignTaskType.text,
+        date: new Date('2026-04-25T00:00:00.000Z'),
+      }),
+      makeDigestRow({
+        slot: 2,
+        title: 'Outreach early',
+        flow_type: CampaignTaskType.doorKnocking,
+        date: new Date('2026-04-21T00:00:00.000Z'),
+      }),
+      makeDigestRow({
+        slot: 3,
+        title: 'Education middle',
+        flow_type: CampaignTaskType.education,
+        date: new Date('2026-04-23T00:00:00.000Z'),
+      }),
+    ])
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    const [, , properties] = (mockAnalytics.track as ReturnType<typeof vi.fn>)
+      .mock.calls[0]
+
+    expect(properties.task_name_1).toBe('Outreach early')
+    expect(properties.task_name_2).toBe('Education middle')
+    expect(properties.task_name_3).toBe('Outreach late')
+    expect(properties.task_due_date_1).toBe('2026-04-21')
+    expect(properties.task_due_date_2).toBe('2026-04-23')
+    expect(properties.task_due_date_3).toBe('2026-04-25')
+  })
+
+  it('keeps empty slots at the end when fewer than 5 tasks exist, with populated tasks sorted by date ascending', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeDigestRow({
+        slot: 1,
+        title: 'Latest',
+        date: new Date('2026-04-26T00:00:00.000Z'),
+      }),
+      makeDigestRow({
+        slot: 2,
+        title: 'Earliest',
+        date: new Date('2026-04-20T00:00:00.000Z'),
+      }),
+      makeDigestRow({
+        slot: 3,
+        title: 'Middle',
+        date: new Date('2026-04-23T00:00:00.000Z'),
+      }),
+    ])
+
+    await service.handleWeeklyTasksDigest({
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    })
+
+    const [, , properties] = (mockAnalytics.track as ReturnType<typeof vi.fn>)
+      .mock.calls[0]
+
+    expect(properties.task_name_1).toBe('Earliest')
+    expect(properties.task_name_2).toBe('Middle')
+    expect(properties.task_name_3).toBe('Latest')
+
+    expect(properties.task_name_4).toBe('')
+    expect(properties.task_due_date_4).toBe('')
+    expect(properties.task_week_number_4).toBe(null)
+    expect(properties.task_name_5).toBe('')
+    expect(properties.task_due_date_5).toBe('')
+    expect(properties.task_week_number_5).toBe(null)
+  })
+
   it('continues processing remaining campaigns when analytics fails for one', async () => {
     mockQueryRaw.mockResolvedValueOnce([
       makeDigestRow({ campaign_id: 1, user_id: 100, slot: 1 }),

--- a/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.ts
+++ b/src/campaigns/tasks/services/weeklyTasksDigestHandler.service.ts
@@ -241,10 +241,14 @@ export class WeeklyTasksDigestHandlerService extends createPrismaBase(
 
     for (const [campaignId, group] of campaigns) {
       try {
+        const sortedTasks = [...group.tasks].sort(
+          (a, b) => a.date.getTime() - b.date.getTime(),
+        )
+
         const properties: WeeklyDigestProperties = {
           plan_tasks_completed: group.completedCount,
           plan_total_tasks: group.completedCount + group.incompleteCount,
-          ...buildTaskProperties(group.tasks),
+          ...buildTaskProperties(sortedTasks),
         }
 
         await this.analytics.track(


### PR DESCRIPTION
Sort the selected tasks for the digest email by date asc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavioral change to the ordering of tasks in the weekly digest analytics payload, with added tests to lock in the new sorting and empty-slot behavior.
> 
> **Overview**
> Ensures the weekly tasks digest event emits selected tasks **sorted by due date ascending** before mapping them into the fixed `task_*_1..5` properties.
> 
> Adds test coverage verifying date-based ordering and that when fewer than 5 tasks exist, the remaining slots stay blank/null at the end (to continue clearing stale HubSpot fields).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e8aac19e44c66a63caba7b1e8feb169c0bae79d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->