### PR TITLE
meetings: store briefing artifact JSON on MeetingBriefing for synchronous list reads

### DIFF
--- a/prisma/schema/meetingBriefing.jsonTypes.d.ts
+++ b/prisma/schema/meetingBriefing.jsonTypes.d.ts
@@ -5,6 +5,7 @@ export {}
 declare global {
   export namespace PrismaJson {
     export type MeetingBriefingArtifact = {
+      meeting_date?: string
       meeting_name?: string
       location?: string
       [key: string]: Prisma.JsonValue | undefined

--- a/prisma/schema/meetingBriefing.jsonTypes.d.ts
+++ b/prisma/schema/meetingBriefing.jsonTypes.d.ts
@@ -1,0 +1,13 @@
+import { Prisma } from '@prisma/client'
+
+export {}
+
+declare global {
+  export namespace PrismaJson {
+    export type MeetingBriefingArtifact = {
+      meeting_name?: string
+      location?: string
+      [key: string]: Prisma.JsonValue | undefined
+    }
+  }
+}

--- a/prisma/schema/meetingBriefing.prisma
+++ b/prisma/schema/meetingBriefing.prisma
@@ -16,6 +16,9 @@ model MeetingBriefing {
 
   artifactFeedback ArtifactFeedback[]
 
+  /// [MeetingBriefingArtifact]
+  artifact Json? @db.JsonB
+
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 

--- a/prisma/schema/migrations/20260515160439_add_artifact_to_meeting_briefing/migration.sql
+++ b/prisma/schema/migrations/20260515160439_add_artifact_to_meeting_briefing/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "meeting_briefing" ADD COLUMN     "artifact" JSONB;

--- a/src/meetings/controllers/meetingsBriefings.controller.test.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.test.ts
@@ -320,6 +320,109 @@ describe('GET /v1/meetings', () => {
     ])
   })
 
+  it('uses artifact meeting_name and location when present', async () => {
+    const orgSlug = 'eo-artifact-fields'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedScheduleRun(orgSlug)
+    mockS3({ 'schedule-key.json': JSON.stringify(foundSchedule) })
+
+    const probe = await service.client.get('/v1/meetings', {
+      headers: { 'x-organization-slug': orgSlug },
+    })
+    const targetDate = (
+      probe.data.meetings as Array<{ meetingDate: string }>
+    )[0].meetingDate
+
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+      },
+    })
+    await service.prisma.meetingBriefing.create({
+      data: {
+        electedOfficeId: eo.id,
+        meetingDate: new Date(targetDate + 'T00:00:00Z'),
+        meetingTime: '19:00',
+        meetingTimezone: 'America/Denver',
+        experimentRunId: briefingRun.runId,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing-key.json',
+        artifact: {
+          meeting_name: 'Special Session',
+          location: 'Annex Hall, 42 Oak St',
+        },
+      },
+    })
+
+    const result = await service.client.get('/v1/meetings', {
+      headers: { 'x-organization-slug': orgSlug },
+    })
+
+    expect(result.status).toBe(200)
+    const target = (
+      result.data.meetings as Array<{
+        meetingDate: string
+        meetingName: string
+        location: string
+        hasBriefing: boolean
+      }>
+    ).find((m) => m.meetingDate === targetDate)
+    expect(target?.meetingName).toBe('Special Session')
+    expect(target?.location).toBe('Annex Hall, 42 Oak St')
+    expect(target?.hasBriefing).toBe(true)
+  })
+
+  it('falls back to schedule when artifact lacks meeting_name/location', async () => {
+    const orgSlug = 'eo-artifact-empty'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedScheduleRun(orgSlug)
+    mockS3({ 'schedule-key.json': JSON.stringify(foundSchedule) })
+
+    const probe = await service.client.get('/v1/meetings', {
+      headers: { 'x-organization-slug': orgSlug },
+    })
+    const targetDate = (
+      probe.data.meetings as Array<{ meetingDate: string }>
+    )[0].meetingDate
+
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+      },
+    })
+    await service.prisma.meetingBriefing.create({
+      data: {
+        electedOfficeId: eo.id,
+        meetingDate: new Date(targetDate + 'T00:00:00Z'),
+        meetingTime: '19:00',
+        meetingTimezone: 'America/Denver',
+        experimentRunId: briefingRun.runId,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing-key.json',
+        artifact: { meeting_name: '', location: '' },
+      },
+    })
+
+    const result = await service.client.get('/v1/meetings', {
+      headers: { 'x-organization-slug': orgSlug },
+    })
+
+    expect(result.status).toBe(200)
+    const target = (
+      result.data.meetings as Array<{
+        meetingDate: string
+        meetingName: string
+        location: string
+      }>
+    ).find((m) => m.meetingDate === targetDate)
+    expect(target?.meetingName).toBe('City Council')
+    expect(target?.location).toBe('City Hall Council Chambers, 200 Main St')
+  })
+
   it('returns ad-hoc briefings outside the projected RRULE dates', async () => {
     const orgSlug = 'eo-adhoc-briefing'
     const eo = await seedElectedOffice(orgSlug)

--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -61,6 +61,7 @@ export class MeetingsBriefingsController {
         meetingDate: true,
         meetingTime: true,
         meetingTimezone: true,
+        artifact: true,
       },
     })
 
