### PR TITLE
Feature/notes intake body nullable

### DIFF
--- a/contracts/src/annotations/Annotation.schema.ts
+++ b/contracts/src/annotations/Annotation.schema.ts
@@ -55,7 +55,10 @@ export type AnnotationAnchor = z.infer<typeof AnnotationAnchorSchema>
 
 export const AnnotationNoteSchema = z.object({
   id: z.string(),
-  body: z.string(),
+  // Optional once a note can be attachment-only (no typed body). Phase 1
+  // create requires a body, but the response shape is nullable for forward
+  // compatibility with Phase 2.
+  body: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
 })

--- a/prisma/schema/annotationNote.prisma
+++ b/prisma/schema/annotationNote.prisma
@@ -1,7 +1,7 @@
 model AnnotationNote {
   id String @id @default(cuid())
 
-  body String @db.Text
+  body String? @db.Text
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/prisma/schema/migrations/20260515194339_annotation_note_body_nullable/migration.sql
+++ b/prisma/schema/migrations/20260515194339_annotation_note_body_nullable/migration.sql
@@ -1,0 +1,4 @@
+-- Make AnnotationNote.body nullable. Top-level intake notes from the
+-- attachments flow (camera/upload) won't have a typed body — only OCR'd text
+-- from the attachment.
+ALTER TABLE "annotation_note" ALTER COLUMN "body" DROP NOT NULL;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Includes a database migration and contract change making `AnnotationNote.body` nullable, which may affect downstream code paths that previously assumed a non-null string.
> 
> **Overview**
> Updates the annotations contract and persistence model to support notes without a typed body by making `AnnotationNote.body` nullable.
> 
> Applies a Prisma schema change and SQL migration to drop the `NOT NULL` constraint on `annotation_note.body`, while keeping create/update request validation requiring a non-empty body for now (forward-compatible with attachment-only notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3581073e038492b95f7b0b82eca1fb5d1225da8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->