### PR TITLE
Compliance state endpoint for resumable runs

### DIFF
--- a/contracts/src/campaigns/ComplianceStateOutput.schema.ts
+++ b/contracts/src/campaigns/ComplianceStateOutput.schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+import { ComplianceStageSchema } from './enums'
+import { DomainStatusSchema } from '../generated/enums'
+
+export const ComplianceStateDomainSchema = z.object({
+  name: z.string(),
+  status: DomainStatusSchema,
+  registrantVerifiedAt: z.string().datetime({ offset: true }).nullable(),
+})
+
+export type ComplianceStateDomain = z.infer<typeof ComplianceStateDomainSchema>
+
+export const ComplianceStateOutputSchema = z.object({
+  stage: ComplianceStageSchema,
+  domain: ComplianceStateDomainSchema.nullable(),
+  websiteId: z.number().int().nullable(),
+  peerlyVerificationId: z.string().nullable(),
+})
+
+export type ComplianceStateOutput = z.infer<typeof ComplianceStateOutputSchema>

--- a/contracts/src/campaigns/enums.ts
+++ b/contracts/src/campaigns/enums.ts
@@ -71,3 +71,17 @@ export const GENERATION_STATUS_VALUES = ['processing', 'completed'] as const
 export type GenerationStatus = (typeof GENERATION_STATUS_VALUES)[number]
 export const GenerationStatusSchema = z.enum(GENERATION_STATUS_VALUES)
 export const GenerationStatus = toEnumObject(GENERATION_STATUS_VALUES)
+
+export const COMPLIANCE_STAGE_VALUES = [
+  'needs_profile',
+  'needs_filing',
+  'pending_domain_purchase',
+  'pending_website_live',
+  'awaiting_pin',
+  'tcr_in_review',
+  'tcr_approved',
+  'tcr_rejected',
+] as const
+export type ComplianceStage = (typeof COMPLIANCE_STAGE_VALUES)[number]
+export const ComplianceStageSchema = z.enum(COMPLIANCE_STAGE_VALUES)
+export const ComplianceStage = toEnumObject(COMPLIANCE_STAGE_VALUES)

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -125,6 +125,9 @@ export {
   GENERATION_STATUS_VALUES,
   GenerationStatus,
   GenerationStatusSchema,
+  COMPLIANCE_STAGE_VALUES,
+  ComplianceStage,
+  ComplianceStageSchema,
 } from './campaigns/enums'
 
 export type {
@@ -189,6 +192,13 @@ export {
   UpdateCampaignM2MSchema,
   type UpdateCampaignM2MInput,
 } from './campaigns/UpdateCampaignM2M.schema'
+
+export {
+  ComplianceStateDomainSchema,
+  type ComplianceStateDomain,
+  ComplianceStateOutputSchema,
+  type ComplianceStateOutput,
+} from './campaigns/ComplianceStateOutput.schema'
 
 export type { Ecanvasser, EcanvasserSummary } from './ecanvasser/types'
 

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -30,6 +30,7 @@ import { CampaignTasksService } from './tasks/services/campaignTasks.service'
 import { AiGenerationService } from './tasks/services/aiGeneration.service'
 import { CampaignTcrComplianceController } from './tcrCompliance/campaignTcrCompliance.controller'
 import { CampaignTcrComplianceService } from './tcrCompliance/services/campaignTcrCompliance.service'
+import { ComplianceStateService } from './tcrCompliance/services/complianceState.service'
 import { WeeklyTasksDigestService } from './tasks/services/weeklyTasksDigest.service'
 import { WeeklyTasksDigestHandlerService } from './tasks/services/weeklyTasksDigestHandler.service'
 import { CampaignUpdateHistoryController } from './updateHistory/campaignUpdateHistory.controller'
@@ -75,6 +76,7 @@ import { CampaignUpdateHistoryService } from './updateHistory/campaignUpdateHist
     LegacyCampaignTasksService,
     AiGenerationService,
     CampaignTcrComplianceService,
+    ComplianceStateService,
     WeeklyTasksDigestService,
     WeeklyTasksDigestHandlerService,
   ],

