### PR TITLE
docs(env): document PUBLIC_API_URL for speech-to-text WS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/gpdb?schema=public"
 VOTER_DATASTORE="postgresql://DB_USER:DB_PASS@DB_URL:DB_PORT/DB_NAME"
 WEBAPP_ROOT_URL=http://localhost:4000
 CORS_ORIGIN=http://localhost:4000
+# Public origin of this gp-api instance. Used to build the WebSocket URL
+# returned by POST /v1/speech/transcribe/session. The browser validates that
+# this host matches NEXT_PUBLIC_API_BASE, so it must point at *this* API
+# (e.g. http://localhost:3000 locally, https://gp-api-dev.goodparty.org in dev,
+# https://gp-api-qa.goodparty.org in qa, https://gp-api.goodparty.org in prod).
+PUBLIC_API_URL=http://localhost:3000
 ASSET_DOMAIN=asset.domain.com
 
 ELECTION_API_URL=https://election-api-dev.goodparty.org


### PR DESCRIPTION
## Summary

- Adds `PUBLIC_API_URL` to `.env.example` with a comment explaining what it's for and the value to use in each environment.

## Why

The speech-to-text gateway (`SpeechToTextService.buildWsUrl`) reads `PUBLIC_API_URL` to construct the WebSocket URL returned by `POST /v1/speech/transcribe/session`. The webapp (`useDictation.buildAbsoluteWsUrl`) then validates that the returned URL's host matches `NEXT_PUBLIC_API_BASE` — a defense-in-depth check against a compromised/misconfigured API handing the browser an attacker-controlled WS URL (mic stream destination).

If `PUBLIC_API_URL` is unset or wrong, dictation fails with either:

- Server-side: `PUBLIC_API_URL env var is required but not set; cannot build WebSocket URL`
- Client-side: `Untrusted WebSocket host: <host>`

Neither error is obvious from the code without this hint, so contributors running dictation locally hit a wall. This PR just documents the variable; no runtime behavior changes.

Recommended values per environment:

| Environment | `PUBLIC_API_URL` |
| --- | --- |
| local | `http://localhost:3000` |
| dev | `https://gp-api-dev.goodparty.org` |
| qa | `https://gp-api-qa.goodparty.org` |
| prod | `https://gp-api.goodparty.org` |

## Follow-up (not in this PR)

Deployed environments (`deploy/index.ts`) don't currently set `PUBLIC_API_URL` in `environmentVariables`, so dictation will throw the server-side error in dev/qa/prod once it's exercised. Easy fix: add `PUBLIC_API_URL: \`https://\${domain}\`` to the `environmentVariables` block — reuses the existing `domain` `select(...)` so each stage gets the right value automatically. Happy to do that in a follow-up PR.

## Test plan

- [x] Locally set `PUBLIC_API_URL=http://localhost:3000`, confirmed dictation no longer throws `Untrusted WebSocket host`.
- [x] No runtime code changed; only `.env.example` is edited.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `.env.example`; no runtime code paths, auth, or data handling are modified.
> 
> **Overview**
> Documents a new `PUBLIC_API_URL` environment variable in `.env.example`, including guidance on setting it per environment, to support building/validating the WebSocket URL used by the speech-to-text dictation flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b1e6bb58a7e0f56ea2e6355bc3186571360b33. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->