### PR TITLE
meetings: gate auto-dispatch behind MEETINGS_AUTOMATION_ENABLED + add manual dispatch endpoint

### DIFF
--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -392,6 +392,12 @@ export = async () => {
         qa: 'agent-dispatch-qa.fifo',
         prod: 'agent-dispatch-prod.fifo',
       }),
+      MEETINGS_AUTOMATION_ENABLED: select({
+        preview: '',
+        dev: '',
+        qa: '',
+        prod: 'true',
+      }),
       SERVE_ANALYSIS_BUCKET_NAME: `serve-analyze-data-${environment === 'preview' ? 'dev' : environment}`,
       MEETING_PIPELINE_BUCKET: 'meeting-pipeline-dev',
       TEVYN_POLL_CSVS_BUCKET: tevynPollCsvsBucket.bucket,
@@ -463,10 +469,7 @@ export = async () => {
         // S3 object using the caller's credentials, so the s3:GetObject grant
         // above covers that side.
         Effect: 'Allow',
-        Action: [
-          'textract:DetectDocumentText',
-          'textract:AnalyzeDocument',
-        ],
+        Action: ['textract:DetectDocumentText', 'textract:AnalyzeDocument'],
         Resource: ['*'],
       },
     ],

--- a/src/meetings/controllers/meetingsBriefings.controller.test.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it, vi } from 'vitest'
-import { ExperimentRunStatus } from '@prisma/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ExperimentRunStatus, UserRole } from '@prisma/client'
+import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
+import { ElectionsService } from '@/elections/services/elections.service'
 import { addDays, getDay, parseISO } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
 import { S3Service } from '@/vendors/aws/services/s3.service'
@@ -641,5 +643,96 @@ describe('GET /v1/meetings/:date/briefing', () => {
     expect(result.data.slug).toBe('city-council-june-8-2026')
     expect(result.data.readingTimeMinutes).toBe(8)
     expect(result.data.meeting.scheduledAt).toBe('2026-06-08T19:00:00-06:00')
+  })
+})
+
+describe('POST /v1/meetings/briefings/dispatch', () => {
+  beforeEach(() => {
+    vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', 'true')
+  })
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  const makeAdmin = () =>
+    service.prisma.user.update({
+      where: { id: service.user.id },
+      data: { roles: [UserRole.admin] },
+    })
+
+  it('returns 403 when caller is not an admin', async () => {
+    const result = await service.client.post(
+      '/v1/meetings/briefings/dispatch',
+      { electedOfficeId: 'any-id', kind: 'schedule' },
+    )
+    expect(result.status).toBe(403)
+  })
+
+  it('returns 400 when body is missing required fields', async () => {
+    await makeAdmin()
+    const result = await service.client.post(
+      '/v1/meetings/briefings/dispatch',
+      {},
+    )
+    expect(result.status).toBe(400)
+  })
+
+  it('returns 404 when elected office is not found', async () => {
+    await makeAdmin()
+    const result = await service.client.post(
+      '/v1/meetings/briefings/dispatch',
+      { electedOfficeId: 'nonexistent', kind: 'schedule' },
+    )
+    expect(result.status).toBe(404)
+  })
+
+  it('returns 200 and dispatches when admin sends a valid request', async () => {
+    await makeAdmin()
+    const orgSlug = `eo-dispatch-${Date.now()}`
+    await service.prisma.organization.create({
+      data: { slug: orgSlug, ownerId: service.user.id, positionId: 'br-pos-d' },
+    })
+    await service.prisma.campaign.create({
+      data: {
+        userId: service.user.id,
+        slug: `test-campaign-${orgSlug}`,
+        organizationSlug: orgSlug,
+        details: {},
+      },
+    })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    vi.spyOn(
+      service.app.get(ElectionsService),
+      'getPositionById',
+    ).mockResolvedValue({
+      id: 'pos-real',
+      brPositionId: 'br-pos-d',
+      brDatabaseId: 'br-db-d',
+      state: 'MN',
+      name: 'City Council',
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.client.post(
+      '/v1/meetings/briefings/dispatch',
+      { electedOfficeId: eo.id, kind: 'schedule' },
+    )
+
+    expect(result.status).toBe(201)
+    expect(result.data).toEqual({ dispatched: true, kind: 'schedule' })
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: 'meeting_schedule',
+      organizationSlug: orgSlug,
+      clerkUserId: service.user.clerkId!,
+      params: {
+        elected_office_id: eo.id,
+        state: 'MN',
+        office: 'City Council',
+      },
+    })
   })
 })

