### PR TITLE
feat(annotations): Pulumi for annotation-attachments bucket + Textrac…

### DIFF
--- a/deploy/components/annotation-attachments-bucket.ts
+++ b/deploy/components/annotation-attachments-bucket.ts
@@ -1,0 +1,112 @@
+import * as aws from '@pulumi/aws'
+
+export interface AnnotationAttachmentsBucketConfig {
+  environment: 'dev' | 'qa' | 'prod'
+}
+
+/**
+ * Private bucket for user-uploaded note attachments (camera shots, agenda
+ * packets, etc.). Reads/writes go through gp-api: presigned PUT for upload,
+ * server-side GetObject for OCR and any future retrieval, server-side
+ * DeleteObject for cleanup. The bucket itself blocks all public access — the
+ * presigned URLs are how the browser gets in.
+ *
+ * CORS is needed because the browser PUTs directly to S3 using the
+ * presigned URL returned by `POST /v1/annotations/:id/note/attachments/presign`.
+ */
+export function createAnnotationAttachmentsBucket({
+  environment,
+}: AnnotationAttachmentsBucketConfig): {
+  bucket: aws.s3.Bucket
+} {
+  const select = <T>(values: Record<'dev' | 'qa' | 'prod', T>): T =>
+    values[environment]
+
+  // Names follow the env (dev/qa/prod), same as assets-bucket. The dev bucket
+  // is being adopted from one created manually in the console; Pulumi takes
+  // it over on first deploy (one-time `pulumi import` if the create errors
+  // out as "already owned"). QA/prod are created fresh on their first deploy.
+  const bucketName = `annotation-attachments-${environment}`
+
+  const bucket = new aws.s3.Bucket('annotation-attachments-bucket', {
+    bucket: bucketName,
+    forceDestroy: false,
+  })
+
+  new aws.s3.BucketPublicAccessBlock('annotation-attachments-pab', {
+    bucket: bucket.id,
+    blockPublicAcls: true,
+    blockPublicPolicy: true,
+    ignorePublicAcls: true,
+    restrictPublicBuckets: true,
+  })
+
+  new aws.s3.BucketServerSideEncryptionConfigurationV2(
+    'annotation-attachments-sse',
+    {
+      bucket: bucket.id,
+      rules: [
+        {
+          applyServerSideEncryptionByDefault: {
+            sseAlgorithm: 'AES256',
+          },
+        },
+      ],
+    },
+  )
+
+  new aws.s3.BucketVersioningV2('annotation-attachments-versioning', {
+    bucket: bucket.id,
+    versioningConfiguration: {
+      status: 'Enabled',
+    },
+  })
+
+  // Decision 4 of the intake plan: keep originals + OCR text indefinitely.
+  // No object expiry — just bound noncurrent-version storage cost.
+  new aws.s3.BucketLifecycleConfigurationV2(
+    'annotation-attachments-lifecycle',
+    {
+      bucket: bucket.id,
+      rules: [
+        {
+          id: 'expire-noncurrent-versions',
+          status: 'Enabled',
+          filter: {},
+          noncurrentVersionExpiration: {
+            noncurrentDays: 30,
+          },
+        },
+      ],
+    },
+  )
+
+  // Allow the browser to PUT directly via presigned URL. Same origins as the
+  // existing assets bucket — keeps the cross-bucket policy consistent.
+  new aws.s3.BucketCorsConfigurationV2('annotation-attachments-cors', {
+    bucket: bucket.id,
+    corsRules: [
+      {
+        allowedHeaders: ['*'],
+        allowedMethods: ['PUT'],
+        allowedOrigins: select({
+          dev: [
+            'http://localhost:4000',
+            'https://dev.goodparty.org',
+            'https://qa.goodparty.org',
+          ],
+          qa: [
+            'http://localhost:4000',
+            'https://gp-ui-git-qa-good-party.vercel.app',
+            'https://qa.goodparty.org',
+          ],
+          prod: ['https://goodparty.org'],
+        }),
+        exposeHeaders: ['ETag'],
+        maxAgeSeconds: 3600,
+      },
+    ],
+  })
+
+  return { bucket }
+}

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -1,5 +1,6 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
+import { createAnnotationAttachmentsBucket } from './components/annotation-attachments-bucket'
 import { createAssetsBucket } from './components/assets-bucket'
 import { createAssetsRouter } from './components/assets-router'
 import { createGrafanaResources } from './components/grafana'
