### PR TITLE
Validate campaign state codes and normalize to uppercase

### DIFF
--- a/src/campaigns/schemas/updateCampaign.schema.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.ts
@@ -5,6 +5,7 @@ import {
   CampaignSchema,
   ElectionLevelSchema,
 } from '@goodparty_org/contracts'
+import { StateSchema } from '@/shared/schemas/State.schema'
 
 // TODO(ENG-6410): This schema uses .passthrough() which allows ANY fields to be sent through,
 // even if not defined here. This is a security/data integrity concern because:
@@ -17,7 +18,7 @@ import {
 
 const CampaignDetailsSchema = z
   .object({
-    state: z.string(),
+    state: StateSchema(),
     ballotLevel: BallotReadyPositionLevelSchema,
     electionDate: z.string(),
     primaryElectionDate: z.string(),

--- a/src/voters/voterFile/util/voterFile.util.test.ts
+++ b/src/voters/voterFile/util/voterFile.util.test.ts
@@ -1,13 +1,13 @@
 import { BadRequestException } from '@nestjs/common'
 import { Campaign } from '@prisma/client'
 import { PinoLogger } from 'nestjs-pino'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { VoterFileType } from '../voterFile.types'
 import { typeToQuery } from './voterFile.util'
 
 const logger = {
-  debug: () => {},
-  warn: () => {},
+  debug: vi.fn(),
+  warn: vi.fn(),
 } as unknown as PinoLogger
 
 const statewideCampaign = (state: string | null | undefined) =>

--- a/src/voters/voterFile/util/voterFile.util.test.ts
+++ b/src/voters/voterFile/util/voterFile.util.test.ts
@@ -1,0 +1,90 @@
+import { BadRequestException } from '@nestjs/common'
+import { Campaign } from '@prisma/client'
+import { PinoLogger } from 'nestjs-pino'
+import { describe, expect, it } from 'vitest'
+import { VoterFileType } from '../voterFile.types'
+import { typeToQuery } from './voterFile.util'
+
+const logger = {
+  debug: () => {},
+  warn: () => {},
+} as unknown as PinoLogger
+
+const statewideCampaign = (state: string | null | undefined) =>
+  ({
+    id: 1,
+    organizationSlug: 'test-org',
+    details: { state },
+  }) as unknown as Campaign
+
+const statewideDistrict = {
+  id: 'dist-1',
+  l2Type: 'State',
+  l2Name: 'CO',
+}
+
+describe('typeToQuery state validation', () => {
+  it('throws BadRequestException for an invalid state', () => {
+    expect(() =>
+      typeToQuery(
+        logger,
+        VoterFileType.full,
+        statewideCampaign('XX'),
+        statewideDistrict,
+      ),
+    ).toThrow(BadRequestException)
+  })
+
+  it('does not throw for a valid uppercase state', () => {
+    const sql = typeToQuery(
+      logger,
+      VoterFileType.full,
+      statewideCampaign('CO'),
+      statewideDistrict,
+    )
+    expect(sql).toContain('FROM public."VoterCO"')
+  })
+
+  it('accepts a lowercase state by uppercasing it', () => {
+    const sql = typeToQuery(
+      logger,
+      VoterFileType.full,
+      statewideCampaign('co'),
+      statewideDistrict,
+    )
+    expect(sql).toContain('FROM public."VoterCO"')
+  })
+
+  it('throws when state is undefined', () => {
+    expect(() =>
+      typeToQuery(
+        logger,
+        VoterFileType.full,
+        statewideCampaign(undefined),
+        statewideDistrict,
+      ),
+    ).toThrow(BadRequestException)
+  })
+
+  it('throws when state is null', () => {
+    expect(() =>
+      typeToQuery(
+        logger,
+        VoterFileType.full,
+        statewideCampaign(null),
+        statewideDistrict,
+      ),
+    ).toThrow(BadRequestException)
+  })
+
+  it('throws for a SQL injection payload', () => {
+    expect(() =>
+      typeToQuery(
+        logger,
+        VoterFileType.full,
+        statewideCampaign('CO"; SELECT pg_sleep(10);--'),
+        statewideDistrict,
+      ),
+    ).toThrow(BadRequestException)
+  })
+})

--- a/src/voters/voterFile/util/voterFile.util.ts
+++ b/src/voters/voterFile/util/voterFile.util.ts
@@ -1,5 +1,6 @@
-import { ConflictException } from '@nestjs/common'
+import { BadRequestException, ConflictException } from '@nestjs/common'
 import { Campaign } from '@prisma/client'
+import { STATE_CODES } from '@/shared/constants/states'
 import { OrgDistrict } from 'src/organizations/organizations.types'
 import { GetVoterFileSchema } from '../schemas/GetVoterFile.schema'
 import {
@@ -50,6 +51,10 @@ export function typeToQuery(
   limit?: number,
 ) {
   const state = campaign.details.state
+  const upperState = typeof state === 'string' ? state.toUpperCase() : ''
+  if (!STATE_CODES.some((code) => code === upperState)) {
+    throw new BadRequestException('Campaign has an invalid state value')
+  }
   const electionDate: string | undefined = campaign.details?.electionDate
   const electionYear = electionDate
     ? Number(String(electionDate).slice(0, 4))
@@ -238,7 +243,7 @@ export function typeToQuery(
 
       whereClause += ` EXISTS (
         SELECT 1
-        FROM public."Voter${state}" b
+        FROM public."Voter${upperState}" b
         WHERE a."Mailing_Families_FamilyID" = b."Mailing_Families_FamilyID"
         GROUP BY b."Mailing_Families_FamilyID"
         HAVING COUNT(*) = 1
@@ -274,7 +279,7 @@ export function typeToQuery(
     }
   }
 
-  return `SELECT ${justCount ? 'COUNT(*)' : columns} FROM public."Voter${state}" ${nestedWhereClause} ${
+  return `SELECT ${justCount ? 'COUNT(*)' : columns} FROM public."Voter${upperState}" ${nestedWhereClause} ${
     whereClause !== ''
       ? `WHERE ${whereClause} ${limit ? `LIMIT ${limit}` : ''}`
       : ''

--- a/src/websites/tests/domains.e2e.ts
+++ b/src/websites/tests/domains.e2e.ts
@@ -202,6 +202,13 @@ test.describe('Websites - Domains', () => {
       multipart: {
         vanityPath,
         status: 'published',
+        'main[title]': 'Test Campaign',
+        'about[bio]': 'A test biography',
+        'about[issues][0][title]': 'Test Issue',
+        'about[issues][0][description]': 'Description',
+        'contact[address]': '123 Main St',
+        'contact[email]': 'test@example.com',
+        'contact[phone]': '5555555555',
       },
     })
 

--- a/src/websites/tests/website-contacts.e2e.ts
+++ b/src/websites/tests/website-contacts.e2e.ts
@@ -56,6 +56,13 @@ test.describe('Websites - Contacts', () => {
       multipart: {
         vanityPath,
         status: 'published',
+        'main[title]': 'Test Campaign',
+        'about[bio]': 'A test biography',
+        'about[issues][0][title]': 'Test Issue',
+        'about[issues][0][description]': 'Description',
+        'contact[address]': '123 Main St',
+        'contact[email]': 'test@example.com',
+        'contact[phone]': '5555555555',
       },
     })
 
@@ -167,6 +174,13 @@ test.describe('Websites - Contacts', () => {
       multipart: {
         vanityPath,
         status: 'published',
+        'main[title]': 'Test Campaign',
+        'about[bio]': 'A test biography',
+        'about[issues][0][title]': 'Test Issue',
+        'about[issues][0][description]': 'Description',
+        'contact[address]': '123 Main St',
+        'contact[email]': 'test@example.com',
+        'contact[phone]': '5555555555',
       },
     })
 
@@ -232,6 +246,13 @@ test.describe('Websites - Contacts', () => {
       multipart: {
         vanityPath,
         status: 'published',
+        'main[title]': 'Test Campaign',
+        'about[bio]': 'A test biography',
+        'about[issues][0][title]': 'Test Issue',
+        'about[issues][0][description]': 'Description',
+        'contact[address]': '123 Main St',
+        'contact[email]': 'test@example.com',
+        'contact[phone]': '5555555555',
       },
     })
 

--- a/src/websites/tests/website-crud.e2e.ts
+++ b/src/websites/tests/website-crud.e2e.ts
@@ -130,9 +130,12 @@ test.describe('Websites - CRUD Operations', () => {
       headers: authHeaders(authToken, orgSlug),
       multipart: {
         'main[title]': mainTitle,
+        'about[bio]': 'A test biography',
         'about[issues][0][title]': issueTitle,
         'about[issues][0][description]': issueDescription,
+        'contact[address]': '123 Main St',
         'contact[email]': contactEmail,
+        'contact[phone]': '5555555555',
         vanityPath: vanityPath,
         status: 'published',
       },

--- a/src/websites/tests/website-vanity-path.e2e.ts
+++ b/src/websites/tests/website-vanity-path.e2e.ts
@@ -178,6 +178,12 @@ test.describe('Websites - Vanity Path', () => {
         vanityPath,
         status: 'published',
         'main[title]': 'Public Website',
+        'about[bio]': 'A test biography',
+        'about[issues][0][title]': 'Test Issue',
+        'about[issues][0][description]': 'Description',
+        'contact[address]': '123 Main St',
+        'contact[email]': 'test@example.com',
+        'contact[phone]': '5555555555',
       },
     })
 

--- a/src/websites/tests/website-views.e2e.ts
+++ b/src/websites/tests/website-views.e2e.ts
@@ -54,6 +54,13 @@ test.describe('Websites - Views', () => {
       multipart: {
         vanityPath,
         status: 'published',
+        'main[title]': 'Test Campaign',
+        'about[bio]': 'A test biography',
+        'about[issues][0][title]': 'Test Issue',
+        'about[issues][0][description]': 'Description',
+        'contact[address]': '123 Main St',
+        'contact[email]': 'test@example.com',
+        'contact[phone]': '5555555555',
       },
     })
 
@@ -108,6 +115,13 @@ test.describe('Websites - Views', () => {
       multipart: {
         vanityPath,
         status: 'published',
+        'main[title]': 'Test Campaign',
+        'about[bio]': 'A test biography',
+        'about[issues][0][title]': 'Test Issue',
+        'about[issues][0][description]': 'Description',
+        'contact[address]': '123 Main St',
+        'contact[email]': 'test@example.com',
+        'contact[phone]': '5555555555',
       },
     })
 
@@ -170,6 +184,13 @@ test.describe('Websites - Views', () => {
       multipart: {
         vanityPath,
         status: 'published',
+        'main[title]': 'Test Campaign',
+        'about[bio]': 'A test biography',
+        'about[issues][0][title]': 'Test Issue',
+        'about[issues][0][description]': 'Description',
+        'contact[address]': '123 Main St',
+        'contact[email]': 'test@example.com',
+        'contact[phone]': '5555555555',
       },
     })
 
@@ -236,6 +257,13 @@ test.describe('Websites - Views', () => {
       multipart: {
         vanityPath,
         status: 'published',
+        'main[title]': 'Test Campaign',
+        'about[bio]': 'A test biography',
+        'about[issues][0][title]': 'Test Issue',
+        'about[issues][0][description]': 'Description',
+        'contact[address]': '123 Main St',
+        'contact[email]': 'test@example.com',
+        'contact[phone]': '5555555555',
       },
     })
 

--- a/src/websites/tests/websites.e2e.ts
+++ b/src/websites/tests/websites.e2e.ts
@@ -109,6 +109,16 @@ test.describe('Candidate Website', () => {
       },
       data: {
         status: 'published',
+        main: { title: 'Test Campaign' },
+        about: {
+          bio: 'A test biography',
+          issues: [{ title: 'Issue One', description: 'Description one' }],
+        },
+        contact: {
+          address: '123 Main St',
+          email: 'test@example.com',
+          phone: '5555555555',
+        },
       },
     })
 


### PR DESCRIPTION
## Summary

Add validation for campaign state values to ensure they match valid US state codes, and normalize state references to uppercase when constructing database queries.

## Changes

- Import `STATE_CODES` constant from shared constants and add state validation in `typeToQuery()` utility
- Throw `BadRequestException` if campaign state is not a valid state code
- Normalize state to uppercase before using in SQL table name construction to ensure consistent table references
- Update `updateCampaign.schema.ts` to use `StateSchema()` for stricter state validation at the schema level

## Implementation details

- State validation occurs early in `typeToQuery()` before any query construction
- Uppercase normalization is applied consistently across all voter table references in the generated SQL
- Schema-level validation via `StateSchema()` provides an additional validation layer at the API boundary

https://claude.ai/code/session_01YBWaAtdCBrxMcYr2WSX6bk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds stricter state validation at the API/schema boundary and in voter-file SQL generation, which could reject or break existing campaigns that store non-standard state values and change which voter tables are queried.
> 
> **Overview**
> Tightens campaign state handling by validating `details.state` with the shared `StateSchema()` in `updateCampaign.schema.ts` instead of accepting any string.
> 
> In voter-file query generation (`typeToQuery`), adds early validation against `STATE_CODES`, throws `BadRequestException` on invalid state values, and uses an uppercased state when constructing `VoterXX` table names to ensure consistent DB table references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd0987d21613f970d380ba39956549ee78eccb3f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->