--- a/src/campaigns/tcrCompliance/campaignTcrCompliance.controller.test.ts
+++ b/src/campaigns/tcrCompliance/campaignTcrCompliance.controller.test.ts
@@ -6,6 +6,8 @@ import { PinoLogger } from 'nestjs-pino'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CampaignTcrComplianceController } from './campaignTcrCompliance.controller'
 import { CampaignTcrComplianceService } from './services/campaignTcrCompliance.service'
+import { ComplianceStateService } from './services/complianceState.service'
+import { ComplianceStage } from '@goodparty_org/contracts'
 import { UsersService } from '../../users/services/users.service'
 import { CampaignsService } from '../services/campaigns.service'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
@@ -38,6 +40,9 @@ describe('CampaignTcrComplianceController', () => {
   }
   let mockUserService: { findByCampaign: ReturnType<typeof vi.fn> }
   let mockCampaignsService: { updateJsonFields: ReturnType<typeof vi.fn> }
+  let mockComplianceStateService: {
+    findStateForCampaign: ReturnType<typeof vi.fn>
+  }
 
   beforeEach(async () => {
     mockAnalytics = {
@@ -60,12 +65,25 @@ describe('CampaignTcrComplianceController', () => {
       updateJsonFields: vi.fn().mockResolvedValue(mockCampaign),
     }
 
+    mockComplianceStateService = {
+      findStateForCampaign: vi.fn().mockResolvedValue({
+        stage: ComplianceStage.awaiting_pin,
+        domain: null,
+        websiteId: null,
+        peerlyVerificationId: null,
+      }),
+    }
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         { provide: UsersService, useValue: mockUserService },
         {
           provide: CampaignTcrComplianceService,
           useValue: mockTcrService,
+        },
+        {
+          provide: ComplianceStateService,
+          useValue: mockComplianceStateService,
         },
         { provide: CampaignsService, useValue: mockCampaignsService },
         { provide: AnalyticsService, useValue: mockAnalytics },
@@ -197,6 +215,31 @@ describe('CampaignTcrComplianceController', () => {
       )
 
       expect(result).toEqual(expectedBrand)
+    })
+  })
+
+  describe('getMyComplianceState', () => {
+    it('delegates to ComplianceStateService with the campaign id', async () => {
+      const expectedState = {
+        stage: ComplianceStage.pending_website_live,
+        domain: {
+          name: 'example.org',
+          status: 'registered' as const,
+          registrantVerifiedAt: null,
+        },
+        websiteId: 42,
+        peerlyVerificationId: null,
+      }
+      mockComplianceStateService.findStateForCampaign.mockResolvedValue(
+        expectedState,
+      )
+
+      const result = await controller.getMyComplianceState(mockCampaign)
+
+      expect(
+        mockComplianceStateService.findStateForCampaign,
+      ).toHaveBeenCalledWith(mockCampaign.id)
+      expect(result).toEqual(expectedState)
     })
   })
 })

--- a/src/campaigns/tcrCompliance/campaignTcrCompliance.controller.ts
+++ b/src/campaigns/tcrCompliance/campaignTcrCompliance.controller.ts
@@ -12,9 +12,12 @@ import {
   NotFoundException,
   Param,
   Post,
+  UseInterceptors,
   UsePipes,
 } from '@nestjs/common'
+import { ZodResponseInterceptor } from '@/shared/interceptors/ZodResponse.interceptor'
 import { CampaignTcrComplianceService } from './services/campaignTcrCompliance.service'
+import { ComplianceStateService } from './services/complianceState.service'
 import { CreateTcrComplianceDto } from './schemas/createTcrComplianceDto.schema'
 import { UseCampaign } from '../decorators/UseCampaign.decorator'
 import { ReqCampaign } from '../decorators/ReqCampaign.decorator'
@@ -27,6 +30,8 @@ import { ReqUser } from '../../authentication/decorators/ReqUser.decorator'
 import { AnalyticsService } from 'src/analytics/analytics.service'
 import { EVENTS } from 'src/vendors/segment/segment.types'
 import { PinoLogger } from 'nestjs-pino'
+import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import { ComplianceStateOutputSchema } from '@goodparty_org/contracts'
 
 @Controller('campaigns/tcr-compliance')
 @UsePipes(ZodValidationPipe)
