### PR TITLE
Block Stripe-managed fields from direct API updates

### DIFF
--- a/src/campaigns/schemas/updateCampaign.schema.test.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { updateCampaignBodySchema } from './updateCampaign.schema'
+
+describe('updateCampaignBodySchema', () => {
+  it('accepts legitimate campaign details', () => {
+    const result = updateCampaignBodySchema.parse({
+      details: { state: 'CA', city: 'Los Angeles' },
+    })
+
+    expect(result.details).toEqual({
+      state: 'CA',
+      city: 'Los Angeles',
+    })
+  })
+
+  it.each([
+    'subscriptionId',
+    'subscriptionCanceledAt',
+    'subscriptionCancelAt',
+    'endOfElectionSubscriptionCanceled',
+    'isProUpdatedAt',
+    'proUpgradeSlackNotifiedAt',
+  ])('strips Stripe-managed field "%s" from details', (field) => {
+    const result = updateCampaignBodySchema.parse({
+      details: { state: 'CA', [field]: 'injected' },
+    })
+
+    expect(result.details).not.toHaveProperty(field)
+    expect(result.details).toHaveProperty('state', 'CA')
+  })
+})

--- a/src/campaigns/schemas/updateCampaign.schema.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.ts
@@ -7,14 +7,14 @@ import {
 } from '@goodparty_org/contracts'
 import { StateSchema } from '@/shared/schemas/State.schema'
 