@@ -119,6 +120,14 @@ export = async () => {
     ignorePublicAcls: true,
     restrictPublicBuckets: true,
   })
+
+  // Private bucket for top-level note attachments (camera shots / uploads).
+  // Browser PUTs via presigned URL; gp-api task role reads back for OCR.
+  // Preview environments share the dev bucket — no per-PR bucket.
+  const annotationAttachmentsBucketName =
+    environment === 'preview'
+      ? 'annotation-attachments-dev'
+      : createAnnotationAttachmentsBucket({ environment }).bucket.bucket
 
   // Assets bucket - used for storing uploaded files, images, etc.
   if (environment !== 'preview') {
@@ -387,6 +396,7 @@ export = async () => {
       MEETING_PIPELINE_BUCKET: 'meeting-pipeline-dev',
       TEVYN_POLL_CSVS_BUCKET: tevynPollCsvsBucket.bucket,
       ZIP_TO_AREA_CODE_BUCKET: zipToAreaCodeBucket.bucket,
+      ANNOTATION_ATTACHMENTS_BUCKET: annotationAttachmentsBucketName,
       DB_HOST: rdsCluster.endpoint,
       DB_USER: rdsCluster.masterUsername,
       DB_NAME: rdsCluster.databaseName,
@@ -445,6 +455,17 @@ export = async () => {
         Action: [
           'transcribe:StartStreamTranscription',
           'transcribe:StartStreamTranscriptionWebSocket',
+        ],
+        Resource: ['*'],
+      },
+      {
+        // OCR for annotation note attachments. DetectDocumentText reads the
+        // S3 object using the caller's credentials, so the s3:GetObject grant
+        // above covers that side.
+        Effect: 'Allow',
+        Action: [
+          'textract:DetectDocumentText',
+          'textract:AnalyzeDocument',
         ],
         Resource: ['*'],
       },


### PR DESCRIPTION
…t IAM

New deploy/components/annotation-attachments-bucket.ts: private bucket per env (dev/qa/prod), versioned, AES256, public-access-block all on, CORS allowing PUT from the webapp origins (matches the assets-bucket origin list). Wired into index.ts and the ANNOTATION_ATTACHMENTS_BUCKET env var is now injected at deploy time. Preview environments point at the dev bucket — no per-PR bucket.

Adds textract:DetectDocumentText and textract:AnalyzeDocument to the gp-api task role permissions (s3 is already wide-open via s3:* so Textract reads using the caller's S3 grant).

The dev bucket will be created manually first so local testing is unblocked; Pulumi takes it over on the next deploy (one-time pulumi import if create-already-exists).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persistent S3 infrastructure and injects its name into the service, plus expands gp-api IAM permissions to include Textract APIs; misconfiguration could affect upload/OCR behavior or data retention/security posture.
> 
> **Overview**
> Adds a new Pulumi-managed, private per-environment S3 bucket for annotation note attachments with **public access blocked**, **AES256 default encryption**, **versioning + noncurrent version expiry**, and CORS allowing browser `PUT` uploads via presigned URLs.
> 
> Wires the bucket into the deploy by setting `ANNOTATION_ATTACHMENTS_BUCKET` for `gp-api` (preview uses the shared dev bucket), and grants the service role `textract:DetectDocumentText`/`textract:AnalyzeDocument` to support OCR on uploaded attachments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f9a63f3e82784e0e140cc0b89715c5159de082f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->