@@ -34,6 +39,7 @@ export class CampaignTcrComplianceController {
   constructor(
     private readonly userService: UsersService,
     private readonly tcrComplianceService: CampaignTcrComplianceService,
+    private readonly complianceStateService: ComplianceStateService,
     private readonly campaignsService: CampaignsService,
     private readonly analytics: AnalyticsService,
     private readonly logger: PinoLogger,
@@ -53,6 +59,14 @@ export class CampaignTcrComplianceController {
       )
     }
     return tcrCompliance
+  }
+
+  @Get('mine/compliance-state')
+  @UseCampaign()
+  @UseInterceptors(ZodResponseInterceptor)
+  @ResponseSchema(ComplianceStateOutputSchema)
+  async getMyComplianceState(@ReqCampaign() campaign: Campaign) {
+    return this.complianceStateService.findStateForCampaign(campaign.id)
   }
 
   @Post()

--- a/src/campaigns/tcrCompliance/services/complianceState.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/complianceState.service.test.ts
@@ -1,0 +1,178 @@
+import {
+  Campaign,
+  Domain,
+  DomainStatus,
+  TcrCompliance,
+  TcrComplianceStatus,
+  Website,
+  WebsiteStatus,
+} from '@prisma/client'
+import { ComplianceStage } from '@goodparty_org/contracts'
+import { describe, expect, it } from 'vitest'
+import { deriveComplianceStage } from './complianceState.service'
+
+const mockCampaign = (
+  overrides?: Partial<Pick<Campaign, 'formattedAddress'>>,
+): Pick<Campaign, 'formattedAddress'> => ({
+  formattedAddress: '123 Main St, Anytown, USA',
+  ...overrides,
+})
+
+const mockWebsite = (
+  status: WebsiteStatus = WebsiteStatus.published,
+): Pick<Website, 'status'> => ({ status })
+
+const mockDomain = (
+  overrides?: Partial<Pick<Domain, 'status' | 'registrantVerifiedAt'>>,
+): Pick<Domain, 'status' | 'registrantVerifiedAt'> => ({
+  status: DomainStatus.registered,
+  registrantVerifiedAt: new Date(),
+  ...overrides,
+})
+
+const mockTcr = (
+  overrides?: Partial<Pick<TcrCompliance, 'status' | 'peerlyIdentityId'>>,
+): Pick<TcrCompliance, 'status' | 'peerlyIdentityId'> => ({
+  status: TcrComplianceStatus.submitted,
+  peerlyIdentityId: null,
+  ...overrides,
+})
+
+describe('deriveComplianceStage', () => {
+  it('returns needs_profile when no address and no compliance record', () => {
+    expect(
+      deriveComplianceStage(
+        mockCampaign({ formattedAddress: null }),
+        null,
+        null,
+        null,
+      ),
+    ).toBe(ComplianceStage.needs_profile)
+  })
+
+  it('returns needs_filing when address present but no compliance record', () => {
+    expect(deriveComplianceStage(mockCampaign(), null, null, null)).toBe(
+      ComplianceStage.needs_filing,
+    )
+  })
+
+  it('returns pending_domain_purchase when compliance record exists but no domain', () => {
+    expect(deriveComplianceStage(mockCampaign(), null, null, mockTcr())).toBe(
+      ComplianceStage.pending_domain_purchase,
+    )
+  })
+
+  it('returns pending_domain_purchase when domain is still pending', () => {
+    expect(
+      deriveComplianceStage(
+        mockCampaign(),
+        mockWebsite(WebsiteStatus.unpublished),
+        mockDomain({
+          status: DomainStatus.pending,
+          registrantVerifiedAt: null,
+        }),
+        mockTcr(),
+      ),
+    ).toBe(ComplianceStage.pending_domain_purchase)
+  })
+
+  it('returns pending_website_live when domain registered but website not published', () => {
+    expect(
+      deriveComplianceStage(
+        mockCampaign(),
+        mockWebsite(WebsiteStatus.unpublished),
+        mockDomain(),
+        mockTcr(),
+      ),
+    ).toBe(ComplianceStage.pending_website_live)
+  })
+
+  it('returns pending_website_live when website published but registrant unverified', () => {
+    expect(
+      deriveComplianceStage(
+        mockCampaign(),
+        mockWebsite(),
+        mockDomain({ registrantVerifiedAt: null }),
+        mockTcr(),
+      ),
+    ).toBe(ComplianceStage.pending_website_live)
+  })
+
+  it('returns awaiting_pin when website is live and TCR was submitted to Peerly', () => {
+    expect(
+      deriveComplianceStage(
+        mockCampaign(),
+        mockWebsite(),
+        mockDomain(),
+        mockTcr({ peerlyIdentityId: 'peerly-123' }),
+      ),
+    ).toBe(ComplianceStage.awaiting_pin)
+  })
+
+  it('returns awaiting_pin when website is live even without peerlyIdentityId', () => {
+    expect(
+      deriveComplianceStage(
+        mockCampaign(),
+        mockWebsite(),
+        mockDomain(),
+        mockTcr(),
+      ),
+    ).toBe(ComplianceStage.awaiting_pin)
+  })
+
+  it('returns tcr_in_review when status is pending', () => {
+    expect(
+      deriveComplianceStage(
+        mockCampaign(),
+        mockWebsite(),
+        mockDomain(),
+        mockTcr({
+          status: TcrComplianceStatus.pending,
+          peerlyIdentityId: 'peerly-123',
+        }),
+      ),
+    ).toBe(ComplianceStage.tcr_in_review)
+  })
+
+  it('returns tcr_approved when status is approved', () => {
+    expect(
+      deriveComplianceStage(
+        mockCampaign(),
+        mockWebsite(),
+        mockDomain(),
+        mockTcr({
+          status: TcrComplianceStatus.approved,
+          peerlyIdentityId: 'peerly-123',
+        }),
+      ),
+    ).toBe(ComplianceStage.tcr_approved)
+  })
+
+  it('returns tcr_rejected when status is rejected', () => {
+    expect(
+      deriveComplianceStage(
+        mockCampaign(),
+        mockWebsite(),
+        mockDomain(),
+        mockTcr({
+          status: TcrComplianceStatus.rejected,
+          peerlyIdentityId: 'peerly-123',
+        }),
+      ),
+    ).toBe(ComplianceStage.tcr_rejected)
+  })
+
+  it('returns tcr_rejected when status is error', () => {
+    expect(
+      deriveComplianceStage(
+        mockCampaign(),
+        mockWebsite(),
+        mockDomain(),
+        mockTcr({
+          status: TcrComplianceStatus.error,
+          peerlyIdentityId: 'peerly-123',
+        }),
+      ),
+    ).toBe(ComplianceStage.tcr_rejected)
+  })
+})