@@ -83,14 +84,24 @@ export class MeetingsBriefingsController {
     for (const row of briefingRows) {
       const date = formatInTimeZone(row.meetingDate, 'UTC', 'yyyy-MM-dd')
       const existing = byDate.get(date)
+      const artifactName = row.artifact?.meeting_name
+      const artifactLocation = row.artifact?.location
       byDate.set(date, {
         meetingDate: date,
         meetingTime: row.meetingTime,
         meetingTimezone: row.meetingTimezone,
         durationMinutes:
           existing?.durationMinutes ?? knownSchedule?.duration_minutes ?? 0,
-        meetingName: existing?.meetingName ?? knownSchedule?.meeting_name ?? '',
-        location: existing?.location ?? knownSchedule?.location ?? '',
+        meetingName:
+          artifactName ||
+          existing?.meetingName ||
+          knownSchedule?.meeting_name ||
+          '',
+        location:
+          artifactLocation ||
+          existing?.location ||
+          knownSchedule?.location ||
+          '',
         hasBriefing: true,
       })
     }

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -199,8 +199,7 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
         duration_minutes: 60,
       }),
       'briefing.json': JSON.stringify({
-        meetingDate: '2026-06-08',
-        meeting: { scheduledAt: '2026-06-08T19:00:00-06:00' },
+        meeting_date: '2026-06-08',
         meeting_name: 'City Council',
         location: 'Council Chambers',
       }),

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -201,6 +201,8 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
       'briefing.json': JSON.stringify({
         meetingDate: '2026-06-08',
         meeting: { scheduledAt: '2026-06-08T19:00:00-06:00' },
+        meeting_name: 'City Council',
+        location: 'Council Chambers',
       }),
     })
 
@@ -220,6 +222,8 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
     expect(row?.artifactBucket).toBe('briefing-bucket')
     expect(row?.artifactKey).toBe('briefing.json')
     expect(row?.experimentRunId).toBe(briefingRun.runId)