--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -1,8 +1,16 @@
-import { Controller, Get, NotFoundException, Param } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+} from '@nestjs/common'
 import { ZodValidationPipe } from 'nestjs-zod'
-import { ElectedOffice } from '@prisma/client'
+import { ElectedOffice, UserRole } from '@prisma/client'
 import { addMonths, subDays } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
+import { Roles } from '@/authentication/decorators/Roles.decorator'
 import { ReqElectedOffice } from '@/electedOffice/decorators/ReqElectedOffice.decorator'
 import { UseElectedOffice } from '@/electedOffice/decorators/UseElectedOffice.decorator'
 import { S3Service } from '@/vendors/aws/services/s3.service'
@@ -11,6 +19,10 @@ import {
   MeetingDateParam,
   MeetingDateParamSchema,
 } from '../schemas/meetingDateParam.schema'
+import {
+  DispatchMeetingAgentDto,
+  DispatchMeetingAgentSchema,
+} from '../schemas/dispatchMeetingAgent.schema'
 import { MeetingBriefingsService } from '../services/meetingBriefings.service'
 
 type MeetingListItem = {
@@ -156,5 +168,23 @@ export class MeetingsBriefingsController {
     } catch {
       throw new NotFoundException()
     }
+  }
+
+  @Roles(UserRole.admin)
+  @Post('briefings/dispatch')
+  async dispatchAgent(
+    @Body(new ZodValidationPipe(DispatchMeetingAgentSchema))
+    body: DispatchMeetingAgentDto,
+  ) {
+    const result = await this.meetingBriefings.dispatchManual(
+      body.electedOfficeId,
+      body.kind,
+    )
+    if (!result.dispatched) {
+      throw new NotFoundException(
+        'Could not resolve dispatch context for that elected office',
+      )
+    }
+    return { dispatched: true, kind: body.kind }
   }
 }

--- a/src/meetings/schemas/dispatchMeetingAgent.schema.ts
+++ b/src/meetings/schemas/dispatchMeetingAgent.schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const DispatchMeetingAgentSchema = z.object({
+  electedOfficeId: z.string().min(1),
+  kind: z.enum(['schedule', 'briefing']),
+})
+
+export type DispatchMeetingAgentDto = z.infer<typeof DispatchMeetingAgentSchema>

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -119,6 +119,38 @@ describe('POST /v1/elected-office dispatches meeting_schedule', () => {
 })
 
 describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
