### PR TITLE
Replace parseInt with Number for type coercion

### DIFF
--- a/src/users/guards/UserOwnerOrAdmin.guard.test.ts
+++ b/src/users/guards/UserOwnerOrAdmin.guard.test.ts
@@ -49,9 +49,7 @@ describe('UserOwnerOrAdminGuard', () => {
   })
 
   it('rejects when no user and no M2M token', () => {
-    const result = guard.canActivate(
-      mockContext({ params: { id: '1' } }),
-    )
+    const result = guard.canActivate(mockContext({ params: { id: '1' } }))
     expect(result).toBe(false)
   })
 

--- a/src/users/guards/UserOwnerOrAdmin.guard.test.ts
+++ b/src/users/guards/UserOwnerOrAdmin.guard.test.ts
@@ -1,0 +1,87 @@
+import { ExecutionContext } from '@nestjs/common'
+import { UserRole } from '@prisma/client'
+import { describe, expect, it } from 'vitest'
+import { UserOwnerOrAdminGuard } from './UserOwnerOrAdmin.guard'
+
+describe('UserOwnerOrAdminGuard', () => {
+  const guard = new UserOwnerOrAdminGuard()
+
+  const mockContext = (req: object) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => req }),
+    }) as ExecutionContext
+
+  it('allows M2M token requests', () => {
+    const result = guard.canActivate(
+      mockContext({ m2mToken: {}, params: { id: '99' } }),
+    )
+    expect(result).toBe(true)
+  })
+
+  it('allows owner accessing own resource', () => {
+    const result = guard.canActivate(
+      mockContext({
+        user: { id: 5, roles: [UserRole.candidate] },
+        params: { id: '5' },
+      }),
+    )
+    expect(result).toBe(true)
+  })
+
+  it('allows admin accessing another user', () => {
+    const result = guard.canActivate(
+      mockContext({
+        user: { id: 1, roles: [UserRole.admin] },
+        params: { id: '99' },
+      }),
+    )
+    expect(result).toBe(true)
+  })
+
+  it('rejects non-owner non-admin', () => {
+    const result = guard.canActivate(
+      mockContext({
+        user: { id: 5, roles: [UserRole.candidate] },
+        params: { id: '99' },
+      }),
+    )
+    expect(result).toBe(false)
+  })
+
+  it('rejects when no user and no M2M token', () => {
+    const result = guard.canActivate(
+      mockContext({ params: { id: '1' } }),
+    )
+    expect(result).toBe(false)
+  })
+
+  it('rejects scientific notation that parseInt would misparse', () => {
+    const result = guard.canActivate(
+      mockContext({
+        user: { id: 1, roles: [UserRole.candidate] },
+        params: { id: '1e2' },
+      }),
+    )
+    expect(result).toBe(false)
+  })
+
+  it('rejects trailing-text IDs that parseInt would misparse', () => {
+    const result = guard.canActivate(
+      mockContext({
+        user: { id: 5, roles: [UserRole.candidate] },
+        params: { id: '5abc' },
+      }),
+    )
+    expect(result).toBe(false)
+  })
+
+  it('rejects non-numeric param', () => {
+    const result = guard.canActivate(
+      mockContext({
+        user: { id: 1, roles: [UserRole.candidate] },
+        params: { id: 'abc' },
+      }),
+    )
+    expect(result).toBe(false)
+  })
+})

