### PR TITLE
refactor: enhance WebsitesController to enforce content completeness …

### DIFF
--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -442,7 +442,7 @@ describe('WebsitesController', () => {
 
       await expect(
         controller.updateWebsite(mockUser, mockCampaign, body, [
-          { fieldname: 'heroImage' } as FileUpload,
+          { fieldname: 'heroFile' } as FileUpload,
         ]),
       ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST })
 

--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -9,6 +9,7 @@ import { WebsitesController } from './websites.controller'
 import { WebsitesService } from '../services/websites.service'
 import { WebsiteContactsService } from '../services/websiteContacts.service'
 import { FilesService } from 'src/files/files.service'
+import { FileUpload } from 'src/files/files.types'
 import { WebsiteViewsService } from '../services/websiteViews.service'
 import { CampaignsService } from 'src/campaigns/services/campaigns.service'
 import { createMockClerkEnricher } from '@/shared/test-utils/mockClerkEnricher.util'
@@ -24,10 +25,26 @@ import { UpdateWebsiteSchema } from '../schemas/UpdateWebsite.schema'
 const mockUser = createMockUser()
 const mockCampaign = createMockCampaign({ userId: mockUser.id })
 
+const completeContent: PrismaJson.WebsiteContent = {
+  main: { title: 'Smith for City Council' },
+  about: {
+    bio: 'A real bio.',
+    issues: [{ title: 'Issue 1', description: 'Description 1' }],
+  },
+  contact: {
+    address: '123 Main St, Springfield, IL',
+    email: 'campaign@example.com',
+    phone: '555-555-5555',
+  },
+}
+
 describe('WebsitesController', () => {
   let controller: WebsitesController
   let mockAnalytics: {
     track: ReturnType<typeof vi.fn>
+  }
+  let mockFilesService: {
+    uploadFile: ReturnType<typeof vi.fn>
   }
   let mockWebsitesService: {
     findUniqueOrThrow: ReturnType<typeof vi.fn>
@@ -41,10 +58,13 @@ describe('WebsitesController', () => {
 
     mockWebsitesService = {
       findUniqueOrThrow: vi.fn().mockResolvedValue({
-        content: {},
+        content: completeContent,
         hasEverBeenPublished: false,
       }),
-      update: vi.fn().mockResolvedValue({ id: 1, content: {} }),
+      update: vi.fn().mockResolvedValue({ id: 1, content: completeContent }),
+    }
+    mockFilesService = {
+      uploadFile: vi.fn().mockResolvedValue('uploaded-file-url'),
     }
 
     const module: TestingModule = await Test.createTestingModule({
@@ -52,7 +72,7 @@ describe('WebsitesController', () => {
         { provide: PrismaService, useValue: {} },
         { provide: WebsitesService, useValue: mockWebsitesService },
         { provide: WebsiteContactsService, useValue: {} },
-        { provide: FilesService, useValue: { uploadFile: vi.fn() } },
+        { provide: FilesService, useValue: mockFilesService },
         { provide: WebsiteViewsService, useValue: {} },
         { provide: CampaignsService, useValue: {} },
         { provide: AnalyticsService, useValue: mockAnalytics },
@@ -94,7 +114,7 @@ describe('WebsitesController', () => {
 
     it('should not track Published event when website has been published before', async () => {
       mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
-        content: {},
+        content: completeContent,
         hasEverBeenPublished: true,
       })
 
@@ -115,22 +135,19 @@ describe('WebsitesController', () => {
     })
 
     it('should only fire the Published event once across publish → unpublish → republish', async () => {
-      // Simulate state: starts unpublished, hasEverBeenPublished = false
       mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
-        content: {},
+        content: completeContent,
         hasEverBeenPublished: false,
       })
 
-      // First publish
       const publishBody = new UpdateWebsiteSchema()
       publishBody.status = WebsiteStatus.published
       await controller.updateWebsite(mockUser, mockCampaign, publishBody)
 
       expect(mockAnalytics.track).toHaveBeenCalledTimes(1)
 
-      // Unpublish
       mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
-        content: {},
+        content: completeContent,
         hasEverBeenPublished: true,
       })
 
@@ -140,7 +157,6 @@ describe('WebsitesController', () => {
 
       expect(mockAnalytics.track).toHaveBeenCalledTimes(1)
 
-      // Re-publish — should NOT fire again
       const republishBody = new UpdateWebsiteSchema()
       republishBody.status = WebsiteStatus.published
       await controller.updateWebsite(mockUser, mockCampaign, republishBody)
@@ -149,7 +165,11 @@ describe('WebsitesController', () => {
     })
 
     it('should still return the update result when analytics tracking fails', async () => {
-      const expectedResult = { id: 1, content: {}, status: 'published' }
+      const expectedResult = {
+        id: 1,
+        content: completeContent,
+        status: 'published',
+      }
       mockWebsitesService.update.mockResolvedValue(expectedResult)
       mockAnalytics.track.mockRejectedValue(new Error('Segment unavailable'))
 
@@ -169,7 +189,7 @@ describe('WebsitesController', () => {
   describe('updateWebsite - domain registrant verification gate', () => {
     it('blocks publishing when an attached domain has not been registrant-verified', async () => {
       mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
-        content: {},
+        content: completeContent,
         hasEverBeenPublished: false,
         domain: { registrantVerifiedAt: null, name: 'foo.com' },
       })
@@ -186,7 +206,7 @@ describe('WebsitesController', () => {
 
     it('allows publishing when the attached domain has been registrant-verified', async () => {
       mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
-        content: {},
+        content: completeContent,
         hasEverBeenPublished: false,
         domain: {
           registrantVerifiedAt: new Date('2026-05-13T00:00:00.000Z'),
@@ -204,7 +224,7 @@ describe('WebsitesController', () => {
 
     it('allows publishing when no custom domain is attached', async () => {
       mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
-        content: {},
+        content: completeContent,
         hasEverBeenPublished: false,
         domain: null,
       })
@@ -230,6 +250,204 @@ describe('WebsitesController', () => {
       await controller.updateWebsite(mockUser, mockCampaign, body)
 
       expect(mockWebsitesService.update).toHaveBeenCalled()
+    })
+  })
+
+  describe('updateWebsite - content completeness gate', () => {
+    const publishBody = () => {
+      const body = new UpdateWebsiteSchema()
+      body.status = WebsiteStatus.published
+      return body
+    }
+
+    it('blocks publish when no content has been authored yet', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: {},
+        hasEverBeenPublished: false,
+      })
+
+      await expect(
+        controller.updateWebsite(mockUser, mockCampaign, publishBody()),
+      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST })
+
+      expect(mockWebsitesService.update).not.toHaveBeenCalled()
+    })
+
+    it('reports every missing required field in the error message', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: {},
+        hasEverBeenPublished: false,
+      })
+
+      await expect(
+        controller.updateWebsite(mockUser, mockCampaign, publishBody()),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message: expect.stringContaining('main.title'),
+      })
+      await expect(
+        controller.updateWebsite(mockUser, mockCampaign, publishBody()),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('about.bio'),
+      })
+      await expect(
+        controller.updateWebsite(mockUser, mockCampaign, publishBody()),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('contact.phone'),
+      })
+    })
+
+    it('blocks publish when about.bio is blank', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: {
+          ...completeContent,
+          about: { ...completeContent.about, bio: '   ' },
+        },
+        hasEverBeenPublished: false,
+      })
+
+      await expect(
+        controller.updateWebsite(mockUser, mockCampaign, publishBody()),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message: expect.stringContaining('about.bio'),
+      })
+    })
+
+    it('blocks publish when about.issues is empty', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: {
+          ...completeContent,
+          about: { ...completeContent.about, issues: [] },
+        },
+        hasEverBeenPublished: false,
+      })
+
+      await expect(
+        controller.updateWebsite(mockUser, mockCampaign, publishBody()),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message: expect.stringContaining('about.issues'),
+      })
+    })
+
+    it('blocks publish when an issue is missing title or description', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: {
+          ...completeContent,
+          about: {
+            ...completeContent.about,
+            issues: [{ title: 'Solo' }],
+          },
+        },
+        hasEverBeenPublished: false,
+      })
+
+      await expect(
+        controller.updateWebsite(mockUser, mockCampaign, publishBody()),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message: expect.stringContaining('about.issues'),
+      })
+    })
+
+    it('returns bad request for malformed issues data', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: {
+          ...completeContent,
+          about: {
+            ...completeContent.about,
+            issues: [undefined as never],
+          },
+        },
+        hasEverBeenPublished: false,
+      })
+
+      await expect(
+        controller.updateWebsite(mockUser, mockCampaign, publishBody()),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message: expect.stringContaining('about.issues'),
+      })
+    })
+
+    it('blocks publish when any contact field is missing', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: {
+          ...completeContent,
+          contact: { ...completeContent.contact, email: undefined },
+        },
+        hasEverBeenPublished: false,
+      })
+
+      await expect(
+        controller.updateWebsite(mockUser, mockCampaign, publishBody()),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message: expect.stringContaining('contact.email'),
+      })
+    })
+
+    it('considers merged content from current state + incoming body', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: {
+          ...completeContent,
+          about: { ...completeContent.about, bio: '' },
+        },
+        hasEverBeenPublished: false,
+      })
+
+      const body = new UpdateWebsiteSchema()
+      body.status = WebsiteStatus.published
+      body.about = { bio: 'Filling the missing bio in this request.' }
+
+      await controller.updateWebsite(mockUser, mockCampaign, body)
+
+      expect(mockWebsitesService.update).toHaveBeenCalled()
+    })
+
+    it('allows publish when all required fields are populated', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: completeContent,
+        hasEverBeenPublished: false,
+      })
+
+      await controller.updateWebsite(mockUser, mockCampaign, publishBody())
+
+      expect(mockWebsitesService.update).toHaveBeenCalled()
+    })
+
+    it('does not gate non-published status transitions', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: {},
+        hasEverBeenPublished: false,
+      })
+
+      const body = new UpdateWebsiteSchema()
+      body.status = WebsiteStatus.unpublished
+
+      await controller.updateWebsite(mockUser, mockCampaign, body)
+
+      expect(mockWebsitesService.update).toHaveBeenCalled()
+    })
+
+    it('does not upload files when publish validation fails', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: {},
+        hasEverBeenPublished: false,
+      })
+
+      const body = new UpdateWebsiteSchema()
+      body.status = WebsiteStatus.published
+
+      await expect(
+        controller.updateWebsite(mockUser, mockCampaign, body, [
+          { fieldname: 'heroImage' } as FileUpload,
+        ]),
+      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST })
+
+      expect(mockFilesService.uploadFile).not.toHaveBeenCalled()
+      expect(mockWebsitesService.update).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -56,6 +56,53 @@ const WEBSITE_CONTENT_INCLUDES = {
   },
 }
 
