### PR TITLE
fat: @mcp audit

### DIFF
--- a/src/campaigns/tcrCompliance/campaignTcrCompliance.controller.ts
+++ b/src/campaigns/tcrCompliance/campaignTcrCompliance.controller.ts
@@ -31,6 +31,7 @@ import { AnalyticsService } from 'src/analytics/analytics.service'
 import { EVENTS } from 'src/vendors/segment/segment.types'
 import { PinoLogger } from 'nestjs-pino'
 import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import { McpTool } from '@/mcp/decorators/McpTool.decorator'
 import { ComplianceStateOutputSchema } from '@goodparty_org/contracts'
 
 @Controller('campaigns/tcr-compliance')
@@ -65,6 +66,18 @@ export class CampaignTcrComplianceController {
   @UseCampaign()
   @UseInterceptors(ZodResponseInterceptor)
   @ResponseSchema(ComplianceStateOutputSchema)
+  @McpTool({
+    description:
+      "Read the calling campaign's full compliance-setup pipeline " +
+      'state: which stages are completed, in progress, or pending ' +
+      '(profile, domain purchase, domain verification, website ' +
+      'publish, TCR submission, CV PIN entry). Call this at the start ' +
+      'of every compliance_setup agent run to decide which steps to ' +
+      'skip and which still need work; the response is the canonical ' +
+      'view across Campaign, Website, Domain, and TcrCompliance ' +
+      'tables, so the agent does not have to read those individually. ' +
+      'Read-only; safe to call repeatedly during a run.',
+  })
   async getMyComplianceState(@ReqCampaign() campaign: Campaign) {
     return this.complianceStateService.findStateForCampaign(campaign.id)
   }

--- a/src/websites/controllers/domains.controller.ts
+++ b/src/websites/controllers/domains.controller.ts
@@ -31,6 +31,7 @@ import {
   PatternedDomainSearchResult,
 } from '../domains.types'
 import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import { McpTool } from '@/mcp/decorators/McpTool.decorator'
 
 @Controller('domains')
 @UsePipes(ZodValidationPipe)
@@ -55,6 +56,19 @@ export class DomainsController {
   @UseCampaign({ include: { user: true } })
   @HttpCode(HttpStatus.OK)
   @ResponseSchema(SearchDomainsResponseSchema)
+  @McpTool({
+    description:
+      'Find available .com / .org / .vote domains for the calling ' +
+      'campaign matching one or more name patterns, under a per-domain ' +
+      'price cap. Use during the compliance_setup flow after the ' +
+      "candidate's profile is saved, to pick a domain before purchase. " +
+      'Patterns are literal candidate domain strings without TLD ' +
+      '(e.g. ["janeforsenate", "voteforjane"]); the server checks ' +
+      'availability across supported TLDs and returns { candidates: ' +
+      '[{ domain, price }] } for ranking. Returns only available ' +
+      'domains; an empty candidates list means nothing matched under ' +
+      'the cap. Read-only; safe to retry.',
+  })
   async searchDomains(
     @ReqCampaign() campaign: Campaign & { user: User },
     @Body() { patterns, maxPrice }: SearchDomainsBodySchema,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds `@McpTool` metadata to two existing read-only endpoints, affecting tool discovery/agent access but not changing business logic. Risk is low as handlers and auth/pipes remain the same, though it increases surface area for automated callers.
> 
> **Overview**
> Exposes two existing read-only endpoints to the MCP tool registry by adding `@McpTool` metadata and agent-oriented descriptions.
> 
> `GET campaigns/tcr-compliance/mine/compliance-state` is now documented as the canonical compliance pipeline state lookup, and `POST /domains/search` is now documented as a patterned domain availability search (with price cap) for compliance setup flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb9b7451584764ed6f01c9ce776a8b6c65055adc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->