### PR TITLE
meetings(list): drop projected past dates; narrow past window to 4d

### DIFF
--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, NotFoundException, Param } from '@nestjs/common'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { ElectedOffice } from '@prisma/client'
-import { addMonths, subMonths } from 'date-fns'
+import { addMonths, subDays } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
 import { ReqElectedOffice } from '@/electedOffice/decorators/ReqElectedOffice.decorator'
 import { UseElectedOffice } from '@/electedOffice/decorators/UseElectedOffice.decorator'
@@ -40,9 +40,10 @@ export class MeetingsBriefingsController {
 
     const now = new Date()
     const windowFrom = parseIsoDateAsUTC(
-      formatInTimeZone(subMonths(now, 2), 'UTC', 'yyyy-MM-dd'),
+      formatInTimeZone(subDays(now, 4), 'UTC', 'yyyy-MM-dd'),
     )
     const windowTo = addMonths(now, 3)
+    const today = formatInTimeZone(now, 'UTC', 'yyyy-MM-dd')
 
     const projectedDates = knownSchedule
       ? this.meetingBriefings.projectMeetingDates({
@@ -69,6 +70,7 @@ export class MeetingsBriefingsController {
 
     if (knownSchedule) {
       for (const date of projectedDates) {
+        if (date < today) continue
         byDate.set(date, {
           meetingDate: date,
           meetingTime: knownSchedule.time,


### PR DESCRIPTION
The /v1/meetings endpoint was projecting RRULE-derived dates two months back with hasBriefing=false, surfacing every past projected date in the candidate dashboard as "Awaiting agenda". Past meetings without briefings are dead state — if the agenda was released, the briefing would exist; if it wasn't, the meeting is over and the user can't act on it.

This PR shrinks the past window from `subMonths(now, 2)` to `subDays(now, 4)` (so real past briefings within ~4 days still surface) and adds a guard in the projected-dates loop to skip any date `< today`. Briefings in the DB still come through via the existing briefingRows path; only projected, briefing-less past dates are dropped.

Pairs with gp-webapp PR #1837 which picks the featured card as the closest meeting to today (past or future) and caps the upcoming list at 5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts date filtering in `GET /meetings`, changing which meeting rows are returned without touching persistence, auth, or external integrations.
> 
> **Overview**
> The `GET /meetings` list endpoint now **limits the historical window** used for schedule projection/briefing lookup from 2 months to the last 4 days.
> 
> It also **drops projected (RRULE-derived) meetings in the past** by skipping any projected date earlier than `today`, while still returning any actual briefing rows found in the DB within the window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d789e01372a2b9aed2eb0f280cdcf314a89403a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->