### PR TITLE
Eng-10225 Add back due date to slack message for outreach.

### DIFF
--- a/src/outreach/schemas/createOutreachSchema.ts
+++ b/src/outreach/schemas/createOutreachSchema.ts
@@ -1,6 +1,7 @@
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 import { OutreachStatus, OutreachType } from '@prisma/client'
+import { isValid, parseISO } from 'date-fns'
 
 export class CreateOutreachSchema extends createZodDto(
   z
@@ -37,6 +38,10 @@ export class CreateOutreachSchema extends createZodDto(
       campaignPlanDueDate: z
         .string()
         .regex(/^\d{4}-\d{2}-\d{2}$/, 'campaignPlanDueDate must be YYYY-MM-DD')
+        .refine(
+          (s) => isValid(parseISO(s)),
+          'campaignPlanDueDate must be a valid calendar date',
+        )
         .optional(),
     })
     .strict()

--- a/src/outreach/schemas/createOutreachSchema.ts
+++ b/src/outreach/schemas/createOutreachSchema.ts
@@ -34,6 +34,10 @@ export class CreateOutreachSchema extends createZodDto(
         .max(50, 'didNpaSubset cannot exceed 50 area codes')
         .optional(),
       title: z.string().optional(),
+      campaignPlanDueDate: z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/, 'campaignPlanDueDate must be YYYY-MM-DD')
+        .optional(),
     })
     .strict()
     .superRefine((data, ctx) => {

--- a/src/outreach/services/outreach.service.test.ts
+++ b/src/outreach/services/outreach.service.test.ts
@@ -27,6 +27,7 @@ const mockOutreachFindMany = vi.fn()
 const mockTcrFindFirstOrThrow = vi.fn()
 const mockPeerlyCreateJob = vi.fn()
 const mockResolveP2pJobGeography = vi.fn()
+const mockNotifySuccess = vi.fn()
 
 vi.mock('../util/campaignGeography.util', () => ({
   resolveP2pJobGeography: (
@@ -80,6 +81,8 @@ describe('OutreachService', () => {
     mockTcrFindFirstOrThrow.mockReset()
     mockPeerlyCreateJob.mockReset()
     mockResolveP2pJobGeography.mockReset()
+    mockNotifySuccess.mockReset()
+    mockNotifySuccess.mockResolvedValue(undefined)
 
     const mockPrismaService = {
       outreach: {
@@ -111,7 +114,7 @@ describe('OutreachService', () => {
         },
         {
           provide: OutreachNotificationService,
-          useValue: { notifySuccess: vi.fn().mockResolvedValue(undefined) },
+          useValue: { notifySuccess: mockNotifySuccess },
         },
         OutreachService,
       ],
@@ -151,6 +154,24 @@ describe('OutreachService', () => {
         include: { voterFileFilter: true },
       })
       expect(result).toEqual(created)
+    })
+
+    it('forwards campaignPlanDueDate from the DTO into notifySuccess', async () => {
+      const dto: CreateOutreachSchema = {
+        ...baseCreateDto,
+        campaignPlanDueDate: '2026-04-19',
+      }
+      mockOutreachCreate.mockResolvedValue({
+        id: 1,
+        ...dto,
+        voterFileFilter: null,
+      })
+
+      await service.create(mockUser, mockCampaign, dto, undefined, undefined)
+
+      expect(mockNotifySuccess).toHaveBeenCalledWith(
+        expect.objectContaining({ campaignPlanDueDate: '2026-04-19' }),
+      )
     })
 
     it('creates non-P2P outreach without imageUrl when both omitted', async () => {

--- a/src/outreach/services/outreach.service.ts
+++ b/src/outreach/services/outreach.service.ts
@@ -181,6 +181,7 @@ export class OutreachService extends createPrismaBase(MODELS.Outreach) {
         campaign,
         outreach,
         audienceRequest: createOutreachDto.audienceRequest,
+        campaignPlanDueDate: createOutreachDto.campaignPlanDueDate,
       })
     } catch (err) {
       this.logger.error(

--- a/src/outreach/services/outreachNotification.service.ts
+++ b/src/outreach/services/outreachNotification.service.ts
@@ -55,6 +55,7 @@ interface NotifySuccessParams {
   campaign: Campaign
   outreach: OutreachWithVoterFileFilter
   audienceRequest?: string
+  campaignPlanDueDate?: string
 }
 
 interface NotifyFailureParams {
@@ -86,6 +87,7 @@ export class OutreachNotificationService {
     campaign,
     outreach,
     audienceRequest,
+    campaignPlanDueDate,
   }: NotifySuccessParams): Promise<void> {
     if (!shouldNotifyCAS(outreach.outreachType)) return
 
@@ -138,6 +140,7 @@ export class OutreachNotificationService {
           formattedAudience: this.formatAudienceFiltersForSlack(audience),
           audienceRequest,
           peerlyJobUrl,
+          campaignPlanDueDate,
         }),
         TARGET_CHANNEL,
       )

--- a/src/voters/util/voterOutreach.util.test.ts
+++ b/src/voters/util/voterOutreach.util.test.ts
@@ -1,0 +1,55 @@
+import { OutreachType } from '@prisma/client'
+import { describe, expect, it } from 'vitest'
+import { SlackMessageType } from 'src/vendors/slack/slackService.types'
+import { buildSlackBlocks } from './voterOutreach.util'
+
+type TextNode = { type: SlackMessageType; text?: string }
+
+const collectTextElementGroups = (node: unknown): TextNode[][] => {
+  if (!node || typeof node !== 'object') return []
+  const { elements } = node as { elements?: unknown }
+  if (!Array.isArray(elements)) return []
+  const hasText = elements.every(
+    (e) => e && typeof e === 'object' && 'text' in (e as object),
+  )
+  if (hasText) return [elements as TextNode[]]
+  return elements.flatMap(collectTextElementGroups)
+}
+
+const findDueDateValue = (
+  blocks: ReturnType<typeof buildSlackBlocks>['blocks'],
+): string | undefined => {
+  const groups = blocks.flatMap(collectTextElementGroups)
+  const group = groups.find((els) =>
+    els.some(
+      (e) => e.type === SlackMessageType.TEXT && e.text === 'Due Date: ',
+    ),
+  )
+  if (!group) return undefined
+  const labelIdx = group.findIndex(
+    (e) => e.type === SlackMessageType.TEXT && e.text === 'Due Date: ',
+  )
+  return group[labelIdx + 1]?.text
+}
+
+describe('buildSlackBlocks - campaignPlanDueDate', () => {
+  const baseParams = {
+    type: OutreachType.text,
+    formattedAudience: [],
+  }
+
+  it('renders the due date as-is when a YYYY-MM-DD string is provided', () => {
+    const { blocks } = buildSlackBlocks({
+      ...baseParams,
+      campaignPlanDueDate: '2026-04-19',
+    })
+
+    expect(findDueDateValue(blocks)).toBe('2026-04-19')
+  })
+
+  it('renders "N/A" when campaignPlanDueDate is omitted', () => {
+    const { blocks } = buildSlackBlocks(baseParams)
+
+    expect(findDueDateValue(blocks)).toBe('N/A')
+  })
+})

--- a/src/voters/util/voterOutreach.util.test.ts
+++ b/src/voters/util/voterOutreach.util.test.ts
@@ -33,22 +33,11 @@ const findDueDateValue = (
 }
 
 describe('buildSlackBlocks - campaignPlanDueDate', () => {
-  const baseParams = {
-    type: OutreachType.text,
-    formattedAudience: [],
-  }
-
-  it('renders the due date as-is when a YYYY-MM-DD string is provided', () => {
+  it('always renders "N/A" for the Due Date line', () => {
     const { blocks } = buildSlackBlocks({
-      ...baseParams,
-      campaignPlanDueDate: '2026-04-19',
+      type: OutreachType.text,
+      formattedAudience: [],
     })
-
-    expect(findDueDateValue(blocks)).toBe('2026-04-19')
-  })
-
-  it('renders "N/A" when campaignPlanDueDate is omitted', () => {
-    const { blocks } = buildSlackBlocks(baseParams)
 
     expect(findDueDateValue(blocks)).toBe('N/A')
   })

--- a/src/voters/util/voterOutreach.util.test.ts
+++ b/src/voters/util/voterOutreach.util.test.ts
@@ -33,11 +33,22 @@ const findDueDateValue = (
 }
 
 describe('buildSlackBlocks - campaignPlanDueDate', () => {
-  it('always renders "N/A" for the Due Date line', () => {
+  const baseParams = {
+    type: OutreachType.text,
+    formattedAudience: [],
+  }
+
+  it('renders the due date as-is when a YYYY-MM-DD string is provided', () => {
     const { blocks } = buildSlackBlocks({
-      type: OutreachType.text,
-      formattedAudience: [],
+      ...baseParams,
+      campaignPlanDueDate: '2026-04-19',
     })
+
+    expect(findDueDateValue(blocks)).toBe('2026-04-19')
+  })
+
+  it('renders "N/A" when campaignPlanDueDate is omitted', () => {
+    const { blocks } = buildSlackBlocks(baseParams)
 
     expect(findDueDateValue(blocks)).toBe('N/A')
   })

--- a/src/voters/util/voterOutreach.util.ts
+++ b/src/voters/util/voterOutreach.util.ts
@@ -36,6 +36,7 @@ type SlackBlocksParams = {
   formattedAudience: Array<AudienceSlackBlock>
   audienceRequest?: string
   peerlyJobUrl?: string
+  campaignPlanDueDate?: string
 }
 
 export function buildSlackBlocks({
@@ -53,6 +54,7 @@ export function buildSlackBlocks({
   formattedAudience,
   audienceRequest,
   peerlyJobUrl,
+  campaignPlanDueDate,
 }: SlackBlocksParams) {
   const blocks = [
     {
@@ -196,9 +198,6 @@ export function buildSlackBlocks({
                 },
               ],
             },
-            // Hardcoded 'N/A': downstream automation parses this message
-            // and expects the "Due Date" line. The original source value was
-            // removed and we don't have a replacement yet.
             {
               type: SlackMessageType.RICH_TEXT_SECTION,
               elements: [
@@ -211,7 +210,7 @@ export function buildSlackBlocks({
                 },
                 {
                   type: SlackMessageType.TEXT,
-                  text: 'N/A',
+                  text: campaignPlanDueDate || 'N/A',
                 },
               ],
             },

--- a/src/voters/util/voterOutreach.util.ts
+++ b/src/voters/util/voterOutreach.util.ts
@@ -36,7 +36,6 @@ type SlackBlocksParams = {
   formattedAudience: Array<AudienceSlackBlock>
   audienceRequest?: string
   peerlyJobUrl?: string
-  campaignPlanDueDate?: string
 }
 
 export function buildSlackBlocks({
@@ -54,9 +53,7 @@ export function buildSlackBlocks({
   formattedAudience,
   audienceRequest,
   peerlyJobUrl,
-  campaignPlanDueDate,
 }: SlackBlocksParams) {
-  const formattedCampaignPlanDueDate = campaignPlanDueDate || 'N/A'
   const blocks = [
     {
       type: SlackMessageType.HEADER,
@@ -199,6 +196,9 @@ export function buildSlackBlocks({
                 },
               ],
             },
+            // Hardcoded 'N/A': downstream automation parses this message
+            // and expects the "Due Date" line. The original source value was
+            // removed and we don't have a replacement yet.
             {
               type: SlackMessageType.RICH_TEXT_SECTION,
               elements: [
@@ -211,7 +211,7 @@ export function buildSlackBlocks({
                 },
                 {
                   type: SlackMessageType.TEXT,
-                  text: formattedCampaignPlanDueDate,
+                  text: 'N/A',
                 },
               ],
             },

--- a/src/voters/util/voterOutreach.util.ts
+++ b/src/voters/util/voterOutreach.util.ts
@@ -36,6 +36,7 @@ type SlackBlocksParams = {
   formattedAudience: Array<AudienceSlackBlock>
   audienceRequest?: string
   peerlyJobUrl?: string
+  campaignPlanDueDate?: string
 }
 
 export function buildSlackBlocks({
@@ -53,7 +54,9 @@ export function buildSlackBlocks({
   formattedAudience,
   audienceRequest,
   peerlyJobUrl,
+  campaignPlanDueDate,
 }: SlackBlocksParams) {
+  const formattedCampaignPlanDueDate = campaignPlanDueDate || 'N/A'
   const blocks = [
     {
       type: SlackMessageType.HEADER,
@@ -193,6 +196,22 @@ export function buildSlackBlocks({
                 {
                   type: SlackMessageType.TEXT,
                   text: date ? String(date) : 'Not available',
+                },
+              ],
+            },
+            {
+              type: SlackMessageType.RICH_TEXT_SECTION,
+              elements: [
+                {
+                  type: SlackMessageType.TEXT,
+                  text: 'Due Date: ',
+                  style: {
+                    bold: true,
+                  },
+                },
+                {
+                  type: SlackMessageType.TEXT,
+                  text: formattedCampaignPlanDueDate,
                 },
               ],
             },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `campaignPlanDueDate` field to the Slack block builder and a small test, with a safe fallback to `N/A` when not provided.
> 
> **Overview**
> Restores a **Due Date** line in the outreach Slack message by extending `buildSlackBlocks` to accept an optional `campaignPlanDueDate` and rendering it (defaulting to `N/A`).
> 
> Adds a focused unit test in `voterOutreach.util.test.ts` to verify the due date is displayed verbatim when provided and falls back to `N/A` when omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 799fda0d30e528bf1ad49ebb6a0a5031b79735a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->