### PR TITLE
fix(briefing-chats): drop topic filter from get_my_notes

### DIFF
--- a/src/chats/briefing-chats/services/briefing-chats.service.test.ts
+++ b/src/chats/briefing-chats/services/briefing-chats.service.test.ts
@@ -632,7 +632,7 @@ describe('BriefingChatsService', () => {
 
         const tools = chatStream.lastArgs?.tools ?? {}
         const tool = tools.get_my_notes as unknown as LlmStreamTool<
-          { topic?: string },
+          Record<string, never>,
           Array<{ id: string }>
         >
         const out = await tool.execute({})
@@ -676,7 +676,7 @@ describe('BriefingChatsService', () => {
 
         const tools = chatStream.lastArgs?.tools ?? {}
         const tool = tools.get_my_notes as unknown as LlmStreamTool<
-          { topic?: string },
+          Record<string, never>,
           Array<{ id: string }>
         >
 
@@ -715,13 +715,13 @@ describe('BriefingChatsService', () => {
 
         const tools = chatStream.lastArgs?.tools ?? {}
         const tool = tools.get_my_notes as unknown as LlmStreamTool<
-          { topic?: string },
+          Record<string, never>,
           Array<{ id: string }>
         >
 
         await tool.execute({})
         await tool.execute({})
-        await tool.execute({ topic: 'b' })
+        await tool.execute({})
 
         expect(notes.loadNotesForChatMock).toHaveBeenCalledTimes(1)
       })

--- a/src/llm/tools/getMyNotes.tool.test.ts
+++ b/src/llm/tools/getMyNotes.tool.test.ts
@@ -22,7 +22,7 @@ const NOTE_B: Note = {
 }
 
 describe('getMyNotes tool', () => {
-  it('returns all notes when no topic is provided', async () => {
+  it('returns every note the provider yields', async () => {
     const provider = new InMemoryNotesProvider([NOTE_A, NOTE_B])
     const tool = buildGetMyNotesTool({ provider })
 
@@ -31,29 +31,11 @@ describe('getMyNotes tool', () => {
     expect(out).toEqual([NOTE_A, NOTE_B])
   })
 
-  it('filters by case-insensitive substring on body', async () => {
-    const provider = new InMemoryNotesProvider([NOTE_A, NOTE_B])
+  it('returns an empty array when the provider has no notes', async () => {
+    const provider = new InMemoryNotesProvider([])
     const tool = buildGetMyNotesTool({ provider })
 
-    const out = await tool.execute({ topic: 'fiscal' })
-
-    expect(out.map((n) => n.id)).toEqual(['n2'])
-  })
-
-  it('filters by case-insensitive substring on highlighted text', async () => {
-    const provider = new InMemoryNotesProvider([NOTE_A, NOTE_B])
-    const tool = buildGetMyNotesTool({ provider })
-
-    const out = await tool.execute({ topic: 'rental' })
-
-    expect(out.map((n) => n.id)).toEqual(['n1'])
-  })
-
-  it('returns an empty array when no note matches', async () => {
-    const provider = new InMemoryNotesProvider([NOTE_A, NOTE_B])
-    const tool = buildGetMyNotesTool({ provider })
-
-    const out = await tool.execute({ topic: 'asteroid mining' })
+    const out = await tool.execute({})
 
     expect(out).toEqual([])
   })

--- a/src/llm/tools/getMyNotes.tool.ts
+++ b/src/llm/tools/getMyNotes.tool.ts
@@ -9,9 +9,7 @@ export interface Note {
   createdAt: string
 }
 
-export interface GetMyNotesInput {
-  topic?: string
-}
+export type GetMyNotesInput = Record<string, never>
 
 export type GetMyNotesOutput = Note[]
 
@@ -19,28 +17,15 @@ export interface NotesProvider {
   list: () => Promise<Note[]>
 }
 
-const getMyNotesInputSchema = z.object({
-  topic: z.string().optional(),
-})
-
-const matchesTopic = (note: Note, topic: string): boolean => {
-  const needle = topic.toLowerCase()
-  if (note.body.toLowerCase().includes(needle)) return true
-  if (note.highlightedText?.toLowerCase().includes(needle)) return true
-  return false
-}
+const getMyNotesInputSchema = z.object({})
 
 export const buildGetMyNotesTool = (deps: {
   provider: NotesProvider
 }): LlmStreamTool<GetMyNotesInput, GetMyNotesOutput> => ({
   description:
-    'Retrieve the user\'s own notes on this briefing — short annotations the user wrote against specific passages. Use this when the question references something the user might have personally flagged or noted (e.g., "what did I think about", "remind me why I noted"). Each note carries the body the user wrote and the briefing text they highlighted.',
+    'Retrieve the user\'s own notes on this briefing — short annotations the user wrote against specific passages. Use this when the question references something the user might have personally flagged or noted (e.g., "what did I think about", "remind me why I noted"). Each note carries the body the user wrote and the briefing text they highlighted. Returns every note for the briefing; you do the filtering yourself.',
   inputSchema: getMyNotesInputSchema,
-  execute: async ({ topic }) => {
-    const all = await deps.provider.list()
-    if (!topic) return all
-    return all.filter((n) => matchesTopic(n, topic))
-  },
+  execute: async () => deps.provider.list(),
 })
 
 export class InMemoryNotesProvider implements NotesProvider {


### PR DESCRIPTION
## Why

The `topic` arg on the `get_my_notes` tool was a dumb substring filter on `body` + `highlightedText`. Brittle (no synonyms, no misspellings, partial-word false positives) and unnecessary at our scale — a user has a handful of notes per briefing, not hundreds. Letting Claude filter in context is both more accurate and removes a footgun where an over-narrow topic returned `[]` and the model concluded the user had no notes at all.

The tool now takes no input and always returns every note for the briefing. Description updated to make that explicit so the model doesn't waste tokens guessing at a filter that no longer exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `get_my_notes` tool contract by removing the `topic` input and always returning all notes, which may break any callers still providing/expecting server-side filtering.
> 
> **Overview**
> **Simplifies `get_my_notes` to be unfiltered.** The tool no longer accepts a `topic` parameter (schema now empty) and always returns whatever the `NotesProvider` lists.
> 
> Tests were updated to drop substring-filter expectations and instead verify full passthrough and the empty-provider case; tool description now explicitly tells the model to do any filtering itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf8277d62d535d4fb17f618ab3e3516373f112e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->