### PR TITLE
feat(briefings): per-agenda-item summary feedback API

### DIFF
--- a/contracts/src/artifactFeedback/ArtifactFeedback.schema.ts
+++ b/contracts/src/artifactFeedback/ArtifactFeedback.schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+export const ARTIFACT_RESOURCE_TYPE_VALUES = ['agenda_item'] as const
+export const ArtifactResourceTypeSchema = z.enum(ARTIFACT_RESOURCE_TYPE_VALUES)
+export type ArtifactResourceType = z.infer<typeof ArtifactResourceTypeSchema>
+
+export const ARTIFACT_FEEDBACK_KIND_VALUES = ['positive', 'negative'] as const
+export const ArtifactFeedbackKindSchema = z.enum(ARTIFACT_FEEDBACK_KIND_VALUES)
+export type ArtifactFeedbackKind = z.infer<typeof ArtifactFeedbackKindSchema>
+
+export const ArtifactFeedbackSchema = z.object({
+  id: z.string(),
+  organization_slug: z.string(),
+  submitter_user_id: z.number().int(),
+  artifact_type: ArtifactResourceTypeSchema,
+  artifact_id: z.string(),
+  feedback: ArtifactFeedbackKindSchema,
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+export type ArtifactFeedback = z.infer<typeof ArtifactFeedbackSchema>
+
+export const SetArtifactFeedbackRequestSchema = z.object({
+  feedback: ArtifactFeedbackKindSchema,
+})
+export type SetArtifactFeedbackRequest = z.infer<
+  typeof SetArtifactFeedbackRequestSchema
+>
+
+export const ArtifactFeedbackResponseSchema = ArtifactFeedbackSchema
+export type ArtifactFeedbackResponse = z.infer<
+  typeof ArtifactFeedbackResponseSchema
+>
+
+export const BriefingFeedbackListResponseSchema = z.object({
+  feedback: z.array(ArtifactFeedbackSchema),
+})
+export type BriefingFeedbackListResponse = z.infer<
+  typeof BriefingFeedbackListResponseSchema
+>

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -295,3 +295,20 @@ export {
   AnnotationsListResponseSchema,
   type AnnotationsListResponse,
 } from './annotations/Annotation.schema'
+
+export {
+  ARTIFACT_RESOURCE_TYPE_VALUES,
+  ArtifactResourceTypeSchema,
+  type ArtifactResourceType,
+  ARTIFACT_FEEDBACK_KIND_VALUES,
+  ArtifactFeedbackKindSchema,
+  type ArtifactFeedbackKind,
+  ArtifactFeedbackSchema,
+  type ArtifactFeedback,
+  SetArtifactFeedbackRequestSchema,
+  type SetArtifactFeedbackRequest,
+  ArtifactFeedbackResponseSchema,
+  type ArtifactFeedbackResponse,
+  BriefingFeedbackListResponseSchema,
+  type BriefingFeedbackListResponse,
+} from './artifactFeedback/ArtifactFeedback.schema'

--- a/prisma/schema/artifactFeedback.prisma
+++ b/prisma/schema/artifactFeedback.prisma
@@ -13,6 +13,9 @@ model ArtifactFeedback {
   organizationSlug String       @map("organization_slug")
   organization     Organization @relation(fields: [organizationSlug], references: [slug], onDelete: Cascade)
 
+  briefingId String          @map("briefing_id")
+  briefing   MeetingBriefing @relation(fields: [briefingId], references: [id], onDelete: Cascade)
+
   submitterUserId Int  @map("submitter_user_id")
   submitter       User @relation(fields: [submitterUserId], references: [id], onDelete: Cascade)
 
@@ -24,8 +27,8 @@ model ArtifactFeedback {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
-  @@unique([submitterUserId, artifactId, artifactType], map: "artifact_feedback_user_artifact_unique")
+  @@unique([submitterUserId, briefingId, artifactId, artifactType], map: "artifact_feedback_user_briefing_item_unique")
   @@index([organizationSlug])
-  @@index([artifactType, artifactId])
+  @@index([briefingId])
   @@map("artifact_feedback")
 }

--- a/prisma/schema/artifactFeedback.prisma
+++ b/prisma/schema/artifactFeedback.prisma
@@ -1,5 +1,10 @@
 enum ArtifactResourceType {
-  briefing
+  agenda_item
+}
+
+enum ArtifactFeedbackKind {
+  positive
+  negative
 }
 
 model ArtifactFeedback {
@@ -14,10 +19,13 @@ model ArtifactFeedback {
   artifactId   String               @map("artifact_id")
   artifactType ArtifactResourceType @map("artifact_type")
 
-  // e.g. "positive" or "negative"
-  feedback String @map("feedback")
+  feedback ArtifactFeedbackKind
 
   createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
+  @@unique([submitterUserId, artifactId, artifactType], map: "artifact_feedback_user_artifact_unique")
+  @@index([organizationSlug])
+  @@index([artifactType, artifactId])
   @@map("artifact_feedback")
 }

--- a/prisma/schema/meetingBriefing.prisma
+++ b/prisma/schema/meetingBriefing.prisma
@@ -14,6 +14,8 @@ model MeetingBriefing {
   artifactBucket String @map("artifact_bucket")
   artifactKey    String @map("artifact_key")
 
+  artifactFeedback ArtifactFeedback[]
+
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 

--- a/prisma/schema/migrations/20260515193000_artifact_feedback_per_agenda_item/migration.sql
+++ b/prisma/schema/migrations/20260515193000_artifact_feedback_per_agenda_item/migration.sql
@@ -1,19 +1,31 @@
+DELETE FROM "artifact_feedback";
+
 ALTER TABLE "artifact_feedback" DROP COLUMN "artifact_type";
 DROP TYPE "ArtifactResourceType";
 CREATE TYPE "ArtifactResourceType" AS ENUM ('agenda_item');
-ALTER TABLE "artifact_feedback" ADD COLUMN "artifact_type" "ArtifactResourceType" NOT NULL;
+ALTER TABLE "artifact_feedback"
+  ADD COLUMN "artifact_type" "ArtifactResourceType" NOT NULL DEFAULT 'agenda_item';
+ALTER TABLE "artifact_feedback" ALTER COLUMN "artifact_type" DROP DEFAULT;
 
 ALTER TABLE "artifact_feedback" DROP COLUMN "feedback";
 CREATE TYPE "ArtifactFeedbackKind" AS ENUM ('positive', 'negative');
-ALTER TABLE "artifact_feedback" ADD COLUMN "feedback" "ArtifactFeedbackKind" NOT NULL;
+ALTER TABLE "artifact_feedback"
+  ADD COLUMN "feedback" "ArtifactFeedbackKind" NOT NULL DEFAULT 'positive';
+ALTER TABLE "artifact_feedback" ALTER COLUMN "feedback" DROP DEFAULT;
 
-ALTER TABLE "artifact_feedback" ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "artifact_feedback"
+  ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
 
-CREATE UNIQUE INDEX "artifact_feedback_user_artifact_unique"
-  ON "artifact_feedback" ("submitter_user_id", "artifact_id", "artifact_type");
+ALTER TABLE "artifact_feedback" ADD COLUMN "briefing_id" TEXT NOT NULL;
+ALTER TABLE "artifact_feedback"
+  ADD CONSTRAINT "artifact_feedback_briefing_id_fkey"
+  FOREIGN KEY ("briefing_id") REFERENCES "meeting_briefing" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE UNIQUE INDEX "artifact_feedback_user_briefing_item_unique"
+  ON "artifact_feedback" ("submitter_user_id", "briefing_id", "artifact_id", "artifact_type");
 
 CREATE INDEX "artifact_feedback_organization_slug_idx"
   ON "artifact_feedback" ("organization_slug");
 
-CREATE INDEX "artifact_feedback_artifact_type_artifact_id_idx"
-  ON "artifact_feedback" ("artifact_type", "artifact_id");
+CREATE INDEX "artifact_feedback_briefing_id_idx"
+  ON "artifact_feedback" ("briefing_id");

--- a/prisma/schema/migrations/20260515193000_artifact_feedback_per_agenda_item/migration.sql
+++ b/prisma/schema/migrations/20260515193000_artifact_feedback_per_agenda_item/migration.sql
@@ -1,0 +1,19 @@
+ALTER TABLE "artifact_feedback" DROP COLUMN "artifact_type";
+DROP TYPE "ArtifactResourceType";
+CREATE TYPE "ArtifactResourceType" AS ENUM ('agenda_item');
+ALTER TABLE "artifact_feedback" ADD COLUMN "artifact_type" "ArtifactResourceType" NOT NULL;
+
+ALTER TABLE "artifact_feedback" DROP COLUMN "feedback";
+CREATE TYPE "ArtifactFeedbackKind" AS ENUM ('positive', 'negative');
+ALTER TABLE "artifact_feedback" ADD COLUMN "feedback" "ArtifactFeedbackKind" NOT NULL;
+
+ALTER TABLE "artifact_feedback" ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE UNIQUE INDEX "artifact_feedback_user_artifact_unique"
+  ON "artifact_feedback" ("submitter_user_id", "artifact_id", "artifact_type");
+
+CREATE INDEX "artifact_feedback_organization_slug_idx"
+  ON "artifact_feedback" ("organization_slug");
+
+CREATE INDEX "artifact_feedback_artifact_type_artifact_id_idx"
+  ON "artifact_feedback" ("artifact_type", "artifact_id");

--- a/src/annotations/services/annotations.service.ts
+++ b/src/annotations/services/annotations.service.ts
@@ -9,7 +9,7 @@ import {
   CreateAnnotationRequest,
 } from '@goodparty_org/contracts'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
-import { parseIsoDateAsUTC } from '@/shared/util/date.util'
+import { resolveBriefingId } from '@/meetings/util/resolveBriefingId'
 
 const MAX_ANNOTATIONS_PER_USER_PER_BRIEFING = 200
 
@@ -63,29 +63,6 @@ function toDTO(row: AnnotationWithRelations): AnnotationDTO {
 @Injectable()
 export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
   /**
-   * Resolve the MeetingBriefing for the active elected office and meeting
-   * date. Throws NotFound when no briefing exists at that date for the
-   * authorized office; uses the same lookup key as
-   * `GET /v1/meetings/:date/briefing`.
-   */
-  private async resolveBriefingId(
-    meetingDate: string,
-    electedOffice: ElectedOffice,
-  ): Promise<string> {
-    const briefing = await this.client.meetingBriefing.findUnique({
-      where: {
-        electedOfficeId_meetingDate: {
-          electedOfficeId: electedOffice.id,
-          meetingDate: parseIsoDateAsUTC(meetingDate),
-        },
-      },
-      select: { id: true },
-    })
-    if (!briefing) throw new NotFoundException('briefing_not_found')
-    return briefing.id
-  }
-
-  /**
    * Verify the user is authorized for the annotation's underlying briefing.
    * Used on update/delete by annotation id, where the URL no longer carries
    * the date.
@@ -109,7 +86,11 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
     userId: number,
     electedOffice: ElectedOffice,
   ): Promise<AnnotationDTO[]> {
-    const briefingId = await this.resolveBriefingId(meetingDate, electedOffice)
+    const briefingId = await resolveBriefingId(
+      this.client,
+      meetingDate,
+      electedOffice,
+    )
     const rows = await this.client.annotation.findMany({
       where: {
         resourceType: 'briefing',
@@ -128,7 +109,11 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
     electedOffice: ElectedOffice,
     input: CreateAnnotationRequest,
   ): Promise<AnnotationDTO> {
-    const briefingId = await this.resolveBriefingId(meetingDate, electedOffice)
+    const briefingId = await resolveBriefingId(
+      this.client,
+      meetingDate,
+      electedOffice,
+    )
 
     const anchorFields = {
       jsonPath: input.anchor.json_path,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,7 @@ import { OnboardingModule } from '@/onboarding/onboarding.module'
 import { PaymentsModule } from '@/payments/payments.module'
 import { MeetingsModule } from '@/meetings/meetings.module'
 import { AnnotationsModule } from '@/annotations/annotations.module'
+import { ArtifactFeedbackModule } from '@/artifactFeedback/artifactFeedback.module'
 import { PollsModule } from '@/polls/polls.module'
 import { PrismaModule } from '@/prisma/prisma.module'
 import { QueueConsumerModule } from '@/queue/consumer/queueConsumer.module'
@@ -83,6 +84,7 @@ import { loggerModule } from './observability/logging/logger-module'
     PollsModule,
     MeetingsModule,
     AnnotationsModule,
+    ArtifactFeedbackModule,
     ElectedOfficeModule,
     OrganizationsModule,
     OnboardingModule,

--- a/src/artifactFeedback/artifactFeedback.module.ts
+++ b/src/artifactFeedback/artifactFeedback.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common'
+import { ElectedOfficeModule } from '@/electedOffice/electedOffice.module'
+import { BriefingFeedbackController } from './controllers/briefingFeedback.controller'
+import { BriefingItemFeedbackController } from './controllers/briefingItemFeedback.controller'
+import { ArtifactFeedbackService } from './services/artifactFeedback.service'
+
+@Module({
+  imports: [ElectedOfficeModule],
+  controllers: [BriefingFeedbackController, BriefingItemFeedbackController],
+  providers: [ArtifactFeedbackService],
+  exports: [ArtifactFeedbackService],
+})
+export class ArtifactFeedbackModule {}

--- a/src/artifactFeedback/controllers/briefingFeedback.controller.ts
+++ b/src/artifactFeedback/controllers/briefingFeedback.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Param } from '@nestjs/common'
+import { ZodValidationPipe } from 'nestjs-zod'
+import { ElectedOffice, User } from '@prisma/client'
+import { BriefingFeedbackListResponseSchema } from '@goodparty_org/contracts'
+import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import { ReqElectedOffice } from '@/electedOffice/decorators/ReqElectedOffice.decorator'
+import { UseElectedOffice } from '@/electedOffice/decorators/UseElectedOffice.decorator'
+import { ReqUser } from '@/authentication/decorators/ReqUser.decorator'
+import {
+  MeetingDateParam,
+  MeetingDateParamSchema,
+} from '@/meetings/schemas/meetingDateParam.schema'
+import { ArtifactFeedbackService } from '../services/artifactFeedback.service'
+
+@Controller('meetings/:date/briefing/feedback')
+export class BriefingFeedbackController {
+  constructor(private readonly feedback: ArtifactFeedbackService) {}
+
+  @UseElectedOffice()
+  @Get()
+  @ResponseSchema(BriefingFeedbackListResponseSchema)
+  async list(
+    @Param(new ZodValidationPipe(MeetingDateParamSchema))
+    { date }: MeetingDateParam,
+    @ReqUser() user: User,
+    @ReqElectedOffice() electedOffice: ElectedOffice,
+  ) {
+    const feedback = await this.feedback.listMineForBriefing({
+      meetingDate: date,
+      userId: user.id,
+      electedOffice,
+    })
+    return { feedback }
+  }
+}

--- a/src/artifactFeedback/controllers/briefingItemFeedback.controller.ts
+++ b/src/artifactFeedback/controllers/briefingItemFeedback.controller.ts
@@ -1,0 +1,59 @@
+import { Body, Controller, Delete, HttpCode, Param, Put } from '@nestjs/common'
+import { ZodValidationPipe } from 'nestjs-zod'
+import { ElectedOffice, User } from '@prisma/client'
+import {
+  ArtifactFeedbackResponseSchema,
+  SetArtifactFeedbackRequest,
+  SetArtifactFeedbackRequestSchema,
+} from '@goodparty_org/contracts'
+import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import { ReqElectedOffice } from '@/electedOffice/decorators/ReqElectedOffice.decorator'
+import { UseElectedOffice } from '@/electedOffice/decorators/UseElectedOffice.decorator'
+import { ReqUser } from '@/authentication/decorators/ReqUser.decorator'
+import {
+  BriefingItemParam,
+  BriefingItemParamSchema,
+} from '../schemas/briefingItemParam.schema'
+import { ArtifactFeedbackService } from '../services/artifactFeedback.service'
+
+@Controller('meetings/:date/briefing/items/:itemId/feedback')
+export class BriefingItemFeedbackController {
+  constructor(private readonly feedback: ArtifactFeedbackService) {}
+
+  @UseElectedOffice()
+  @Put()
+  @ResponseSchema(ArtifactFeedbackResponseSchema)
+  async set(
+    @Param(new ZodValidationPipe(BriefingItemParamSchema))
+    { date, itemId }: BriefingItemParam,
+    @ReqUser() user: User,
+    @ReqElectedOffice() electedOffice: ElectedOffice,
+    @Body(new ZodValidationPipe(SetArtifactFeedbackRequestSchema))
+    body: SetArtifactFeedbackRequest,
+  ) {
+    return this.feedback.setForItem({
+      meetingDate: date,
+      itemId,
+      userId: user.id,
+      electedOffice,
+      feedback: body.feedback,
+    })
+  }
+
+  @UseElectedOffice()
+  @Delete()
+  @HttpCode(204)
+  async clear(
+    @Param(new ZodValidationPipe(BriefingItemParamSchema))
+    { date, itemId }: BriefingItemParam,
+    @ReqUser() user: User,
+    @ReqElectedOffice() electedOffice: ElectedOffice,
+  ): Promise<void> {
+    await this.feedback.clearForItem({
+      meetingDate: date,
+      itemId,
+      userId: user.id,
+      electedOffice,
+    })
+  }
+}

--- a/src/artifactFeedback/schemas/briefingItemParam.schema.ts
+++ b/src/artifactFeedback/schemas/briefingItemParam.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const BriefingItemParamSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, {
+    message: 'date must be YYYY-MM-DD',
+  }),
+  itemId: z.string().min(1),
+})
+
+export type BriefingItemParam = z.infer<typeof BriefingItemParamSchema>

--- a/src/artifactFeedback/services/artifactFeedback.service.ts
+++ b/src/artifactFeedback/services/artifactFeedback.service.ts
@@ -1,0 +1,125 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
+import {
+  ArtifactFeedback as ArtifactFeedbackRow,
+  ArtifactFeedbackKind,
+  ArtifactResourceType,
+  ElectedOffice,
+  Prisma,
+} from '@prisma/client'
+import { ArtifactFeedback as ArtifactFeedbackDTO } from '@goodparty_org/contracts'
+import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
+import { parseIsoDateAsUTC } from '@/shared/util/date.util'
+
+type BriefingScope = {
+  meetingDate: string
+  userId: number
+  electedOffice: ElectedOffice
+}
+
+type ItemScope = BriefingScope & { itemId: string }
+
+type SetFeedbackArgs = ItemScope & { feedback: ArtifactFeedbackKind }
+
+function toDTO(row: ArtifactFeedbackRow): ArtifactFeedbackDTO {
+  return {
+    id: row.id,
+    organization_slug: row.organizationSlug,
+    submitter_user_id: row.submitterUserId,
+    artifact_type: row.artifactType,
+    artifact_id: row.artifactId,
+    feedback: row.feedback,
+    created_at: row.createdAt.toISOString(),
+    updated_at: row.updatedAt.toISOString(),
+  }
+}
+
+@Injectable()
+export class ArtifactFeedbackService extends createPrismaBase(
+  MODELS.ArtifactFeedback,
+) {
+  private async resolveBriefingId(
+    meetingDate: string,
+    electedOffice: ElectedOffice,
+  ): Promise<string> {
+    const briefing = await this.client.meetingBriefing.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: electedOffice.id,
+          meetingDate: parseIsoDateAsUTC(meetingDate),
+        },
+      },
+      select: { id: true },
+    })
+    if (!briefing) throw new NotFoundException('briefing_not_found')
+    return briefing.id
+  }
+
+  async listMineForBriefing(
+    args: BriefingScope,
+  ): Promise<ArtifactFeedbackDTO[]> {
+    const { meetingDate, userId, electedOffice } = args
+    await this.resolveBriefingId(meetingDate, electedOffice)
+    const rows = await this.client.artifactFeedback.findMany({
+      where: {
+        organizationSlug: electedOffice.organizationSlug,
+        submitterUserId: userId,
+        artifactType: ArtifactResourceType.agenda_item,
+      },
+      orderBy: { updatedAt: 'desc' },
+    })
+    return rows.map(toDTO)
+  }
+
+  async setForItem(args: SetFeedbackArgs): Promise<ArtifactFeedbackDTO> {
+    const { meetingDate, itemId, userId, electedOffice, feedback } = args
+    await this.resolveBriefingId(meetingDate, electedOffice)
+
+    const row = await this.client.$transaction(
+      async (tx) => {
+        return tx.artifactFeedback.upsert({
+          where: {
+            submitterUserId_artifactId_artifactType: {
+              submitterUserId: userId,
+              artifactId: itemId,
+              artifactType: ArtifactResourceType.agenda_item,
+            },
+          },
+          create: {
+            organizationSlug: electedOffice.organizationSlug,
+            submitterUserId: userId,
+            artifactId: itemId,
+            artifactType: ArtifactResourceType.agenda_item,
+            feedback,
+          },
+          update: {
+            feedback,
+            organizationSlug: electedOffice.organizationSlug,
+          },
+        })
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    )
+
+    if (row.organizationSlug !== electedOffice.organizationSlug) {
+      throw new ForbiddenException('feedback_not_accessible')
+    }
+    return toDTO(row)
+  }
+
+  async clearForItem(args: ItemScope): Promise<void> {
+    const { meetingDate, itemId, userId, electedOffice } = args
+    await this.resolveBriefingId(meetingDate, electedOffice)
+    await this.client.artifactFeedback.deleteMany({
+      where: {
+        organizationSlug: electedOffice.organizationSlug,
+        submitterUserId: userId,
+        artifactId: itemId,
+        artifactType: ArtifactResourceType.agenda_item,
+      },
+    })
+  }
+}

--- a/src/artifactFeedback/services/artifactFeedback.service.ts
+++ b/src/artifactFeedback/services/artifactFeedback.service.ts
@@ -4,7 +4,6 @@ import {
   ArtifactFeedbackKind,
   ArtifactResourceType,
   ElectedOffice,
-  Prisma,
 } from '@prisma/client'
 import { ArtifactFeedback as ArtifactFeedbackDTO } from '@goodparty_org/contracts'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
@@ -65,29 +64,25 @@ export class ArtifactFeedbackService extends createPrismaBase(
       electedOffice,
     )
 
-    const row = await this.client.$transaction(
-      (tx) =>
-        tx.artifactFeedback.upsert({
-          where: {
-            submitterUserId_briefingId_artifactId_artifactType: {
-              submitterUserId: userId,
-              briefingId,
-              artifactId: itemId,
-              artifactType: ArtifactResourceType.agenda_item,
-            },
-          },
-          create: {
-            organizationSlug: electedOffice.organizationSlug,
-            briefingId,
-            submitterUserId: userId,
-            artifactId: itemId,
-            artifactType: ArtifactResourceType.agenda_item,
-            feedback,
-          },
-          update: { feedback },
-        }),
-      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
-    )
+    const row = await this.client.artifactFeedback.upsert({
+      where: {
+        submitterUserId_briefingId_artifactId_artifactType: {
+          submitterUserId: userId,
+          briefingId,
+          artifactId: itemId,
+          artifactType: ArtifactResourceType.agenda_item,
+        },
+      },
+      create: {
+        organizationSlug: electedOffice.organizationSlug,
+        briefingId,
+        submitterUserId: userId,
+        artifactId: itemId,
+        artifactType: ArtifactResourceType.agenda_item,
+        feedback,
+      },
+      update: { feedback },
+    })
 
     return toDTO(row)
   }

--- a/src/artifactFeedback/services/artifactFeedback.service.ts
+++ b/src/artifactFeedback/services/artifactFeedback.service.ts
@@ -1,8 +1,4 @@
-import {
-  ForbiddenException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common'
+import { Injectable } from '@nestjs/common'
 import {
   ArtifactFeedback as ArtifactFeedbackRow,
   ArtifactFeedbackKind,
@@ -12,7 +8,7 @@ import {
 } from '@prisma/client'
 import { ArtifactFeedback as ArtifactFeedbackDTO } from '@goodparty_org/contracts'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
-import { parseIsoDateAsUTC } from '@/shared/util/date.util'
+import { resolveBriefingId } from '@/meetings/util/resolveBriefingId'
 
 type BriefingScope = {
   meetingDate: string
@@ -41,31 +37,18 @@ function toDTO(row: ArtifactFeedbackRow): ArtifactFeedbackDTO {
 export class ArtifactFeedbackService extends createPrismaBase(
   MODELS.ArtifactFeedback,
 ) {
-  private async resolveBriefingId(
-    meetingDate: string,
-    electedOffice: ElectedOffice,
-  ): Promise<string> {
-    const briefing = await this.client.meetingBriefing.findUnique({
-      where: {
-        electedOfficeId_meetingDate: {
-          electedOfficeId: electedOffice.id,
-          meetingDate: parseIsoDateAsUTC(meetingDate),
-        },
-      },
-      select: { id: true },
-    })
-    if (!briefing) throw new NotFoundException('briefing_not_found')
-    return briefing.id
-  }
-
   async listMineForBriefing(
     args: BriefingScope,
   ): Promise<ArtifactFeedbackDTO[]> {
     const { meetingDate, userId, electedOffice } = args
-    await this.resolveBriefingId(meetingDate, electedOffice)
+    const briefingId = await resolveBriefingId(
+      this.client,
+      meetingDate,
+      electedOffice,
+    )
     const rows = await this.client.artifactFeedback.findMany({
       where: {
-        organizationSlug: electedOffice.organizationSlug,
+        briefingId,
         submitterUserId: userId,
         artifactType: ArtifactResourceType.agenda_item,
       },
@@ -76,46 +59,49 @@ export class ArtifactFeedbackService extends createPrismaBase(
 
   async setForItem(args: SetFeedbackArgs): Promise<ArtifactFeedbackDTO> {
     const { meetingDate, itemId, userId, electedOffice, feedback } = args
-    await this.resolveBriefingId(meetingDate, electedOffice)
+    const briefingId = await resolveBriefingId(
+      this.client,
+      meetingDate,
+      electedOffice,
+    )
 
     const row = await this.client.$transaction(
-      async (tx) => {
-        return tx.artifactFeedback.upsert({
+      (tx) =>
+        tx.artifactFeedback.upsert({
           where: {
-            submitterUserId_artifactId_artifactType: {
+            submitterUserId_briefingId_artifactId_artifactType: {
               submitterUserId: userId,
+              briefingId,
               artifactId: itemId,
               artifactType: ArtifactResourceType.agenda_item,
             },
           },
           create: {
             organizationSlug: electedOffice.organizationSlug,
+            briefingId,
             submitterUserId: userId,
             artifactId: itemId,
             artifactType: ArtifactResourceType.agenda_item,
             feedback,
           },
-          update: {
-            feedback,
-            organizationSlug: electedOffice.organizationSlug,
-          },
-        })
-      },
+          update: { feedback },
+        }),
       { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
     )
 
-    if (row.organizationSlug !== electedOffice.organizationSlug) {
-      throw new ForbiddenException('feedback_not_accessible')
-    }
     return toDTO(row)
   }
 
   async clearForItem(args: ItemScope): Promise<void> {
     const { meetingDate, itemId, userId, electedOffice } = args
-    await this.resolveBriefingId(meetingDate, electedOffice)
+    const briefingId = await resolveBriefingId(
+      this.client,
+      meetingDate,
+      electedOffice,
+    )
     await this.client.artifactFeedback.deleteMany({
       where: {
-        organizationSlug: electedOffice.organizationSlug,
+        briefingId,
         submitterUserId: userId,
         artifactId: itemId,
         artifactType: ArtifactResourceType.agenda_item,

--- a/src/artifactFeedback/tests/briefingItemFeedback.controller.test.ts
+++ b/src/artifactFeedback/tests/briefingItemFeedback.controller.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it } from 'vitest'
+import { ExperimentRunStatus } from '@prisma/client'
+import { useTestService } from '@/test-service'
+
+const service = useTestService()
+
+const seedElectedOffice = async (orgSlug: string, userId?: number) => {
+  await service.prisma.organization.create({
+    data: { slug: orgSlug, ownerId: userId ?? service.user.id },
+  })
+  return service.prisma.electedOffice.create({
+    data: {
+      organizationSlug: orgSlug,
+      userId: userId ?? service.user.id,
+    },
+  })
+}
+
+const seedBriefing = async (
+  eoId: string,
+  orgSlug: string,
+  meetingDate: string,
+) => {
+  const briefingRun = await service.prisma.experimentRun.create({
+    data: {
+      organizationSlug: orgSlug,
+      experimentType: 'meeting_briefing',
+      status: ExperimentRunStatus.COMPLETED,
+    },
+  })
+  return service.prisma.meetingBriefing.create({
+    data: {
+      electedOfficeId: eoId,
+      meetingDate: new Date(meetingDate + 'T00:00:00Z'),
+      meetingTime: '19:00',
+      meetingTimezone: 'America/Denver',
+      experimentRunId: briefingRun.runId,
+      artifactBucket: 'briefing-bucket',
+      artifactKey: `${meetingDate}.json`,
+    },
+  })
+}
+
+const orgHeader = (slug: string) => ({
+  headers: { 'x-organization-slug': slug },
+})
+
+const ITEM_ID = 'item_alpha_uuid'
+const OTHER_ITEM_ID = 'item_beta_uuid'
+const DATE = '2026-06-08'
+const NO_BRIEFING_FOR_DATE_TEST =
+  'returns 404 when no briefing exists for the date'
+
+describe('PUT /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
+  it('creates the feedback row when none exists', async () => {
+    const orgSlug = 'eo-fb-create'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    const result = await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'positive' },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data).toMatchObject({
+      organization_slug: orgSlug,
+      submitter_user_id: service.user.id,
+      artifact_type: 'agenda_item',
+      artifact_id: ITEM_ID,
+      feedback: 'positive',
+    })
+
+    const rows = await service.prisma.artifactFeedback.findMany({
+      where: { submitterUserId: service.user.id, artifactId: ITEM_ID },
+    })
+    expect(rows).toHaveLength(1)
+  })
+
+  it('switching positive -> negative updates the same row in place', async () => {
+    const orgSlug = 'eo-fb-switch'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    const first = await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'positive' },
+      orgHeader(orgSlug),
+    )
+    const second = await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'negative' },
+      orgHeader(orgSlug),
+    )
+
+    expect(second.status).toBe(200)
+    expect(second.data.id).toBe(first.data.id)
+    expect(second.data.feedback).toBe('negative')
+
+    const rows = await service.prisma.artifactFeedback.findMany({
+      where: { submitterUserId: service.user.id, artifactId: ITEM_ID },
+    })
+    expect(rows).toHaveLength(1)
+    expect(rows[0].feedback).toBe('negative')
+  })
+
+  it('repeating the same vote is idempotent (single row)', async () => {
+    const orgSlug = 'eo-fb-idempotent'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'positive' },
+      orgHeader(orgSlug),
+    )
+    await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'positive' },
+      orgHeader(orgSlug),
+    )
+
+    const rows = await service.prisma.artifactFeedback.findMany({
+      where: { submitterUserId: service.user.id, artifactId: ITEM_ID },
+    })
+    expect(rows).toHaveLength(1)
+  })
+
+  it('rejects an invalid feedback value', async () => {
+    const orgSlug = 'eo-fb-bad-value'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    const result = await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'maybe' },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it(NO_BRIEFING_FOR_DATE_TEST, async () => {
+    const orgSlug = 'eo-fb-no-briefing'
+    await seedElectedOffice(orgSlug)
+
+    const result = await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'positive' },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(404)
+  })
+
+  it('returns 404 when the org slug does not match the user', async () => {
+    const orgSlug = 'eo-fb-foreign-org'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    const result = await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'positive' },
+      orgHeader('not-my-org'),
+    )
+
+    expect(result.status).toBe(404)
+  })
+
+  it('two users can vote on the same item without colliding', async () => {
+    const orgSlug = 'eo-fb-two-users'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    const otherUser = await service.prisma.user.create({
+      data: {
+        clerkId: 'fb_other_user',
+        email: 'fb-other@goodparty.org',
+        firstName: 'Other',
+        lastName: 'User',
+      },
+    })
+
+    await service.prisma.artifactFeedback.create({
+      data: {
+        organizationSlug: orgSlug,
+        submitterUserId: otherUser.id,
+        artifactId: ITEM_ID,
+        artifactType: 'agenda_item',
+        feedback: 'negative',
+      },
+    })
+
+    const result = await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'positive' },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(200)
+    const rows = await service.prisma.artifactFeedback.findMany({
+      where: { artifactId: ITEM_ID },
+      orderBy: { submitterUserId: 'asc' },
+    })
+    expect(rows).toHaveLength(2)
+    const mine = rows.find((r) => r.submitterUserId === service.user.id)
+    const theirs = rows.find((r) => r.submitterUserId === otherUser.id)
+    expect(mine?.feedback).toBe('positive')
+    expect(theirs?.feedback).toBe('negative')
+  })
+})
+
+describe('DELETE /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
+  it('deletes the row and returns 204', async () => {
+    const orgSlug = 'eo-fb-delete'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    await service.prisma.artifactFeedback.create({
+      data: {
+        organizationSlug: orgSlug,
+        submitterUserId: service.user.id,
+        artifactId: ITEM_ID,
+        artifactType: 'agenda_item',
+        feedback: 'positive',
+      },
+    })
+
+    const result = await service.client.delete(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(204)
+    const remaining = await service.prisma.artifactFeedback.findMany({
+      where: { submitterUserId: service.user.id, artifactId: ITEM_ID },
+    })
+    expect(remaining).toHaveLength(0)
+  })
+
+  it('is idempotent when no row exists (still 204)', async () => {
+    const orgSlug = 'eo-fb-delete-noop'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    const result = await service.client.delete(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(204)
+  })
+
+  it('does not touch another user feedback for the same item', async () => {
+    const orgSlug = 'eo-fb-delete-isolation'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    const otherUser = await service.prisma.user.create({
+      data: {
+        clerkId: 'fb_delete_other',
+        email: 'fb-delete-other@goodparty.org',
+        firstName: 'Other',
+        lastName: 'User',
+      },
+    })
+
+    await service.prisma.artifactFeedback.create({
+      data: {
+        organizationSlug: orgSlug,
+        submitterUserId: otherUser.id,
+        artifactId: ITEM_ID,
+        artifactType: 'agenda_item',
+        feedback: 'positive',
+      },
+    })
+
+    await service.client.delete(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      orgHeader(orgSlug),
+    )
+
+    const remaining = await service.prisma.artifactFeedback.findMany({
+      where: { artifactId: ITEM_ID },
+    })
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].submitterUserId).toBe(otherUser.id)
+  })
+
+  it(NO_BRIEFING_FOR_DATE_TEST, async () => {
+    const orgSlug = 'eo-fb-delete-404'
+    await seedElectedOffice(orgSlug)
+
+    const result = await service.client.delete(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(404)
+  })
+})
+
+describe('GET /v1/meetings/:date/briefing/feedback', () => {
+  it('returns only the requesting user own feedback rows', async () => {
+    const orgSlug = 'eo-fb-list-isolation'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    const otherUser = await service.prisma.user.create({
+      data: {
+        clerkId: 'fb_list_other',
+        email: 'fb-list-other@goodparty.org',
+        firstName: 'Other',
+        lastName: 'User',
+      },
+    })
+
+    await service.prisma.artifactFeedback.createMany({
+      data: [
+        {
+          organizationSlug: orgSlug,
+          submitterUserId: service.user.id,
+          artifactId: ITEM_ID,
+          artifactType: 'agenda_item',
+          feedback: 'positive',
+        },
+        {
+          organizationSlug: orgSlug,
+          submitterUserId: service.user.id,
+          artifactId: OTHER_ITEM_ID,
+          artifactType: 'agenda_item',
+          feedback: 'negative',
+        },
+        {
+          organizationSlug: orgSlug,
+          submitterUserId: otherUser.id,
+          artifactId: ITEM_ID,
+          artifactType: 'agenda_item',
+          feedback: 'negative',
+        },
+      ],
+    })
+
+    const result = await service.client.get(
+      `/v1/meetings/${DATE}/briefing/feedback`,
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data.feedback).toHaveLength(2)
+    const byItem = Object.fromEntries(
+      result.data.feedback.map(
+        (f: { artifact_id: string; feedback: string }) => [
+          f.artifact_id,
+          f.feedback,
+        ],
+      ),
+    )
+    expect(byItem[ITEM_ID]).toBe('positive')
+    expect(byItem[OTHER_ITEM_ID]).toBe('negative')
+  })
+
+  it('returns empty list when the user has no feedback', async () => {
+    const orgSlug = 'eo-fb-list-empty'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    const result = await service.client.get(
+      `/v1/meetings/${DATE}/briefing/feedback`,
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data.feedback).toEqual([])
+  })
+
+  it(NO_BRIEFING_FOR_DATE_TEST, async () => {
+    const orgSlug = 'eo-fb-list-no-briefing'
+    await seedElectedOffice(orgSlug)
+
+    const result = await service.client.get(
+      `/v1/meetings/${DATE}/briefing/feedback`,
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(404)
+  })
+})

--- a/src/artifactFeedback/tests/briefingItemFeedback.controller.test.ts
+++ b/src/artifactFeedback/tests/briefingItemFeedback.controller.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ExperimentRunStatus } from '@prisma/client'
+import { ExperimentRunStatus, MeetingBriefing } from '@prisma/client'
 import { useTestService } from '@/test-service'
 
 const service = useTestService()
@@ -20,7 +20,7 @@ const seedBriefing = async (
   eoId: string,
   orgSlug: string,
   meetingDate: string,
-) => {
+): Promise<MeetingBriefing> => {
   const briefingRun = await service.prisma.experimentRun.create({
     data: {
       organizationSlug: orgSlug,
@@ -48,6 +48,7 @@ const orgHeader = (slug: string) => ({
 const ITEM_ID = 'item_alpha_uuid'
 const OTHER_ITEM_ID = 'item_beta_uuid'
 const DATE = '2026-06-08'
+const OTHER_DATE = '2026-06-15'
 const NO_BRIEFING_FOR_DATE_TEST =
   'returns 404 when no briefing exists for the date'
 
@@ -55,7 +56,7 @@ describe('PUT /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
   it('creates the feedback row when none exists', async () => {
     const orgSlug = 'eo-fb-create'
     const eo = await seedElectedOffice(orgSlug)
-    await seedBriefing(eo.id, orgSlug, DATE)
+    const briefing = await seedBriefing(eo.id, orgSlug, DATE)
 
     const result = await service.client.put(
       `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
@@ -73,15 +74,16 @@ describe('PUT /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
     })
 
     const rows = await service.prisma.artifactFeedback.findMany({
-      where: { submitterUserId: service.user.id, artifactId: ITEM_ID },
+      where: { briefingId: briefing.id, submitterUserId: service.user.id },
     })
     expect(rows).toHaveLength(1)
+    expect(rows[0].artifactId).toBe(ITEM_ID)
   })
 
   it('switching positive -> negative updates the same row in place', async () => {
     const orgSlug = 'eo-fb-switch'
     const eo = await seedElectedOffice(orgSlug)
-    await seedBriefing(eo.id, orgSlug, DATE)
+    const briefing = await seedBriefing(eo.id, orgSlug, DATE)
 
     const first = await service.client.put(
       `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
@@ -99,7 +101,7 @@ describe('PUT /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
     expect(second.data.feedback).toBe('negative')
 
     const rows = await service.prisma.artifactFeedback.findMany({
-      where: { submitterUserId: service.user.id, artifactId: ITEM_ID },
+      where: { briefingId: briefing.id, submitterUserId: service.user.id },
     })
     expect(rows).toHaveLength(1)
     expect(rows[0].feedback).toBe('negative')
@@ -108,7 +110,7 @@ describe('PUT /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
   it('repeating the same vote is idempotent (single row)', async () => {
     const orgSlug = 'eo-fb-idempotent'
     const eo = await seedElectedOffice(orgSlug)
-    await seedBriefing(eo.id, orgSlug, DATE)
+    const briefing = await seedBriefing(eo.id, orgSlug, DATE)
 
     await service.client.put(
       `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
@@ -122,9 +124,38 @@ describe('PUT /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
     )
 
     const rows = await service.prisma.artifactFeedback.findMany({
-      where: { submitterUserId: service.user.id, artifactId: ITEM_ID },
+      where: { briefingId: briefing.id, submitterUserId: service.user.id },
     })
     expect(rows).toHaveLength(1)
+  })
+
+  it('the same item id in two different briefings produces two independent rows', async () => {
+    const orgSlug = 'eo-fb-cross-briefing'
+    const eo = await seedElectedOffice(orgSlug)
+    const briefingOne = await seedBriefing(eo.id, orgSlug, DATE)
+    const briefingTwo = await seedBriefing(eo.id, orgSlug, OTHER_DATE)
+
+    await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'positive' },
+      orgHeader(orgSlug),
+    )
+    await service.client.put(
+      `/v1/meetings/${OTHER_DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'negative' },
+      orgHeader(orgSlug),
+    )
+
+    const rowsOne = await service.prisma.artifactFeedback.findMany({
+      where: { briefingId: briefingOne.id, submitterUserId: service.user.id },
+    })
+    const rowsTwo = await service.prisma.artifactFeedback.findMany({
+      where: { briefingId: briefingTwo.id, submitterUserId: service.user.id },
+    })
+    expect(rowsOne).toHaveLength(1)
+    expect(rowsOne[0].feedback).toBe('positive')
+    expect(rowsTwo).toHaveLength(1)
+    expect(rowsTwo[0].feedback).toBe('negative')
   })
 
   it('rejects an invalid feedback value', async () => {
@@ -171,7 +202,7 @@ describe('PUT /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
   it('two users can vote on the same item without colliding', async () => {
     const orgSlug = 'eo-fb-two-users'
     const eo = await seedElectedOffice(orgSlug)
-    await seedBriefing(eo.id, orgSlug, DATE)
+    const briefing = await seedBriefing(eo.id, orgSlug, DATE)
 
     const otherUser = await service.prisma.user.create({
       data: {
@@ -185,6 +216,7 @@ describe('PUT /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
     await service.prisma.artifactFeedback.create({
       data: {
         organizationSlug: orgSlug,
+        briefingId: briefing.id,
         submitterUserId: otherUser.id,
         artifactId: ITEM_ID,
         artifactType: 'agenda_item',
@@ -200,7 +232,7 @@ describe('PUT /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
 
     expect(result.status).toBe(200)
     const rows = await service.prisma.artifactFeedback.findMany({
-      where: { artifactId: ITEM_ID },
+      where: { briefingId: briefing.id, artifactId: ITEM_ID },
       orderBy: { submitterUserId: 'asc' },
     })
     expect(rows).toHaveLength(2)
@@ -215,11 +247,12 @@ describe('DELETE /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
   it('deletes the row and returns 204', async () => {
     const orgSlug = 'eo-fb-delete'
     const eo = await seedElectedOffice(orgSlug)
-    await seedBriefing(eo.id, orgSlug, DATE)
+    const briefing = await seedBriefing(eo.id, orgSlug, DATE)
 
     await service.prisma.artifactFeedback.create({
       data: {
         organizationSlug: orgSlug,
+        briefingId: briefing.id,
         submitterUserId: service.user.id,
         artifactId: ITEM_ID,
         artifactType: 'agenda_item',
@@ -234,7 +267,7 @@ describe('DELETE /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
 
     expect(result.status).toBe(204)
     const remaining = await service.prisma.artifactFeedback.findMany({
-      where: { submitterUserId: service.user.id, artifactId: ITEM_ID },
+      where: { briefingId: briefing.id, submitterUserId: service.user.id },
     })
     expect(remaining).toHaveLength(0)
   })
@@ -255,7 +288,7 @@ describe('DELETE /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
   it('does not touch another user feedback for the same item', async () => {
     const orgSlug = 'eo-fb-delete-isolation'
     const eo = await seedElectedOffice(orgSlug)
-    await seedBriefing(eo.id, orgSlug, DATE)
+    const briefing = await seedBriefing(eo.id, orgSlug, DATE)
 
     const otherUser = await service.prisma.user.create({
       data: {
@@ -269,6 +302,7 @@ describe('DELETE /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
     await service.prisma.artifactFeedback.create({
       data: {
         organizationSlug: orgSlug,
+        briefingId: briefing.id,
         submitterUserId: otherUser.id,
         artifactId: ITEM_ID,
         artifactType: 'agenda_item',
@@ -282,10 +316,52 @@ describe('DELETE /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
     )
 
     const remaining = await service.prisma.artifactFeedback.findMany({
-      where: { artifactId: ITEM_ID },
+      where: { briefingId: briefing.id, artifactId: ITEM_ID },
     })
     expect(remaining).toHaveLength(1)
     expect(remaining[0].submitterUserId).toBe(otherUser.id)
+  })
+
+  it('does not touch the same user feedback in a different briefing', async () => {
+    const orgSlug = 'eo-fb-delete-cross-briefing'
+    const eo = await seedElectedOffice(orgSlug)
+    const briefingOne = await seedBriefing(eo.id, orgSlug, DATE)
+    const briefingTwo = await seedBriefing(eo.id, orgSlug, OTHER_DATE)
+
+    await service.prisma.artifactFeedback.createMany({
+      data: [
+        {
+          organizationSlug: orgSlug,
+          briefingId: briefingOne.id,
+          submitterUserId: service.user.id,
+          artifactId: ITEM_ID,
+          artifactType: 'agenda_item',
+          feedback: 'positive',
+        },
+        {
+          organizationSlug: orgSlug,
+          briefingId: briefingTwo.id,
+          submitterUserId: service.user.id,
+          artifactId: ITEM_ID,
+          artifactType: 'agenda_item',
+          feedback: 'positive',
+        },
+      ],
+    })
+
+    await service.client.delete(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      orgHeader(orgSlug),
+    )
+
+    const remainingOne = await service.prisma.artifactFeedback.findMany({
+      where: { briefingId: briefingOne.id },
+    })
+    const remainingTwo = await service.prisma.artifactFeedback.findMany({
+      where: { briefingId: briefingTwo.id },
+    })
+    expect(remainingOne).toHaveLength(0)
+    expect(remainingTwo).toHaveLength(1)
   })
 
   it(NO_BRIEFING_FOR_DATE_TEST, async () => {
@@ -302,10 +378,11 @@ describe('DELETE /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
 })
 
 describe('GET /v1/meetings/:date/briefing/feedback', () => {
-  it('returns only the requesting user own feedback rows', async () => {
+  it('returns only the requesting user own feedback rows for that briefing', async () => {
     const orgSlug = 'eo-fb-list-isolation'
     const eo = await seedElectedOffice(orgSlug)
-    await seedBriefing(eo.id, orgSlug, DATE)
+    const briefing = await seedBriefing(eo.id, orgSlug, DATE)
+    const otherBriefing = await seedBriefing(eo.id, orgSlug, OTHER_DATE)
 
     const otherUser = await service.prisma.user.create({
       data: {
@@ -320,6 +397,7 @@ describe('GET /v1/meetings/:date/briefing/feedback', () => {
       data: [
         {
           organizationSlug: orgSlug,
+          briefingId: briefing.id,
           submitterUserId: service.user.id,
           artifactId: ITEM_ID,
           artifactType: 'agenda_item',
@@ -327,6 +405,7 @@ describe('GET /v1/meetings/:date/briefing/feedback', () => {
         },
         {
           organizationSlug: orgSlug,
+          briefingId: briefing.id,
           submitterUserId: service.user.id,
           artifactId: OTHER_ITEM_ID,
           artifactType: 'agenda_item',
@@ -334,7 +413,16 @@ describe('GET /v1/meetings/:date/briefing/feedback', () => {
         },
         {
           organizationSlug: orgSlug,
+          briefingId: briefing.id,
           submitterUserId: otherUser.id,
+          artifactId: ITEM_ID,
+          artifactType: 'agenda_item',
+          feedback: 'negative',
+        },
+        {
+          organizationSlug: orgSlug,
+          briefingId: otherBriefing.id,
+          submitterUserId: service.user.id,
           artifactId: ITEM_ID,
           artifactType: 'agenda_item',
           feedback: 'negative',

--- a/src/meetings/util/resolveBriefingId.ts
+++ b/src/meetings/util/resolveBriefingId.ts
@@ -1,0 +1,21 @@
+import { NotFoundException } from '@nestjs/common'
+import { ElectedOffice, PrismaClient } from '@prisma/client'
+import { parseIsoDateAsUTC } from '@/shared/util/date.util'
+
+export async function resolveBriefingId(
+  prisma: Pick<PrismaClient, 'meetingBriefing'>,
+  meetingDate: string,
+  electedOffice: Pick<ElectedOffice, 'id'>,
+): Promise<string> {
+  const briefing = await prisma.meetingBriefing.findUnique({
+    where: {
+      electedOfficeId_meetingDate: {
+        electedOfficeId: electedOffice.id,
+        meetingDate: parseIsoDateAsUTC(meetingDate),
+      },
+    },
+    select: { id: true },
+  })
+  if (!briefing) throw new NotFoundException('briefing_not_found')
+  return briefing.id
+}


### PR DESCRIPTION
## Summary

Wires the merged `ArtifactFeedback` schema (#1597) into a working "Was this summary helpful?" feature on each meeting briefing agenda item. Companion PR in gp-webapp: thegoodparty/gp-webapp#summary-feedback.

## Schema changes

Edit to `prisma/schema/artifactFeedback.prisma`:

- Replaced `ArtifactResourceType.briefing` with `agenda_item` (the only artifact we currently care about).
- Promoted `feedback` from free `TEXT` to a typed `ArtifactFeedbackKind` enum (`positive` | `negative`).
- Added `@@unique([submitterUserId, artifactId, artifactType])` — one row per (user, artifact). Load-bearing for the upsert hot path and for the single-latest-wins invariant.
- Added `@@index([organizationSlug])` (addresses bugbot review on #1597) and `@@index([artifactType, artifactId])` (future aggregations).
- Added `updatedAt` so a flip positive→negative is observable separately from the original create.

Migration `20260515193000_artifact_feedback_per_agenda_item/migration.sql` recreates the type and column; safe because the previous migration shipped the schema only with no rows yet.

## API

- `GET /v1/meetings/:date/briefing/feedback` — bulk read of the current user's per-item votes for one briefing (one round-trip hydrates every FeedbackRow on the page).
- `PUT /v1/meetings/:date/briefing/items/:itemId/feedback` — body `{ feedback: 'positive' | 'negative' }`. Idempotent. Switching value updates the row in place.
- `DELETE /v1/meetings/:date/briefing/items/:itemId/feedback` — clear the user's vote. Idempotent (204 even when nothing existed).

The service resolves the briefing via `(electedOffice, meetingDate)` for authorization (same pattern as `AnnotationsService`), then upserts inside a `Serializable` transaction. The DB unique constraint backs up the application-level invariant under concurrent writes.

## Tests

14 vitest integration tests in `src/artifactFeedback/tests/briefingItemFeedback.controller.test.ts`:

- creates the feedback row when none exists
- switching positive → negative updates the same row in place
- repeating the same vote is idempotent (single row)
- rejects an invalid feedback value
- 404 when no briefing exists for the date
- 404 when the org slug does not match the user
- two users can vote on the same item without colliding
- deletes the row and returns 204
- DELETE is idempotent when no row exists
- DELETE does not touch another user's feedback for the same item
- 404 for DELETE on missing briefing
- GET returns only the requesting user's own feedback rows
- GET returns empty list when the user has no feedback
- 404 for GET on missing briefing

## Test plan

- [ ] CI green
- [ ] Pair with gp-webapp `summary-feedback` branch and click thumbs up/down on an agenda item end-to-end

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persisted feedback endpoints and changes the `artifact_feedback` schema/migration (including a destructive `DELETE FROM artifact_feedback`), so issues could affect data integrity and new API behavior.
> 
> **Overview**
> Adds a new per-agenda-item “helpful/unhelpful” feedback capability for meeting briefings, including new Zod contract types and Nest controllers for `GET /v1/meetings/:date/briefing/feedback` plus `PUT`/`DELETE /v1/meetings/:date/briefing/items/:itemId/feedback`.
> 
> Updates the Prisma model and migration to scope feedback to a `briefing_id`, type `feedback` as an enum, add `updated_at`, and enforce a uniqueness constraint per (user, briefing, item, type); wires this into an `upsert`-based service and adds integration tests covering create/update/idempotency/auth scoping and not-found cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb0314d8f9659657bf09af1dc32995dfd762180. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->