### PR TITLE
scripts: seed-dev-briefings — example meeting_schedule + updated briefing for serve@fightclub.org

### DIFF
--- a/scripts/seed-dev-briefings.ts
+++ b/scripts/seed-dev-briefings.ts
@@ -1,0 +1,342 @@
+/**
+ * Seed dev briefings data for serve@fightclub.org's elected office.
+ *
+ * Produces:
+ *   1. A meeting_schedule ExperimentRun + S3 artifact (idempotent, one per org).
+ *   2. Adds meeting_name + location to the latest seeded meeting_briefing
+ *      artifact in S3.
+ *   3. If gp-api PR #1599 has shipped (meeting_briefing.artifact column
+ *      exists), updates that column too. Otherwise logs a warning and skips.
+ *
+ * Targets dev only. Configure with:
+ *   AWS_PROFILE=work
+ *   DATABASE_URL=<dev gp-api Postgres URL>
+ *   AWS_REGION=us-west-2 (optional; defaults below)
+ *
+ * Usage:
+ *   AWS_PROFILE=work npx tsx scripts/seed-dev-briefings.ts
+ */
+import 'dotenv/config'
+import { PrismaClient } from '@prisma/client'
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+  NoSuchKey,
+} from '@aws-sdk/client-s3'
+import { randomUUID } from 'crypto'
+
+const SERVE_EMAIL = 'serve@fightclub.org'
+const ARTIFACT_BUCKET = 'gp-agent-artifacts-dev'
+const AWS_REGION = process.env.AWS_REGION ?? 'us-west-2'
+const SCHEDULE_EXPERIMENT_TYPE = 'meeting_schedule'
+
+const MEETING_NAME = 'City Council'
+const LOCATION =
+  "Cheyenne City Hall Council Chambers, 2101 O'Neil Ave, Cheyenne, WY 82001"
+
+type MeetingScheduleFoundArtifact = {
+  generated_at: string
+  status: 'found'
+  meeting_name: string
+  location: string
+  rrule: string
+  human: string
+  time: string
+  timezone: string
+  duration_minutes: number
+  sources: { url: string; note: string }[]
+}
+
+const buildScheduleArtifact = (): MeetingScheduleFoundArtifact => ({
+  generated_at: new Date().toISOString(),
+  status: 'found',
+  meeting_name: MEETING_NAME,
+  location: LOCATION,
+  rrule: 'FREQ=WEEKLY;BYDAY=MO',
+  human: 'Every Monday',
+  time: '18:00',
+  timezone: 'America/Denver',
+  duration_minutes: 90,
+  sources: [
+    {
+      url: 'https://www.cheyennecity.org/Your-Government/Elected-Officials/City-Council',
+      note: 'Cheyenne City Council schedule page',
+    },
+  ],
+})
+
+const getJson = async <T>(
+  s3: S3Client,
+  bucket: string,
+  key: string,
+): Promise<T | null> => {
+  try {
+    const resp = await s3.send(
+      new GetObjectCommand({ Bucket: bucket, Key: key }),
+    )
+    if (!resp.Body) return null
+    const raw = await resp.Body.transformToString()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return JSON.parse(raw) as T
+  } catch (err) {
+    if (err instanceof NoSuchKey) return null
+    throw err
+  }
+}
+
+const putJson = async (
+  s3: S3Client,
+  bucket: string,
+  key: string,
+  body: unknown,
+): Promise<void> => {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: JSON.stringify(body, null, 2),
+      ContentType: 'application/json',
+    }),
+  )
+}
+
+const checkArtifactColumnExists = async (
+  prisma: PrismaClient,
+): Promise<boolean> => {
+  const rows = await prisma.$queryRaw<{ column_name: string }[]>`
+    SELECT column_name FROM information_schema.columns
+    WHERE table_name = 'meeting_briefing' AND column_name = 'artifact'
+  `
+  return rows.length > 0
+}
+
+const findElectedOfficeForServeUser = async (prisma: PrismaClient) => {
+  const user = await prisma.user.findFirst({
+    where: { email: SERVE_EMAIL },
+    select: { id: true, email: true },
+  })
+  if (!user) {
+    throw new Error(
+      `User ${SERVE_EMAIL} not found in DB. Check DATABASE_URL points at dev.`,
+    )
+  }
+
+  const office = await prisma.electedOffice.findFirst({
+    where: { userId: user.id },
+    orderBy: { createdAt: 'desc' },
+  })
+  if (!office) {
+    throw new Error(
+      `No ElectedOffice found for user ${SERVE_EMAIL} (id ${user.id}).`,
+    )
+  }
+  return { user, office }
+}
+
+const ensureScheduleRun = async (
+  prisma: PrismaClient,
+  s3: S3Client,
+  organizationSlug: string,
+) => {
+  const existing = await prisma.experimentRun.findFirst({
+    where: {
+      organizationSlug,
+      experimentType: SCHEDULE_EXPERIMENT_TYPE,
+      status: 'COMPLETED',
+      artifactBucket: { not: null },
+      artifactKey: { not: null },
+    },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  if (existing && existing.artifactBucket && existing.artifactKey) {
+    const current = await getJson<MeetingScheduleFoundArtifact>(
+      s3,
+      existing.artifactBucket,
+      existing.artifactKey,
+    )
+    const needsRewrite =
+      !current ||
+      current.status !== 'found' ||
+      current.meeting_name !== MEETING_NAME ||
+      current.location !== LOCATION
+
+    if (needsRewrite) {
+      await putJson(
+        s3,
+        existing.artifactBucket,
+        existing.artifactKey,
+        buildScheduleArtifact(),
+      )
+      console.log(
+        `Rewrote existing schedule artifact at s3://${existing.artifactBucket}/${existing.artifactKey}`,
+      )
+    } else {
+      console.log(
+        `Schedule artifact already up to date at s3://${existing.artifactBucket}/${existing.artifactKey}`,
+      )
+    }
+
+    return {
+      runId: existing.runId,
+      bucket: existing.artifactBucket,
+      key: existing.artifactKey,
+      created: false,
+    }
+  }
+
+  const artifactKey = `${SCHEDULE_EXPERIMENT_TYPE}/${randomUUID()}/artifact.json`
+  await putJson(s3, ARTIFACT_BUCKET, artifactKey, buildScheduleArtifact())
+
+  const params = {
+    state: 'WY',
+    city: 'Cheyenne',
+    office: MEETING_NAME,
+  }
+
+  const created = await prisma.experimentRun.create({
+    data: {
+      organizationSlug,
+      experimentType: SCHEDULE_EXPERIMENT_TYPE,
+      status: 'COMPLETED',
+      params,
+      artifactBucket: ARTIFACT_BUCKET,
+      artifactKey,
+    },
+  })
+
+  console.log(
+    `Created schedule ExperimentRun ${created.runId} → s3://${ARTIFACT_BUCKET}/${artifactKey}`,
+  )
+
+  return {
+    runId: created.runId,
+    bucket: ARTIFACT_BUCKET,
+    key: artifactKey,
+    created: true,
+  }
+}
+
+const patchBriefingArtifact = async (
+  prisma: PrismaClient,
+  s3: S3Client,
+  electedOfficeId: string,
+  hasArtifactColumn: boolean,
+) => {
+  const briefing = await prisma.meetingBriefing.findFirst({
+    where: { electedOfficeId },
+    orderBy: { meetingDate: 'desc' },
+  })
+  if (!briefing) {
+    console.log(
+      `No MeetingBriefing row found for elected office ${electedOfficeId}. Skipping briefing patch.`,
+    )
+    return null
+  }
+
+  const current = await getJson<Record<string, unknown>>(
+    s3,
+    briefing.artifactBucket,
+    briefing.artifactKey,
+  )
+  if (!current) {
+    console.log(
+      `Briefing artifact missing at s3://${briefing.artifactBucket}/${briefing.artifactKey}. Skipping.`,
+    )
+    return null
+  }
+
+  const updated = {
+    ...current,
+    meeting_name: MEETING_NAME,
+    location: LOCATION,
+  }
+
+  await putJson(s3, briefing.artifactBucket, briefing.artifactKey, updated)
+  console.log(
+    `Updated briefing artifact at s3://${briefing.artifactBucket}/${briefing.artifactKey} (added meeting_name + location)`,
+  )
+
+  if (hasArtifactColumn) {
+    await prisma.$executeRaw`
+      UPDATE meeting_briefing
+      SET artifact = ${JSON.stringify(updated)}::jsonb,
+          updated_at = NOW()
+      WHERE id = ${briefing.id}
+    `
+    console.log(
+      `Updated meeting_briefing.artifact column for briefing ${briefing.id}`,
+    )
+  } else {
+    console.warn(
+      `meeting_briefing.artifact column does not exist in this DB; ` +
+        `skipping column update (PR #1599 not yet deployed).`,
+    )
+  }
+
+  return {
+    briefingId: briefing.id,
+    bucket: briefing.artifactBucket,
+    key: briefing.artifactKey,
+  }
+}
+
+const main = async () => {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    throw new Error(
+      'DATABASE_URL is not set. Point it at the gp-api dev Postgres.',
+    )
+  }
+
+  const prisma = new PrismaClient()
+  const s3 = new S3Client({ region: AWS_REGION })
+
+  try {
+    const hasArtifactColumn = await checkArtifactColumnExists(prisma)
+    console.log(
+      `meeting_briefing.artifact column present: ${hasArtifactColumn}`,
+    )
+
+    const { user, office } = await findElectedOfficeForServeUser(prisma)
+    console.log(
+      `Found elected office ${office.id} (org ${office.organizationSlug}) for user ${user.email}`,
+    )
+
+    const schedule = await ensureScheduleRun(
+      prisma,
+      s3,
+      office.organizationSlug,
+    )
+
+    const patched = await patchBriefingArtifact(
+      prisma,
+      s3,
+      office.id,
+      hasArtifactColumn,
+    )
+
+    console.log('\n— Summary —')
+    console.log(
+      JSON.stringify(
+        {
+          electedOfficeId: office.id,
+          organizationSlug: office.organizationSlug,
+          schedule,
+          briefing: patched,
+          hasArtifactColumn,
+        },
+        null,
+        2,
+      ),
+    )
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Dev state this produces

For the seeded `serve@fightclub.org` elected office (Cheyenne City Council — Ward 1), running this script leaves dev with:

1. A `meeting_schedule` `ExperimentRun` (`status: COMPLETED`) plus an S3 artifact at `s3://gp-agent-artifacts-dev/meeting_schedule/<uuid>/artifact.json` — Cheyenne City Council, weekly Mondays at 18:00 America/Denver, 90 minutes.
2. The existing seeded `meeting_briefing` artifact (already in S3, referenced by the existing `MeetingBriefing` row) rewritten with the new v2 top-level `meeting_name: "City Council"` and `location: "Cheyenne City Hall Council Chambers, 2101 O'Neil Ave, Cheyenne, WY 82001"`. All existing items / sources / executive_summary are preserved.
3. If `meeting_briefing.artifact` exists (i.e. #1599 has been deployed to dev), the `artifact` column is populated with the same JSON so list reads are synchronous.

## Why

The briefings UI is hard to demo against the current seeded data because the v2 artifact shape requires `meeting_name` + `location` and dev has no `meeting_schedule` row for the elected office. The companion runbooks PR makes those fields required in the artifact schema; this script gets dev in sync so we can demo with realistic, end-to-end data.

## Forward-compat with #1599

Step 5 — writing the parsed artifact JSON to `meeting_briefing.artifact` — depends on the column added by #1599. The script probes `information_schema.columns` first; if the column is missing it logs a clear warning and skips step 5 only. Steps 3–4 remain useful.

## Notes for the operator

- Run with `AWS_PROFILE=work npx tsx scripts/seed-dev-briefings.ts` and `DATABASE_URL` pointed at the gp-api dev Postgres.
- Idempotent: re-runs reuse the existing `ExperimentRun` and overwrite the briefing artifact in place.
- Could not run from the worktree where this PR was authored — dev DB / `work` AWS profile not available locally — so the run-and-verify step is on the user. The script has been lint+type-check clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since it only adds a standalone dev-only script, but it does write to S3 and updates dev database rows (including a raw SQL `UPDATE`) when executed.
> 
> **Overview**
> Adds `scripts/seed-dev-briefings.ts` to seed demo-ready dev data for `serve@fightclub.org`.
> 
> When run, it **idempotently** ensures a completed `meeting_schedule` `ExperimentRun` exists with a corresponding JSON artifact in `gp-agent-artifacts-dev`, and patches the latest `meeting_briefing` S3 artifact to include top-level `meeting_name` and `location`. If the `meeting_briefing.artifact` column exists, it also writes the same JSON into that column; otherwise it logs a warning and skips the DB update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5904a2fd8d8647fd90cc043ebaca887b8d6928f9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->