### PR TITLE
Drop city requirement from meeting_briefing + meeting_schedule dispatch

### DIFF
--- a/src/generated/agent-job-contracts.ts
+++ b/src/generated/agent-job-contracts.ts
@@ -35,10 +35,6 @@ export interface AgentJobContracts {
   meeting_briefing: {
     Input: {
       /**
-       * City name as it appears in L2 (title-case, e.g. "New York").
-       */
-      city: string
-      /**
        * L2 district value to match (e.g. "25"). Required if l2DistrictType is set.
        */
       l2DistrictName?: string
@@ -1006,15 +1002,11 @@ export interface MeetingBriefingPlaceholder {
 }
 export interface MeetingScheduleInput {
   /**
-   * Full city name (e.g. Burnsville).
-   */
-  city: string
-  /**
    * Opaque gp-api ElectedOffice.id; passed through to the callback. Not used during research.
    */
   elected_office_id?: string
   /**
-   * Governing body name (e.g. City Council).
+   * Full position/office name as it appears to the candidate (e.g. 'Burnsville City Council Member', 'Mayor of Cheyenne'). Usually contains the jurisdiction verbatim; when generic (e.g. just 'City Council'), the agent must infer the city from the position + state via WebSearch.
    */
   office: string
   /**

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -10,7 +10,7 @@ const service = useTestService()
 
 const seedOrgAndCampaign = async (
   orgSlug: string,
-  options: { positionId?: string; city?: string } = {},
+  options: { positionId?: string } = {},
 ) => {
   await service.prisma.organization.create({
     data: {
@@ -24,7 +24,7 @@ const seedOrgAndCampaign = async (
       userId: service.user.id,
       slug: `test-campaign-${orgSlug}`,
       organizationSlug: orgSlug,
-      details: options.city ? { city: options.city } : {},
+      details: {},
     },
   })
 }
@@ -36,12 +36,9 @@ const mockS3 = (responses: Record<string, string | undefined>) => {
 }
 
 describe('POST /v1/elected-office dispatches meeting_schedule', () => {
-  it('dispatches when org has position + campaign has city', async () => {
+  it('dispatches when org has a position', async () => {
     const orgSlug = `eo-create-${Date.now()}`
-    await seedOrgAndCampaign(orgSlug, {
-      positionId: 'br-pos-123',
-      city: 'Burnsville',
-    })
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-123' })
 
     vi.spyOn(
       service.app.get(ElectionsService),
@@ -70,27 +67,16 @@ describe('POST /v1/elected-office dispatches meeting_schedule', () => {
       clerkUserId: service.user.clerkId!,
       params: {
         elected_office_id: res.data.id as string,
-        city: 'Burnsville',
         state: 'MN',
         office: 'City Council',
       },
     })
   })
 
-  it('does not dispatch when campaign has no city', async () => {
-    const orgSlug = `eo-no-city-${Date.now()}`
-    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-456' })
+  it('does not dispatch when org has no position', async () => {
+    const orgSlug = `eo-no-position-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug)
 
-    vi.spyOn(
-      service.app.get(ElectionsService),
-      'getPositionById',
-    ).mockResolvedValue({
-      id: 'pos-real-id',
-      brPositionId: 'br-pos-456',
-      brDatabaseId: 'br-db-456',
-      state: 'MN',
-      name: 'City Council',
-    })
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
       .mockResolvedValue(undefined)
@@ -109,10 +95,7 @@ describe('POST /v1/elected-office dispatches meeting_schedule', () => {
 describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
   it('dispatches meeting_briefing for the org after meeting_schedule completes', async () => {
     const orgSlug = `eo-chain-${Date.now()}`
-    await seedOrgAndCampaign(orgSlug, {
-      positionId: 'br-pos-chain',
-      city: 'Burnsville',
-    })
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-chain' })
     await service.prisma.electedOffice.create({
       data: {
         organizationSlug: orgSlug,
@@ -156,7 +139,6 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
       clerkUserId: service.user.clerkId!,
       params: {
         officialName: `${service.user.firstName} ${service.user.lastName}`,
-        city: 'Burnsville',
         state: 'MN',
         positionName: 'City Council',
       },
@@ -252,10 +234,7 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
 describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
   it('dispatches only for EOs without a future briefing', async () => {
     const orgSlugA = `eo-cron-a-${Date.now()}`
-    await seedOrgAndCampaign(orgSlugA, {
-      positionId: 'br-pos-cron-a',
-      city: 'Burnsville',
-    })
+    await seedOrgAndCampaign(orgSlugA, { positionId: 'br-pos-cron-a' })
     const campaignA = await service.prisma.campaign.findFirst({
       where: { organizationSlug: orgSlugA },
     })
@@ -288,7 +267,7 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
         userId: otherUser.id,
         slug: `test-campaign-${orgSlugB}`,
         organizationSlug: orgSlugB,
-        details: { city: 'Burnsville' },
+        details: {},
       },
     })
     await service.prisma.electedOffice.create({

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -41,21 +41,10 @@ type DispatchContext = {
   organizationSlug: string
   clerkUserId: string
   officialName: string
-  city: string
   state: string
   positionName: string
   l2DistrictType?: string
   l2DistrictName?: string
-}
-
-const readStringField = (json: unknown, key: string): string => {
-  if (json === null || typeof json !== 'object' || Array.isArray(json)) {
-    return ''
-  }
-  // narrowing a JSON object — runtime guard above guarantees shape
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-  const value = (json as Record<string, unknown>)[key]
-  return typeof value === 'string' ? value : ''
 }
 
 @Injectable()
@@ -128,7 +117,6 @@ export class MeetingBriefingsService extends createPrismaBase(
       clerkUserId: ctx.clerkUserId,
       params: {
         elected_office_id: ctx.electedOfficeId,
-        city: ctx.city,
         state: ctx.state,
         office: ctx.positionName,
       },
@@ -190,7 +178,6 @@ export class MeetingBriefingsService extends createPrismaBase(
       clerkUserId: ctx.clerkUserId,
       params: {
         officialName: ctx.officialName,
-        city: ctx.city,
         state: ctx.state,
         positionName: ctx.positionName,
         ...(ctx.l2DistrictType ? { l2DistrictType: ctx.l2DistrictType } : {}),
@@ -216,7 +203,6 @@ export class MeetingBriefingsService extends createPrismaBase(
       clerkUserId: ctx.clerkUserId,
       params: {
         officialName: ctx.officialName,
-        city: ctx.city,
         state: ctx.state,
         positionName: ctx.positionName,
         ...(ctx.l2DistrictType ? { l2DistrictType: ctx.l2DistrictType } : {}),
@@ -228,7 +214,7 @@ export class MeetingBriefingsService extends createPrismaBase(
   private async resolveDispatchContext(
     electedOffice: ElectedOffice,
   ): Promise<DispatchContext | null> {
-    const [user, organization, campaign] = await Promise.all([
+    const [user, organization] = await Promise.all([
       this.client.user.findUnique({
         where: { id: electedOffice.userId },
       }),
@@ -236,12 +222,6 @@ export class MeetingBriefingsService extends createPrismaBase(
         where: { slug: electedOffice.organizationSlug },
         select: { positionId: true, customPositionName: true },
       }),
-      electedOffice.campaignId
-        ? this.client.campaign.findUnique({
-            where: { id: electedOffice.campaignId },
-            select: { details: true },
-          })
-        : Promise.resolve(null),
     ])
 
     if (!user?.clerkId) {
@@ -260,15 +240,13 @@ export class MeetingBriefingsService extends createPrismaBase(
     const state = position?.state ?? ''
     const positionName =
       organization?.customPositionName ?? position?.name ?? ''
-    const city = readStringField(campaign?.details ?? null, 'city')
     const officialName = getUserFullName(user)
 
-    if (!city || !state || !positionName || !officialName) {
+    if (!state || !positionName || !officialName) {
       this.logger.warn(
         {
           electedOfficeId: electedOffice.id,
           missing: {
-            city: !city,
             state: !state,
             positionName: !positionName,
             officialName: !officialName,
@@ -284,7 +262,6 @@ export class MeetingBriefingsService extends createPrismaBase(
       organizationSlug: electedOffice.organizationSlug,
       clerkUserId: user.clerkId,
       officialName,
-      city,
       state,
       positionName,
       l2DistrictType: position?.district?.L2DistrictType,


### PR DESCRIPTION
## Why

Every `POST /v1/elected-office` in dev has been silently skipping its experiment dispatch because `MeetingBriefingsService.resolveDispatchContext` required `campaign.details.city`, and most users have no city stored on their campaign record. Observed in Grafana on Doug Taylor (user id 108659): EO created cleanly with 201, then `MeetingBriefingsService` immediately logs `skipping dispatch: missing required context, missing.city = true`, and no `meeting_schedule` or `meeting_briefing` agent run is queued.

## What changes

`city` is no longer required to dispatch either experiment. The agent derives the jurisdiction itself from `positionName` + `l2DistrictName` + `state` (for `meeting_briefing`) or the full position name + `state` (for `meeting_schedule`). The companion runbooks change ([runbooks#29](https://github.com/thegoodparty/runbooks/pull/29)) is already merged and published to `agent-experiment-metadata-dev` — this PR makes gp-api match that contract.

Concretely:
- Drop `city` from `DispatchContext` and from the `dispatchRun.params` payload in `onElectedOfficeCreated`, `dispatchBriefingIfNeeded`, and `dispatchFirstBriefingForOrg`.
- Drop the `campaign` lookup from `resolveDispatchContext` (its only consumer was the city read).
- Drop the now-unused `readStringField` helper.
- Regenerate `src/generated/agent-job-contracts.ts` from the updated dev manifests via `tsx scripts/generate-agent-job-types.ts`.
- Update tests to match: rename the city-present/city-absent scenarios to position-present/position-absent, drop the `city` arg from the seed helper, drop city assertions from the dispatch-shape expectations.

## Verified

- `npx vitest run src/meetings/services/meetingBriefings.service.test.ts` → 6 passed.
- `npx eslint` on the touched files → 0 errors (2 pre-existing complexity/duplicate-string warnings).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `meeting_schedule`/`meeting_briefing` dispatch contract by removing `city` from the params and dispatch gating, which could break downstream agent expectations if any environment is still using the old schema.
> 
> **Overview**
> Removes the `city` requirement from `MeetingBriefingsService` dispatch logic so `POST /v1/elected-office` and follow-on briefing scheduling no longer silently skip when a campaign lacks `details.city`.
> 
> Updates the generated agent job contracts so `meeting_briefing` and `meeting_schedule` inputs no longer include `city`, and adjusts tests to seed empty campaign details and assert dispatch/skip behavior based on presence of an org position (not campaign city).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b767a99f16a57a4b443dc4c39ec5fe37826c92bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->