### PR TITLE
fix(meetings): merge projected + actual briefings in list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -186,7 +186,7 @@
     },
     "contracts": {
       "name": "@goodparty_org/contracts",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
         "validator": "^13.12.0",
         "zod": "^3.23.8"

--- a/src/meetings/controllers/meetingsBriefings.controller.test.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import { ExperimentRunStatus } from '@prisma/client'
-import { getDay, parseISO } from 'date-fns'
+import { addDays, getDay, parseISO } from 'date-fns'
+import { formatInTimeZone } from 'date-fns-tz'
 import { S3Service } from '@/vendors/aws/services/s3.service'
+import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import { useTestService } from '@/test-service'
 
 const service = useTestService()
@@ -289,10 +291,11 @@ describe('GET /v1/meetings', () => {
         status: ExperimentRunStatus.COMPLETED,
       },
     })
+    const today = formatInTimeZone(new Date(), 'UTC', 'yyyy-MM-dd')
     await service.prisma.meetingBriefing.create({
       data: {
         electedOfficeId: eo.id,
-        meetingDate: new Date('2026-05-20T00:00:00Z'),
+        meetingDate: parseIsoDateAsUTC(today),
         meetingTime: '20:00',
         meetingTimezone: 'America/Chicago',
         experimentRunId: briefingRun.runId,
@@ -309,7 +312,7 @@ describe('GET /v1/meetings', () => {
     expect(result.data.scheduleKnown).toBe(false)
     expect(result.data.meetings).toEqual([
       expect.objectContaining({
-        meetingDate: '2026-05-20',
+        meetingDate: today,
         meetingTime: '20:00',
         meetingTimezone: 'America/Chicago',
         hasBriefing: true,
@@ -332,10 +335,12 @@ describe('GET /v1/meetings', () => {
       ),
     )
 
-    let adhocDate = '2026-05-20'
+    let adhocDate = formatInTimeZone(new Date(), 'UTC', 'yyyy-MM-dd')
     while (projectedDates.has(adhocDate)) {
-      adhocDate = adhocDate.replace(/\d{2}$/, (d) =>
-        String(+d + 1).padStart(2, '0'),
+      adhocDate = formatInTimeZone(
+        addDays(parseIsoDateAsUTC(adhocDate), 1),
+        'UTC',
+        'yyyy-MM-dd',
       )
     }
 
@@ -349,7 +354,7 @@ describe('GET /v1/meetings', () => {
     await service.prisma.meetingBriefing.create({
       data: {
         electedOfficeId: eo.id,
-        meetingDate: new Date(adhocDate + 'T00:00:00Z'),
+        meetingDate: parseIsoDateAsUTC(adhocDate),
         meetingTime: '20:00',
         meetingTimezone: 'America/Denver',
         experimentRunId: briefingRun.runId,

--- a/src/meetings/controllers/meetingsBriefings.controller.test.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.test.ts
@@ -278,6 +278,100 @@ describe('GET /v1/meetings', () => {
         .every((m) => !m.hasBriefing),
     ).toBe(true)
   })
+
+  it('returns actual briefings even when no schedule is known', async () => {
+    const orgSlug = 'eo-briefings-no-schedule'
+    const eo = await seedElectedOffice(orgSlug)
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+      },
+    })
+    await service.prisma.meetingBriefing.create({
+      data: {
+        electedOfficeId: eo.id,
+        meetingDate: new Date('2026-05-20T00:00:00Z'),
+        meetingTime: '20:00',
+        meetingTimezone: 'America/Chicago',
+        experimentRunId: briefingRun.runId,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing-key.json',
+      },
+    })
+
+    const result = await service.client.get('/v1/meetings', {
+      headers: { 'x-organization-slug': orgSlug },
+    })
+
+    expect(result.status).toBe(200)
+    expect(result.data.scheduleKnown).toBe(false)
+    expect(result.data.meetings).toEqual([
+      expect.objectContaining({
+        meetingDate: '2026-05-20',
+        meetingTime: '20:00',
+        meetingTimezone: 'America/Chicago',
+        hasBriefing: true,
+      }),
+    ])
+  })
+
+  it('returns ad-hoc briefings outside the projected RRULE dates', async () => {
+    const orgSlug = 'eo-adhoc-briefing'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedScheduleRun(orgSlug)
+    mockS3({ 'schedule-key.json': JSON.stringify(foundSchedule) })
+
+    const probe = await service.client.get('/v1/meetings', {
+      headers: { 'x-organization-slug': orgSlug },
+    })
+    const projectedDates = new Set(
+      (probe.data.meetings as Array<{ meetingDate: string }>).map(
+        (m) => m.meetingDate,
+      ),
+    )
+
+    let adhocDate = '2026-05-20'
+    while (projectedDates.has(adhocDate)) {
+      adhocDate = adhocDate.replace(/\d{2}$/, (d) =>
+        String(+d + 1).padStart(2, '0'),
+      )
+    }
+
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+      },
+    })
+    await service.prisma.meetingBriefing.create({
+      data: {
+        electedOfficeId: eo.id,
+        meetingDate: new Date(adhocDate + 'T00:00:00Z'),
+        meetingTime: '20:00',
+        meetingTimezone: 'America/Denver',
+        experimentRunId: briefingRun.runId,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing-key.json',
+      },
+    })
+
+    const result = await service.client.get('/v1/meetings', {
+      headers: { 'x-organization-slug': orgSlug },
+    })
+
+    expect(result.status).toBe(200)
+    const adhoc = (
+      result.data.meetings as Array<{
+        meetingDate: string
+        hasBriefing: boolean
+      }>
+    ).find((m) => m.meetingDate === adhocDate)
+    expect(adhoc).toBeDefined()
+    expect(adhoc?.hasBriefing).toBe(true)
+  })
 })
 
 const validBriefingArtifact = {

--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -39,7 +39,9 @@ export class MeetingsBriefingsController {
     const knownSchedule = schedule?.status === 'found' ? schedule : null
 
     const now = new Date()
-    const windowFrom = subMonths(now, 2)
+    const windowFrom = parseIsoDateAsUTC(
+      formatInTimeZone(subMonths(now, 2), 'UTC', 'yyyy-MM-dd'),
+    )
     const windowTo = addMonths(now, 3)
 
     const projectedDates = knownSchedule

--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -6,11 +6,22 @@ import { formatInTimeZone } from 'date-fns-tz'
 import { ReqElectedOffice } from '@/electedOffice/decorators/ReqElectedOffice.decorator'
 import { UseElectedOffice } from '@/electedOffice/decorators/UseElectedOffice.decorator'
 import { S3Service } from '@/vendors/aws/services/s3.service'
+import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import {
   MeetingDateParam,
   MeetingDateParamSchema,
 } from '../schemas/meetingDateParam.schema'
 import { MeetingBriefingsService } from '../services/meetingBriefings.service'
+
+type MeetingListItem = {
+  meetingDate: string
+  meetingTime: string
+  meetingTimezone: string
+  durationMinutes: number
+  meetingName: string
+  location: string
+  hasBriefing: boolean
+}
 
 @Controller('meetings')
 export class MeetingsBriefingsController {
@@ -25,42 +36,68 @@ export class MeetingsBriefingsController {
     const schedule = await this.meetingBriefings.loadLatestScheduleForOrg(
       electedOffice.organizationSlug,
     )
-    if (!schedule || schedule.status === 'not_found') {
-      return { scheduleKnown: false, meetings: [] }
-    }
+    const knownSchedule = schedule?.status === 'found' ? schedule : null
 
     const now = new Date()
-    const dates = this.meetingBriefings.projectMeetingDates({
-      schedule,
-      from: subMonths(now, 2),
-      to: addMonths(now, 3),
-    })
+    const windowFrom = subMonths(now, 2)
+    const windowTo = addMonths(now, 3)
 
-    const briefings = await this.meetingBriefings.findMany({
+    const projectedDates = knownSchedule
+      ? this.meetingBriefings.projectMeetingDates({
+          schedule: knownSchedule,
+          from: windowFrom,
+          to: windowTo,
+        })
+      : []
+
+    const briefingRows = await this.meetingBriefings.findMany({
       where: {
         electedOfficeId: electedOffice.id,
-        meetingDate: { in: dates.map((d) => new Date(d)) },
+        meetingDate: { gte: windowFrom, lte: windowTo },
       },
-      select: { meetingDate: true },
+      select: {
+        meetingDate: true,
+        meetingTime: true,
+        meetingTimezone: true,
+      },
     })
-    const haveBriefing = new Set(
-      briefings.map((b) =>
-        formatInTimeZone(b.meetingDate, 'UTC', 'yyyy-MM-dd'),
-      ),
+
+    const byDate = new Map<string, MeetingListItem>()
+
+    if (knownSchedule) {
+      for (const date of projectedDates) {
+        byDate.set(date, {
+          meetingDate: date,
+          meetingTime: knownSchedule.time,
+          meetingTimezone: knownSchedule.timezone,
+          durationMinutes: knownSchedule.duration_minutes,
+          meetingName: knownSchedule.meeting_name,
+          location: knownSchedule.location,
+          hasBriefing: false,
+        })
+      }
+    }
+
+    for (const row of briefingRows) {
+      const date = formatInTimeZone(row.meetingDate, 'UTC', 'yyyy-MM-dd')
+      const existing = byDate.get(date)
+      byDate.set(date, {
+        meetingDate: date,
+        meetingTime: row.meetingTime,
+        meetingTimezone: row.meetingTimezone,
+        durationMinutes:
+          existing?.durationMinutes ?? knownSchedule?.duration_minutes ?? 0,
+        meetingName: existing?.meetingName ?? knownSchedule?.meeting_name ?? '',
+        location: existing?.location ?? knownSchedule?.location ?? '',
+        hasBriefing: true,
+      })
+    }
+
+    const meetings = [...byDate.values()].sort((a, b) =>
+      a.meetingDate.localeCompare(b.meetingDate),
     )
 
-    return {
-      scheduleKnown: true,
-      meetings: dates.map((d) => ({
-        meetingDate: d,
-        meetingTime: schedule.time,
-        meetingTimezone: schedule.timezone,
-        durationMinutes: schedule.duration_minutes,
-        meetingName: schedule.meeting_name,
-        location: schedule.location,
-        hasBriefing: haveBriefing.has(d),
-      })),
-    }
+    return { scheduleKnown: !!knownSchedule, meetings }
   }
 
   @UseElectedOffice()
@@ -74,7 +111,7 @@ export class MeetingsBriefingsController {
       where: {
         electedOfficeId_meetingDate: {
           electedOfficeId: electedOffice.id,
-          meetingDate: new Date(date),
+          meetingDate: parseIsoDateAsUTC(date),
         },
       },
     })

--- a/src/queue/consumer/queueConsumer.module.ts
+++ b/src/queue/consumer/queueConsumer.module.ts
@@ -14,6 +14,7 @@ import { PollsModule } from 'src/polls/polls.module'
 import { ElectedOfficeModule } from 'src/electedOffice/electedOffice.module'
 import { ContactsModule } from 'src/contacts/contacts.module'
 import { AgentExperimentsModule } from 'src/agentExperiments/agentExperiments.module'
+import { MeetingsModule } from 'src/meetings/meetings.module'
 import { AwsModule } from 'src/vendors/aws/aws.module'
 
 @Module({
@@ -39,6 +40,7 @@ import { AwsModule } from 'src/vendors/aws/aws.module'
     ContactsModule,
     AwsModule,
     AgentExperimentsModule,
+    MeetingsModule,
   ],
   providers: [QueueConsumerService],
 })


### PR DESCRIPTION
The `GET /v1/meetings` list bailed with an empty array whenever the schedule was missing or `not_found`. That hid every actual briefing the org already had, and also dropped any ad-hoc briefing whose date wasn't on the schedule's RRULE.

The list now seeds from the projected RRULE dates (when the schedule is `found`) and overlays every `MeetingBriefing` row in the window. Ad-hoc briefings appear. Orgs without a schedule still see their real briefings. Briefing-backed rows take their time/timezone from the stored row, falling back to the schedule for name/location.

Also fixed the briefing-detail lookup key to use `parseIsoDateAsUTC` — same UTC-vs-local issue the upsert key already had.

Follow-up to #1594.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `GET /v1/meetings` response construction and DB query windowing, which can affect what meetings users see (including ordering and fields) even when schedules are missing or partial.
> 
> **Overview**
> `GET /v1/meetings` no longer returns an empty list when the schedule is missing/`not_found`; it now **merges projected RRULE dates (when available) with all actual `MeetingBriefing` rows in the time window**, so ad-hoc briefings and schedule-less orgs still see real briefings.
> 
> Briefing-backed items now take `meetingTime`/`meetingTimezone` from the stored briefing row (falling back to schedule fields for name/location/duration), and the list is built via a date-keyed map and sorted by `meetingDate`. The briefing detail lookup (`GET /v1/meetings/:date/briefing`) switches to `parseIsoDateAsUTC` to avoid local-vs-UTC date key mismatches.
> 
> Tests add coverage for schedule-less briefings and ad-hoc briefings outside the projected RRULE dates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa1ead4d52a1ad8fa4d45b564a018ac025b1f353. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->