--- a/src/campaigns/tcrCompliance/services/complianceState.service.ts
+++ b/src/campaigns/tcrCompliance/services/complianceState.service.ts
@@ -49,7 +49,7 @@ export class ComplianceStateService extends createPrismaBase(MODELS.Campaign) {
           }
         : null,
       websiteId: website?.id ?? null,
-      peerlyVerificationId: null,
+      peerlyVerificationId: tcrCompliance?.peerlyIdentityId ?? null,
     }
   }
 }

--- a/src/campaigns/tcrCompliance/services/complianceState.service.ts
+++ b/src/campaigns/tcrCompliance/services/complianceState.service.ts
@@ -1,0 +1,99 @@
+import { Injectable } from '@nestjs/common'
+import {
+  Campaign,
+  Domain,
+  DomainStatus,
+  TcrCompliance,
+  TcrComplianceStatus,
+  Website,
+  WebsiteStatus,
+} from '@prisma/client'
+import {
+  ComplianceStage,
+  type ComplianceStateOutput,
+} from '@goodparty_org/contracts'
+import { formatISO } from 'date-fns'
+import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
+
+const DOMAIN_REGISTERED_STATUSES: DomainStatus[] = [
+  DomainStatus.registered,
+  DomainStatus.active,
+]
+
+@Injectable()
+export class ComplianceStateService extends createPrismaBase(MODELS.Campaign) {
+  async findStateForCampaign(
+    campaignId: number,
+  ): Promise<ComplianceStateOutput> {
+    const campaign = await this.model.findUniqueOrThrow({
+      where: { id: campaignId },
+      include: {
+        tcrCompliance: true,
+        website: { include: { domain: true } },
+      },
+    })
+
+    const website = campaign.website ?? null
+    const domain = website?.domain ?? null
+    const tcrCompliance = campaign.tcrCompliance ?? null
+
+    return {
+      stage: deriveComplianceStage(campaign, website, domain, tcrCompliance),
+      domain: domain
+        ? {
+            name: domain.name,
+            status: domain.status,
+            registrantVerifiedAt: domain.registrantVerifiedAt
+              ? formatISO(domain.registrantVerifiedAt)
+              : null,
+          }
+        : null,
+      websiteId: website?.id ?? null,
+      peerlyVerificationId: null,
+    }
+  }
+}
+
+export const deriveComplianceStage = (
+  campaign: Pick<Campaign, 'formattedAddress'>,
+  website: Pick<Website, 'status'> | null,
+  domain: Pick<Domain, 'status' | 'registrantVerifiedAt'> | null,
+  tcrCompliance: Pick<TcrCompliance, 'status' | 'peerlyIdentityId'> | null,
+): ComplianceStage => {
+  if (!tcrCompliance) {
+    return campaign.formattedAddress
+      ? ComplianceStage.needs_filing
+      : ComplianceStage.needs_profile
+  }
+
+  if (tcrCompliance.status === TcrComplianceStatus.approved) {
+    return ComplianceStage.tcr_approved
+  }
+  if (
+    tcrCompliance.status === TcrComplianceStatus.rejected ||
+    tcrCompliance.status === TcrComplianceStatus.error
+  ) {
+    return ComplianceStage.tcr_rejected
+  }
+  if (tcrCompliance.status === TcrComplianceStatus.pending) {
+    return ComplianceStage.tcr_in_review
+  }
+
+  if (tcrCompliance.peerlyIdentityId) {
+    return ComplianceStage.awaiting_pin
+  }
+
+  const domainRegistered = Boolean(
+    domain && DOMAIN_REGISTERED_STATUSES.includes(domain.status),
+  )
+  if (!domainRegistered) {
+    return ComplianceStage.pending_domain_purchase
+  }
+
+  const websiteLive =
+    website?.status === WebsiteStatus.published &&
+    Boolean(domain?.registrantVerifiedAt)
+  return websiteLive
+    ? ComplianceStage.awaiting_pin
+    : ComplianceStage.pending_website_live
+}

