### PR TITLE
fix(users): order Clerk test-user cleanup oldest-first

### DIFF
--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -585,6 +585,7 @@ export class UsersService extends createPrismaBase(MODELS.User) {
         this.clerkClient.users.getUserList({
           limit: 500,
           query: TEST_USER_DOMAIN,
+          orderBy: '+created_at',
         }),
       )
 


### PR DESCRIPTION
The scheduled `deleteTestUsers` job in `UsersService` was reliably reaping DB rows but almost never deleting from Clerk — over the past 7 days in dev, DB cleanup ran ~5,118 deletes while Clerk cleanup ran 58 (in a single pass).

`clerkClient.users.getUserList` defaults to `orderBy: '-created_at'` (newest first). With `limit: 500` and our client-side `createdAt < cutoff (3h ago)` filter, each pass would fetch the 500 _newest_ matching users — almost all younger than the cutoff — and filter them all out. The stale backlog (now ~26k in dev) is never reached.

Adding `orderBy: '+created_at'` flips this so each pass works through the oldest 500 first, which is what the filter is selecting for anyway. The backlog will drain gradually at ~500/pass × 4 passes/day; that's intentional — no need to one-shot it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change confined to the scheduled test-user cleanup job; it only affects deletion ordering for `@test.goodparty.org` accounts in Clerk and should not impact real users.
> 
> **Overview**
> Adjusts the `UsersService.deleteTestUsers` scheduled job to request Clerk users ordered *oldest-first* by adding `orderBy: '+created_at'` to `getUserList`.
> 
> This ensures each pass processes the oldest matching test accounts within the 500-user fetch limit, allowing the `createdAt < cutoff` filter to actually select deletable users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b47736ce6660df1cbee88b21d897cf00dc4e574. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->