+    expect(row?.artifact?.meeting_name).toBe('City Council')
+    expect(row?.artifact?.location).toBe('Council Chambers')
   })
 
   it('skips when run is not COMPLETED', async () => {

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -307,6 +307,9 @@ export class MeetingBriefingsService extends createPrismaBase(
       )
       return
     }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const artifact = parsed as unknown as PrismaJson.MeetingBriefingArtifact
+
     const dateString = parsed.meeting?.scheduledAt?.slice(0, 10) ?? ''
     if (!/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
       this.logger.error(
@@ -342,6 +345,7 @@ export class MeetingBriefingsService extends createPrismaBase(
         experimentRunId: run.runId,
         artifactBucket: run.artifactBucket,
         artifactKey: run.artifactKey,
+        artifact,
       },
       update: {
         meetingTime,
@@ -349,6 +353,7 @@ export class MeetingBriefingsService extends createPrismaBase(
         experimentRunId: run.runId,
         artifactBucket: run.artifactBucket,
         artifactKey: run.artifactKey,
+        artifact,
       },
     })
   }

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -13,11 +13,14 @@ import { ElectionsService } from '@/elections/services/elections.service'
 import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
 import { S3Service } from '@/vendors/aws/services/s3.service'
 import { parseIsoDateAsUTC } from '@/shared/util/date.util'
-import { Briefing, MeetingSchedule } from '@/generated/agent-job-contracts'
+import { MeetingSchedule } from '@/generated/agent-job-contracts'
 
-// JSON.parse returns unknown — no way to infer parsed shape at compile time
-// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-const parseBriefing = (raw: string): Briefing => JSON.parse(raw) as Briefing
+const parseBriefingArtifact = (
+  raw: string,
+): PrismaJson.MeetingBriefingArtifact =>
+  // JSON.parse returns unknown — no way to infer parsed shape at compile time
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  JSON.parse(raw) as PrismaJson.MeetingBriefingArtifact
 const parseSchedule = (raw: string): MeetingSchedule =>
   // JSON.parse returns unknown — no way to infer parsed shape at compile time
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -297,9 +300,9 @@ export class MeetingBriefingsService extends createPrismaBase(
       return
     }
 
-    let parsed: Briefing
+    let artifact: PrismaJson.MeetingBriefingArtifact
     try {
-      parsed = parseBriefing(raw)
+      artifact = parseBriefingArtifact(raw)
     } catch {
       this.logger.error(
         { runId: run.runId },
@@ -307,14 +310,13 @@ export class MeetingBriefingsService extends createPrismaBase(
       )
       return
     }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const artifact = parsed as unknown as PrismaJson.MeetingBriefingArtifact
 
-    const dateString = parsed.meeting?.scheduledAt?.slice(0, 10) ?? ''
+    const dateString =
+      typeof artifact.meeting_date === 'string' ? artifact.meeting_date : ''
     if (!/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
       this.logger.error(
         { runId: run.runId, dateString },
-        'meeting_briefing artifact has invalid meeting.scheduledAt',
+        'meeting_briefing artifact has invalid meeting_date',
       )
       return
     }


### PR DESCRIPTION
## Why

`GET /v1/meetings` was the only consumer that needed `meeting_name` and `location` per briefing, and those fields live inside the briefing artifact JSON in S3. Reading them on every list request meant N S3 round-trips on a hot path that's already O(months × candidates). On top of that, seeded dev users always saw empty `meetingName`/`location` because no real artifact ever got generated.

Mirror the v2 artifact onto a typed `Json?` column on `MeetingBriefing` at the same moment we record the row. The list endpoint now reads name/location straight from Postgres and falls back to the schedule projection when the artifact lacks those fields. The detail endpoint (`GET /v1/meetings/:date/briefing`) still streams the full artifact from S3 — only the list path needed this.

The column is intentionally a `Json` with `prisma-json-types-generator` (annotated `[MeetingBriefingArtifact]`) rather than separate columns: the artifact shape is large, partially-stable, and owned by the runbooks repo. Modeling only the two fields gp-api actually reads keeps the type narrow without coupling us to the rest of the schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new JSONB column and changes `GET /v1/meetings` to prefer DB-stored artifact fields, which could affect meeting name/location output and requires a safe migration/backfill strategy.
> 
> **Overview**
> `MeetingBriefing` now stores a typed `artifact` JSON payload (new `artifact` JSONB column + Prisma JSON type), written during `meeting_briefing` run completion.
> 
> `GET /v1/meetings` now reads `meeting_name`/`location` from the stored `artifact` when present, falling back to the projected schedule values otherwise. Tests are updated to assert the new precedence/fallback behavior and that the service persists these fields on upsert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d92954618a5e7f7919752dad703843c02bd7ef38. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->