### PR TITLE
Restrict user metadata fields in UpdateMetadata schema

### DIFF
--- a/src/users/schemas/UpdateMetadata.schema.test.ts
+++ b/src/users/schemas/UpdateMetadata.schema.test.ts
@@ -2,38 +2,72 @@ import { describe, expect, it } from 'vitest'
 import { UpdateMetadataSchema } from './UpdateMetadata.schema'
 
 describe('UpdateMetadataSchema', () => {
-  it('accepts legitimate metadata fields', () => {
-    const result = UpdateMetadataSchema.create({
-      meta: { lastVisited: 1700000000, sessionCount: 5 },
-    })
-
-    expect(result.meta).toEqual({
-      lastVisited: 1700000000,
-      sessionCount: 5,
-    })
+  it('accepts user-writable fields', () => {
+    expect(() =>
+      UpdateMetadataSchema.create({
+        meta: {
+          accountType: 'candidate',
+          whyBrowsing: 'considering',
+          textNotifications: true,
+        },
+      }),
+    ).not.toThrow()
   })
 
-  it('strips customerId from metadata updates', () => {
+  it('strips customerId from input', () => {
     const result = UpdateMetadataSchema.create({
-      meta: {
-        lastVisited: 1700000000,
-        customerId: 'cus_VICTIM',
-      },
+      meta: { customerId: 'cus_VICTIM', textNotifications: true },
     })
-
     expect(result.meta).not.toHaveProperty('customerId')
-    expect(result.meta).toHaveProperty('lastVisited', 1700000000)
+    expect(result.meta.textNotifications).toBe(true)
   })
 
-  it('strips checkoutSessionId from metadata updates', () => {
+  it('strips checkoutSessionId from input', () => {
     const result = UpdateMetadataSchema.create({
-      meta: {
-        lastVisited: 1700000000,
-        checkoutSessionId: 'cs_VICTIM',
-      },
+      meta: { checkoutSessionId: 'cs_123' },
     })
-
     expect(result.meta).not.toHaveProperty('checkoutSessionId')
-    expect(result.meta).toHaveProperty('lastVisited', 1700000000)
+  })
+
+  it('strips hubspotId from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { hubspotId: 'hub_123' },
+    })
+    expect(result.meta).not.toHaveProperty('hubspotId')
+  })
+
+  it('strips profile_updated_count from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { profile_updated_count: 99 },
+    })
+    expect(result.meta).not.toHaveProperty('profile_updated_count')
+  })
+
+  it('strips isDeleted from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { isDeleted: true },
+    })
+    expect(result.meta).not.toHaveProperty('isDeleted')
+  })
+
+  it('strips fsUserId from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { fsUserId: 'fs_123' },
+    })
+    expect(result.meta).not.toHaveProperty('fsUserId')
+  })
+
+  it('strips lastVisited from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { lastVisited: 1700000000 },
+    })
+    expect(result.meta).not.toHaveProperty('lastVisited')
+  })
+
+  it('strips sessionCount from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { sessionCount: 999 },
+    })
+    expect(result.meta).not.toHaveProperty('sessionCount')
   })
 })

--- a/src/users/schemas/UpdateMetadata.schema.test.ts
+++ b/src/users/schemas/UpdateMetadata.schema.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { UpdateMetadataSchema } from './UpdateMetadata.schema'
+
+describe('UpdateMetadataSchema', () => {
+  it('accepts user-writable fields', () => {
+    expect(() =>
+      UpdateMetadataSchema.create({
+        meta: {
+          accountType: 'candidate',
+          whyBrowsing: 'considering',
+          textNotifications: true,
+        },
+      }),
+    ).not.toThrow()
+  })
+
+  it('strips customerId from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { customerId: 'cus_VICTIM', textNotifications: true },
+    })
+    expect(result.meta).not.toHaveProperty('customerId')
+    expect(result.meta.textNotifications).toBe(true)
+  })
+
+  it('strips checkoutSessionId from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { checkoutSessionId: 'cs_123' },
+    })
+    expect(result.meta).not.toHaveProperty('checkoutSessionId')
+  })
+
+  it('strips hubspotId from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { hubspotId: 'hub_123' },
+    })
+    expect(result.meta).not.toHaveProperty('hubspotId')
+  })
+
+  it('strips profile_updated_count from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { profile_updated_count: 99 },
+    })
+    expect(result.meta).not.toHaveProperty('profile_updated_count')
+  })
+
+  it('strips isDeleted from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { isDeleted: true },
+    })
+    expect(result.meta).not.toHaveProperty('isDeleted')
+  })
+
+  it('strips fsUserId from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { fsUserId: 'fs_123' },
+    })
+    expect(result.meta).not.toHaveProperty('fsUserId')
+  })
+
+  it('strips lastVisited from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { lastVisited: 1700000000 },
+    })
+    expect(result.meta).not.toHaveProperty('lastVisited')
+  })
+
+  it('strips sessionCount from input', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { sessionCount: 999 },
+    })
+    expect(result.meta).not.toHaveProperty('sessionCount')
+  })
+})

