### PR TITLE
Hardcode outreach pricing and remove pricePerContact parameter

### DIFF
--- a/src/outreach/services/outreachPurchase.service.test.ts
+++ b/src/outreach/services/outreachPurchase.service.test.ts
@@ -1,0 +1,215 @@
+import { BadRequestException } from '@nestjs/common'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { FREE_TEXTS_OFFER } from '@/shared/constants/freeTextsOffer'
+import {
+  calcTextAmountInCents,
+  PRICE_PER_TEXT_TENTH_CENTS,
+} from '@/shared/util/textPricing.util'
+import { CampaignsService } from 'src/campaigns/services/campaigns.service'
+import { OutreachPurchaseMetadata } from '../types/outreach.types'
+import { OutreachPurchaseHandlerService } from './outreachPurchase.service'
+import { describe, expect, it, vi } from 'vitest'
+
+const mockCampaignsService = {
+  checkFreeTextsEligibility: vi.fn(),
+  redeemFreeTexts: vi.fn(),
+} as unknown as CampaignsService
+
+const service = new OutreachPurchaseHandlerService(
+  mockCampaignsService,
+  createMockLogger(),
+)
+
+const baseMetadata: OutreachPurchaseMetadata = {
+  contactCount: 500,
+  outreachType: 'p2p',
+  audienceSize: 1000,
+}
+
+describe('calcTextAmountInCents', () => {
+  it('returns 4 cents for 1 text', () => {
+    expect(calcTextAmountInCents(1)).toBe(4)
+  })
+
+  it('returns 0 for 0 texts', () => {
+    expect(calcTextAmountInCents(0)).toBe(0)
+  })
+
+  it('returns 1750 cents for 500 texts', () => {
+    expect(calcTextAmountInCents(500)).toBe(1750)
+  })
+
+  it('uses integer arithmetic consistently', () => {
+    expect(calcTextAmountInCents(3)).toBe(
+      Math.floor((3 * PRICE_PER_TEXT_TENTH_CENTS + 5) / 10),
+    )
+  })
+})
+
+describe('OutreachPurchaseHandlerService', () => {
+  describe('validatePurchase', () => {
+    it('throws when contactCount is missing', async () => {
+      await expect(
+        service.validatePurchase({
+          ...baseMetadata,
+          contactCount: 0,
+        }),
+      ).rejects.toThrow(BadRequestException)
+    })
+
+    it('passes with valid contactCount', async () => {
+      await expect(
+        service.validatePurchase(baseMetadata),
+      ).resolves.toBeUndefined()
+    })
+
+    it('ignores pricePerContact from client', async () => {
+      await expect(
+        service.validatePurchase({
+          ...baseMetadata,
+          pricePerContact: 0,
+        }),
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('calculateAmount', () => {
+    it('uses server-side pricing, not client pricePerContact', async () => {
+      const amount = await service.calculateAmount({
+        ...baseMetadata,
+        campaignId: undefined,
+        pricePerContact: 0,
+      })
+
+      expect(amount).toBe(calcTextAmountInCents(500))
+      expect(amount).toBeGreaterThan(0)
+    })
+
+    it('skips discount check when outreachType is not p2p', async () => {
+      const amount = await service.calculateAmount({
+        ...baseMetadata,
+        campaignId: 1,
+        outreachType: 'text',
+      })
+
+      expect(amount).toBe(calcTextAmountInCents(500))
+      expect(
+        mockCampaignsService.checkFreeTextsEligibility,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('skips discount check when campaignId is missing', async () => {
+      const amount = await service.calculateAmount({
+        ...baseMetadata,
+        campaignId: undefined,
+      })
+
+      expect(amount).toBe(calcTextAmountInCents(500))
+      expect(
+        mockCampaignsService.checkFreeTextsEligibility,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('applies free texts discount for eligible p2p campaign', async () => {
+      vi.mocked(
+        mockCampaignsService.checkFreeTextsEligibility,
+      ).mockResolvedValue(true)
+
+      const contactCount = 7000
+      const amount = await service.calculateAmount({
+        ...baseMetadata,
+        contactCount,
+        campaignId: 1,
+      })
+
+      const billable = contactCount - FREE_TEXTS_OFFER.COUNT
+      expect(amount).toBe(calcTextAmountInCents(billable))
+    })
+
+    it('returns 0 when contactCount equals FREE_TEXTS_OFFER.COUNT exactly', async () => {
+      vi.mocked(
+        mockCampaignsService.checkFreeTextsEligibility,
+      ).mockResolvedValue(true)
+
+      const amount = await service.calculateAmount({
+        ...baseMetadata,
+        contactCount: FREE_TEXTS_OFFER.COUNT,
+        campaignId: 1,
+      })
+
+      expect(amount).toBe(0)
+    })
+
+    it('returns 0 when contactCount is below FREE_TEXTS_OFFER.COUNT', async () => {
+      vi.mocked(
+        mockCampaignsService.checkFreeTextsEligibility,
+      ).mockResolvedValue(true)
+
+      const amount = await service.calculateAmount({
+        ...baseMetadata,
+        contactCount: 100,
+        campaignId: 1,
+      })
+
+      expect(amount).toBe(0)
+    })
+
+    it('charges full price when campaign has no offer', async () => {
+      vi.mocked(
+        mockCampaignsService.checkFreeTextsEligibility,
+      ).mockResolvedValue(false)
+
+      const amount = await service.calculateAmount({
+        ...baseMetadata,
+        contactCount: 500,
+        campaignId: 1,
+      })
+
+      expect(amount).toBe(calcTextAmountInCents(500))
+    })
+  })
+
+  describe('calculateDiscount', () => {
+    it('returns 0 for non-p2p outreachType', async () => {
+      const discount = await service.calculateDiscount(500, 1, 'text')
+
+      expect(discount).toBe(0)
+    })
+
+    it('returns 0 when campaignId is missing', async () => {
+      const discount = await service.calculateDiscount(500, undefined, 'p2p')
+
+      expect(discount).toBe(0)
+    })
+
+    it('returns 0 when campaign has no offer', async () => {
+      vi.mocked(
+        mockCampaignsService.checkFreeTextsEligibility,
+      ).mockResolvedValue(false)
+
+      const discount = await service.calculateDiscount(500, 1, 'p2p')
+
+      expect(discount).toBe(0)
+    })
+
+    it('caps discount at FREE_TEXTS_OFFER.COUNT when contactCount exceeds it', async () => {
+      vi.mocked(
+        mockCampaignsService.checkFreeTextsEligibility,
+      ).mockResolvedValue(true)
+
+      const discount = await service.calculateDiscount(10000, 1, 'p2p')
+
+      expect(discount).toBe(calcTextAmountInCents(FREE_TEXTS_OFFER.COUNT))
+    })
+
+    it('discounts actual contactCount when below FREE_TEXTS_OFFER.COUNT', async () => {
+      vi.mocked(
+        mockCampaignsService.checkFreeTextsEligibility,
+      ).mockResolvedValue(true)
+
+      const discount = await service.calculateDiscount(200, 1, 'p2p')
+
+      expect(discount).toBe(calcTextAmountInCents(200))
+    })
+  })
+})

--- a/src/outreach/services/outreachPurchase.service.ts
+++ b/src/outreach/services/outreachPurchase.service.ts
@@ -13,7 +13,9 @@ function calcAmountInCents(contactCount: number): number {
 }
 
 @Injectable()
-export class OutreachPurchaseHandlerService implements PurchaseHandler<OutreachPurchaseMetadata> {
+export class OutreachPurchaseHandlerService
+  implements PurchaseHandler<OutreachPurchaseMetadata>
+{
   constructor(
     private readonly campaignsService: CampaignsService,
     private readonly logger: PinoLogger,

--- a/src/outreach/services/outreachPurchase.service.ts
+++ b/src/outreach/services/outreachPurchase.service.ts
@@ -5,10 +5,15 @@ import { FREE_TEXTS_OFFER } from 'src/shared/constants/freeTextsOffer'
 import { OutreachPurchaseMetadata } from '../types/outreach.types'
 import { PinoLogger } from 'nestjs-pino'
 
+const PRICE_PER_CONTACT_TENTH_CENTS = 35
+
+function calcAmountInCents(contactCount: number): number {
+  const totalTenthCents = contactCount * PRICE_PER_CONTACT_TENTH_CENTS
+  return Math.floor((totalTenthCents + 5) / 10)
+}
+
 @Injectable()
-export class OutreachPurchaseHandlerService
-  implements PurchaseHandler<OutreachPurchaseMetadata>
-{
+export class OutreachPurchaseHandlerService implements PurchaseHandler<OutreachPurchaseMetadata> {
   constructor(
     private readonly campaignsService: CampaignsService,
     private readonly logger: PinoLogger,
@@ -18,25 +23,19 @@ export class OutreachPurchaseHandlerService
 
   async validatePurchase({
     contactCount,
-    pricePerContact,
   }: OutreachPurchaseMetadata): Promise<void> {
     if (!contactCount) {
       throw new BadRequestException('contactCount is required')
-    }
-
-    if (pricePerContact === null || pricePerContact === undefined) {
-      throw new BadRequestException('pricePerContact is required')
     }
   }
 
   async calculateAmount({
     contactCount,
-    pricePerContact,
     campaignId,
     outreachType,
   }: OutreachPurchaseMetadata): Promise<number> {
     if (!campaignId || outreachType !== 'p2p') {
-      return contactCount * pricePerContact
+      return calcAmountInCents(contactCount)
     }
 
     const hasOffer =
@@ -47,7 +46,7 @@ export class OutreachPurchaseHandlerService
         0,
         contactCount - FREE_TEXTS_OFFER.COUNT,
       )
-      const finalAmount = discountedContactCount * pricePerContact
+      const finalAmount = calcAmountInCents(discountedContactCount)
 
       this.logger.info(
         `Campaign ${campaignId}: applying free texts discount (${contactCount} contacts, ${discountedContactCount} billable, amount: ${finalAmount})`,
@@ -56,12 +55,11 @@ export class OutreachPurchaseHandlerService
       return finalAmount
     }
 
-    return contactCount * pricePerContact
+    return calcAmountInCents(contactCount)
   }
 
   async calculateDiscount(
     contactCount: number,
-    pricePerContact: number,
     campaignId?: number,
     outreachType?: string,
   ): Promise<number> {
@@ -73,9 +71,8 @@ export class OutreachPurchaseHandlerService
       await this.campaignsService.checkFreeTextsEligibility(campaignId)
 
     if (hasOffer) {
-      // Calculate discount amount for up to 5,000 texts
       const freeTexts = Math.min(contactCount, FREE_TEXTS_OFFER.COUNT)
-      return freeTexts * pricePerContact
+      return calcAmountInCents(freeTexts)
     }
 
     return 0

--- a/src/outreach/services/outreachPurchase.service.ts
+++ b/src/outreach/services/outreachPurchase.service.ts
@@ -2,15 +2,9 @@ import { BadRequestException, Injectable } from '@nestjs/common'
 import { CampaignsService } from 'src/campaigns/services/campaigns.service'
 import { PurchaseHandler } from 'src/payments/purchase.types'
 import { FREE_TEXTS_OFFER } from 'src/shared/constants/freeTextsOffer'
+import { calcTextAmountInCents } from 'src/shared/util/textPricing.util'
 import { OutreachPurchaseMetadata } from '../types/outreach.types'
 import { PinoLogger } from 'nestjs-pino'
-
-const PRICE_PER_CONTACT_TENTH_CENTS = 35
-
-function calcAmountInCents(contactCount: number): number {
-  const totalTenthCents = contactCount * PRICE_PER_CONTACT_TENTH_CENTS
-  return Math.floor((totalTenthCents + 5) / 10)
-}
 
 @Injectable()
 export class OutreachPurchaseHandlerService
@@ -37,7 +31,7 @@ export class OutreachPurchaseHandlerService
     outreachType,
   }: OutreachPurchaseMetadata): Promise<number> {
     if (!campaignId || outreachType !== 'p2p') {
-      return calcAmountInCents(contactCount)
+      return calcTextAmountInCents(contactCount)
     }
 
     const hasOffer =
@@ -48,7 +42,7 @@ export class OutreachPurchaseHandlerService
         0,
         contactCount - FREE_TEXTS_OFFER.COUNT,
       )
-      const finalAmount = calcAmountInCents(discountedContactCount)
+      const finalAmount = calcTextAmountInCents(discountedContactCount)
 
       this.logger.info(
         `Campaign ${campaignId}: applying free texts discount (${contactCount} contacts, ${discountedContactCount} billable, amount: ${finalAmount})`,
@@ -57,7 +51,7 @@ export class OutreachPurchaseHandlerService
       return finalAmount
     }
 
-    return calcAmountInCents(contactCount)
+    return calcTextAmountInCents(contactCount)
   }
 
   async calculateDiscount(
@@ -74,7 +68,7 @@ export class OutreachPurchaseHandlerService
 
     if (hasOffer) {
       const freeTexts = Math.min(contactCount, FREE_TEXTS_OFFER.COUNT)
-      return calcAmountInCents(freeTexts)
+      return calcTextAmountInCents(freeTexts)
     }
 
     return 0

--- a/src/outreach/types/outreach.types.ts
+++ b/src/outreach/types/outreach.types.ts
@@ -6,7 +6,7 @@ export type OutreachWithVoterFileFilter = Prisma.OutreachGetPayload<{
 }>
 export interface OutreachPurchaseMetadata extends BasePurchaseMetadata {
   contactCount: number
-  pricePerContact: number
+  pricePerContact?: number
   outreachType: string
   audienceSize: number
   audienceRequest?: string

--- a/src/polls/services/pollPurchase.service.ts
+++ b/src/polls/services/pollPurchase.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable } from '@nestjs/common'
 import { ElectedOfficeService } from 'src/electedOffice/services/electedOffice.service'
 import { PurchaseHandler } from 'src/payments/purchase.types'
+import { calcTextAmountInCents } from 'src/shared/util/textPricing.util'
 import { UsersService } from 'src/users/services/users.service'
 import { version as uuidVersion } from 'uuid'
 import z from 'zod'
@@ -49,13 +50,6 @@ const PollPurchaseMetadataSchema = z.union([
   }),
 ])
 
-const PRICE_PER_TEXT_TENTH_CENTS = 35
-
-function calcAmountInCents(textCount: number): number {
-  const totalTenthCents = textCount * PRICE_PER_TEXT_TENTH_CENTS // integer
-  return Math.floor((totalTenthCents + 5) / 10)
-}
-
 @Injectable()
 export class PollPurchaseHandlerService implements PurchaseHandler<unknown> {
   constructor(
@@ -78,8 +72,8 @@ export class PollPurchaseHandlerService implements PurchaseHandler<unknown> {
     const metadata = PollPurchaseMetadataSchema.parse(rawMetadata)
 
     return metadata.pollPurchaseType === PollPurchaseType.expansion
-      ? calcAmountInCents(metadata.count)
-      : calcAmountInCents(metadata.audienceSize)
+      ? calcTextAmountInCents(metadata.count)
+      : calcTextAmountInCents(metadata.audienceSize)
   }
 
   async handlePollPostPurchase(

--- a/src/shared/util/textPricing.util.ts
+++ b/src/shared/util/textPricing.util.ts
@@ -1,0 +1,6 @@
+export const PRICE_PER_TEXT_TENTH_CENTS = 35
+
+export function calcTextAmountInCents(textCount: number): number {
+  const totalTenthCents = textCount * PRICE_PER_TEXT_TENTH_CENTS
+  return Math.floor((totalTenthCents + 5) / 10)
+}


### PR DESCRIPTION
## Summary

Replaces dynamic `pricePerContact` parameter with a hardcoded pricing model for outreach purchases. Pricing is now calculated as 3.5¢ per contact (35 tenths of cents), with proper rounding applied.

## Changes

- **Extract pricing logic**: Created `calcAmountInCents()` helper function that calculates amount in cents from contact count using the constant `PRICE_PER_CONTACT_TENTH_CENTS = 35`
- **Remove parameter**: Removed `pricePerContact` from `validatePurchase()` and `calculateDiscount()` method signatures
- **Make parameter optional**: Changed `pricePerContact` to optional in `OutreachPurchaseMetadata` type
- **Update calculations**: Replaced all `contactCount * pricePerContact` expressions with `calcAmountInCents(contactCount)` calls
- **Simplify validation**: Removed the validation check for `pricePerContact` since it's no longer required

## Implementation Details

The `calcAmountInCents()` function uses banker's rounding (round half up) by adding 5 to the total tenths of cents before dividing by 10, ensuring consistent pricing across all purchase scenarios including the free texts discount logic.

https://claude.ai/code/session_014PHFszKb5oweSxdr8Gj4HV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how outreach purchase amounts/discounts are computed by hardcoding a new rounding-based price calculation, which can affect billing totals. Also relaxes metadata validation by no longer requiring `pricePerContact`, so downstream callers relying on client-provided pricing may behave differently.
> 
> **Overview**
> Outreach purchase pricing is now **server-calculated** at a fixed rate (3.5¢/contact) via a new `calcAmountInCents()` helper with rounding, replacing all `contactCount * pricePerContact` computations (including free-texts discount handling).
> 
> `pricePerContact` is no longer required: validation for it is removed and `OutreachPurchaseMetadata.pricePerContact` is made optional to decouple pricing from client-provided metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fe525de841b8ab9bdd6367e3ffa4f2a841021b6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->