+const isNonEmpty = (value: string | undefined | null) =>
+  typeof value === 'string' && value.trim().length > 0
+
+type WebsiteIssueForPublish = {
+  title?: string | null
+  description?: string | null
+}
+
+const isIssueReadyToPublish = (
+  issue: WebsiteIssueForPublish,
+): issue is { title: string; description: string } =>
+  isNonEmpty(issue.title) && isNonEmpty(issue.description)
+
+const REQUIRED_PUBLISH_FIELDS: Array<{
+  path: string
+  check: (content: PrismaJson.WebsiteContent) => boolean
+}> = [
+  { path: 'main.title', check: (c) => isNonEmpty(c.main?.title) },
+  { path: 'about.bio', check: (c) => isNonEmpty(c.about?.bio) },
+  {
+    path: 'about.issues',
+    check: (c) =>
+      Array.isArray(c.about?.issues) &&
+      c.about.issues.length > 0 &&
+      c.about.issues.every(
+        (issue) =>
+          typeof issue === 'object' &&
+          issue !== null &&
+          isIssueReadyToPublish(issue as WebsiteIssueForPublish),
+      ),
+  },
+  { path: 'contact.address', check: (c) => isNonEmpty(c.contact?.address) },
+  { path: 'contact.email', check: (c) => isNonEmpty(c.contact?.email) },
+  { path: 'contact.phone', check: (c) => isNonEmpty(c.contact?.phone) },
+]
+
+const assertReadyToPublish = (content: PrismaJson.WebsiteContent) => {
+  const missing = REQUIRED_PUBLISH_FIELDS.filter(
+    ({ check }) => !check(content),
+  ).map(({ path }) => path)
+  if (missing.length > 0) {
+    throw new BadRequestException(
+      `Website content is missing required fields for publishing: ${missing.join(', ')}`,
+    )
+  }
+}
+
 @Controller('websites')
 @UsePipes(ZodValidationPipe)
 export class WebsitesController {
@@ -206,6 +253,13 @@ export class WebsitesController {
       updatedContent.about.issues = body.about.issues
     }
 
+    if (body.status === WebsiteStatus.published) {
+      assertReadyToPublish(updatedContent)
+    }
+
+    const isFirstPublish =
+      body.status === WebsiteStatus.published && !hasEverBeenPublished
+
     const [logo, hero] = await Promise.all([
       logoFile ? this.files.uploadFile(logoFile, 'uploads') : null,
       heroFile ? this.files.uploadFile(heroFile, 'uploads') : null,
@@ -224,9 +278,6 @@ export class WebsitesController {
       updatedContent.main ||= {}
       updatedContent.main.image = undefined
     }
-
-    const isFirstPublish =
-      body.status === WebsiteStatus.published && !hasEverBeenPublished
 
     const result = await this.websites.update({
       where: { campaignId },


### PR DESCRIPTION
…for publishing

- Added validation to ensure required fields are present before publishing a website.
- Introduced utility functions to check for non-empty values and validate issues.
- Updated tests to cover new content completeness checks and error handling for missing fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new pre-publish validation gate in `updateWebsite` that can prevent publishing and change observed API behavior (400s) for previously-allowed requests. Risk is contained to the publish path and covered by expanded unit tests, but could impact users with partially-authored sites or malformed `about.issues` data.
> 
> **Overview**
> **Publishing is now gated on content completeness.** When `updateWebsite` is called with `status: published`, it validates merged website content and rejects with `400 Bad Request` listing all missing required fields (e.g., `main.title`, `about.bio`, `about.issues`, and `contact.*`).
> 
> The controller now validates `about.issues` shape/entries (non-empty `title`/`description`) and runs this check **before** any file uploads, so failed publish attempts do not upload assets.
> 
> Tests were updated/expanded to use a realistic `completeContent` fixture, mock `FilesService.uploadFile`, and cover the new completeness gate scenarios and error messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4a78b290ffd1f1396b4fe59dad71f08e65ee959. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->