-// TODO(ENG-6410): This schema uses .passthrough() which allows ANY fields to be sent through,
-// even if not defined here. This is a security/data integrity concern because:
-// 1. Subscription fields (subscriptionId, subscriptionCancelAt, etc.) can be directly
-//    modified via this API, potentially causing desync with Stripe.
-// 2. These fields should ONLY be modified by Stripe webhook handlers.
-// 3. To fix: Add .transform() to strip subscription fields, or remove .passthrough()
-//    and explicitly define all allowed fields.
-// See: ENG-4918, ENG-6495 for related subscription sync bugs.
+const STRIPE_MANAGED_DETAIL_KEYS = [
+  'subscriptionId',
+  'subscriptionCanceledAt',
+  'subscriptionCancelAt',
+  'endOfElectionSubscriptionCanceled',
+  'isProUpdatedAt',
+  'proUpgradeSlackNotifiedAt',
+]
 
 const CampaignDetailsSchema = z
   .object({
@@ -26,8 +26,6 @@ const CampaignDetailsSchema = z
     knowRun: z.enum(['yes']),
     runForOffice: z.enum(['yes', 'no']),
     pledged: z.boolean(),
-    isProUpdatedAt: z.number(),
-    proUpgradeSlackNotifiedAt: z.number(),
     customIssues: z.array(
       z.object({
         title: z.string(),
@@ -62,12 +60,6 @@ const CampaignDetailsSchema = z
     funFact: z.string(),
     campaignCommittee: z.string(),
     statementName: z.string(),
-    // TODO(ENG-6410): These subscription fields should be BLOCKED from direct updates, not just validated.
-    // They should only be modified via Stripe webhook handlers (paymentEventsService.ts).
-    subscriptionId: z.string().nullish(),
-    endOfElectionSubscriptionCanceled: z.boolean(),
-    subscriptionCanceledAt: z.number(),
-    subscriptionCancelAt: z.number(),
     filingPeriodsStart: z.string().nullish(),
     filingPeriodsEnd: z.string().nullish(),
     officeTermLength: z.string(),
@@ -78,6 +70,13 @@ const CampaignDetailsSchema = z
   })
   .partial()
   .passthrough()
+  .transform((details) => {
+    const safe = { ...details }
+    for (const key of STRIPE_MANAGED_DETAIL_KEYS) {
+      delete safe[key]
+    }
+    return safe
+  })
 
 export const updateCampaignBodySchema = CampaignSchema.pick({
   slug: true,

--- a/src/campaigns/schemas/updateCampaign.schema.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.ts
@@ -7,15 +7,6 @@ import {
 } from '@goodparty_org/contracts'
 import { StateSchema } from '@/shared/schemas/State.schema'
 
-const STRIPE_MANAGED_DETAIL_KEYS = [
-  'subscriptionId',
-  'subscriptionCanceledAt',
-  'subscriptionCancelAt',
-  'endOfElectionSubscriptionCanceled',
-  'isProUpdatedAt',
-  'proUpgradeSlackNotifiedAt',
-]
-
 const CampaignDetailsSchema = z
   .object({
     state: StateSchema(),
@@ -69,14 +60,6 @@ const CampaignDetailsSchema = z
     tier: z.string(),
   })
   .partial()
-  .passthrough()
-  .transform((details) => {
-    const safe = { ...details }
-    for (const key of STRIPE_MANAGED_DETAIL_KEYS) {
-      delete safe[key]
-    }
-    return safe
-  })
 
 export const updateCampaignBodySchema = CampaignSchema.pick({
   slug: true,

--- a/src/campaigns/schemas/updateCampaign.schema.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.ts
@@ -6,14 +6,14 @@ import {
   ElectionLevelSchema,
 } from '@goodparty_org/contracts'
 
-// TODO(ENG-6410): This schema uses .passthrough() which allows ANY fields to be sent through,
-// even if not defined here. This is a security/data integrity concern because:
-// 1. Subscription fields (subscriptionId, subscriptionCancelAt, etc.) can be directly
-//    modified via this API, potentially causing desync with Stripe.
-// 2. These fields should ONLY be modified by Stripe webhook handlers.
-// 3. To fix: Add .transform() to strip subscription fields, or remove .passthrough()
-//    and explicitly define all allowed fields.
-// See: ENG-4918, ENG-6495 for related subscription sync bugs.
+const STRIPE_MANAGED_DETAIL_KEYS = [
+  'subscriptionId',
+  'subscriptionCanceledAt',
+  'subscriptionCancelAt',
+  'endOfElectionSubscriptionCanceled',
+  'isProUpdatedAt',
+  'proUpgradeSlackNotifiedAt',
+]
 
 const CampaignDetailsSchema = z
   .object({
@@ -25,8 +25,6 @@ const CampaignDetailsSchema = z
     knowRun: z.enum(['yes']),
     runForOffice: z.enum(['yes', 'no']),
     pledged: z.boolean(),
-    isProUpdatedAt: z.number(),
-    proUpgradeSlackNotifiedAt: z.number(),
     customIssues: z.array(
       z.object({
         title: z.string(),
@@ -61,12 +59,6 @@ const CampaignDetailsSchema = z
     funFact: z.string(),
     campaignCommittee: z.string(),
     statementName: z.string(),
-    // TODO(ENG-6410): These subscription fields should be BLOCKED from direct updates, not just validated.
-    // They should only be modified via Stripe webhook handlers (paymentEventsService.ts).
-    subscriptionId: z.string().nullish(),
-    endOfElectionSubscriptionCanceled: z.boolean(),
-    subscriptionCanceledAt: z.number(),
-    subscriptionCancelAt: z.number(),
     filingPeriodsStart: z.string().nullish(),
     filingPeriodsEnd: z.string().nullish(),
     officeTermLength: z.string(),
@@ -77,6 +69,13 @@ const CampaignDetailsSchema = z
   })
   .partial()
   .passthrough()
+  .transform((details) => {
+    const safe = { ...details }
+    for (const key of STRIPE_MANAGED_DETAIL_KEYS) {
+      delete safe[key]
+    }
+    return safe
+  })
 
 export const updateCampaignBodySchema = CampaignSchema.pick({
   slug: true,

--- a/src/users/schemas/UpdateMetadata.schema.test.ts
+++ b/src/users/schemas/UpdateMetadata.schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { UpdateMetadataSchema } from './UpdateMetadata.schema'
+
+describe('UpdateMetadataSchema', () => {
+  it('accepts legitimate metadata fields', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: { lastVisited: 1700000000, sessionCount: 5 },
+    })
+
+    expect(result.meta).toEqual({
+      lastVisited: 1700000000,
+      sessionCount: 5,
+    })
+  })
+
+  it('strips customerId from metadata updates', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: {
+        lastVisited: 1700000000,
+        customerId: 'cus_VICTIM',
+      },
+    })
+
+    expect(result.meta).not.toHaveProperty('customerId')
+    expect(result.meta).toHaveProperty('lastVisited', 1700000000)
+  })
+
+  it('strips checkoutSessionId from metadata updates', () => {
+    const result = UpdateMetadataSchema.create({
+      meta: {
+        lastVisited: 1700000000,
+        checkoutSessionId: 'cs_VICTIM',
+      },
+    })
+
+    expect(result.meta).not.toHaveProperty('checkoutSessionId')
+    expect(result.meta).toHaveProperty('lastVisited', 1700000000)
+  })
+})

--- a/src/users/schemas/UpdateMetadata.schema.ts
+++ b/src/users/schemas/UpdateMetadata.schema.ts
@@ -2,8 +2,13 @@ import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 import { UserMetaDataObjectSchema } from '@goodparty_org/contracts'
 
+const UserWritableMetaDataSchema = UserMetaDataObjectSchema.omit({
+  customerId: true,
+  checkoutSessionId: true,
+})
+
 export class UpdateMetadataSchema extends createZodDto(
   z.object({
-    meta: UserMetaDataObjectSchema,
+    meta: UserWritableMetaDataSchema,
   }),
 ) {}

--- a/src/users/users.controller.test.ts
+++ b/src/users/users.controller.test.ts
@@ -365,7 +365,7 @@ describe('UsersController', () => {
 
   describe('updateMetadata', () => {
     it('patches user metadata with the provided meta', () => {
-      const meta = { customerId: 'cus_456' }
+      const meta = { lastVisited: 1700000000 }
       controller.updateMetadata(mockUser, { meta })
 
       expect(usersService.patchUserMetaData).toHaveBeenCalledWith(userId, meta)


### PR DESCRIPTION
## Summary

Prevents direct modification of Stripe-managed subscription and payment fields through campaign and user metadata update endpoints. These fields should only be modified by Stripe webhook handlers to maintain data integrity and prevent desync with Stripe.

## Changes

- **Campaign details schema** (`updateCampaign.schema.ts`):
  - Removed schema definitions for `subscriptionId`, `subscriptionCanceledAt`, `subscriptionCancelAt`, `endOfElectionSubscriptionCanceled`, `isProUpdatedAt`, and `proUpgradeSlackNotifiedAt`
  - Added `STRIPE_MANAGED_DETAIL_KEYS` constant listing all protected fields
  - Implemented `.transform()` to strip these fields from incoming requests, allowing `.passthrough()` to remain for forward compatibility while blocking sensitive updates

- **User metadata schema** (`UpdateMetadata.schema.ts`):
  - Created `UserWritableMetaDataSchema` that explicitly omits `customerId` and `checkoutSessionId`
  - Updated `UpdateMetadataSchema` to use the restricted schema instead of the full `UserMetaDataObjectSchema`

- **Test update** (`users.controller.test.ts`):
  - Changed test fixture from attempting to set `customerId` (now blocked) to `lastVisited` (allowed)

## Implementation Details

The campaign schema uses a transform-based approach rather than removing `.passthrough()` to maintain backward compatibility while preventing abuse. The user metadata schema uses explicit omission for clarity and type safety.

https://claude.ai/code/session_019Gp3Q5kVQXACcfb2kjpyoJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes request validation/transforms for update endpoints; could silently drop fields clients previously relied on, but scope is limited to specific Stripe-managed keys.
> 
> **Overview**
> Prevents clients from directly mutating Stripe-managed subscription/payment fields via update endpoints.
> 
> Campaign `details` updates now *strip* a defined set of Stripe-managed keys during schema transformation (while still allowing other passthrough fields). User metadata updates now validate against a writable-only schema that omits `customerId` and `checkoutSessionId`, and the related controller test fixture is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29f27698d00bc20aa80a39ce692b0d65001ae4cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->