### PR TITLE
artifact feedback schema

### DIFF
--- a/prisma/schema/artifactFeedback.prisma
+++ b/prisma/schema/artifactFeedback.prisma
@@ -1,0 +1,23 @@
+enum ArtifactResourceType {
+  briefing
+}
+
+model ArtifactFeedback {
+  id String @id @default(uuid(7))
+
+  organizationSlug String       @map("organization_slug")
+  organization     Organization @relation(fields: [organizationSlug], references: [slug], onDelete: Cascade)
+
+  submitterUserId Int  @map("submitter_user_id")
+  submitter       User @relation(fields: [submitterUserId], references: [id], onDelete: Cascade)
+
+  artifactId   String               @map("artifact_id")
+  artifactType ArtifactResourceType @map("artifact_type")
+
+  // e.g. "positive" or "negative"
+  feedback String @map("feedback")
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@map("artifact_feedback")
+}

--- a/prisma/schema/migrations/20260515190538_artifact_feedback/migration.sql
+++ b/prisma/schema/migrations/20260515190538_artifact_feedback/migration.sql
@@ -1,0 +1,21 @@
+-- CreateEnum
+CREATE TYPE "ArtifactResourceType" AS ENUM ('briefing');
+
+-- CreateTable
+CREATE TABLE "artifact_feedback" (
+    "id" TEXT NOT NULL,
+    "organization_slug" TEXT NOT NULL,
+    "submitter_user_id" INTEGER NOT NULL,
+    "artifact_id" TEXT NOT NULL,
+    "artifact_type" "ArtifactResourceType" NOT NULL,
+    "feedback" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "artifact_feedback_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "artifact_feedback" ADD CONSTRAINT "artifact_feedback_organization_slug_fkey" FOREIGN KEY ("organization_slug") REFERENCES "organization"("slug") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "artifact_feedback" ADD CONSTRAINT "artifact_feedback_submitter_user_id_fkey" FOREIGN KEY ("submitter_user_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema/organization.prisma
+++ b/prisma/schema/organization.prisma
@@ -1,16 +1,17 @@
 model Organization {
-  createdAt          DateTime          @default(now()) @map("created_at")
-  updatedAt          DateTime          @default(now()) @updatedAt @map("updated_at")
-  slug               String            @id
-  owner              User              @relation(fields: [ownerId], references: [id], onDelete: Cascade)
-  ownerId            Int               @map("owner_id")
-  positionId         String?           @map("position_id")
-  overrideDistrictId String?           @map("override_district_id")
-  customPositionName String?           @map("custom_position_name")
+  createdAt          DateTime           @default(now()) @map("created_at")
+  updatedAt          DateTime           @default(now()) @updatedAt @map("updated_at")
+  slug               String             @id
+  owner              User               @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  ownerId            Int                @map("owner_id")
+  positionId         String?            @map("position_id")
+  overrideDistrictId String?            @map("override_district_id")
+  customPositionName String?            @map("custom_position_name")
   campaign           Campaign?
   electedOffice      ElectedOffice?
   voterFileFilters   VoterFileFilter[]
   experimentRuns     ExperimentRun[]
+  artifactFeedbacks  ArtifactFeedback[]
 
   @@index([ownerId])
   @@map("organization")

--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -31,6 +31,7 @@ model User {
   electedOffices        ElectedOffice[]
   annotations           Annotation[]
   chatConversations     ChatConversation[]
+  artifactFeedbacks     ArtifactFeedback[]
 
   @@index([firstName])
   @@index([lastName])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new persistent storage (table + enum) with cascading foreign keys, which can affect database integrity and deletes if misused. Otherwise changes are schema-only and isolated.
> 
> **Overview**
> Adds a new Prisma schema for `ArtifactFeedback`, including an `ArtifactResourceType` enum (currently only `briefing`) and a migration that creates the `artifact_feedback` table.
> 
> Links feedback records to `Organization` and `User` via new relations on both models, with `ON DELETE CASCADE` foreign keys, and stores `artifact_id`, `artifact_type`, `feedback`, and `created_at`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9487f3bdfe7d51ed00434199182d5d42a1735b10. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->