### PR TITLE
fix(meetings): return awaiting_agenda instead of 404 for meetings without briefing

### DIFF
--- a/src/meetings/controllers/meetingsBriefings.controller.test.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.test.ts
@@ -546,7 +546,7 @@ describe('GET /v1/meetings/:date/briefing', () => {
     expect(result.status).toBe(400)
   })
 
-  it('returns 404 when no briefing row exists for that date', async () => {
+  it('returns awaiting_agenda when no briefing row exists for that date', async () => {
     const orgSlug = 'eo-missing-briefing'
     await seedElectedOffice(orgSlug)
 
@@ -555,7 +555,32 @@ describe('GET /v1/meetings/:date/briefing', () => {
       { headers: { 'x-organization-slug': orgSlug } },
     )
 
-    expect(result.status).toBe(404)
+    expect(result.status).toBe(200)
+    expect(result.data.status).toBe('awaiting_agenda')
+    expect(result.data.meetingDate).toBe('2026-06-08')
+  })
+
+  it('returns schedule info in awaiting_agenda when schedule is known', async () => {
+    const orgSlug = 'eo-awaiting-with-schedule'
+    await seedElectedOffice(orgSlug)
+    await seedScheduleRun(orgSlug)
+    mockS3({ 'schedule-key.json': JSON.stringify(foundSchedule) })
+
+    const result = await service.client.get(
+      '/v1/meetings/2026-06-08/briefing',
+      { headers: { 'x-organization-slug': orgSlug } },
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data).toEqual({
+      status: 'awaiting_agenda',
+      meetingDate: '2026-06-08',
+      meetingName: foundSchedule.meeting_name,
+      meetingTime: foundSchedule.time,
+      meetingTimezone: foundSchedule.timezone,
+      location: foundSchedule.location,
+      durationMinutes: foundSchedule.duration_minutes,
+    })
   })
 
   it('returns 404 when S3 object is missing', async () => {

--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -128,7 +128,21 @@ export class MeetingsBriefingsController {
         },
       },
     })
-    if (!row) throw new NotFoundException()
+    if (!row) {
+      const schedule = await this.meetingBriefings.loadLatestScheduleForOrg(
+        electedOffice.organizationSlug,
+      )
+      const info = schedule?.status === 'found' ? schedule : null
+      return {
+        status: 'awaiting_agenda',
+        meetingDate: date,
+        meetingName: info?.meeting_name ?? '',
+        meetingTime: info?.time ?? '',
+        meetingTimezone: info?.timezone ?? '',
+        location: info?.location ?? '',
+        durationMinutes: info?.duration_minutes ?? 0,
+      }
+    }
 
     const raw = await this.s3.getFile(row.artifactBucket, row.artifactKey)
     if (!raw) throw new NotFoundException()


### PR DESCRIPTION
## Summary

- `GET /v1/meetings/:date/briefing` previously returned 404 for any date where a briefing artifact hadn't been generated yet (the "Awaiting agenda" rows in the meetings list)
- Now returns `{ status: 'awaiting_agenda', meetingDate, meetingName, meetingTime, meetingTimezone, location, durationMinutes }` using schedule data when available
- Existing `status: 'briefing_ready'` responses (full artifact JSON) are unchanged

## Test plan

- [ ] `GET /v1/meetings/:date/briefing` returns 200 with `status: 'awaiting_agenda'` for a date with no briefing row
- [ ] Response includes schedule-sourced meeting info when a schedule is known
- [ ] Existing briefing artifact passthrough still returns 200 with the full artifact
- [ ] All 20 existing + new controller tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `GET /v1/meetings/:date/briefing` contract from a 404 to a 200 with a new `awaiting_agenda` payload, which may impact API consumers expecting a missing-resource error. Logic is straightforward but touches request/response behavior and relies on schedule lookup as a fallback.
> 
> **Overview**
> `GET /v1/meetings/:date/briefing` now returns a **200** with `status: 'awaiting_agenda'` when no `MeetingBriefing` row exists, instead of throwing `NotFoundException`.
> 
> When available, the response is enriched with schedule-derived fields (`meetingName`, `meetingTime`, `meetingTimezone`, `location`, `durationMinutes`); existing behavior for briefing artifacts (S3 fetch + JSON passthrough, 404 on missing/invalid JSON) remains unchanged. Tests were updated/added to cover the new fallback and schedule-enrichment cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c32f3d0f0642e4388ad9ef1ad5492fb3d6d3420d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->