### PR TITLE
meetings: don't persist MeetingBriefing rows for placeholder briefing_status

### DIFF
--- a/prisma/schema/meetingBriefing.jsonTypes.d.ts
+++ b/prisma/schema/meetingBriefing.jsonTypes.d.ts
@@ -5,6 +5,12 @@ export {}
 declare global {
   export namespace PrismaJson {
     export type MeetingBriefingArtifact = {
+      briefing_status?:
+        | 'briefing_ready'
+        | 'agenda_provided_by_user'
+        | 'awaiting_agenda'
+        | 'no_meeting_found'
+        | 'error'
       meeting_date?: string
       meeting_name?: string
       location?: string

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -181,6 +181,7 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
         duration_minutes: 60,
       }),
       'briefing.json': JSON.stringify({
+        briefing_status: 'briefing_ready',
         meeting_date: '2026-06-08',
         meeting_name: 'City Council',
         location: 'Council Chambers',
@@ -205,6 +206,64 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
     expect(row?.experimentRunId).toBe(briefingRun.runId)
     expect(row?.artifact?.meeting_name).toBe('City Council')
     expect(row?.artifact?.location).toBe('Council Chambers')
+  })
+
+  it('does not write a MeetingBriefing row for placeholder briefing_status (awaiting_agenda)', async () => {
+    const orgSlug = `eo-awaiting-${Date.now()}`
+    await service.prisma.organization.create({
+      data: { slug: orgSlug, ownerId: service.user.id },
+    })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_schedule',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'schedule-bucket',
+        artifactKey: 'schedule.json',
+      },
+    })
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing.json',
+        params: { elected_office_id: eo.id },
+      },
+    })
+    mockS3({
+      'schedule.json': JSON.stringify({
+        status: 'known',
+        rrule: 'FREQ=WEEKLY;BYDAY=MO',
+        time: '19:00',
+        timezone: 'America/Chicago',
+        duration_minutes: 60,
+      }),
+      'briefing.json': JSON.stringify({
+        briefing_status: 'awaiting_agenda',
+        meeting_date: '2026-06-08',
+        meeting_name: 'City Council',
+        location: 'Council Chambers',
+      }),
+    })
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(briefingRun)
+
+    const row = await service.prisma.meetingBriefing.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: eo.id,
+          meetingDate: new Date('2026-06-08'),
+        },
+      },
+    })
+    expect(row).toBeNull()
   })
 
   it('skips when run is not COMPLETED', async () => {

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -266,6 +266,63 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
     expect(row).toBeNull()
   })
 
