### PR TITLE
feat(annotations): OCR fields on AnnotationNoteAttachment

### DIFF
--- a/prisma/schema/annotationNoteAttachment.prisma
+++ b/prisma/schema/annotationNoteAttachment.prisma
@@ -18,13 +18,14 @@ model AnnotationNoteAttachment {
   sizeBytes  Int    @map("size_bytes")
 
   ocrStatus      OcrStatus @default(pending) @map("ocr_status")
-  ocrText        String?   @db.Text @map("ocr_text")
-  ocrError       String?   @map("ocr_error")
-  ocrCompletedAt DateTime? @map("ocr_completed_at")
+  ocrText        String?   @db.Text          @map("ocr_text")
+  ocrError       String?   @db.Text          @map("ocr_error")
+  ocrCompletedAt DateTime?                   @map("ocr_completed_at")
 
   createdAt DateTime @default(now()) @map("created_at")
 
-  @@index([noteId])
+  // The composite (note_id, ocr_status) index also serves noteId-only lookups
+  // via its leading column, so we drop the standalone noteId index.
   @@index([noteId, ocrStatus])
   @@map("annotation_note_attachment")
 }

--- a/prisma/schema/annotationNoteAttachment.prisma
+++ b/prisma/schema/annotationNoteAttachment.prisma
@@ -1,3 +1,11 @@
+enum OcrStatus {
+  pending
+  processing
+  completed
+  failed
+  skipped
+}
+
 model AnnotationNoteAttachment {
   id String @id @default(cuid())
 
@@ -9,8 +17,14 @@ model AnnotationNoteAttachment {
   mimeType   String @map("mime_type")
   sizeBytes  Int    @map("size_bytes")
 
+  ocrStatus      OcrStatus @default(pending) @map("ocr_status")
+  ocrText        String?   @db.Text @map("ocr_text")
+  ocrError       String?   @map("ocr_error")
+  ocrCompletedAt DateTime? @map("ocr_completed_at")
+
   createdAt DateTime @default(now()) @map("created_at")
 
   @@index([noteId])
+  @@index([noteId, ocrStatus])
   @@map("annotation_note_attachment")
 }

--- a/prisma/schema/migrations/20260515202429_annotation_attachment_ocr/migration.sql
+++ b/prisma/schema/migrations/20260515202429_annotation_attachment_ocr/migration.sql
@@ -1,0 +1,13 @@
+-- OCR pipeline groundwork for attachment-bearing notes (camera / upload).
+-- Each attachment goes through OCR (or skip, for plain text) and the
+-- extracted text becomes part of the note's effective content.
+CREATE TYPE "OcrStatus" AS ENUM ('pending', 'processing', 'completed', 'failed', 'skipped');
+
+ALTER TABLE "annotation_note_attachment"
+  ADD COLUMN "ocr_status" "OcrStatus" NOT NULL DEFAULT 'pending',
+  ADD COLUMN "ocr_text" TEXT,
+  ADD COLUMN "ocr_error" TEXT,
+  ADD COLUMN "ocr_completed_at" TIMESTAMP(3);
+
+CREATE INDEX "annotation_note_attachment_note_id_ocr_status_idx"
+  ON "annotation_note_attachment" ("note_id", "ocr_status");

--- a/prisma/schema/migrations/20260515202429_annotation_attachment_ocr/migration.sql
+++ b/prisma/schema/migrations/20260515202429_annotation_attachment_ocr/migration.sql
@@ -9,5 +9,9 @@ ALTER TABLE "annotation_note_attachment"
   ADD COLUMN "ocr_error" TEXT,
   ADD COLUMN "ocr_completed_at" TIMESTAMP(3);
 
+-- The composite index below serves noteId-only lookups via its leading
+-- column, so drop the standalone noteId index to avoid duplicate maintenance.
+DROP INDEX "annotation_note_attachment_note_id_idx";
+
 CREATE INDEX "annotation_note_attachment_note_id_ocr_status_idx"
   ON "annotation_note_attachment" ("note_id", "ocr_status");


### PR DESCRIPTION
Adds OcrStatus enum (pending/processing/completed/failed/skipped) and ocr_text / ocr_error / ocr_completed_at columns. Index on (note_id, ocr_status) for the polling path. Migration-only PR so develop picks up the new columns ahead of the Phase 2 API + frontend work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, migration-only schema change adding new nullable columns and an index; main risk is migration/runtime mismatch if deployed out of order.
> 
> **Overview**
> Adds an `OcrStatus` enum and new OCR-related columns (`ocr_status`, `ocr_text`, `ocr_error`, `ocr_completed_at`) on `AnnotationNoteAttachment`, defaulting status to `pending`.
> 
> Includes a migration to create the `OcrStatus` Postgres enum, back the new columns, and add an index on (`note_id`, `ocr_status`) for status-based lookup/polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b876f4e8c5d8ac999996aaf54dc0cee837605979. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->