### PR TITLE
fix(grafana): skip RuleGroup creation for controllers with zero alerts

### DIFF
--- a/deploy/components/grafana.ts
+++ b/deploy/components/grafana.ts
@@ -236,11 +236,18 @@ export const createGrafanaResources = async ({
   })
 
   for (const controller of CONTROLLER_NAMES) {
+    const rules = controllerAlerts(controller).map(alertToRule)
+    // Grafana's RuleGroup schema requires `rules` to have at least 1 item:
+    // > Attribute rule requires 1 item minimum, but config has only 0 declared.
+    // CONTROLLER_NAMES is auto-generated from src and can include controllers
+    // with no public routes (currently `mcp`), which produce zero alerts.
+    // An empty RuleGroup adds no value, so skip them rather than fail preview.
+    if (rules.length === 0) continue
     new grafana.alerting.RuleGroup(`${controller}-rules`, {
       name: `${controller} routes`,
       folderUid: alertFolder.uid,
       intervalSeconds: 60,
-      rules: controllerAlerts(controller).map(alertToRule),
+      rules,
     })
   }
 


### PR DESCRIPTION
The dev preview was surfacing:

  error: grafana:alerting/ruleGroup:RuleGroup resource 'mcp-rules' has a
  problem: Not enough list items. Attribute rule requires 1 item minimum,
  but config has only 0 declared.. Examine values at 'mcp-rules.rules'.

`CONTROLLER_NAMES` is auto-generated from src/ and includes controllers with no public routes (currently `mcp`). The loop over CONTROLLER_NAMES in createGrafanaResources was creating one Grafana RuleGroup per controller, including for `mcp` -> empty rules array -> schema rejection.

Skip the RuleGroup entirely when there are no alerts to register. Defensive against any future controller that has no routes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive change in Grafana provisioning that only avoids creating empty `RuleGroup`s; could only impact alert visibility for controllers that unexpectedly generate zero rules.
> 
> **Overview**
> Prevents Grafana provisioning failures by **skipping per-controller `grafana.alerting.RuleGroup` creation when `controllerAlerts(controller)` returns zero rules**, avoiding schema validation errors from empty `rules` arrays.
> 
> The loop now precomputes `rules` once and continues early for controllers with no public routes (e.g., `mcp`), keeping previews and deploys from failing on auto-generated `CONTROLLER_NAMES` entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 467ab65085b15394f0fb7adbc29c931ae98345f5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->