### PR TITLE
agent-job-types: dereference schemas before composing + adopt new meeting_briefing contract

### DIFF
--- a/scripts/generate-agent-job-types.ts
+++ b/scripts/generate-agent-job-types.ts
@@ -5,6 +5,7 @@
 import { execSync } from 'node:child_process'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { compile, JSONSchema } from 'json-schema-to-typescript'
+import RefParser from '@apidevtools/json-schema-ref-parser'
 import prettier from 'prettier'
 
 const main = async () => {
@@ -27,13 +28,16 @@ const main = async () => {
       ),
     )
 
+    const inputSchema = await RefParser.dereference(manifest.input_schema)
+    const outputSchema = await RefParser.dereference(manifest.output_schema)
+
     jobSchemas[experiment.id] = {
       type: 'object',
       additionalProperties: false,
       required: ['Input', 'Output'],
       properties: {
-        Input: manifest.input_schema,
-        Output: manifest.output_schema,
+        Input: inputSchema as JSONSchema,
+        Output: outputSchema as JSONSchema,
       },
     }
   }

--- a/src/generated/agent-job-contracts.ts
+++ b/src/generated/agent-job-contracts.ts
@@ -1,3 +1,9 @@
+/**
+ * v2 artifact schema for the meeting_briefing experiment. Drop into manifest.json's output_schema field at port time.
+ */
+export type MeetingBriefingOutput =
+  | MeetingBriefingFull
+  | MeetingBriefingPlaceholder
 export type MeetingSchedule = MeetingScheduleFound | MeetingScheduleNotFound
 
 export interface AgentJobContracts {
@@ -29,23 +35,31 @@ export interface AgentJobContracts {
   meeting_briefing: {
     Input: {
       /**
-       * Full city name (e.g. Burnsville).
+       * City name as it appears in L2 (title-case, e.g. "New York").
        */
       city: string
       /**
-       * Opaque gp-api ElectedOffice.id; passed through to the callback. Not used during research.
+       * L2 district value to match (e.g. "25"). Required if l2DistrictType is set.
        */
-      elected_office_id?: string
+      l2DistrictName?: string
       /**
-       * Governing body name (e.g. City Council).
+       * L2 voter file column for the official's district (e.g. City_Council_Commissioner_District). ASCII identifier shape — interpolated as a backtick-quoted column name in Databricks SQL. Omit for at-large officials.
        */
-      office: string
+      l2DistrictType?: string
       /**
-       * Two-letter state code (e.g. MN).
+       * Full name of the elected official (e.g. "Shekar Krishnan").
+       */
+      officialName: string
+      /**
+       * The EO's position.
+       */
+      positionName?: string
+      /**
+       * 2-letter state code (e.g. NY).
        */
       state: string
     }
-    Output: Briefing
+    Output: MeetingBriefingOutput
   }
   meeting_schedule: {
     Input: MeetingScheduleInput
@@ -173,58 +187,822 @@ export interface DistrictIssueSnapshotOutput {
   state: string
   total_active_voters: number
 }
-export interface Briefing {
-  actionItems: {
-    budgetImpact: {
-      sources: string[]
-      summary: string
-    } | null
-    constituentSentiment: {
-      detail?: string
-      sources: string[]
-      summary: string
-    } | null
-    id: string
-    overview: string
-    recentNews: {
-      outlet: string
-      title: string
-      url: string
-    }[]
-    sources: {
-      iconInitial: string
+export interface MeetingBriefingFull {
+  /**
+   * Full briefing produced. UI renders normal briefing.
+   */
+  briefing_status: 'briefing_ready' | 'agenda_provided_by_user'
+  /**
+   * Self-identification of the briefing kind.
+   */
+  briefing_type:
+    | 'city_council_meeting'
+    | 'county_legislature_meeting'
+    | 'school_board_meeting'
+  /**
+   * May be empty when briefing_status is awaiting_agenda or no_meeting_found. Capped at 200 to bound the validator's O(claims × sources × extracts) substring scan.
+   *
+   * @maxItems 200
+   */
+  claims: {
+    claim_id: string
+    claim_text: string
+    claim_type:
+      | 'budget_number'
+      | 'vote_count'
+      | 'legal_citation'
+      | 'staff_recommendation'
+      | 'constituent_sentiment'
+      | 'news_context'
+      | 'historical_context'
+      | 'inferred'
+    claim_weight: 'high' | 'medium' | 'low'
+    item_id: string
+    required_source_type:
+      | 'agenda_packet'
+      | 'government_website'
+      | 'news'
+      | 'haystaq'
+      | 'none'
+    route_if_unsupported: 'block_release' | 'omit_claim' | 'flag_as_inferred'
+    section:
+      | 'overview'
+      | 'constituent_sentiment'
+      | 'recent_news'
+      | 'budget_impact'
+      | 'talking_points'
+    /**
+     * @minItems 1
+     * @maxItems 10
+     */
+    source_extracts:
+      | [string]
+      | [string, string]
+      | [string, string, string]
+      | [string, string, string, string]
+      | [string, string, string, string, string]
+      | [string, string, string, string, string, string]
+      | [string, string, string, string, string, string, string]
+      | [string, string, string, string, string, string, string, string]
+      | [string, string, string, string, string, string, string, string, string]
+      | [
+          string,
+          string,
+          string,
+          string,
+          string,
+          string,
+          string,
+          string,
+          string,
+          string,
+        ]
+    /**
+     * @minItems 1
+     */
+    source_ids: [string, ...string[]]
+  }[]
+  /**
+   * Required verbatim disclaimer per required_disclosure.md.
+   */
+  disclosure: string
+  estimated_read_minutes: number
+  executive_summary: string
+  /**
+   * Experiment id, echoed from PARAMS.
+   */
+  experiment_id: string
+  /**
+   * ISO 8601 UTC timestamp when the briefing was generated.
+   */
+  generated_at: string
+  /**
+   * @minItems 1
+   */
+  items: [
+    {
+      display: {
+        budget_impact?: null | {
+          /**
+           * @minItems 1
+           */
+          figures: [
+            {
+              label: string
+              source_id: string
+              value: string
+            },
+            ...{
+              label: string
+              source_id: string
+              value: string
+            }[],
+          ]
+          /**
+           * References to ids in the top-level sources[] list that back this section as a whole. Complements per-figure figures[].source_id (which cites the specific document a number was extracted from); this section-level list cites the section overall and renders as inline source pills in the UI. Required-but-may-be-empty: emit [] when the section's narrative draws solely from figures whose source_id already covers it.
+           */
+          source_ids: string[]
+          summary: string
+        }
+        constituent_sentiment?: null | {
+          detail?: string | null
+          district_note?: string | null
+          haystaq_column: string
+          haystaq_status: 'ok' | 'no_match' | 'city_mismatch' | 'no_column'
+          mean_score: number
+          /**
+           * Short string describing what high values represent. Derived from the catalog entry's `meaning` field (e.g. "supports gun control").
+           */
+          score_direction: string
+          /**
+           * References to ids in the top-level sources[] list that back this section as a whole. Required-but-may-be-empty: emit [] when no specific source cites the section (rare for haystaq sentiment, which should reference the Haystaq source entry). Authors must not fabricate citations to pad this list.
+           */
+          source_ids: string[]
+          summary: string
+          voter_count: number
+        }
+        recent_news?:
+          | null
+          | [
+              {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                headline: string
+                publication: string
+                publication_date?: string | null
+                /**
+                 * Optional cross-reference to a sources[] entry id; populate when the article also appears in sources[].
+                 */
+                source_id?: string | null
+                url: string
+              },
+            ]
+          | [
+              {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                headline: string
+                publication: string
+                publication_date?: string | null
+                /**
+                 * Optional cross-reference to a sources[] entry id; populate when the article also appears in sources[].
+                 */
+                source_id?: string | null
+                url: string
+              },
+              {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                headline: string
+                publication: string
+                publication_date?: string | null
+                /**
+                 * Optional cross-reference to a sources[] entry id; populate when the article also appears in sources[].
+                 */
+                source_id?: string | null
+                url: string
+              },
+            ]
+          | [
+              {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                headline: string
+                publication: string
+                publication_date?: string | null
+                /**
+                 * Optional cross-reference to a sources[] entry id; populate when the article also appears in sources[].
+                 */
+                source_id?: string | null
+                url: string
+              },
+              {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                headline: string
+                publication: string
+                publication_date?: string | null
+                /**
+                 * Optional cross-reference to a sources[] entry id; populate when the article also appears in sources[].
+                 */
+                source_id?: string | null
+                url: string
+              },
+              {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                headline: string
+                publication: string
+                publication_date?: string | null
+                /**
+                 * Optional cross-reference to a sources[] entry id; populate when the article also appears in sources[].
+                 */
+                source_id?: string | null
+                url: string
+              },
+            ]
+        summary: string
+        talking_points?:
+          | null
+          | [string, string, string]
+          | [string, string, string, string]
+          | [string, string, string, string, string]
+      }
       id: string
-      kind: 'internal' | 'official' | 'news' | 'community'
-      label: string
-      url: string | null
-    }[]
-    talkingPoints: string[]
-    title: string
-  }[]
-  agenda: {
-    hasBriefing: boolean
-    id: string
-    kind: 'procedural' | 'consent' | 'public_input' | 'action' | 'informational'
-    title: string
-    whatToExpect?: string
-  }[]
-  executiveSummary: string
-  generatedAt: string
-  id: string
-  meeting: {
-    body: string
-    id: string
-    location: string
+      /**
+       * Agenda item number as a string (e.g. '5F'). Set to null only for the single placeholder item emitted when briefing_status is awaiting_agenda or no_meeting_found.
+       */
+      item_number: string | null
+      research: {
+        full_treatment: null | {
+          budget_detail: null | {
+            /**
+             * @minItems 1
+             */
+            figures: [
+              {
+                label: string
+                value: string
+                verbatim_extract: string
+              },
+              ...{
+                label: string
+                value: string
+                verbatim_extract: string
+              }[],
+            ]
+          }
+          haystaq_detail: null | {
+            city_mean_score?: number | null
+            city_voter_count?: number | null
+            complementary_field?: string | null
+            district_mean_score?: number | null
+            district_voter_count?: number | null
+            haystaq_column: string | null
+            haystaq_status: 'ok' | 'no_match' | 'city_mismatch' | 'no_column'
+            query_executed?: string | null
+          }
+          news_articles:
+            | null
+            | {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                body_text: string
+                headline: string
+                publication: string
+                publication_date?: string | null
+                url: string
+              }[]
+        }
+        /**
+         * @minItems 1
+         */
+        raw_context: [
+          {
+            chunk_id: string
+            item_id: string
+            item_title: string
+            /**
+             * @minItems 1
+             */
+            pages: [number, ...number[]]
+            section_heading?: string | null
+            source_id: string
+            text: string
+            tier: 'featured' | 'queued' | 'standard'
+          },
+          ...{
+            chunk_id: string
+            item_id: string
+            item_title: string
+            /**
+             * @minItems 1
+             */
+            pages: [number, ...number[]]
+            section_heading?: string | null
+            source_id: string
+            text: string
+            tier: 'featured' | 'queued' | 'standard'
+          }[],
+        ]
+      }
+      tier: 'featured' | 'queued' | 'standard'
+      /**
+       * Free-form short snake_case reasons explaining the tier assignment. Preferred values for the common cases: 'vote_required', 'public_position_required', 'budget_threshold', 'constituent_alignment', 'procedural', 'ceremonial', 'consent_routine', 'first_reading_only', 'received_and_filed_or_callup', 'land_use_referral', 'out_of_district', 'symbolic_resolution', 'placeholder'. Agent may use a domain-specific reason when none of the preferred values fit, but reuse preferred values when they apply (do not invent 'procedural_minutes' when 'procedural' already covers it).
+       *
+       * @minItems 1
+       */
+      tier_reason: [string, ...string[]]
+      title: string
+      vote_required: boolean
+    },
+    ...{
+      display: {
+        budget_impact?: null | {
+          /**
+           * @minItems 1
+           */
+          figures: [
+            {
+              label: string
+              source_id: string
+              value: string
+            },
+            ...{
+              label: string
+              source_id: string
+              value: string
+            }[],
+          ]
+          /**
+           * References to ids in the top-level sources[] list that back this section as a whole. Complements per-figure figures[].source_id (which cites the specific document a number was extracted from); this section-level list cites the section overall and renders as inline source pills in the UI. Required-but-may-be-empty: emit [] when the section's narrative draws solely from figures whose source_id already covers it.
+           */
+          source_ids: string[]
+          summary: string
+        }
+        constituent_sentiment?: null | {
+          detail?: string | null
+          district_note?: string | null
+          haystaq_column: string
+          haystaq_status: 'ok' | 'no_match' | 'city_mismatch' | 'no_column'
+          mean_score: number
+          /**
+           * Short string describing what high values represent. Derived from the catalog entry's `meaning` field (e.g. "supports gun control").
+           */
+          score_direction: string
+          /**
+           * References to ids in the top-level sources[] list that back this section as a whole. Required-but-may-be-empty: emit [] when no specific source cites the section (rare for haystaq sentiment, which should reference the Haystaq source entry). Authors must not fabricate citations to pad this list.
+           */
+          source_ids: string[]
+          summary: string
+          voter_count: number
+        }
+        recent_news?:
+          | null
+          | [
+              {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                headline: string
+                publication: string
+                publication_date?: string | null
+                /**
+                 * Optional cross-reference to a sources[] entry id; populate when the article also appears in sources[].
+                 */
+                source_id?: string | null
+                url: string
+              },
+            ]
+          | [
+              {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                headline: string
+                publication: string
+                publication_date?: string | null
+                /**
+                 * Optional cross-reference to a sources[] entry id; populate when the article also appears in sources[].
+                 */
+                source_id?: string | null
+                url: string
+              },
+              {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                headline: string
+                publication: string
+                publication_date?: string | null
+                /**
+                 * Optional cross-reference to a sources[] entry id; populate when the article also appears in sources[].
+                 */
+                source_id?: string | null
+                url: string
+              },
+            ]
+          | [
+              {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                headline: string
+                publication: string
+                publication_date?: string | null
+                /**
+                 * Optional cross-reference to a sources[] entry id; populate when the article also appears in sources[].
+                 */
+                source_id?: string | null
+                url: string
+              },
+              {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                headline: string
+                publication: string
+                publication_date?: string | null
+                /**
+                 * Optional cross-reference to a sources[] entry id; populate when the article also appears in sources[].
+                 */
+                source_id?: string | null
+                url: string
+              },
+              {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                headline: string
+                publication: string
+                publication_date?: string | null
+                /**
+                 * Optional cross-reference to a sources[] entry id; populate when the article also appears in sources[].
+                 */
+                source_id?: string | null
+                url: string
+              },
+            ]
+        summary: string
+        talking_points?:
+          | null
+          | [string, string, string]
+          | [string, string, string, string]
+          | [string, string, string, string, string]
+      }
+      id: string
+      /**
+       * Agenda item number as a string (e.g. '5F'). Set to null only for the single placeholder item emitted when briefing_status is awaiting_agenda or no_meeting_found.
+       */
+      item_number: string | null
+      research: {
+        full_treatment: null | {
+          budget_detail: null | {
+            /**
+             * @minItems 1
+             */
+            figures: [
+              {
+                label: string
+                value: string
+                verbatim_extract: string
+              },
+              ...{
+                label: string
+                value: string
+                verbatim_extract: string
+              }[],
+            ]
+          }
+          haystaq_detail: null | {
+            city_mean_score?: number | null
+            city_voter_count?: number | null
+            complementary_field?: string | null
+            district_mean_score?: number | null
+            district_voter_count?: number | null
+            haystaq_column: string | null
+            haystaq_status: 'ok' | 'no_match' | 'city_mismatch' | 'no_column'
+            query_executed?: string | null
+          }
+          news_articles:
+            | null
+            | {
+                article_type:
+                  | 'reporting'
+                  | 'opinion'
+                  | 'editorial'
+                  | 'press_release'
+                  | 'government_communication'
+                body_text: string
+                headline: string
+                publication: string
+                publication_date?: string | null
+                url: string
+              }[]
+        }
+        /**
+         * @minItems 1
+         */
+        raw_context: [
+          {
+            chunk_id: string
+            item_id: string
+            item_title: string
+            /**
+             * @minItems 1
+             */
+            pages: [number, ...number[]]
+            section_heading?: string | null
+            source_id: string
+            text: string
+            tier: 'featured' | 'queued' | 'standard'
+          },
+          ...{
+            chunk_id: string
+            item_id: string
+            item_title: string
+            /**
+             * @minItems 1
+             */
+            pages: [number, ...number[]]
+            section_heading?: string | null
+            source_id: string
+            text: string
+            tier: 'featured' | 'queued' | 'standard'
+          }[],
+        ]
+      }
+      tier: 'featured' | 'queued' | 'standard'
+      /**
+       * Free-form short snake_case reasons explaining the tier assignment. Preferred values for the common cases: 'vote_required', 'public_position_required', 'budget_threshold', 'constituent_alignment', 'procedural', 'ceremonial', 'consent_routine', 'first_reading_only', 'received_and_filed_or_callup', 'land_use_referral', 'out_of_district', 'symbolic_resolution', 'placeholder'. Agent may use a domain-specific reason when none of the preferred values fit, but reuse preferred values when they apply (do not invent 'procedural_minutes' when 'procedural' already covers it).
+       *
+       * @minItems 1
+       */
+      tier_reason: [string, ...string[]]
+      title: string
+      vote_required: boolean
+    }[],
+  ]
+  /**
+   * Customary location for the meeting (e.g. 'City Hall Council Chambers, 200 Main St'). Required-but-may-be-empty: emit an empty string when no source for the run mentions a venue (e.g. a user-supplied agenda PDF that lacks a header). Otherwise prefer the room-level location and fall back to building + street address when only the building is given.
+   */
+  location: string
+  /**
+   * YYYY-MM-DD. For agenda_provided_by_user or awaiting_agenda runs, this is the target meeting date; for no_meeting_found it may be an estimated next date.
+   */
+  meeting_date: string
+  /**
+   * Official name of the meeting body as the source refers to it (e.g. 'City Council', 'Planning Board'). Used as the list-row title in the candidate dashboard. Mirrors meeting_schedule.meeting_name when a schedule exists.
+   */
+  meeting_name: string
+  official_name: string
+  required_data_points: {
+    allowed_source_types?: (
+      | 'agenda_packet'
+      | 'news'
+      | 'government_website'
+      | 'campaign'
+      | 'haystaq'
+    )[]
+    citation_required: boolean
     name: string
-    scheduledAt: string
-    type: 'city_council' | 'planning_board' | 'town_hall'
+    required: boolean
+    scope: 'all_items' | 'featured_queued' | 'featured'
+    skip_reasons_allowed?: string[]
+  }[]
+  run_metadata: {
+    /**
+     * Permanent URL to the agenda packet. May be null when briefing_status is awaiting_agenda or no_meeting_found.
+     */
+    agenda_packet_url: string | null
+    briefing_version?: string
+    /**
+     * Curated trail of agent judgment calls. Separate from conversation/log.txt; this is QA-facing.
+     */
+    run_decisions?: {
+      decision: string
+      reason: string
+      timestamp: string
+    }[]
+    source_bundle_retrieved_at: string
   }
-  meetingDate: string
-  meetingId: string
-  readingTimeMinutes: number
-  slug: string
-  status: 'briefing_ready' | 'awaiting_agenda' | 'generating' | 'failed'
-  title: string
+  sources: {
+    article_date?: string | null
+    article_type?:
+      | 'reporting'
+      | 'opinion'
+      | 'editorial'
+      | 'press_release'
+      | 'government_communication'
+      | null
+    district_voters_n?: number | null
+    haystaq_column?: string | null
+    id: string
+    name: string
+    page_number?: number | null
+    publisher?: string | null
+    retrieved_at: string
+    retrieved_text_or_snapshot: string
+    score_value?: number | null
+    section_heading?: string | null
+    source_type:
+      | 'agenda_packet'
+      | 'news'
+      | 'government_website'
+      | 'campaign'
+      | 'haystaq'
+    specific_claim_found?: string | null
+    url?: string | null
+  }[]
+}
+export interface MeetingBriefingPlaceholder {
+  /**
+   * Early-exit / placeholder artifact. UI renders a check-back state. Use 'awaiting_agenda' when the meeting is on the calendar but the agenda packet has not been published. Use 'no_meeting_found' when no upcoming meeting exists within the 60-day search window. Use 'error' for unrecoverable run failures — populate run_metadata.run_decisions[] with the diagnostic trail.
+   */
+  briefing_status: 'awaiting_agenda' | 'no_meeting_found' | 'error'
+  /**
+   * Self-identification of the briefing kind.
+   */
+  briefing_type:
+    | 'city_council_meeting'
+    | 'county_legislature_meeting'
+    | 'school_board_meeting'
+  /**
+   * Always empty for placeholder/early-exit artifacts.
+   *
+   * @maxItems 0
+   */
+  claims: []
+  /**
+   * Required verbatim disclaimer per required_disclosure.md.
+   */
+  disclosure: string
+  estimated_read_minutes: number
+  executive_summary: string
+  /**
+   * Experiment id, echoed from PARAMS.
+   */
+  experiment_id: string
+  /**
+   * ISO 8601 UTC timestamp when the briefing was generated.
+   */
+  generated_at: string
+  /**
+   * @minItems 1
+   * @maxItems 1
+   */
+  items: [
+    {
+      display: {
+        budget_impact?: null
+        constituent_sentiment?: null
+        recent_news?: null
+        summary: string
+        talking_points?: null
+      }
+      id: 'item_001'
+      item_number: null
+      research: {
+        full_treatment: null
+        /**
+         * @minItems 1
+         */
+        raw_context: [
+          {
+            chunk_id: string
+            item_id: string
+            item_title: string
+            /**
+             * @minItems 1
+             */
+            pages: [number, ...number[]]
+            section_heading?: string | null
+            source_id: string
+            text: string
+            tier: 'featured' | 'queued' | 'standard'
+          },
+          ...{
+            chunk_id: string
+            item_id: string
+            item_title: string
+            /**
+             * @minItems 1
+             */
+            pages: [number, ...number[]]
+            section_heading?: string | null
+            source_id: string
+            text: string
+            tier: 'featured' | 'queued' | 'standard'
+          }[],
+        ]
+      }
+      tier: 'standard'
+      /**
+       * @minItems 1
+       * @maxItems 1
+       */
+      tier_reason: ['placeholder']
+      title: string
+      vote_required: false
+    },
+  ]
+  /**
+   * Customary location for the meeting. Required-but-may-be-empty: populate when the meeting is identified (awaiting_agenda), emit an empty string when no_meeting_found or error.
+   */
+  location: string
+  /**
+   * YYYY-MM-DD. For agenda_provided_by_user or awaiting_agenda runs, this is the target meeting date; for no_meeting_found it may be an estimated next date.
+   */
+  meeting_date: string
+  /**
+   * Official name of the meeting body (e.g. 'City Council'). Required-but-may-be-empty: populate when the meeting is identified (awaiting_agenda), emit an empty string when no_meeting_found or error.
+   */
+  meeting_name: string
+  official_name: string
+  required_data_points: {
+    allowed_source_types?: (
+      | 'agenda_packet'
+      | 'news'
+      | 'government_website'
+      | 'campaign'
+      | 'haystaq'
+    )[]
+    citation_required: boolean
+    name: string
+    required: boolean
+    scope: 'all_items' | 'featured_queued' | 'featured'
+    skip_reasons_allowed?: string[]
+  }[]
+  run_metadata: {
+    /**
+     * Permanent URL to the agenda packet. May be null when briefing_status is awaiting_agenda or no_meeting_found.
+     */
+    agenda_packet_url: string | null
+    briefing_version?: string
+    /**
+     * Curated trail of agent judgment calls. Separate from conversation/log.txt; this is QA-facing.
+     */
+    run_decisions?: {
+      decision: string
+      reason: string
+      timestamp: string
+    }[]
+    source_bundle_retrieved_at: string
+  }
+  sources: {
+    article_date?: string | null
+    article_type?:
+      | 'reporting'
+      | 'opinion'
+      | 'editorial'
+      | 'press_release'
+      | 'government_communication'
+      | null
+    district_voters_n?: number | null
+    haystaq_column?: string | null
+    id: string
+    name: string
+    page_number?: number | null
+    publisher?: string | null
+    retrieved_at: string
+    retrieved_text_or_snapshot: string
+    score_value?: number | null
+    section_heading?: string | null
+    source_type:
+      | 'agenda_packet'
+      | 'news'
+      | 'government_website'
+      | 'campaign'
+      | 'haystaq'
+    specific_claim_found?: string | null
+    url?: string | null
+  }[]
 }
 export interface MeetingScheduleInput {
   /**

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -113,7 +113,7 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
       positionId: 'br-pos-chain',
       city: 'Burnsville',
     })
-    const eo = await service.prisma.electedOffice.create({
+    await service.prisma.electedOffice.create({
       data: {
         organizationSlug: orgSlug,
         userId: service.user.id,
@@ -155,10 +155,10 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
       organizationSlug: orgSlug,
       clerkUserId: service.user.clerkId!,
       params: {
-        elected_office_id: eo.id,
+        officialName: `${service.user.firstName} ${service.user.lastName}`,
         city: 'Burnsville',
         state: 'MN',
-        office: 'City Council',
+        positionName: 'City Council',
       },
     })
   })
@@ -291,7 +291,7 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
         details: { city: 'Burnsville' },
       },
     })
-    const eoB = await service.prisma.electedOffice.create({
+    await service.prisma.electedOffice.create({
       data: {
         organizationSlug: orgSlugB,
         userId: otherUser.id,
@@ -338,9 +338,10 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
     expect(dispatchSpy).toHaveBeenCalledTimes(1)
     expect(dispatchSpy).toHaveBeenCalledWith(
       expect.objectContaining({
+        type: 'meeting_briefing',
         organizationSlug: orgSlugB,
         params: expect.objectContaining({
-          elected_office_id: eoB.id,
+          positionName: 'City Council',
         }),
       }),
     )

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -14,6 +14,7 @@ import { ExperimentRunsService } from '@/agentExperiments/services/experimentRun
 import { S3Service } from '@/vendors/aws/services/s3.service'
 import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import { MeetingSchedule } from '@/generated/agent-job-contracts'
+import { getUserFullName } from '@/users/util/users.util'
 
 const parseBriefingArtifact = (
   raw: string,
@@ -39,9 +40,12 @@ type DispatchContext = {
   electedOfficeId: string
   organizationSlug: string
   clerkUserId: string
+  officialName: string
   city: string
   state: string
-  office: string
+  positionName: string
+  l2DistrictType?: string
+  l2DistrictName?: string
 }
 
 const readStringField = (json: unknown, key: string): string => {
@@ -126,7 +130,7 @@ export class MeetingBriefingsService extends createPrismaBase(
         elected_office_id: ctx.electedOfficeId,
         city: ctx.city,
         state: ctx.state,
-        office: ctx.office,
+        office: ctx.positionName,
       },
     })
   }
@@ -185,10 +189,12 @@ export class MeetingBriefingsService extends createPrismaBase(
       organizationSlug: ctx.organizationSlug,
       clerkUserId: ctx.clerkUserId,
       params: {
-        elected_office_id: ctx.electedOfficeId,
+        officialName: ctx.officialName,
         city: ctx.city,
         state: ctx.state,
-        office: ctx.office,
+        positionName: ctx.positionName,
+        ...(ctx.l2DistrictType ? { l2DistrictType: ctx.l2DistrictType } : {}),
+        ...(ctx.l2DistrictName ? { l2DistrictName: ctx.l2DistrictName } : {}),
       },
     })
   }
@@ -209,10 +215,12 @@ export class MeetingBriefingsService extends createPrismaBase(
       organizationSlug: ctx.organizationSlug,
       clerkUserId: ctx.clerkUserId,
       params: {
-        elected_office_id: ctx.electedOfficeId,
+        officialName: ctx.officialName,
         city: ctx.city,
         state: ctx.state,
-        office: ctx.office,
+        positionName: ctx.positionName,
+        ...(ctx.l2DistrictType ? { l2DistrictType: ctx.l2DistrictType } : {}),
+        ...(ctx.l2DistrictName ? { l2DistrictName: ctx.l2DistrictName } : {}),
       },
     })
   }
@@ -223,7 +231,6 @@ export class MeetingBriefingsService extends createPrismaBase(
     const [user, organization, campaign] = await Promise.all([
       this.client.user.findUnique({
         where: { id: electedOffice.userId },
-        select: { clerkId: true },
       }),
       this.client.organization.findUnique({
         where: { slug: electedOffice.organizationSlug },
@@ -246,17 +253,26 @@ export class MeetingBriefingsService extends createPrismaBase(
     }
 
     const position = organization?.positionId
-      ? await this.elections.getPositionById(organization.positionId)
+      ? await this.elections.getPositionById(organization.positionId, {
+          includeDistrict: true,
+        })
       : null
     const state = position?.state ?? ''
-    const office = organization?.customPositionName ?? position?.name ?? ''
+    const positionName =
+      organization?.customPositionName ?? position?.name ?? ''
     const city = readStringField(campaign?.details ?? null, 'city')
+    const officialName = getUserFullName(user)
 
-    if (!city || !state || !office) {
+    if (!city || !state || !positionName || !officialName) {
       this.logger.warn(
         {
           electedOfficeId: electedOffice.id,
-          missing: { city: !city, state: !state, office: !office },
+          missing: {
+            city: !city,
+            state: !state,
+            positionName: !positionName,
+            officialName: !officialName,
+          },
         },
         'skipping dispatch: missing required context',
       )
@@ -267,9 +283,12 @@ export class MeetingBriefingsService extends createPrismaBase(
       electedOfficeId: electedOffice.id,
       organizationSlug: electedOffice.organizationSlug,
       clerkUserId: user.clerkId,
+      officialName,
       city,
       state,
-      office,
+      positionName,
+      l2DistrictType: position?.district?.L2DistrictType,
+      l2DistrictName: position?.district?.L2DistrictName,
     }
   }
 
@@ -282,14 +301,18 @@ export class MeetingBriefingsService extends createPrismaBase(
       return
     }
 
-    const electedOfficeId = readStringField(run.params, 'elected_office_id')
-    if (!electedOfficeId) {
+    const electedOffice = await this.client.electedOffice.findUnique({
+      where: { organizationSlug: run.organizationSlug },
+      select: { id: true },
+    })
+    if (!electedOffice) {
       this.logger.error(
-        { runId: run.runId },
-        'meeting_briefing run missing elected_office_id param',
+        { runId: run.runId, organizationSlug: run.organizationSlug },
+        'meeting_briefing completed but no ElectedOffice for the org',
       )
       return
     }
+    const electedOfficeId = electedOffice.id
 
     const raw = await this.s3.getFile(run.artifactBucket, run.artifactKey)
     if (!raw) {


### PR DESCRIPTION
Two things bundled because one enables the other:

**1. Fix codegen.** Regenerating agent job types via `npx tsx scripts/generate-agent-job-types.ts` blew up with `MissingPointerError: Missing $ref pointer "#/definitions/<x>"` whenever a manifest's `output_schema` used internal `$ref`s. The schemas are standalone-valid, but `json-schema-to-typescript` resolves `$ref: "#/..."` from the *outer* root of the compiled tree — and the script wraps each schema under `properties.<id>.properties.Output`, so those pointers resolve against the wrapper instead of the embedded schema's own `definitions`. `$id`-scoped resolution doesn't fix it (verified). Pre-dereferencing each `input_schema` / `output_schema` standalone via `@apidevtools/json-schema-ref-parser` (already a direct dep of `json-schema-to-typescript`) makes the wrapper a no-op for ref resolution. This has burned us twice and prompted a separate "inline schema" workaround on the runbooks side; the fix lets manifests keep using `$ref`s normally.

**2. Adopt the new meeting_briefing contract.** With codegen working, regenerating `agent-job-contracts.ts` surfaces the runbooks-side schema change: `elected_office_id` and `office` were dropped in favor of `officialName` + `positionName`, with optional `l2DistrictType` / `l2DistrictName`. The dispatcher (`MeetingBriefingsService`) was rewired to derive each new field from existing helpers — `getUserFullName(user)` for `officialName`, `elections.getPositionById(..., { includeDistrict: true })` for the L2 fields. The completion-callback path used to read `elected_office_id` out of `run.params`; it now looks up the `ElectedOffice` by `organizationSlug` (which is `@unique` on the model), since that field is no longer in the params shape.

Companion: thegoodparty/runbooks#28 adds CI to catch genuinely-broken `$ref` targets at manifest PR time so this category of bug fails on the runbooks PR, not on a downstream regen.