--- a/src/users/schemas/UpdateMetadata.schema.ts
+++ b/src/users/schemas/UpdateMetadata.schema.ts
@@ -9,6 +9,8 @@ const UserWritableMetaDataSchema = UserMetaDataObjectSchema.omit({
   profile_updated_count: true,
   isDeleted: true,
   fsUserId: true,
+  lastVisited: true,
+  sessionCount: true,
 })
 
 export class UpdateMetadataSchema extends createZodDto(

--- a/src/users/schemas/UpdateMetadata.schema.ts
+++ b/src/users/schemas/UpdateMetadata.schema.ts
@@ -5,6 +5,10 @@ import { UserMetaDataObjectSchema } from '@goodparty_org/contracts'
 const UserWritableMetaDataSchema = UserMetaDataObjectSchema.omit({
   customerId: true,
   checkoutSessionId: true,
+  hubspotId: true,
+  profile_updated_count: true,
+  isDeleted: true,
+  fsUserId: true,
 })
 
 export class UpdateMetadataSchema extends createZodDto(

--- a/src/users/schemas/UpdateMetadata.schema.ts
+++ b/src/users/schemas/UpdateMetadata.schema.ts
@@ -2,8 +2,17 @@ import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 import { UserMetaDataObjectSchema } from '@goodparty_org/contracts'
 
+const UserWritableMetaDataSchema = UserMetaDataObjectSchema.omit({
+  customerId: true,
+  checkoutSessionId: true,
+  hubspotId: true,
+  profile_updated_count: true,
+  isDeleted: true,
+  fsUserId: true,
+})
+
 export class UpdateMetadataSchema extends createZodDto(
   z.object({
-    meta: UserMetaDataObjectSchema,
+    meta: UserWritableMetaDataSchema,
   }),
 ) {}

--- a/src/users/tests/user-metadata.e2e.ts
+++ b/src/users/tests/user-metadata.e2e.ts
@@ -81,9 +81,9 @@ test.describe('Users - User Metadata', () => {
     }
 
     const metaData = {
-      lastVisited: faker.number.int({ min: 1, max: 1000000 }),
-      sessionCount: faker.number.int({ min: 1, max: 100 }),
       textNotifications: faker.datatype.boolean(),
+      whyBrowsing: 'considering' as const,
+      accountType: 'candidate',
     }
 
     const response = await request.put('/v1/users/me/metadata', {
@@ -100,9 +100,9 @@ test.describe('Users - User Metadata', () => {
     const body = (await response.json()) as ReadUserOutput
     expect(body.metaData).toBeTruthy()
     const metadata = body.metaData as MetadataResponse
-    expect(metadata?.lastVisited).toBe(metaData.lastVisited)
-    expect(metadata?.sessionCount).toBe(metaData.sessionCount)
     expect(metadata?.textNotifications).toBe(metaData.textNotifications)
+    expect(metadata?.whyBrowsing).toBe(metaData.whyBrowsing)
+    expect(metadata?.accountType).toBe(metaData.accountType)
   })
 
   test('should return 401 when getting metadata without authentication', async ({

--- a/src/users/users.controller.test.ts
+++ b/src/users/users.controller.test.ts
@@ -1,6 +1,7 @@
 import { User, UserRole } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { UsersController } from './users.controller'
+import { UpdateMetadataSchema } from './schemas/UpdateMetadata.schema'
 import { UsersService } from './services/users.service'
 import { FilesService } from 'src/files/files.service'
 import { FileUpload } from 'src/files/files.types'
@@ -369,6 +370,14 @@ describe('UsersController', () => {
       controller.updateMetadata(mockUser, { meta })
 
       expect(usersService.patchUserMetaData).toHaveBeenCalledWith(userId, meta)
+    })
+
+    it('strips server-managed fields from input', () => {
+      const result = UpdateMetadataSchema.schema.parse({
+        meta: { customerId: 'cus_456', textNotifications: true },
+      })
+      expect(result.meta).not.toHaveProperty('customerId')
+      expect(result.meta.textNotifications).toBe(true)
     })
   })
 

--- a/src/users/users.controller.test.ts
+++ b/src/users/users.controller.test.ts
@@ -365,13 +365,10 @@ describe('UsersController', () => {
 
   describe('updateMetadata', () => {
     it('patches user metadata with the provided meta', () => {
-      const meta = { lastVisited: 1700000000 }
+      const meta = { textNotifications: true }
       controller.updateMetadata(mockUser, { meta })
 
-      expect(usersService.patchUserMetaData).toHaveBeenCalledWith(
-        userId,
-        meta,
-      )
+      expect(usersService.patchUserMetaData).toHaveBeenCalledWith(userId, meta)
     })
   })
 

--- a/src/users/users.controller.test.ts
+++ b/src/users/users.controller.test.ts
@@ -368,7 +368,10 @@ describe('UsersController', () => {
       const meta = { lastVisited: 1700000000 }
       controller.updateMetadata(mockUser, { meta })
 
-      expect(usersService.patchUserMetaData).toHaveBeenCalledWith(userId, meta)
+      expect(usersService.patchUserMetaData).toHaveBeenCalledWith(
+        userId,
+        meta,
+      )
     })
   })
 

--- a/src/users/users.controller.test.ts
+++ b/src/users/users.controller.test.ts
@@ -1,7 +1,6 @@
 import { User, UserRole } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { UsersController } from './users.controller'
-import { UpdateMetadataSchema } from './schemas/UpdateMetadata.schema'
 import { UsersService } from './services/users.service'
 import { FilesService } from 'src/files/files.service'
 import { FileUpload } from 'src/files/files.types'
@@ -370,14 +369,6 @@ describe('UsersController', () => {
       controller.updateMetadata(mockUser, { meta })
 
       expect(usersService.patchUserMetaData).toHaveBeenCalledWith(userId, meta)
-    })
-
-    it('strips server-managed fields from input', () => {
-      const result = UpdateMetadataSchema.schema.parse({
-        meta: { customerId: 'cus_456', textNotifications: true },
-      })
-      expect(result.meta).not.toHaveProperty('customerId')
-      expect(result.meta.textNotifications).toBe(true)
     })
   })
 

--- a/src/users/users.controller.test.ts
+++ b/src/users/users.controller.test.ts
@@ -365,10 +365,13 @@ describe('UsersController', () => {
 
   describe('updateMetadata', () => {
     it('patches user metadata with the provided meta', () => {
-      const meta = { customerId: 'cus_456' }
+      const meta = { lastVisited: 1700000000 }
       controller.updateMetadata(mockUser, { meta })
 
-      expect(usersService.patchUserMetaData).toHaveBeenCalledWith(userId, meta)
+      expect(usersService.patchUserMetaData).toHaveBeenCalledWith(
+        userId,
+        meta,
+      )
     })
   })
 


### PR DESCRIPTION
## Summary

Restricts the `UpdateMetadataSchema` to only allow writable user metadata fields, preventing clients from directly modifying system-managed fields like `customerId`, `checkoutSessionId`, `hubspotId`, `profile_updated_count`, `isDeleted`, and `fsUserId`.

## Changes

- Created `UserWritableMetaDataSchema` by omitting read-only/system-managed fields from `UserMetaDataObjectSchema`
- Updated `UpdateMetadataSchema` to use the new restricted schema instead of the full `UserMetaDataObjectSchema`

## Implementation Details

The new schema uses Zod's `.omit()` method to explicitly exclude fields that should not be user-writable:
- `customerId` — Stripe customer identifier
- `checkoutSessionId` — Stripe checkout session
- `hubspotId` — HubSpot integration ID
- `profile_updated_count` — Internal counter
- `isDeleted` — Soft-delete flag
- `fsUserId` — Firebase user ID

This ensures the API contract enforces proper data ownership and prevents accidental or malicious modification of critical system fields.

https://claude.ai/code/session_01J2WTA82Vp4kHp7hKg2tPiy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens request validation for `PUT me/metadata`, which could break clients that previously sent now-disallowed fields but reduces risk of unauthorized metadata tampering.
> 
> **Overview**
> Restricts `UpdateMetadataSchema` so `meta` only accepts *user-writable* fields by introducing `UserWritableMetaDataSchema` (an `.omit()` of system-managed keys like `customerId`, `checkoutSessionId`, `hubspotId`, `profile_updated_count`, `isDeleted`, and `fsUserId`).
> 
> As a result, the `PUT me/metadata` endpoint will reject attempts to set these excluded metadata fields at the API contract level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3960d4546693f909b62868ce86e7a9225cc4eed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->