### PR TITLE
fix(speech): raise STT WebSocket audio rate cap to fit 16 kHz PCM

### DIFF
--- a/src/speech/ws/speechToText.gateway.ts
+++ b/src/speech/ws/speechToText.gateway.ts
@@ -23,7 +23,13 @@ const SESSION_HARD_CAP_MS = 10 * 60_000
 const WARN_BEFORE_CAP_MS = 60_000
 const WARN_AT_MS = SESSION_HARD_CAP_MS - WARN_BEFORE_CAP_MS
 
-const RATE_LIMIT_BYTES_PER_SEC = 16 * 1024
+// The client streams 16 kHz mono 16-bit PCM, i.e. 32_000 bytes/sec at steady
+// state. We allow ~1.5× headroom for the frame burstiness introduced by the
+// AudioWorklet (which posts one 2048-sample frame every ~128 ms rather than a
+// perfectly uniform stream) before flagging the session as abusive. A lower
+// cap (we previously used 16 KB/sec) trips on every legitimate session as
+// soon as the 2-second grace window elapses.
+const RATE_LIMIT_BYTES_PER_SEC = 48 * 1024
 const RATE_LIMIT_GRACE_MS = 2_000
 
 const ClientStopMessageSchema = z.object({ type: z.literal('stop') }).strict()


### PR DESCRIPTION
The client streams 16 kHz mono 16-bit PCM (~32 KB/s) but the server capped sessions at 16 KB/s, so every legitimate dictation tripped RATE_LIMIT once the 2s grace window elapsed. Raise the cap to 48 KB/s (~1.5x expected throughput) to absorb AudioWorklet frame burstiness, and document the math so the regression doesn't recur.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adjusts a single constant and adds documentation; behavior change is limited to allowing higher throughput before rate-limit closes sessions.
> 
> **Overview**
> Fixes false-positive `RATE_LIMIT` closures on the speech-to-text WebSocket by raising the allowed incoming audio throughput from `16 KB/s` to `48 KB/s`.
> 
> Adds inline documentation explaining the expected `16 kHz` mono `16-bit PCM` byte rate and why extra headroom is needed for bursty `AudioWorklet` frame delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e0f457254bcadda9a19a35bf32848e9f743d2bc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->