### PR TITLE
Reduce OTel metric cardinality to stop Grafana billing spike

### DIFF
--- a/src/otel.ts
+++ b/src/otel.ts
@@ -20,7 +20,7 @@ import {
   type LogRecordProcessor,
 } from '@opentelemetry/sdk-logs'
 import type { SdkLogRecord } from '@opentelemetry/sdk-logs/build/src/export/SdkLogRecord'
-import type { Context } from '@opentelemetry/api'
+import type { Attributes, Context } from '@opentelemetry/api'
 import { PrismaInstrumentation } from '@prisma/instrumentation'
 import { PinoInstrumentation } from '@opentelemetry/instrumentation-pino'
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
@@ -114,12 +114,35 @@ if (!headers) {
     shutdown: () => Promise.resolve(),
   }
 
+  const HIGH_CARDINALITY_SPAN_ATTRS = [
+    'net.host.name',
+    'net.host.ip',
+    'net.peer.name',
+    'net.peer.ip',
+    'http.host',
+    'host.name',
+    'host.id',
+    'service.instance.id',
+  ]
+  const cardinalityScrubProcessor: SpanProcessor = {
+    onStart: () => undefined,
+    onEnd: (span: ReadableSpan) => {
+      const attrs = span.attributes as Attributes
+      for (const attr of HIGH_CARDINALITY_SPAN_ATTRS) {
+        delete attrs[attr]
+      }
+    },
+    forceFlush: () => Promise.resolve(),
+    shutdown: () => Promise.resolve(),
+  }
+
   const traceExporter = new OTLPTraceExporter({
     url: `${endpoint}/v1/traces`,
     headers: parsedHeaders,
   })
 
   const sdk = new NodeSDK({
+    autoDetectResources: false,
     resource,
     metricReader: new PeriodicExportingMetricReader({
       exporter: new OTLPMetricExporter({
@@ -147,6 +170,7 @@ if (!headers) {
       ),
     ),
     spanProcessors: [
+      cardinalityScrubProcessor,
       new BatchSpanProcessor(traceExporter),
       prismaConnectionMetricProcessor,
     ],


### PR DESCRIPTION
## Why

Grafana Cloud billable metric series jumped from ~16k to ~91k starting around April 25, 2026 — a 5.6x increase driving the unexpected billing climb. Active series stays at ~10k throughout, which means the spike comes from series **churn**, not concurrent volume.

Two sources of cardinality, both from our OTel setup:

1. **`NodeSDK` auto-detected resource attributes.** The SDK defaults to running `host`, `process`, and `os` detectors and merging them into our resource. That adds `host.name` (Fargate task private IP, fresh per task), `host.id`, `process.pid`, `process.command_args`, etc. to `target_info` — and those resource attrs propagate as labels on every metric we emit. New task = new label combo = new billable series.

2. **`net.host.name` / `http.host` on HTTP server spans.** Fastify/HTTP instrumentation records the inbound `Host` header verbatim. Grafana Cloud's server-side spanmetrics generator turns those spans into `http_server_duration_milliseconds_*` series, one per unique Host. Inspecting the label values showed PR preview ELB DNS names with random suffixes (`gpapi-pr-1206-1416172677.us-west-2.elb.amazonaws.com`) and a long tail of internet-wide bot scanner Host headers (`m.hilarionbet501.com`, `weatlhleap.com`, `ckklxlu.shop`, etc.). Each fresh Host = another permanent series for the billing window.

## What this PR does

- `autoDetectResources: false` on `NodeSDK` — keeps our explicit `{service.name, deployment.environment.name}` resource and nothing else.
- New `cardinalityScrubProcessor` runs before the batch exporter and deletes `net.host.name`, `net.host.ip`, `net.peer.name`, `net.peer.ip`, `http.host`, `host.name`, `host.id`, `service.instance.id` from each span. This severs the upstream source feeding the server-side spanmetrics generator.

After deploy, `target_info` should collapse to ~1 series per environment, and the `http_server_duration_*` series Grafana generates from our traces should stop ingesting the ephemeral-Host churn.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OpenTelemetry tracing/metrics configuration and mutates span attributes, which could remove useful labels and affect dashboards/alerting if downstream queries depend on them.
> 
> **Overview**
> Reduces Grafana/OpenTelemetry series churn by disabling `NodeSDK` resource autodetection (`autoDetectResources: false`), limiting emitted resource labels to the explicitly configured resource.
> 
> Adds a new `cardinalityScrubProcessor` span processor that deletes high-cardinality network/host attributes (e.g., `http.host`, `net.*`, `host.*`, `service.instance.id`) from spans before export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1600334b528e787d6abbbca353205b751809a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->