### PR TITLE
Merge pull request #1591 from thegoodparty/fix-infra

### DIFF
--- a/deploy/components/grafana.ts
+++ b/deploy/components/grafana.ts
@@ -236,11 +236,18 @@ export const createGrafanaResources = async ({
   })
 
   for (const controller of CONTROLLER_NAMES) {
+    const rules = controllerAlerts(controller).map(alertToRule)
+    // Grafana's RuleGroup schema requires `rules` to have at least 1 item:
+    // > Attribute rule requires 1 item minimum, but config has only 0 declared.
+    // CONTROLLER_NAMES is auto-generated from src and can include controllers
+    // with no public routes (currently `mcp`), which produce zero alerts.
+    // An empty RuleGroup adds no value, so skip them rather than fail preview.
+    if (rules.length === 0) continue
     new grafana.alerting.RuleGroup(`${controller}-rules`, {
       name: `${controller} routes`,
       folderUid: alertFolder.uid,
       intervalSeconds: 60,
-      rules: controllerAlerts(controller).map(alertToRule),
+      rules,
     })
   }
 


### PR DESCRIPTION
fix(grafana): skip RuleGroup creation for controllers with zero alerts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small infra change that only affects Grafana alert provisioning by avoiding invalid empty `RuleGroup` resources; main risk is accidentally skipping alerts if `controllerAlerts` unexpectedly returns an empty list.
> 
> **Overview**
> Prevents Pulumi/Grafana provisioning failures by **skipping per-controller alert `RuleGroup` creation when `controllerAlerts(controller)` yields zero rules** (e.g., auto-generated controllers with no public routes).
> 
> This precomputes `rules` once and adds a guard to avoid creating empty `RuleGroup`s that violate Grafana’s schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e5cc47eb9d2298b0cd1eb44f64b3c601e78b050. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->