### PR TITLE
Add campaignEmail field to Campaign model and update related tests

### DIFF
--- a/prisma/schema/campaign.prisma
+++ b/prisma/schema/campaign.prisma
@@ -20,6 +20,7 @@ model Campaign {
   tier                  CampaignTier?
   formattedAddress      String?                 @map("formatted_address")
   placeId               String?                 @map("place_id")
+  campaignEmail         String?                 @map("campaign_email")
   /// [CampaignData]
   data                     Json                    @default("{}") @db.JsonB
   /// [CampaignDetails]

--- a/prisma/schema/migrations/20260512205726_add_campaign_email/migration.sql
+++ b/prisma/schema/migrations/20260512205726_add_campaign_email/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "campaign" ADD COLUMN     "campaign_email" TEXT;

--- a/seed/factories/campaign.factory.ts
+++ b/seed/factories/campaign.factory.ts
@@ -25,6 +25,7 @@ export const campaignFactory = generateFactory<Campaign>(() => {
     tier: faker.helpers.arrayElement(Object.values(CampaignTier)),
     formattedAddress: null,
     placeId: null,
+    campaignEmail: null,
     data: {
       hubSpotUpdates: {
         election_results: faker.lorem.word(),

--- a/src/campaigns/campaigns.controller.test.ts
+++ b/src/campaigns/campaigns.controller.test.ts
@@ -64,6 +64,7 @@ const campaignDefaults = {
   tier: null,
   formattedAddress: null,
   placeId: null,
+  campaignEmail: null,
   aiContent: {},
   vendorTsData: {},
   canDownloadFederal: false,

--- a/src/payments/services/purchase.service.test.ts
+++ b/src/payments/services/purchase.service.test.ts
@@ -105,6 +105,7 @@ describe('PurchaseService', () => {
     tier: null,
     formattedAddress: null,
     placeId: null,
+    campaignEmail: null,
     data: {},
     details: {},
     aiContent: {},

--- a/src/queue/consumer/queueConsumer.service.test.ts
+++ b/src/queue/consumer/queueConsumer.service.test.ts
@@ -732,6 +732,108 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
   })
 })
 
+describe('QueueConsumerService - handleDomainEmailForwardingMessage', () => {
+  let service: QueueConsumerService
+  let domainsService: {
+    shouldEnableDomainPurchase: ReturnType<typeof vi.fn>
+    setupDomainEmailForwarding: ReturnType<typeof vi.fn>
+    model: {
+      findUniqueOrThrow: ReturnType<typeof vi.fn>
+      update: ReturnType<typeof vi.fn>
+    }
+  }
+
+  const domain = { id: 123, name: 'example.org' }
+
+  beforeEach(() => {
+    domainsService = {
+      shouldEnableDomainPurchase: vi.fn().mockReturnValue(true),
+      setupDomainEmailForwarding: vi.fn().mockResolvedValue({
+        id: 'fed_123',
+        name: domain.name,
+        verification_record: 'verify_123',
+      }),
+      model: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue(domain),
+        update: vi.fn().mockResolvedValue(undefined),
+      },
+    }
+
+    service = new QueueConsumerService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      domainsService as unknown as DomainsService,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      createMockLogger(),
+    )
+  })
+
+  it('persists emailForwardingDomainId when setupDomainEmailForwarding succeeds', async () => {
+    const message: Message = {
+      MessageId: 'msg-domain-success',
+      Body: JSON.stringify({
+        type: QueueType.DOMAIN_EMAIL_FORWARDING,
+        data: { domainId: domain.id },
+      }),
+    }
+
+    const result = await service.processMessage(message)
+
+    expect(result).toBe(true)
+    expect(domainsService.setupDomainEmailForwarding).toHaveBeenCalledWith(
+      domain,
+    )
+    expect(domainsService.model.update).toHaveBeenCalledWith({
+      where: { id: domain.id },
+      data: { emailForwardingDomainId: 'fed_123' },
+    })
+  })
+
+  it('throws when shouldEnableDomainPurchase is false', async () => {
+    domainsService.shouldEnableDomainPurchase.mockReturnValue(false)
+    const handler = Reflect.get(
+      service,
+      'handleDomainEmailForwardingMessage',
+    ) as ((data: { domainId: number }) => Promise<boolean>) | undefined
+
+    await expect(
+      Reflect.apply(handler!, service, [{ domainId: domain.id }]),
+    ).rejects.toThrow(
+      `Domain purchasing is disabled - skipping backfill for domainId: ${domain.id}`,
+    )
+  })
+
+  it('re-throws expected error message when setupDomainEmailForwarding fails', async () => {
+    domainsService.setupDomainEmailForwarding.mockRejectedValue(
+      new Error('forwarding provider failed'),
+    )
+    const handler = Reflect.get(
+      service,
+      'handleDomainEmailForwardingMessage',
+    ) as ((data: { domainId: number }) => Promise<boolean>) | undefined
+
+    await expect(
+      Reflect.apply(handler!, service, [{ domainId: domain.id }]),
+    ).rejects.toThrow(
+      `Error setting up email forwarding for domain *@${domain.name}`,
+    )
+  })
+})
+
 describe('QueueConsumerService - triggerPollExecution', () => {
   let service: QueueConsumerService
   let pollsService: {

--- a/src/queue/consumer/queueConsumer.service.ts
+++ b/src/queue/consumer/queueConsumer.service.ts
@@ -497,12 +497,11 @@ export class QueueConsumerService {
 
   private async handleDomainEmailForwardingMessage({
     domainId,
-    forwardingEmailAddress,
   }: DomainEmailForwardingMessage): Promise<boolean> {
     if (!this.domainsService.shouldEnableDomainPurchase()) {
       const message = `Domain purchasing is disabled - skipping backfill for domainId: ${domainId}`
       this.logger.debug(message)
-      throw new Error(message, { cause: { domainId, forwardingEmailAddress } })
+      throw new Error(message, { cause: { domainId } })
     }
     const domain = await this.domainsService.model.findUniqueOrThrow({
       where: { id: domainId },
@@ -510,17 +509,13 @@ export class QueueConsumerService {
 
     let forwardEmailDomain: ForwardEmailDomainResponse | null = null
     try {
-      forwardEmailDomain = await this.domainsService.setupDomainEmailForwarding(
-        domain,
-        forwardingEmailAddress,
-      )
-      this.logger.debug(
-        `Email forwarding set up for domain *@${domain.name} -> ${forwardingEmailAddress}`,
-      )
+      forwardEmailDomain =
+        await this.domainsService.setupDomainEmailForwarding(domain)
+      this.logger.debug(`Email forwarding set up for domain *@${domain.name}`)
     } catch {
-      const message = `Error setting up email forwarding for domain *@${domain.name} -> ${forwardingEmailAddress}`
+      const message = `Error setting up email forwarding for domain *@${domain.name}`
       this.logger.error(message)
-      throw new Error(message, { cause: { domainId, forwardingEmailAddress } })
+      throw new Error(message, { cause: { domainId } })
     }
 
     forwardEmailDomain &&

--- a/src/queue/queue.types.ts
+++ b/src/queue/queue.types.ts
@@ -54,7 +54,6 @@ export type TcrComplianceStatusCheckMessage = {
 
 export type DomainEmailForwardingMessage = {
   domainId: number
-  forwardingEmailAddress: string
 }
 
 export const CampaignPlanCompleteMessageSchema = z.discriminatedUnion(

--- a/src/shared/services/voterFileDownloadAccess.service.test.ts
+++ b/src/shared/services/voterFileDownloadAccess.service.test.ts
@@ -367,6 +367,7 @@ function createMockCampaign(
     tier: null,
     formattedAddress: null,
     placeId: null,
+    campaignEmail: null,
     userId: 1,
     data: {},
     aiContent: {},

--- a/src/shared/test-utils/mockData.util.ts
+++ b/src/shared/test-utils/mockData.util.ts
@@ -41,6 +41,7 @@ export const createMockCampaign = (
   details: {},
   formattedAddress: null,
   placeId: null,
+  campaignEmail: null,
   aiContent: {},
   vendorTsData: {},
   canDownloadFederal: false,

--- a/src/vendors/peerly/p2p.controller.test.ts
+++ b/src/vendors/peerly/p2p.controller.test.ts
@@ -22,6 +22,7 @@ const mockCampaign: Campaign = {
   tier: null,
   formattedAddress: null,
   placeId: null,
+  campaignEmail: null,
   aiContent: {},
   vendorTsData: {},
   canDownloadFederal: false,

--- a/src/vendors/peerly/services/p2pPhoneListUpload.service.test.ts
+++ b/src/vendors/peerly/services/p2pPhoneListUpload.service.test.ts
@@ -26,6 +26,7 @@ const mockCampaign: Campaign = {
   tier: null,
   formattedAddress: null,
   placeId: null,
+  campaignEmail: null,
   aiContent: {},
   vendorTsData: {},
   canDownloadFederal: false,

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -874,6 +874,7 @@ describe('DomainsService', () => {
 
       await service.setupDomainEmailForwarding(mockDomain)
 
+      expect(mockPrisma.$transaction).toHaveBeenCalledOnce()
       expect(mockPrisma.campaign.update).toHaveBeenCalledWith({
         where: { id: 42 },
         data: { campaignEmail: `info@${mockDomain.name}` },

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -14,9 +14,8 @@ import { PinoLogger } from 'nestjs-pino'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DomainsService } from './domains.service'
 import { RegisterDomainSchema } from '../schemas/RegisterDomain.schema'
-import { createMockClerkEnricher } from '@/shared/test-utils/mockClerkEnricher.util'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
-import { ClerkUserEnricherService } from '@/vendors/clerk/services/clerk-user-enricher.service'
+import { MessageGroup, QueueType } from 'src/queue/queue.types'
 import {
   createMockCampaign,
   createMockUser,
@@ -55,7 +54,20 @@ describe('DomainsService', () => {
     checkDomainAvailability: ReturnType<typeof vi.fn>
     getDomainSuggestions: ReturnType<typeof vi.fn>
   }
-  let mockVercel: { checkDomainPrice: ReturnType<typeof vi.fn> }
+  let mockVercel: {
+    checkDomainPrice: ReturnType<typeof vi.fn>
+    listDnsRecords: ReturnType<typeof vi.fn>
+    createMXRecords: ReturnType<typeof vi.fn>
+    createTXTVerificationRecord: ReturnType<typeof vi.fn>
+  }
+  let mockForwardEmail: {
+    getDomain: ReturnType<typeof vi.fn>
+    addDomain: ReturnType<typeof vi.fn>
+    getCatchAllDomainAliases: ReturnType<typeof vi.fn>
+    createCatchAllAlias: ReturnType<typeof vi.fn>
+    updateDomainAlias: ReturnType<typeof vi.fn>
+  }
+  let mockQueue: { sendMessage: ReturnType<typeof vi.fn> }
   let mockPrisma: {
     domain: {
       findMany: ReturnType<typeof vi.fn>
@@ -67,6 +79,10 @@ describe('DomainsService', () => {
     website: {
       findUniqueOrThrow: ReturnType<typeof vi.fn>
       findUnique: ReturnType<typeof vi.fn>
+      update: ReturnType<typeof vi.fn>
+    }
+    campaign: {
+      update: ReturnType<typeof vi.fn>
     }
     $transaction: ReturnType<typeof vi.fn>
     $executeRaw: ReturnType<typeof vi.fn>
@@ -77,7 +93,24 @@ describe('DomainsService', () => {
       checkDomainAvailability: vi.fn(),
       getDomainSuggestions: vi.fn().mockResolvedValue({ SuggestionsList: [] }),
     }
-    mockVercel = { checkDomainPrice: vi.fn() }
+    mockVercel = {
+      checkDomainPrice: vi.fn(),
+      listDnsRecords: vi.fn().mockResolvedValue([]),
+      createMXRecords: vi.fn().mockResolvedValue(undefined),
+      createTXTVerificationRecord: vi.fn().mockResolvedValue(undefined),
+    }
+    mockForwardEmail = {
+      getDomain: vi.fn().mockResolvedValue(null),
+      addDomain: vi.fn().mockResolvedValue({
+        id: 'fed_1',
+        verification_record: 'vr',
+        name: mockDomain.name,
+      }),
+      getCatchAllDomainAliases: vi.fn().mockResolvedValue([]),
+      createCatchAllAlias: vi.fn().mockResolvedValue({ id: 'alias_1' }),
+      updateDomainAlias: vi.fn().mockResolvedValue({ id: 'alias_1' }),
+    }
+    mockQueue = { sendMessage: vi.fn().mockResolvedValue(undefined) }
     mockAnalytics = {
       track: vi.fn().mockResolvedValue(undefined),
     }
@@ -107,6 +140,10 @@ describe('DomainsService', () => {
           domain: mockDomain,
         }),
         findUnique: vi.fn().mockResolvedValue(null),
+        update: vi.fn().mockResolvedValue(undefined),
+      },
+      campaign: {
+        update: vi.fn().mockResolvedValue(undefined),
       },
       $executeRaw: vi.fn().mockResolvedValue(0),
       $transaction: vi.fn(
@@ -123,13 +160,9 @@ describe('DomainsService', () => {
         { provide: VercelService, useValue: mockVercel },
         { provide: PaymentsService, useValue: mockPayments },
         { provide: StripeService, useValue: mockStripe },
-        { provide: ForwardEmailService, useValue: {} },
-        { provide: QueueProducerService, useValue: {} },
+        { provide: ForwardEmailService, useValue: mockForwardEmail },
+        { provide: QueueProducerService, useValue: mockQueue },
         { provide: AnalyticsService, useValue: mockAnalytics },
-        {
-          provide: ClerkUserEnricherService,
-          useValue: createMockClerkEnricher(),
-        },
         { provide: PinoLogger, useValue: createMockLogger() },
         DomainsService,
       ],
@@ -768,6 +801,120 @@ describe('DomainsService', () => {
         errorCode: 'BILLING_DOMAIN_PAYMENT_ID_MISSING',
       })
       expect(mockPayments.retrievePayment).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('setupDomainEmailForwarding', () => {
+    it('always forwards to the candidate-domains@goodparty.org alias', async () => {
+      mockPrisma.website.findUnique.mockResolvedValue({
+        content: { contact: { phone: '555' } },
+      })
+
+      await service.setupDomainEmailForwarding(mockDomain)
+
+      expect(mockForwardEmail.createCatchAllAlias).toHaveBeenCalledWith(
+        'candidate-domains@goodparty.org',
+        expect.objectContaining({ id: 'fed_1' }),
+      )
+      expect(mockForwardEmail.updateDomainAlias).not.toHaveBeenCalled()
+    })
+
+    it('updates existing aliases to point at the GP alias', async () => {
+      mockForwardEmail.getCatchAllDomainAliases.mockResolvedValue([
+        { id: 'existing_alias' },
+      ])
+      mockPrisma.website.findUnique.mockResolvedValue({
+        content: {},
+      })
+
+      await service.setupDomainEmailForwarding(mockDomain)
+
+      expect(mockForwardEmail.updateDomainAlias).toHaveBeenCalledWith(
+        'existing_alias',
+        'candidate-domains@goodparty.org',
+        expect.objectContaining({ id: 'fed_1' }),
+      )
+      expect(mockForwardEmail.createCatchAllAlias).not.toHaveBeenCalled()
+    })
+
+    it('persists info@<domain> on Website.content.contact.email, preserving other content', async () => {
+      mockPrisma.website.findUnique.mockResolvedValue({
+        content: {
+          main: { title: 'keep me' },
+          contact: { phone: '555-555-5555' },
+        },
+        campaignId: 42,
+      })
+
+      await service.setupDomainEmailForwarding(mockDomain)
+
+      expect(mockPrisma.website.findUnique).toHaveBeenCalledWith({
+        where: { id: mockDomain.websiteId },
+        select: { content: true, campaignId: true },
+      })
+      expect(mockPrisma.website.update).toHaveBeenCalledWith({
+        where: { id: mockDomain.websiteId },
+        data: {
+          content: {
+            main: { title: 'keep me' },
+            contact: {
+              phone: '555-555-5555',
+              email: `info@${mockDomain.name}`,
+            },
+          },
+        },
+      })
+    })
+
+    it('persists campaignEmail on the Campaign row', async () => {
+      mockPrisma.website.findUnique.mockResolvedValue({
+        content: {},
+        campaignId: 42,
+      })
+
+      await service.setupDomainEmailForwarding(mockDomain)
+
+      expect(mockPrisma.campaign.update).toHaveBeenCalledWith({
+        where: { id: 42 },
+        data: { campaignEmail: `info@${mockDomain.name}` },
+      })
+    })
+
+    it('skips persistence when no Website row exists for the domain', async () => {
+      mockPrisma.website.findUnique.mockResolvedValue(null)
+
+      await service.setupDomainEmailForwarding(mockDomain)
+
+      expect(mockPrisma.website.update).not.toHaveBeenCalled()
+      expect(mockPrisma.campaign.update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('backfillDomainEmailRedirects', () => {
+    it('enqueues a message without forwardingEmailAddress', async () => {
+      vi.spyOn(service, 'shouldEnableDomainPurchase').mockReturnValue(true)
+      mockPrisma.domain.findMany.mockResolvedValue([{ id: 1 }, { id: 2 }])
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (service as any).backfillDomainEmailRedirects()
+
+      expect(mockQueue.sendMessage).toHaveBeenCalledTimes(2)
+      expect(mockQueue.sendMessage).toHaveBeenNthCalledWith(
+        1,
+        {
+          type: QueueType.DOMAIN_EMAIL_FORWARDING,
+          data: { domainId: 1 },
+        },
+        MessageGroup.domainEmailRedirect,
+      )
+      expect(mockQueue.sendMessage).toHaveBeenNthCalledWith(
+        2,
+        {
+          type: QueueType.DOMAIN_EMAIL_FORWARDING,
+          data: { domainId: 2 },
+        },
+        MessageGroup.domainEmailRedirect,
+      )
     })
   })
 })

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -881,6 +881,21 @@ describe('DomainsService', () => {
       })
     })
 
+    it('reads website content after transaction starts', async () => {
+      mockPrisma.website.findUnique.mockResolvedValue({
+        content: {},
+        campaignId: 42,
+      })
+
+      await service.setupDomainEmailForwarding(mockDomain)
+
+      expect(mockPrisma.$transaction).toHaveBeenCalledOnce()
+      expect(mockPrisma.website.findUnique).toHaveBeenCalledOnce()
+      expect(
+        mockPrisma.website.findUnique.mock.invocationCallOrder[0],
+      ).toBeGreaterThan(mockPrisma.$transaction.mock.invocationCallOrder[0])
+    })
+
     it('skips persistence when no Website row exists for the domain', async () => {
       mockPrisma.website.findUnique.mockResolvedValue(null)
 

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -888,6 +888,18 @@ describe('DomainsService', () => {
       expect(mockPrisma.website.update).not.toHaveBeenCalled()
       expect(mockPrisma.campaign.update).not.toHaveBeenCalled()
     })
+
+    it('returns ForwardEmail domain even when campaign email persistence fails', async () => {
+      mockPrisma.website.findUnique.mockResolvedValue({
+        content: {},
+        campaignId: 42,
+      })
+      mockPrisma.website.update.mockRejectedValue(new Error('db write failed'))
+
+      const result = await service.setupDomainEmailForwarding(mockDomain)
+
+      expect(result).toMatchObject({ id: 'fed_1' })
+    })
   })
 
   describe('backfillDomainEmailRedirects', () => {

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -910,6 +910,14 @@ describe('DomainsService', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (service as any).backfillDomainEmailRedirects()
 
+      expect(mockPrisma.domain.findMany).toHaveBeenCalledWith({
+        where: {
+          emailForwardingDomainId: null,
+          status: {
+            in: [DomainStatus.submitted, DomainStatus.registered],
+          },
+        },
+      })
       expect(mockQueue.sendMessage).toHaveBeenCalledTimes(2)
       expect(mockQueue.sendMessage).toHaveBeenNthCalledWith(
         1,

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -904,7 +904,14 @@ export class DomainsService
       )
     }
 
-    await this.persistCampaignEmail(domain)
+    try {
+      await this.persistCampaignEmail(domain)
+    } catch (e) {
+      this.logger.error(
+        { e },
+        `Failed to persist campaign email for domain ${domain.name}`,
+      )
+    }
 
     return forwardEmailDomain
   }

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -44,7 +44,6 @@ import {
   PatternedDomainSearchResult,
 } from '../domains.types'
 import { RegisterDomainSchema } from '../schemas/RegisterDomain.schema'
-import { ClerkUserEnricherService } from '@/vendors/clerk/services/clerk-user-enricher.service'
 import {
   expandDomainPatterns,
   PatternExpansionLimitError,
@@ -63,6 +62,8 @@ const DOMAIN_RESERVATION_KIND = {
 const DOMAIN_PURCHASE_IN_PROGRESS_MESSAGE =
   'Domain registration already in progress for this campaign'
 
+const GP_CAMPAIGN_DOMAIN_FORWARD_ADDRESS = 'candidate-domains@goodparty.org'
+
 const { ENABLE_DOMAIN_SETUP } = process.env
 
 @Injectable()
@@ -78,7 +79,6 @@ export class DomainsService
     private readonly forwardEmailService: ForwardEmailService,
     private queueService: QueueProducerService,
     private readonly analytics: AnalyticsService,
-    private readonly clerkEnricher: ClerkUserEnricherService,
   ) {
     super()
   }
@@ -94,29 +94,10 @@ export class DomainsService
       where: {
         emailForwardingDomainId: null,
       },
-      include: {
-        website: {
-          include: {
-            campaign: {
-              include: {
-                user: true,
-              },
-            },
-          },
-        },
-      },
     })
 
-    for (const { id: domainId, website } of domains) {
-      const { campaign } = website
-      const enrichedUser = campaign.user
-        ? await this.clerkEnricher.enrichUser(campaign.user)
-        : campaign.user
-      const { email: forwardingEmailAddress } = enrichedUser!
-      const messageData = {
-        domainId,
-        forwardingEmailAddress,
-      }
+    for (const { id: domainId } of domains) {
+      const messageData = { domainId }
       this.logger.debug(
         { messageData },
         'Found domain with no email forwarding, enqueuing task:',
@@ -124,10 +105,7 @@ export class DomainsService
       await this.queueService.sendMessage(
         {
           type: QueueType.DOMAIN_EMAIL_FORWARDING,
-          data: {
-            domainId,
-            forwardingEmailAddress,
-          },
+          data: { domainId },
         },
         MessageGroup.domainEmailRedirect,
       )
@@ -789,10 +767,8 @@ export class DomainsService
     }
   }
 
-  async setupDomainEmailForwarding(
-    domain: Domain,
-    forwardingEmailAddress: string,
-  ) {
+  async setupDomainEmailForwarding(domain: Domain) {
+    const forwardingEmailAddress = GP_CAMPAIGN_DOMAIN_FORWARD_ADDRESS
     let forwardEmailDomain: ForwardEmailDomainResponse | null = null
     let existingForwardEmailDomain: ForwardEmailDomainResponse | null = null
     try {
@@ -927,7 +903,39 @@ export class DomainsService
         { cause: e },
       )
     }
+
+    await this.persistCampaignEmail(domain)
+
     return forwardEmailDomain
+  }
+
+  private async persistCampaignEmail(domain: Domain) {
+    const website = await this.client.website.findUnique({
+      where: { id: domain.websiteId },
+      select: { content: true, campaignId: true },
+    })
+    if (!website) return
+
+    const campaignEmail = `info@${domain.name}`
+    const content = website.content ?? {}
+
+    await this.client.website.update({
+      where: { id: domain.websiteId },
+      data: {
+        content: {
+          ...content,
+          contact: {
+            ...(content.contact ?? {}),
+            email: campaignEmail,
+          },
+        },
+      },
+    })
+
+    await this.client.campaign.update({
+      where: { id: website.campaignId },
+      data: { campaignEmail },
+    })
   }
 
   // called after payment is accepted, send registration request to Vercel
@@ -1042,16 +1050,11 @@ export class DomainsService
       }
 
       try {
-        forwardEmailDomain = await this.setupDomainEmailForwarding(
-          domain,
-          contact.email,
-        )
-        this.logger.debug(
-          `Email forwarding set up for domain *@${domain.name} -> ${contact.email}`,
-        )
+        forwardEmailDomain = await this.setupDomainEmailForwarding(domain)
+        this.logger.debug(`Email forwarding set up for domain *@${domain.name}`)
       } catch (e) {
         this.logger.error(
-          `Error setting up email forwarding for domain *@${domain.name} -> ${contact.email} : ${e instanceof Error ? e.message : 'error unknown while attempting to setup email forwarding'}`,
+          `Error setting up email forwarding for domain *@${domain.name} : ${e instanceof Error ? e.message : 'error unknown while attempting to setup email forwarding'}`,
         )
         // Not throwing an error here to allow for continued execution
       }

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -914,7 +914,7 @@ export class DomainsService
         { e },
         `Failed to persist campaign email for domain ${domain.name}`,
       )
-      throw e
+    }
     }
 
     return forwardEmailDomain

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -929,22 +929,24 @@ export class DomainsService
     const campaignEmail = `info@${domain.name}`
     const content = website.content ?? {}
 
-    await this.client.website.update({
-      where: { id: domain.websiteId },
-      data: {
-        content: {
-          ...content,
-          contact: {
-            ...(content.contact ?? {}),
-            email: campaignEmail,
+    await this.client.$transaction(async (tx) => {
+      await tx.website.update({
+        where: { id: domain.websiteId },
+        data: {
+          content: {
+            ...content,
+            contact: {
+              ...(content.contact ?? {}),
+              email: campaignEmail,
+            },
           },
         },
-      },
-    })
+      })
 
-    await this.client.campaign.update({
-      where: { id: website.campaignId },
-      data: { campaignEmail },
+      await tx.campaign.update({
+        where: { id: website.campaignId },
+        data: { campaignEmail },
+      })
     })
   }
 

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -93,6 +93,9 @@ export class DomainsService
     const domains = await this.model.findMany({
       where: {
         emailForwardingDomainId: null,
+        status: {
+          in: [DomainStatus.submitted, DomainStatus.registered],
+        },
       },
     })
 

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -914,6 +914,7 @@ export class DomainsService
         { e },
         `Failed to persist campaign email for domain ${domain.name}`,
       )
+      throw e
     }
 
     return forwardEmailDomain

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -921,16 +921,16 @@ export class DomainsService
   }
 
   private async persistCampaignEmail(domain: Domain) {
-    const website = await this.client.website.findUnique({
-      where: { id: domain.websiteId },
-      select: { content: true, campaignId: true },
-    })
-    if (!website) return
-
-    const campaignEmail = `info@${domain.name}`
-    const content = website.content ?? {}
-
     await this.client.$transaction(async (tx) => {
+      const website = await tx.website.findUnique({
+        where: { id: domain.websiteId },
+        select: { content: true, campaignId: true },
+      })
+      if (!website) return
+
+      const campaignEmail = `info@${domain.name}`
+      const content = website.content ?? {}
+
       await tx.website.update({
         where: { id: domain.websiteId },
         data: {

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -915,7 +915,6 @@ export class DomainsService
         `Failed to persist campaign email for domain ${domain.name}`,
       )
     }
-    }
 
     return forwardEmailDomain
   }


### PR DESCRIPTION
- Introduced campaignEmail field in the Campaign model within the Prisma schema.
- Updated campaign factory and various test files to include campaignEmail initialization.
- Modified DomainsService to persist campaignEmail when setting up domain email forwarding.
- Adjusted error handling in the setupDomainEmailForwarding method to remove unnecessary parameters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new nullable `Campaign.campaignEmail` column and writes to it during domain email-forwarding setup, touching both DB schema and domain provisioning flow. Risk is moderate because it changes background queue message payloads and adds transactional DB writes during email-forwarding, which could affect domain setup/backfill behavior if assumptions are wrong.
> 
> **Overview**
> Adds a new nullable `campaignEmail` field to the `Campaign` Prisma model (with migration) and updates factories/mocks/tests to include it.
> 
> Simplifies domain email-forwarding/backfill to *always* forward to `candidate-domains@goodparty.org` (removing `forwardingEmailAddress` from `DomainEmailForwardingMessage` and related error/logging), and extends `DomainsService.setupDomainEmailForwarding` to persist `info@<domain>` onto both `Website.content.contact.email` and `Campaign.campaignEmail` in a transaction (best-effort, non-fatal on persistence failure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 884e1eea0820465d0acd263a9b6a9eb30267b21c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->