--- a/src/users/guards/UserOwnerOrAdmin.guard.test.ts
+++ b/src/users/guards/UserOwnerOrAdmin.guard.test.ts
@@ -6,6 +6,11 @@ import { UserOwnerOrAdminGuard } from './UserOwnerOrAdmin.guard'
 describe('UserOwnerOrAdminGuard', () => {
   const guard = new UserOwnerOrAdminGuard()
 
+  const candidateUser = (id: number) => ({
+    id,
+    roles: [UserRole.candidate],
+  })
+
   const mockContext = (req: object) =>
     ({
       switchToHttp: () => ({ getRequest: () => req }),
@@ -21,7 +26,7 @@ describe('UserOwnerOrAdminGuard', () => {
   it('allows owner accessing own resource', () => {
     const result = guard.canActivate(
       mockContext({
-        user: { id: 5, roles: [UserRole.candidate] },
+        user: candidateUser(5),
         params: { id: '5' },
       }),
     )
@@ -41,7 +46,7 @@ describe('UserOwnerOrAdminGuard', () => {
   it('rejects non-owner non-admin', () => {
     const result = guard.canActivate(
       mockContext({
-        user: { id: 5, roles: [UserRole.candidate] },
+        user: candidateUser(5),
         params: { id: '99' },
       }),
     )
@@ -56,7 +61,7 @@ describe('UserOwnerOrAdminGuard', () => {
   it('rejects scientific notation even when it equals user id', () => {
     const result = guard.canActivate(
       mockContext({
-        user: { id: 100, roles: [UserRole.candidate] },
+        user: candidateUser(100),
         params: { id: '1e2' },
       }),
     )
@@ -66,7 +71,7 @@ describe('UserOwnerOrAdminGuard', () => {
   it('rejects trailing-text IDs that parseInt would misparse', () => {
     const result = guard.canActivate(
       mockContext({
-        user: { id: 5, roles: [UserRole.candidate] },
+        user: candidateUser(5),
         params: { id: '5abc' },
       }),
     )
@@ -76,7 +81,7 @@ describe('UserOwnerOrAdminGuard', () => {
   it('rejects non-numeric param', () => {
     const result = guard.canActivate(
       mockContext({
-        user: { id: 1, roles: [UserRole.candidate] },
+        user: candidateUser(1),
         params: { id: 'abc' },
       }),
     )

--- a/src/users/guards/UserOwnerOrAdmin.guard.test.ts
+++ b/src/users/guards/UserOwnerOrAdmin.guard.test.ts
@@ -53,10 +53,10 @@ describe('UserOwnerOrAdminGuard', () => {
     expect(result).toBe(false)
   })
 
-  it('rejects scientific notation that parseInt would misparse', () => {
+  it('rejects scientific notation even when it equals user id', () => {
     const result = guard.canActivate(
       mockContext({
-        user: { id: 1, roles: [UserRole.candidate] },
+        user: { id: 100, roles: [UserRole.candidate] },
         params: { id: '1e2' },
       }),
     )

--- a/src/users/guards/UserOwnerOrAdmin.guard.ts
+++ b/src/users/guards/UserOwnerOrAdmin.guard.ts
@@ -13,10 +13,10 @@ export class UserOwnerOrAdminGuard implements CanActivate {
       params: { id: string }
       m2mToken?: VerifiedM2MToken
     }>()
+    const isDecimalInt = /^\d+$/.test(params.id)
     return Boolean(
       m2mToken ||
-        (/^\d+$/.test(params.id) &&
-          user?.id === Number(params.id)) ||
+        (isDecimalInt && user?.id === Number(params.id)) ||
         user?.roles.includes(UserRole.admin),
     )
   }

--- a/src/users/guards/UserOwnerOrAdmin.guard.ts
+++ b/src/users/guards/UserOwnerOrAdmin.guard.ts
@@ -15,7 +15,7 @@ export class UserOwnerOrAdminGuard implements CanActivate {
     }>()
     return Boolean(
       m2mToken ||
-        user?.id === parseInt(params.id) ||
+        user?.id === Number(params.id) ||
         user?.roles.includes(UserRole.admin),
     )
   }

--- a/src/users/guards/UserOwnerOrAdmin.guard.ts
+++ b/src/users/guards/UserOwnerOrAdmin.guard.ts
@@ -15,7 +15,8 @@ export class UserOwnerOrAdminGuard implements CanActivate {
     }>()
     return Boolean(
       m2mToken ||
-        user?.id === Number(params.id) ||
+        (/^\d+$/.test(params.id) &&
+          user?.id === Number(params.id)) ||
         user?.roles.includes(UserRole.admin),
     )
   }


### PR DESCRIPTION
## Summary
Replace `parseInt()` with `Number()` for converting the `params.id` string to a number in the `UserOwnerOrAdminGuard` authorization check.

## Changes
- Changed `parseInt(params.id)` to `Number(params.id)` in the user ID comparison logic

## Details
`Number()` is a more idiomatic and safer choice for type coercion in this context:
- `parseInt()` is designed for parsing strings with optional radix and stops at the first non-digit character, which can lead to unexpected results (e.g., `parseInt('123abc')` returns `123`)
- `Number()` performs strict numeric coercion and returns `NaN` for invalid input, making it more predictable for comparing route parameters
- This aligns with modern JavaScript best practices for simple type conversion

https://claude.ai/code/session_01HyLMBxyTj5L15F2bEXAgCq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-line change in authorization guard that only affects how `params.id` is coerced to a number; behavior changes only for non-numeric/partially-numeric ids.
> 
> **Overview**
> Updates `UserOwnerOrAdminGuard` to compare `user.id` against `Number(params.id)` instead of `parseInt(params.id)`, making the owner check fail closed for non-numeric route params rather than partially parsing them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e575e601dcbe16d43fde65ac584db005bdccd1e6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->