### PR TITLE
fix(briefing-chats): surface attachment-only notes to the AI assistant

### DIFF
--- a/src/chats/briefing-chats/services/briefingNotes.service.test.ts
+++ b/src/chats/briefing-chats/services/briefingNotes.service.test.ts
@@ -1,8 +1,18 @@
-import { AnnotationKind, AnnotationResourceType } from '@prisma/client'
+import {
+  AnnotationKind,
+  AnnotationResourceType,
+  OcrStatus,
+} from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
 import { PrismaService } from '@/prisma/prisma.service'
 import { BriefingNotesService } from './briefingNotes.service'
+
+interface FakeAttachmentRow {
+  fileName: string
+  ocrStatus: OcrStatus
+  ocrText: string | null
+}
 
 interface FakeAnnotationRow {
   id: string
@@ -10,7 +20,7 @@ interface FakeAnnotationRow {
   start: number | null
   end: number | null
   createdAt: Date
-  note: { body: string } | null
+  note: { body: string | null; attachments: FakeAttachmentRow[] } | null
 }
 
 const buildService = (deps: {
@@ -43,30 +53,73 @@ const buildService = (deps: {
 
 describe('BriefingNotesService', () => {
   describe('countNotesForUser', () => {
-    it('counts annotations scoped to user + briefing + kind=note with a note attached', async () => {
-      const count = vi.fn().mockResolvedValue(3)
-      const svc = buildService({ count })
+    it('counts only notes that will produce readable content for the LLM', async () => {
+      const rows: FakeAnnotationRow[] = [
+        {
+          id: 'typed',
+          jsonPath: null,
+          start: null,
+          end: null,
+          createdAt: new Date('2026-05-10T15:00:00Z'),
+          note: { body: 'hello', attachments: [] },
+        },
+        {
+          id: 'attachment-completed',
+          jsonPath: null,
+          start: null,
+          end: null,
+          createdAt: new Date('2026-05-10T15:00:00Z'),
+          note: {
+            body: null,
+            attachments: [
+              {
+                fileName: 'sign.jpg',
+                ocrStatus: OcrStatus.completed,
+                ocrText: 'VOTE NO',
+              },
+            ],
+          },
+        },
+        {
+          id: 'attachment-pending',
+          jsonPath: null,
+          start: null,
+          end: null,
+          createdAt: new Date('2026-05-10T15:00:00Z'),
+          note: {
+            body: null,
+            attachments: [
+              {
+                fileName: 'flyer.jpg',
+                ocrStatus: OcrStatus.pending,
+                ocrText: null,
+              },
+            ],
+          },
+        },
+        {
+          id: 'truly-empty',
+          jsonPath: null,
+          start: null,
+          end: null,
+          createdAt: new Date('2026-05-10T15:00:00Z'),
+          note: { body: '', attachments: [] },
+        },
+      ]
+      const findMany = vi.fn().mockResolvedValue(rows)
+      const svc = buildService({ findMany })
 
       const out = await svc.countNotesForUser({
         userId: 7,
         briefingId: 'brief-1',
       })
 
-      expect(out).toBe(3)
-      expect(count).toHaveBeenCalledWith({
-        where: {
-          authorUserId: 7,
-          resourceId: 'brief-1',
-          resourceType: AnnotationResourceType.briefing,
-          kind: AnnotationKind.note,
-          note: { isNot: null },
-        },
-      })
+      expect(out).toBe(2)
     })
 
     it('returns 0 when the user has no notes on the briefing', async () => {
-      const count = vi.fn().mockResolvedValue(0)
-      const svc = buildService({ count })
+      const findMany = vi.fn().mockResolvedValue([])
+      const svc = buildService({ findMany })
 
       const out = await svc.countNotesForUser({
         userId: 7,
@@ -74,16 +127,6 @@ describe('BriefingNotesService', () => {
       })
 
       expect(out).toBe(0)
-    })
-
-    it('does not load notes or parse the artifact', async () => {
-      const count = vi.fn().mockResolvedValue(2)
-      const findMany = vi.fn()
-      const svc = buildService({ count, findMany })
-
-      await svc.countNotesForUser({ userId: 1, briefingId: 'b' })
-
-      expect(findMany).not.toHaveBeenCalled()
     })
   })
 
@@ -104,7 +147,7 @@ describe('BriefingNotesService', () => {
           start: null,
           end: null,
           createdAt: new Date('2026-05-10T15:00:00Z'),
-          note: { body: 'general thought' },
+          note: { body: 'general thought', attachments: [] },
         },
       ]
       findMany.mockResolvedValueOnce(rows)
@@ -142,7 +185,7 @@ describe('BriefingNotesService', () => {
           start: null,
           end: null,
           createdAt: new Date('2026-05-11T15:00:00Z'),
-          note: { body: 'kept' },
+          note: { body: 'kept', attachments: [] },
         },
       ]
       findMany.mockResolvedValueOnce(rows)
@@ -167,7 +210,10 @@ describe('BriefingNotesService', () => {
         start: 0,
         end: 11,
         createdAt: new Date('2026-05-12T10:00:00Z'),
-        note: { body: 'Worth flagging for the next session.' },
+        note: {
+          body: 'Worth flagging for the next session.',
+          attachments: [],
+        },
       }
       findMany.mockResolvedValueOnce([writtenByAnnotationsApi])
 
@@ -197,7 +243,7 @@ describe('BriefingNotesService', () => {
           resourceType: AnnotationResourceType.briefing,
           kind: AnnotationKind.note,
         },
-        include: { note: true },
+        include: { note: { include: { attachments: true } } },
         orderBy: { createdAt: 'asc' },
       })
     })
@@ -209,7 +255,7 @@ describe('BriefingNotesService', () => {
         start: 0,
         end: 5,
         createdAt: new Date('2026-05-12T10:00:00Z'),
-        note: { body: 'note on now-deleted section' },
+        note: { body: 'note on now-deleted section', attachments: [] },
       }
       findMany.mockResolvedValueOnce([row])
 
@@ -228,6 +274,168 @@ describe('BriefingNotesService', () => {
           createdAt: '2026-05-12T10:00:00.000Z',
         },
       ])
+    })
+
+    it('uses completed OCR text when the note body is empty', async () => {
+      const rows: FakeAnnotationRow[] = [
+        {
+          id: 'attachment-only',
+          jsonPath: null,
+          start: null,
+          end: null,
+          createdAt: new Date('2026-05-13T10:00:00Z'),
+          note: {
+            body: null,
+            attachments: [
+              {
+                fileName: 'yard-sign.jpg',
+                ocrStatus: OcrStatus.completed,
+                ocrText: 'RE-ELECT JANE',
+              },
+            ],
+          },
+        },
+      ]
+      findMany.mockResolvedValueOnce(rows)
+
+      const out = await svc.loadNotesForChat({
+        userId: 7,
+        briefingId: 'b',
+        artifactContent: '{}',
+      })
+
+      expect(out).toEqual([
+        {
+          id: 'attachment-only',
+          body: '[yard-sign.jpg]\nRE-ELECT JANE',
+          jsonPath: null,
+          highlightedText: null,
+          createdAt: '2026-05-13T10:00:00.000Z',
+        },
+      ])
+    })
+
+    it('concatenates multiple completed attachments with file-name prefixes', async () => {
+      const rows: FakeAnnotationRow[] = [
+        {
+          id: 'multi',
+          jsonPath: null,
+          start: null,
+          end: null,
+          createdAt: new Date('2026-05-13T10:00:00Z'),
+          note: {
+            body: null,
+            attachments: [
+              {
+                fileName: 'a.jpg',
+                ocrStatus: OcrStatus.completed,
+                ocrText: 'one',
+              },
+              {
+                fileName: 'b.jpg',
+                ocrStatus: OcrStatus.completed,
+                ocrText: 'two',
+              },
+            ],
+          },
+        },
+      ]
+      findMany.mockResolvedValueOnce(rows)
+
+      const out = await svc.loadNotesForChat({
+        userId: 7,
+        briefingId: 'b',
+        artifactContent: '{}',
+      })
+
+      expect(out[0].body).toBe('[a.jpg]\none\n\n[b.jpg]\ntwo')
+    })
+
+    it('skips notes whose only attachment has not finished OCR yet', async () => {
+      const rows: FakeAnnotationRow[] = [
+        {
+          id: 'pending',
+          jsonPath: null,
+          start: null,
+          end: null,
+          createdAt: new Date('2026-05-13T10:00:00Z'),
+          note: {
+            body: null,
+            attachments: [
+              {
+                fileName: 'flyer.jpg',
+                ocrStatus: OcrStatus.pending,
+                ocrText: null,
+              },
+            ],
+          },
+        },
+        {
+          id: 'failed',
+          jsonPath: null,
+          start: null,
+          end: null,
+          createdAt: new Date('2026-05-13T10:00:00Z'),
+          note: {
+            body: null,
+            attachments: [
+              {
+                fileName: 'blurry.jpg',
+                ocrStatus: OcrStatus.failed,
+                ocrText: null,
+              },
+            ],
+          },
+        },
+        {
+          id: 'kept',
+          jsonPath: null,
+          start: null,
+          end: null,
+          createdAt: new Date('2026-05-13T10:00:00Z'),
+          note: { body: 'typed', attachments: [] },
+        },
+      ]
+      findMany.mockResolvedValueOnce(rows)
+
+      const out = await svc.loadNotesForChat({
+        userId: 7,
+        briefingId: 'b',
+        artifactContent: '{}',
+      })
+
+      expect(out.map((n) => n.id)).toEqual(['kept'])
+    })
+
+    it('prefers typed body over OCR text when both exist', async () => {
+      const rows: FakeAnnotationRow[] = [
+        {
+          id: 'mixed',
+          jsonPath: null,
+          start: null,
+          end: null,
+          createdAt: new Date('2026-05-13T10:00:00Z'),
+          note: {
+            body: 'my caption',
+            attachments: [
+              {
+                fileName: 'sign.jpg',
+                ocrStatus: OcrStatus.completed,
+                ocrText: 'OCR TEXT',
+              },
+            ],
+          },
+        },
+      ]
+      findMany.mockResolvedValueOnce(rows)
+
+      const out = await svc.loadNotesForChat({
+        userId: 7,
+        briefingId: 'b',
+        artifactContent: '{}',
+      })
+
+      expect(out[0].body).toBe('my caption')
     })
   })
 })

--- a/src/chats/briefing-chats/services/briefingNotes.service.ts
+++ b/src/chats/briefing-chats/services/briefingNotes.service.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@nestjs/common'
-import { AnnotationKind, AnnotationResourceType } from '@prisma/client'
+import {
+  AnnotationKind,
+  AnnotationResourceType,
+  OcrStatus,
+} from '@prisma/client'
 import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
 import type { Note } from '@/llm/tools/getMyNotes.tool'
 import { extractHighlight } from './extractHighlight'
@@ -15,20 +19,24 @@ export interface CountNotesArgs {
   briefingId: string
 }
 
+interface AttachmentRow {
+  fileName: string
+  ocrStatus: OcrStatus
+  ocrText: string | null
+}
+
+const buildBodyFromAttachments = (
+  attachments: AttachmentRow[],
+): string | null => {
+  const readable = attachments.filter(
+    (a) => a.ocrStatus === OcrStatus.completed && a.ocrText,
+  )
+  if (readable.length === 0) return null
+  return readable.map((a) => `[${a.fileName}]\n${a.ocrText}`).join('\n\n')
+}
+
 @Injectable()
 export class BriefingNotesService extends createPrismaBase(MODELS.Annotation) {
-  countNotesForUser(args: CountNotesArgs): Promise<number> {
-    return this.count({
-      where: {
-        authorUserId: args.userId,
-        resourceId: args.briefingId,
-        resourceType: AnnotationResourceType.briefing,
-        kind: AnnotationKind.note,
-        note: { isNot: null },
-      },
-    })
-  }
-
   async loadNotesForChat(args: LoadNotesArgs): Promise<Note[]> {
     const rows = await this.findMany({
       where: {
@@ -37,22 +45,37 @@ export class BriefingNotesService extends createPrismaBase(MODELS.Annotation) {
         resourceType: AnnotationResourceType.briefing,
         kind: AnnotationKind.note,
       },
-      include: { note: true },
+      include: { note: { include: { attachments: true } } },
       orderBy: { createdAt: 'asc' },
     })
 
     const notes: Note[] = []
     for (const row of rows) {
-      if (row.note == null || !row.note.body) continue
+      if (row.note == null) continue
+      const typed =
+        row.note.body && row.note.body.length > 0 ? row.note.body : null
+      const fromAttachments = typed
+        ? null
+        : buildBodyFromAttachments(row.note.attachments)
+      const body = typed ?? fromAttachments
+      if (body == null) continue
       const highlight = extractHighlight(args.artifactContent, row)
       notes.push({
         id: row.id,
-        body: row.note.body,
+        body,
         jsonPath: row.jsonPath,
         highlightedText: highlight?.text ?? null,
         createdAt: row.createdAt.toISOString(),
       })
     }
     return notes
+  }
+
+  async countNotesForUser(args: CountNotesArgs): Promise<number> {
+    const notes = await this.loadNotesForChat({
+      ...args,
+      artifactContent: '',
+    })
+    return notes.length
   }
 }


### PR DESCRIPTION
## Why

The AI chat assistant on a briefing has a `get_my_notes` tool meant to pull the user's notes into context. In QA we found it returns nothing for any note that's a file or photo upload — which is most of them, since the Add Notes flow defaults to camera/upload.

Root cause: `loadNotesForChat` only loaded `note.body` and skipped any annotation with an empty body. File/photo notes carry their readable text on `AnnotationNoteAttachment.ocrText`, not on the note body. They were dropped silently. Worse, `countNotesForUser` over-counted, so the system prompt advertised "you have N notes" while the tool resolved to `[]` — making the assistant confidently claim no notes exist.

This blocked the upcoming OCR worker integration from being useful even after it lands: the read path wasn't ready.

## What changed

- `briefingNotes.service.ts` now includes `note.attachments` in its query and falls back to concatenated `ocrText` (one attachment per block, prefixed with the file name so the model can cite it) when body is empty.
- Notes with no body **and** no completed OCR are skipped — they have nothing to say yet.
- `countNotesForUser` defers to the same filter so count and tool output can never diverge.
- Tests expanded with cases for typed-only, attachment-only completed, multiple attachments, pending/failed skipped, and body-wins-over-OCR-when-both-exist.

## Companion

Frontend QA pass for the same feature: thegoodparty/gp-webapp#1844

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the server-side logic that determines which briefing notes are surfaced to the LLM and how they’re counted, which could affect chat context and user-visible “note count” messaging. Main risk is behavioral (filtering/formatting) and a slightly heavier DB query due to including attachments.
> 
> **Overview**
> Briefing chat note retrieval now **surfaces attachment-only notes** by loading `note.attachments` and falling back to concatenated *completed* OCR text (prefixed with file names) when `note.body` is empty, while skipping notes with no typed body and no completed OCR.
> 
> `countNotesForUser` is rewritten to reuse the same filtering as `loadNotesForChat` (preventing count/output drift), and tests are expanded to cover typed vs OCR precedence, multiple attachments, and pending/failed OCR being excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca3209a1d2952b3d66dc3cbfa7940876585cc87e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