+  beforeEach(() => {
+    vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', 'true')
+  })
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('does not dispatch briefing on schedule completion when MEETINGS_AUTOMATION_ENABLED is unset', async () => {
+    vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', '')
+    const orgSlug = `eo-chain-gate-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-chain-gate' })
+    await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    const scheduleRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_schedule',
+        status: ExperimentRunStatus.COMPLETED,
+      },
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(scheduleRun)
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
   it('dispatches meeting_briefing for the org after meeting_schedule completes', async () => {
     const orgSlug = `eo-chain-${Date.now()}`
     await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-chain' })

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -1,5 +1,5 @@
 import { ExperimentRunStatus } from '@prisma/client'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ElectionsService } from '@/elections/services/elections.service'
 import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
 import { S3Service } from '@/vendors/aws/services/s3.service'
@@ -36,6 +36,32 @@ const mockS3 = (responses: Record<string, string | undefined>) => {
 }
 
 describe('POST /v1/elected-office dispatches meeting_schedule', () => {
+  beforeEach(() => {
+    vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', 'true')
+  })
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('skips dispatch when MEETINGS_AUTOMATION_ENABLED is unset', async () => {
+    vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', '')
+    const orgSlug = `eo-gate-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-gate' })
+
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const res = await service.client.post(
+      '/v1/elected-office',
+      {},
+      { headers: { 'x-organization-slug': orgSlug } },
+    )
+
+    expect(res.status).toBe(201)
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
   it('dispatches when org has a position', async () => {
     const orgSlug = `eo-create-${Date.now()}`
     await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-123' })
@@ -232,6 +258,22 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
 })
 
 describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
+  beforeEach(() => {
+    vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', 'true')
+  })
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('skips entirely when MEETINGS_AUTOMATION_ENABLED is unset', async () => {
+    vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', '')
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+    await service.app.get(MeetingBriefingsService).dispatchDailyBriefings()
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
   it('dispatches only for EOs without a future briefing', async () => {
     const orgSlugA = `eo-cron-a-${Date.now()}`
     await seedOrgAndCampaign(orgSlugA, { positionId: 'br-pos-cron-a' })
@@ -324,5 +366,80 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
         }),
       }),
     )
+  })
+})
+
+describe('MeetingBriefingsService.dispatchManual', () => {
+  it('dispatches a schedule run regardless of the env gate', async () => {
+    vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', '')
+    const orgSlug = `eo-manual-schedule-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-manual-s' })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    vi.spyOn(
+      service.app.get(ElectionsService),
+      'getPositionById',
+    ).mockResolvedValue({
+      id: 'pos-real-id',
+      brPositionId: 'br-pos-manual-s',
+      brDatabaseId: 'br-db-manual-s',
+      state: 'MN',
+      name: 'City Council',
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.app
+      .get(MeetingBriefingsService)
+      .dispatchManual(eo.id, 'schedule')
+
+    expect(result.dispatched).toBe(true)
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'meeting_schedule' }),
+    )
+    vi.unstubAllEnvs()
+  })
+
+  it('dispatches a briefing run when kind is briefing', async () => {
+    const orgSlug = `eo-manual-briefing-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-manual-b' })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    vi.spyOn(
+      service.app.get(ElectionsService),
+      'getPositionById',
+    ).mockResolvedValue({
+      id: 'pos-real-id',
+      brPositionId: 'br-pos-manual-b',
+      brDatabaseId: 'br-db-manual-b',
+      state: 'MN',
+      name: 'City Council',
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.app
+      .get(MeetingBriefingsService)
+      .dispatchManual(eo.id, 'briefing')
+
+    expect(result.dispatched).toBe(true)
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'meeting_briefing' }),
+    )
+  })
+
+  it('returns dispatched:false for unknown electedOfficeId', async () => {
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+    const result = await service.app
+      .get(MeetingBriefingsService)
+      .dispatchManual('not-a-real-id', 'schedule')
+    expect(result.dispatched).toBe(false)
+    expect(dispatchSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -178,6 +178,13 @@ export class MeetingBriefingsService extends createPrismaBase(
     if (run.status !== ExperimentRunStatus.COMPLETED) return
 
     if (run.experimentType === SCHEDULE_EXPERIMENT_TYPE) {
+      if (!isAutomationEnabled()) {
+        this.logger.info(
+          { runId: run.runId },
+          'meetings automation disabled; skipping briefing dispatch on schedule completion',
+        )
+        return
+      }
       await this.dispatchFirstBriefingForOrg(run.organizationSlug)
       return
     }

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -30,6 +30,11 @@ const parseSchedule = (raw: string): MeetingSchedule =>
 const SCHEDULE_EXPERIMENT_TYPE = 'meeting_schedule'
 const BRIEFING_EXPERIMENT_TYPE = 'meeting_briefing'
 
+const isAutomationEnabled = () =>
+  process.env.MEETINGS_AUTOMATION_ENABLED === 'true'
+
+export type ManualDispatchKind = 'schedule' | 'briefing'
+
 export type ProjectArgs = {
   schedule: MeetingSchedule
   from: Date
@@ -108,9 +113,20 @@ export class MeetingBriefingsService extends createPrismaBase(
   }
 
   async onElectedOfficeCreated(electedOffice: ElectedOffice): Promise<void> {
+    if (!isAutomationEnabled()) {
+      this.logger.info(
+        { electedOfficeId: electedOffice.id },
+        'meetings automation disabled; skipping auto schedule dispatch',
+      )
+      return
+    }
     const ctx = await this.resolveDispatchContext(electedOffice)
     if (!ctx) return
 
+    await this.dispatchSchedule(ctx)
+  }
+
+  private async dispatchSchedule(ctx: DispatchContext): Promise<void> {
     await this.experimentRuns.dispatchRun({
       type: SCHEDULE_EXPERIMENT_TYPE,
       organizationSlug: ctx.organizationSlug,
@@ -121,6 +137,41 @@ export class MeetingBriefingsService extends createPrismaBase(
         office: ctx.positionName,
       },
     })
+  }
+
+  private async dispatchBriefing(ctx: DispatchContext): Promise<void> {
+    await this.experimentRuns.dispatchRun({
+      type: BRIEFING_EXPERIMENT_TYPE,
+      organizationSlug: ctx.organizationSlug,
+      clerkUserId: ctx.clerkUserId,
+      params: {
+        officialName: ctx.officialName,
+        state: ctx.state,
+        positionName: ctx.positionName,
+        ...(ctx.l2DistrictType ? { l2DistrictType: ctx.l2DistrictType } : {}),
+        ...(ctx.l2DistrictName ? { l2DistrictName: ctx.l2DistrictName } : {}),
+      },
+    })
+  }
+
+  async dispatchManual(
+    electedOfficeId: string,
+    kind: ManualDispatchKind,
+  ): Promise<{ dispatched: boolean }> {
+    const electedOffice = await this.client.electedOffice.findUnique({
+      where: { id: electedOfficeId },
+    })
+    if (!electedOffice) return { dispatched: false }
+
+    const ctx = await this.resolveDispatchContext(electedOffice)
+    if (!ctx) return { dispatched: false }
+
+    if (kind === 'schedule') {
+      await this.dispatchSchedule(ctx)
+    } else {
+      await this.dispatchBriefing(ctx)
+    }
+    return { dispatched: true }
   }
 
   async onExperimentRunCompleted(run: ExperimentRun): Promise<void> {
@@ -138,6 +189,12 @@ export class MeetingBriefingsService extends createPrismaBase(
 
   @Cron('0 7 * * *')
   async dispatchDailyBriefings(): Promise<void> {
+    if (!isAutomationEnabled()) {
+      this.logger.info(
+        'meetings automation disabled; skipping daily briefing cron',
+      )
+      return
+    }
     const offices = await this.client.electedOffice.findMany({
       select: { id: true, organizationSlug: true, userId: true },
     })
@@ -172,18 +229,7 @@ export class MeetingBriefingsService extends createPrismaBase(
     const ctx = await this.resolveDispatchContext(electedOffice)
     if (!ctx) return
 
-    await this.experimentRuns.dispatchRun({
-      type: BRIEFING_EXPERIMENT_TYPE,
-      organizationSlug: ctx.organizationSlug,
-      clerkUserId: ctx.clerkUserId,
-      params: {
-        officialName: ctx.officialName,
-        state: ctx.state,
-        positionName: ctx.positionName,
-        ...(ctx.l2DistrictType ? { l2DistrictType: ctx.l2DistrictType } : {}),
-        ...(ctx.l2DistrictName ? { l2DistrictName: ctx.l2DistrictName } : {}),
-      },
-    })
+    await this.dispatchBriefing(ctx)
   }
 
   private async dispatchFirstBriefingForOrg(


### PR DESCRIPTION
## Why

Daily briefing cron and the POST /v1/elected-office hook were dispatching meeting_schedule + meeting_briefing agent runs for every elected office in non-prod, including for every new e2e/test user. We confirmed in dev Loki: ~74 meeting_schedule + 74 meeting_briefing dispatches across 38 fresh Clerk users in roughly 2 hours.

Two changes here:

1. Gate the daily cron and the auto-trigger that fires from elected-office creation behind a new `MEETINGS_AUTOMATION_ENABLED` env var. Leave it unset in dev/qa/preview; set it to `true` in prod when we're ready to ship.
2. Add `POST /v1/meetings/briefings/dispatch` (admin-only) so we can still hand-fire schedule and briefing agents on demand from the gp-webapp dev tools bar.

The schedule→briefing chain in `onExperimentRunCompleted` is intentionally left alone — a manual schedule will still auto-trigger a follow-up briefing on completion, which is what we want when QAing the full pipeline.

## Companion PR

gp-webapp adds the manual trigger UI: thegoodparty/gp-webapp `swain/meeting-agent-manual-dispatch`.

## Rollout

1. Merge + deploy this PR.
2. Set `MEETINGS_AUTOMATION_ENABLED=true` in the gp-api **prod** task definition.
3. Leave it unset in dev/qa/preview.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when agent runs are dispatched by introducing an env gate on automatic schedule/briefing triggers, which could unintentionally stop expected automation if misconfigured. Adds a new admin-only endpoint that can trigger agent dispatches on demand, increasing operational impact if abused or called with wrong IDs.
> 
> **Overview**
> **Gates meetings automation behind `MEETINGS_AUTOMATION_ENABLED`.** Automatic dispatch on elected-office creation and the daily briefing cron now no-op (with log) unless the env var is set to `true`.
> 
> **Adds manual dispatch for admins.** Introduces `POST /v1/meetings/briefings/dispatch` (validated via new `DispatchMeetingAgentSchema`) that calls `MeetingBriefingsService.dispatchManual` to trigger either a `meeting_schedule` or `meeting_briefing` run and returns 404 when dispatch context can’t be resolved.
> 
> Updates tests to cover the env gating behavior and the new manual dispatch path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42a9c2d181b8699450bdf97775e0957b1e52832c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->