### PR TITLE
Switch TTS default to AWS Polly generative engine (Amy, British English)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @goodparty_org/contracts
 
+## 0.6.0
+
+### Minor Changes
+
+- Add `'generative'` to `SpeechSynthesisEngineSchema` and `'Amy'` to
+  `SpeechSynthesisVoiceSchema`. Export `GENERATIVE_VOICE_VALUES` — the
+  subset of voices that support the generative engine (`Joanna`, `Matthew`,
+  `Salli`, `Ruth`, `Stephen`, `Amy`). Update default voice/engine from
+  `Joanna`/`neural` to `Amy`/`generative`. Add a cross-field refine to
+  `SynthesizeSpeechRequestSchema` that rejects any `voiceId` × `engine:
+  'generative'` pairing where the voice is not in `GENERATIVE_VOICE_VALUES`.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodparty_org/contracts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Shared Zod schemas and TypeScript types for the GoodParty API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/contracts/src/speech/synthesizeSpeech.schema.ts
+++ b/contracts/src/speech/synthesizeSpeech.schema.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod'
 
-export const SPEECH_SYNTHESIS_ENGINE_VALUES = ['neural', 'standard'] as const
+export const SPEECH_SYNTHESIS_ENGINE_VALUES = [
+  'neural',
+  'standard',
+  'generative',
+] as const
 export type SpeechSynthesisEngine =
   (typeof SPEECH_SYNTHESIS_ENGINE_VALUES)[number]
 export const SpeechSynthesisEngineSchema = z.enum(
@@ -18,6 +22,7 @@ export const SPEECH_SYNTHESIS_VOICE_VALUES = [
   'Justin',
   'Ruth',
   'Stephen',
+  'Amy',
 ] as const
 export type SpeechSynthesisVoice =
   (typeof SPEECH_SYNTHESIS_VOICE_VALUES)[number]
@@ -51,8 +56,8 @@ export const SynthesizeSpeechRequestSchema = z.object({
     ),
   options: z
     .object({
-      voiceId: SpeechSynthesisVoiceSchema.default('Joanna'),
-      engine: SpeechSynthesisEngineSchema.default('neural'),
+      voiceId: SpeechSynthesisVoiceSchema.default('Amy'),
+      engine: SpeechSynthesisEngineSchema.default('generative'),
     })
     .optional(),
 })

--- a/contracts/src/speech/synthesizeSpeech.schema.ts
+++ b/contracts/src/speech/synthesizeSpeech.schema.ts
@@ -28,6 +28,15 @@ export type SpeechSynthesisVoice =
   (typeof SPEECH_SYNTHESIS_VOICE_VALUES)[number]
 export const SpeechSynthesisVoiceSchema = z.enum(SPEECH_SYNTHESIS_VOICE_VALUES)
 
+export const GENERATIVE_VOICE_VALUES: readonly SpeechSynthesisVoice[] = [
+  'Joanna',
+  'Matthew',
+  'Salli',
+  'Ruth',
+  'Stephen',
+  'Amy',
+]
+
 /**
  * Hard cap on a single synthesis request, in characters of text. Sized to
  * cover a typical full meeting briefing read-out (~5,000 words / 30,000
@@ -59,6 +68,12 @@ export const SynthesizeSpeechRequestSchema = z.object({
       voiceId: SpeechSynthesisVoiceSchema.default('Amy'),
       engine: SpeechSynthesisEngineSchema.default('generative'),
     })
+    .refine(
+      ({ voiceId, engine }) =>
+        engine !== 'generative' ||
+        GENERATIVE_VOICE_VALUES.includes(voiceId),
+      { message: 'Selected voice does not support the generative engine' },
+    )
     .optional(),
 })
 export type SynthesizeSpeechRequest = z.infer<

--- a/src/speech/services/textToSpeech.service.ts
+++ b/src/speech/services/textToSpeech.service.ts
@@ -57,8 +57,8 @@ export class TextToSpeechService {
       )
     }
 
-    const voiceId: VoiceId = request.options?.voiceId ?? 'Joanna'
-    const engine: Engine = request.options?.engine ?? 'neural'
+    const voiceId: VoiceId = request.options?.voiceId ?? 'Amy'
+    const engine: Engine = request.options?.engine ?? 'generative'
 
     // The contracts schema enforces non-empty + max length on request.text;
     // chunkBySentence may still yield zero chunks if the input is purely


### PR DESCRIPTION
## Summary

- Adds `generative` to the `SpeechSynthesisEngine` enum in contracts
- Adds `Amy` (British English) to the `SpeechSynthesisVoice` enum in contracts
- Updates default voice/engine from `Joanna`/`neural` to `Amy`/`generative`

## Test plan

- [ ] All 27 speech unit tests pass
- [ ] Lint passes clean on changed files
- [ ] Verify Amy/generative voice sounds correct via the briefings read-aloud feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default Polly `engine`/`voiceId` used for TTS, which can affect audio output quality, availability by region, and cost/caching behavior for existing clients relying on defaults.
> 
> **Overview**
> Switches the default text-to-speech configuration from `Joanna`/`neural` to **`Amy`/`generative`**.
> 
> Updates the contracts schema to allow the new `generative` engine and `Amy` voice, and aligns the server-side fallback defaults in `TextToSpeechService` when callers omit `options`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8fdb6fd271bb125bcd8c4f2a24b7e47c01e410. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->