### PR TITLE
test(speech): integration test pinning the session wsUrl contract

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -7,6 +7,9 @@ DATABASE_URL="postgresql://DB_USER:DB_PASS@DB_URL:DB_PORT/DB_NAME"
 VOTER_DATASTORE="postgresql://DB_USER:DB_PASS@DB_URL:DB_PORT/DB_NAME"
 WEBAPP_ROOT_URL=http://localhost:4000
 CORS_ORIGIN=http://localhost:4000
+# Used by SpeechToTextService.buildWsUrl. A distinct, non-localhost host
+# makes URL assertions in the speech integration test unambiguous.
+PUBLIC_API_URL=http://test-api.local:3000
 ASSET_DOMAIN=asset.domain.com
 
 ELECTION_API_URL=https://election-api-dev.goodparty.org

--- a/src/speech/controllers/speechToText.controller.integration.test.ts
+++ b/src/speech/controllers/speechToText.controller.integration.test.ts
@@ -1,0 +1,66 @@
+import { HttpStatus } from '@nestjs/common'
+import { describe, expect, it } from 'vitest'
+import { TranscriptionTicketService } from '@/speech/services/transcriptionTicket.service'
+import { TRANSCRIBE_STREAM_PATH } from '@/speech/ws/speechToText.gateway'
+import { useTestService } from '@/test-service'
+
+const service = useTestService()
+
+const SESSION_PATH = '/v1/speech/transcribe/session'
+
+// `PUBLIC_API_URL` is read at module load time by SpeechToTextService, so it
+// must be set in .env.test before bootstrap. Mirroring that value here keeps
+// the assertion source-of-truth alongside the test.
+const EXPECTED_PUBLIC_API_URL = 'http://test-api.local:3000'
+
+describe('POST /v1/speech/transcribe/session (integration)', () => {
+  it('mints a session whose wsUrl is built from PUBLIC_API_URL + stream path + ticket', async () => {
+    expect(process.env.PUBLIC_API_URL).toBe(EXPECTED_PUBLIC_API_URL)
+
+    const before = Date.now()
+    const res = await service.client.post(SESSION_PATH, {})
+    const after = Date.now()
+
+    expect(res.status).toBe(HttpStatus.CREATED)
+    expect(res.data).toEqual({
+      wsUrl: expect.any(String),
+      expiresAt: expect.any(String),
+    })
+
+    const url = new URL(res.data.wsUrl)
+    // Scheme must be flipped from http(s) to ws(s) by buildWsUrl.
+    expect(url.protocol).toBe('ws:')
+    // The host (host + port) must match PUBLIC_API_URL exactly so the
+    // browser's defense-in-depth host check in useDictation passes.
+    expect(url.host).toBe(new URL(EXPECTED_PUBLIC_API_URL).host)
+    expect(url.pathname).toBe(TRANSCRIBE_STREAM_PATH)
+
+    const ticket = url.searchParams.get('ticket')
+    expect(ticket).toBeTruthy()
+
+    // The ticket should be a valid JWT that decodes back to the logged-in
+    // user and the transcription-specific typ claim, proving the gateway
+    // can authorise the resulting WebSocket connection.
+    const ticketService = service.app.get(TranscriptionTicketService)
+    const payload = ticketService.verify(ticket as string)
+    expect(payload).toMatchObject({
+      uid: service.user.id,
+      typ: 'transcription_ticket',
+    })
+
+    const expiresMs = new Date(res.data.expiresAt).getTime()
+    expect(Number.isNaN(expiresMs)).toBe(false)
+    // Ticket TTL is 60s; allow a generous window for test machine slop.
+    expect(expiresMs).toBeGreaterThanOrEqual(before + 55_000)
+    expect(expiresMs).toBeLessThanOrEqual(after + 65_000)
+  })
+
+  it('rejects unauthenticated requests', async () => {
+    const res = await service.client.post(
+      SESSION_PATH,
+      {},
+      { headers: { Authorization: 'Bearer not-a-real-token' } },
+    )
+    expect(res.status).toBe(HttpStatus.UNAUTHORIZED)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a controller-level integration test for `POST /v1/speech/transcribe/session` that pins down the **wsUrl contract** the browser depends on.

This is the regression test for the bug that motivated #1617: when `PUBLIC_API_URL` is missing or wrong, `useDictation.buildAbsoluteWsUrl` raises `Untrusted WebSocket host` and dictation breaks before the socket ever opens. The new test fails fast on the server side if the contract drifts.

## What it asserts

- Response shape: `{ wsUrl, expiresAt }` with `201 CREATED`.
- `wsUrl` scheme is `ws:` (flipped from `http:` by `buildWsUrl`).
- `wsUrl` host matches `PUBLIC_API_URL` exactly.
- `wsUrl` path is `TRANSCRIBE_STREAM_PATH`.
- The `ticket` query param decodes via `TranscriptionTicketService.verify` to the logged-in user, with the `transcription_ticket` typ claim.
- `expiresAt` is roughly 60s in the future (matches `TICKET_TTL_SECONDS`).
- An unauth request returns 401.

## .env.test change

`PUBLIC_API_URL` is captured at module-load time by `SpeechToTextService` (`const PUBLIC_BASE_URL = process.env.PUBLIC_API_URL ?? ''`), so `.env.test` must set it before `useTestService` boots the app. Used `http://test-api.local:3000` — distinct, non-localhost, and obviously fake so URL assertions in the test are unambiguous.

## What's intentionally **not** covered

- **WebSocket upgrade.** Possible to test but adds Fastify-WS flake; the URL contract is the high-value piece for catching regressions.
- **AWS Transcribe streaming.** Wrong layer — needs real creds, slow, brittle. Belongs in a manual/e2e validation, not CI.
- **Rate-limit 429.** Already covered at the unit level in `userRequestBudget.test.ts`. Adding it here is awkward because `SpeechToTextService` is a process singleton, and its in-memory budget would leak across tests in the same suite. Worth revisiting if/when we add a reset hook.

## Test plan

- [x] `npx vitest run src/speech/controllers/speechToText.controller.integration.test.ts` — both tests pass locally (454 ms + a few ms for the auth test).
- [ ] CI green.

## Companion PR

- #1617 (docs) documents `PUBLIC_API_URL` in `.env.example`. This PR can land independently.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new integration test and a test-only env var to lock down URL construction behavior, without changing production logic.
> 
> **Overview**
> Adds a controller-level integration test for `POST /v1/speech/transcribe/session` that pins the response contract: returns `201` with `{ wsUrl, expiresAt }`, builds `wsUrl` from `PUBLIC_API_URL` (scheme flipped to `ws:`), `TRANSCRIBE_STREAM_PATH`, and a valid `ticket` JWT, and sets an expiry ~60s in the future.
> 
> Updates `.env.test` to define a non-localhost `PUBLIC_API_URL` (`http://test-api.local:3000`) so the test can make unambiguous host assertions and catch regressions where the env var is missing/misconfigured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9832d312a47667ff48839cdae7acc63fa7dc2826. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->