+  it('does not write a MeetingBriefing row when briefing_status is missing from the artifact', async () => {
+    const orgSlug = `eo-missing-status-${Date.now()}`
+    await service.prisma.organization.create({
+      data: { slug: orgSlug, ownerId: service.user.id },
+    })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_schedule',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'schedule-bucket',
+        artifactKey: 'schedule.json',
+      },
+    })
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing.json',
+        params: { elected_office_id: eo.id },
+      },
+    })
+    mockS3({
+      'schedule.json': JSON.stringify({
+        status: 'known',
+        rrule: 'FREQ=WEEKLY;BYDAY=MO',
+        time: '19:00',
+        timezone: 'America/Chicago',
+        duration_minutes: 60,
+      }),
+      'briefing.json': JSON.stringify({
+        meeting_date: '2026-06-08',
+        meeting_name: 'City Council',
+        location: 'Council Chambers',
+      }),
+    })
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(briefingRun)
+
+    const row = await service.prisma.meetingBriefing.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: eo.id,
+          meetingDate: new Date('2026-06-08'),
+        },
+      },
+    })
+    expect(row).toBeNull()
+  })
+
   it('skips when run is not COMPLETED', async () => {
     const orgSlug = `eo-running-${Date.now()}`
     await service.prisma.organization.create({

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -266,6 +266,62 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
     expect(row).toBeNull()
   })
 
+  it('does not write a MeetingBriefing row when briefing_status is error', async () => {
+    const orgSlug = `eo-error-${Date.now()}`
+    await service.prisma.organization.create({
+      data: { slug: orgSlug, ownerId: service.user.id },
+    })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_schedule',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'schedule-bucket',
+        artifactKey: 'schedule.json',
+      },
+    })
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing.json',
+        params: { elected_office_id: eo.id },
+      },
+    })
+    mockS3({
+      'schedule.json': JSON.stringify({
+        status: 'known',
+        rrule: 'FREQ=WEEKLY;BYDAY=MO',
+        time: '19:00',
+        timezone: 'America/Chicago',
+        duration_minutes: 60,
+      }),
+      'briefing.json': JSON.stringify({
+        briefing_status: 'error',
+        meeting_date: '2026-06-08',
+      }),
+    })
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(briefingRun)
+
+    const row = await service.prisma.meetingBriefing.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: eo.id,
+          meetingDate: new Date('2026-06-08'),
+        },
+      },
+    })
+    expect(row).toBeNull()
+  })
+
   it('does not write a MeetingBriefing row when briefing_status is missing from the artifact', async () => {
     const orgSlug = `eo-missing-status-${Date.now()}`
     await service.prisma.organization.create({

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -319,6 +319,13 @@ export class MeetingBriefingsService extends createPrismaBase(
       )
       return
     }
+    if (briefingStatus === 'error') {
+      this.logger.error(
+        { runId: run.runId, briefingStatus },
+        'meeting_briefing artifact reports an unrecoverable error; skipping row write',
+      )
+      return
+    }
     if (
       briefingStatus !== 'briefing_ready' &&
       briefingStatus !== 'agenda_provided_by_user'

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -312,6 +312,13 @@ export class MeetingBriefingsService extends createPrismaBase(
     }
 
     const briefingStatus = artifact.briefing_status
+    if (briefingStatus === undefined) {
+      this.logger.error(
+        { runId: run.runId },
+        'meeting_briefing artifact missing briefing_status field',
+      )
+      return
+    }
     if (
       briefingStatus !== 'briefing_ready' &&
       briefingStatus !== 'agenda_provided_by_user'

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -311,6 +311,18 @@ export class MeetingBriefingsService extends createPrismaBase(
       return
     }
 
+    const briefingStatus = artifact.briefing_status
+    if (
+      briefingStatus !== 'briefing_ready' &&
+      briefingStatus !== 'agenda_provided_by_user'
+    ) {
+      this.logger.info(
+        { runId: run.runId, briefingStatus },
+        'meeting_briefing produced a placeholder; skipping row write so the next cron run retries',
+      )
+      return
+    }
+
     const dateString =
       typeof artifact.meeting_date === 'string' ? artifact.meeting_date : ''
     if (!/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {


### PR DESCRIPTION
The v2 briefing artifact's `briefing_status` has two branches:

- **Full** (`briefing_ready`, `agenda_provided_by_user`) — real briefing content.
- **Placeholder** (`awaiting_agenda`, `no_meeting_found`, `error`) — the agent ran but had nothing to brief on. Just metadata + a copy explaining why.

Before this PR, `upsertBriefingRow` wrote a `MeetingBriefing` row regardless. A placeholder artifact (most commonly `awaiting_agenda` — the meeting exists but the agenda packet hasn't been posted) ended up looking like a ready briefing in the dashboard: name, location, "Briefing ready" pill, full layout — body saying the agenda isn't out yet. And because a row existed, `dispatchDailyBriefings` skipped the EO on the next cron, so we never retried once the agenda actually published.

Skipping the row write for placeholder statuses fixes both problems: the dashboard correctly shows the awaiting state via the schedule projection path, and the next cron run will dispatch a fresh `meeting_briefing` for that EO. The ExperimentRun + S3 artifact still land for audit.

Found on `swain+dougtaylor@goodparty.org` in dev: `meeting_briefing` row `019e2e83-f7f8` (2026-05-19) had `briefing_status: awaiting_agenda`. Cleaned up the stale row out of band before opening this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when `MeetingBriefing` rows are persisted, which affects dashboard state and whether the daily cron will re-dispatch briefings; mistakes could cause missed briefings or unexpected retries. Scope is limited to meeting briefing ingestion and covered by a new regression test.
> 
> **Overview**
> Prevents persisting `MeetingBriefing` rows when the `meeting_briefing` artifact is a *placeholder* (any `briefing_status` other than `briefing_ready` or `agenda_provided_by_user`), so the next cron run can retry and the UI won’t treat placeholders as ready briefings.
> 
> Updates the Prisma JSON type to include `briefing_status` and adds a test ensuring placeholder artifacts (e.g. `awaiting_agenda`) do **not** create a `MeetingBriefing` row, while ready artifacts still upsert as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8162d4507067910387abe57bc50b8d868cbdbcd2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->