--- a/src/campaigns/tcrCompliance/services/complianceState.service.ts
+++ b/src/campaigns/tcrCompliance/services/complianceState.service.ts
@@ -16,6 +16,7 @@ import { formatISO } from 'date-fns'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 
 const DOMAIN_REGISTERED_STATUSES: DomainStatus[] = [
+  DomainStatus.submitted,
   DomainStatus.registered,
   DomainStatus.active,
 ]


### PR DESCRIPTION
- Introduced ComplianceStage enum with various compliance states.
- Added ComplianceStateService to manage compliance state logic.
- Updated CampaignTcrComplianceController to include a new endpoint for retrieving compliance state.
- Enhanced tests to validate the new compliance state functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new API endpoint backed by new stage-derivation logic that reads campaign/website/domain/TCR compliance data; incorrect stage mapping could misroute users through the compliance flow. Changes are localized but touch Prisma queries and public contract types.
> 
> **Overview**
> Introduces a typed compliance-state model in `@goodparty_org/contracts`, including a new `ComplianceStage` enum and `ComplianceStateOutputSchema` for API responses.
> 
> Adds `ComplianceStateService` to compute a campaign’s current compliance stage from `Campaign` address, `Website`/`Domain` status, and `TcrCompliance` status, and wires it into the campaigns module.
> 
> Exposes `GET /campaigns/tcr-compliance/mine/compliance-state` on `CampaignTcrComplianceController` with Zod response validation, and adds unit tests for both the stage-derivation logic and the controller delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffdf7e57d05dab95251c8cbd6cf6cdcb9285fd4e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->