### PR TITLE
Eng 7552 submit tcr

### DIFF
--- a/contracts/src/campaigns/SubmitToPeerlyOutput.schema.ts
+++ b/contracts/src/campaigns/SubmitToPeerlyOutput.schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+import { ComplianceStageSchema } from './enums'
+
+export const SubmitToPeerlyPinDeliveryChannelsSchema = z.object({
+  email: z.string(),
+  phone: z.string(),
+})
+
+export type SubmitToPeerlyPinDeliveryChannels = z.infer<
+  typeof SubmitToPeerlyPinDeliveryChannelsSchema
+>
+
+export const SubmitToPeerlyOutputSchema = z.object({
+  tcrComplianceId: z.string(),
+  peerlyIdentityId: z.string(),
+  peerlyIdentityProfileLink: z.string().nullable(),
+  peerly10DLCBrandSubmissionKey: z.string().nullable(),
+  peerlyVerificationId: z.string().nullable(),
+  stage: ComplianceStageSchema,
+  pinDeliveryChannels: SubmitToPeerlyPinDeliveryChannelsSchema,
+})
+
+export type SubmitToPeerlyOutput = z.infer<typeof SubmitToPeerlyOutputSchema>

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -200,6 +200,13 @@ export {
   type ComplianceStateOutput,
 } from './campaigns/ComplianceStateOutput.schema'
 
+export {
+  SubmitToPeerlyPinDeliveryChannelsSchema,
+  type SubmitToPeerlyPinDeliveryChannels,
+  SubmitToPeerlyOutputSchema,
+  type SubmitToPeerlyOutput,
+} from './campaigns/SubmitToPeerlyOutput.schema'
+
 export type { Ecanvasser, EcanvasserSummary } from './ecanvasser/types'
 
 export {

--- a/prisma/schema/migrations/20260520000000_add_tcr_compliance_peerly_cv_verification_id/migration.sql
+++ b/prisma/schema/migrations/20260520000000_add_tcr_compliance_peerly_cv_verification_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "tcr_compliance" ADD COLUMN     "peerly_cv_verification_id" TEXT;

--- a/prisma/schema/migrations/20260520000001_add_tcr_compliance_peerly_submission_started_at/migration.sql
+++ b/prisma/schema/migrations/20260520000001_add_tcr_compliance_peerly_submission_started_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "tcr_compliance" ADD COLUMN     "peerly_submission_started_at" TIMESTAMP(3);

--- a/prisma/schema/tcrCompliance.prisma
+++ b/prisma/schema/tcrCompliance.prisma
@@ -45,6 +45,7 @@ model TcrCompliance {
   peerlyRegistrationLink        String? @map("peerly_registration_link")
   peerlyIdentityProfileLink     String? @map("peerly_identity_profile_link")
   peerly10DLCBrandSubmissionKey String? @unique @map("peerly_10dlc_brand_submission_key")
+  peerlyCvVerificationId        String? @map("peerly_cv_verification_id")
 
   @@map("tcr_compliance")
 }

--- a/prisma/schema/tcrCompliance.prisma
+++ b/prisma/schema/tcrCompliance.prisma
@@ -41,11 +41,12 @@ model TcrCompliance {
   campaign       Campaign             @relation(fields: [campaignId], references: [id], onDelete: Cascade)
   campaignId     Int                  @unique @map("campaign_id")
 
-  peerlyIdentityId              String? @unique @map("peerly_identity_id")
-  peerlyRegistrationLink        String? @map("peerly_registration_link")
-  peerlyIdentityProfileLink     String? @map("peerly_identity_profile_link")
-  peerly10DLCBrandSubmissionKey String? @unique @map("peerly_10dlc_brand_submission_key")
-  peerlyCvVerificationId        String? @map("peerly_cv_verification_id")
+  peerlyIdentityId              String?   @unique @map("peerly_identity_id")
+  peerlyRegistrationLink        String?   @map("peerly_registration_link")
+  peerlyIdentityProfileLink     String?   @map("peerly_identity_profile_link")
+  peerly10DLCBrandSubmissionKey String?   @unique @map("peerly_10dlc_brand_submission_key")
+  peerlyCvVerificationId        String?   @map("peerly_cv_verification_id")
+  peerlySubmissionStartedAt     DateTime? @map("peerly_submission_started_at")
 
   @@map("tcr_compliance")
 }

--- a/src/campaigns/tcrCompliance/campaignTcrCompliance.controller.test.ts
+++ b/src/campaigns/tcrCompliance/campaignTcrCompliance.controller.test.ts
@@ -37,6 +37,7 @@ describe('CampaignTcrComplianceController', () => {
     fetchByCampaignId: ReturnType<typeof vi.fn>
     create: ReturnType<typeof vi.fn>
     createAgentic: ReturnType<typeof vi.fn>
+    submitToPeerlyForAgent: ReturnType<typeof vi.fn>
     retrieveCampaignVerifyToken: ReturnType<typeof vi.fn>
     submitCampaignVerifyToken: ReturnType<typeof vi.fn>
     model: { update: ReturnType<typeof vi.fn> }
@@ -58,6 +59,7 @@ describe('CampaignTcrComplianceController', () => {
       createAgentic: vi
         .fn()
         .mockResolvedValue({ record: mockTcrCompliance, created: true }),
+      submitToPeerlyForAgent: vi.fn(),
       retrieveCampaignVerifyToken: vi.fn().mockResolvedValue('cv-token-123'),
       submitCampaignVerifyToken: vi.fn().mockResolvedValue({ brand: 'ok' }),
       model: { update: vi.fn().mockResolvedValue(mockTcrCompliance) },
@@ -326,6 +328,61 @@ describe('CampaignTcrComplianceController', () => {
       )
 
       expect(result).toEqual(expectedBrand)
+    })
+  })
+
+  describe('submitToPeerly', () => {
+    const submitToPeerlyDto = {
+      ein: '12-3456789',
+      committeeName: 'Test Committee',
+      filingUrl: 'https://example.gov/filing',
+      email: 'test@example.com',
+      phone: '5555555555',
+      officeLevel: 'state' as const,
+      fecCommitteeId: undefined,
+      committeeType: CommitteeType.CANDIDATE,
+      websiteUrl: 'https://janedoe.com',
+    }
+
+    it('delegates to service.submitToPeerlyForAgent and returns its output', async () => {
+      const expectedOutput = {
+        tcrComplianceId: 'tcr-1',
+        peerlyIdentityId: 'peerly-id-1',
+        peerlyIdentityProfileLink: 'https://peerly/profile/1',
+        peerly10DLCBrandSubmissionKey: 'brand-key-1',
+        peerlyVerificationId: 'cv-verif-1',
+        stage: ComplianceStage.awaiting_pin,
+        pinDeliveryChannels: {
+          email: submitToPeerlyDto.email,
+          phone: submitToPeerlyDto.phone,
+        },
+      }
+      mockTcrService.submitToPeerlyForAgent = vi
+        .fn()
+        .mockResolvedValue(expectedOutput)
+
+      const result = await controller.submitToPeerly(
+        mockCampaign,
+        submitToPeerlyDto,
+      )
+
+      expect(mockTcrService.submitToPeerlyForAgent).toHaveBeenCalledWith(
+        mockUser,
+        mockCampaign,
+        submitToPeerlyDto,
+      )
+      expect(result).toEqual(expectedOutput)
+    })
+
+    it('throws NotFoundException when the campaign has no user', async () => {
+      mockUserService.findByCampaign.mockResolvedValue(null)
+      mockTcrService.submitToPeerlyForAgent = vi.fn()
+
+      await expect(
+        controller.submitToPeerly(mockCampaign, submitToPeerlyDto),
+      ).rejects.toThrow('User not found for this campaign')
+
+      expect(mockTcrService.submitToPeerlyForAgent).not.toHaveBeenCalled()
     })
   })
 

--- a/src/campaigns/tcrCompliance/campaignTcrCompliance.controller.ts
+++ b/src/campaigns/tcrCompliance/campaignTcrCompliance.controller.ts
@@ -20,6 +20,7 @@ import { CampaignTcrComplianceService } from './services/campaignTcrCompliance.s
 import { ComplianceStateService } from './services/complianceState.service'
 import { CreateTcrComplianceDto } from './schemas/createTcrComplianceDto.schema'
 import { CreateAgenticTcrComplianceDto } from './schemas/createAgenticTcrComplianceDto.schema'
+import { SubmitToPeerlyDto } from './schemas/submitToPeerlyDto.schema'
 import { UseCampaign } from '../decorators/UseCampaign.decorator'
 import { ReqCampaign } from '../decorators/ReqCampaign.decorator'
 import { Campaign, TcrComplianceStatus, User } from '@prisma/client'
@@ -33,7 +34,10 @@ import { EVENTS } from 'src/vendors/segment/segment.types'
 import { PinoLogger } from 'nestjs-pino'
 import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
 import { McpTool } from '@/mcp/decorators/McpTool.decorator'
-import { ComplianceStateOutputSchema } from '@goodparty_org/contracts'
+import {
+  ComplianceStateOutputSchema,
+  SubmitToPeerlyOutputSchema,
+} from '@goodparty_org/contracts'
 
 @Controller('campaigns/tcr-compliance')
 @UsePipes(ZodValidationPipe)
@@ -81,6 +85,43 @@ export class CampaignTcrComplianceController {
   })
   async getMyComplianceState(@ReqCampaign() campaign: Campaign) {
     return this.complianceStateService.findStateForCampaign(campaign.id)
+  }
+
+  @Post('submit-to-peerly')
+  @UseCampaign()
+  @HttpCode(HttpStatus.OK)
+  @UseInterceptors(ZodResponseInterceptor)
+  @ResponseSchema(SubmitToPeerlyOutputSchema)
+  @McpTool({
+    description:
+      "Submit the candidate's TCR/Identity registration to Peerly for " +
+      "10DLC compliance. Use after the candidate's website is " +
+      'published and live on a verified domain (compliance stage = ' +
+      '`pending_website_live` complete). Required inputs: EIN, ' +
+      'committee name, office level, election filing details, contact ' +
+      'email and phone, and the verified website URL. Creates the ' +
+      'Peerly Identity, Identity Profile, 10DLC Brand, and Campaign ' +
+      'Verify Request; Peerly then sends a PIN to the candidate via the ' +
+      'contact channels supplied. Returns the Peerly identity id, ' +
+      'verification id, advanced compliance stage (`awaiting_pin`), and ' +
+      'the PIN delivery channels the candidate should check. Idempotent ' +
+      'on retry: a second call returns the existing record without ' +
+      're-submitting to Peerly.',
+  })
+  async submitToPeerly(
+    @ReqCampaign() campaign: Campaign,
+    @Body() input: SubmitToPeerlyDto,
+  ) {
+    const user = await this.userService.findByCampaign(campaign)
+    if (!user) {
+      throw new NotFoundException('User not found for this campaign')
+    }
+
+    return this.tcrComplianceService.submitToPeerlyForAgent(
+      user,
+      campaign,
+      input,
+    )
   }
 
   @Post('agentic')

--- a/src/campaigns/tcrCompliance/campaignTcrCompliance.controller.ts
+++ b/src/campaigns/tcrCompliance/campaignTcrCompliance.controller.ts
@@ -95,18 +95,20 @@ export class CampaignTcrComplianceController {
   @McpTool({
     description:
       "Submit the candidate's TCR/Identity registration to Peerly for " +
-      "10DLC compliance. Use after the candidate's website is " +
-      'published and live on a verified domain (compliance stage = ' +
-      '`pending_website_live` complete). Required inputs: EIN, ' +
-      'committee name, office level, election filing details, contact ' +
-      'email and phone, and the verified website URL. Creates the ' +
-      'Peerly Identity, Identity Profile, 10DLC Brand, and Campaign ' +
-      'Verify Request; Peerly then sends a PIN to the candidate via the ' +
-      'contact channels supplied. Returns the Peerly identity id, ' +
-      'verification id, advanced compliance stage (`awaiting_pin`), and ' +
-      'the PIN delivery channels the candidate should check. Idempotent ' +
-      'on retry: a second call returns the existing record without ' +
-      're-submitting to Peerly.',
+      '10DLC compliance. Precondition (enforced by the route): the ' +
+      'compliance stage must be `awaiting_pin` — i.e., the domain is ' +
+      "registered and the candidate's website is published and " +
+      'verified live. Calls with any earlier stage return 422. ' +
+      'Required inputs: EIN, committee name, office level, election ' +
+      'filing details, contact email and phone, and the verified ' +
+      'website URL. Creates the Peerly Identity, Identity Profile, ' +
+      '10DLC Brand, and Campaign Verify Request; Peerly then sends a ' +
+      'PIN to the candidate via the contact channels supplied. ' +
+      'Returns the Peerly identity id, CV verification id, derived ' +
+      'compliance stage (`awaiting_pin`), and the PIN delivery ' +
+      'channels (from the persisted record) the candidate should ' +
+      'check. Idempotent on retry: a second call returns the existing ' +
+      'record without re-submitting to Peerly.',
   })
   async submitToPeerly(
     @ReqCampaign() campaign: Campaign,

--- a/src/campaigns/tcrCompliance/schemas/submitToPeerlyDto.schema.ts
+++ b/src/campaigns/tcrCompliance/schemas/submitToPeerlyDto.schema.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+import { createZodDto } from 'nestjs-zod'
+import {
+  tcrComplianceBaseShape,
+  tcrComplianceSuperRefine,
+  tcrComplianceTransform,
+} from './tcrComplianceBase.schema'
+
+export class SubmitToPeerlyDto extends createZodDto(
+  z
+    .object({
+      ein: tcrComplianceBaseShape.ein,
+      committeeName: tcrComplianceBaseShape.committeeName,
+      filingUrl: tcrComplianceBaseShape.filingUrl,
+      email: tcrComplianceBaseShape.email,
+      phone: tcrComplianceBaseShape.phone,
+      officeLevel: tcrComplianceBaseShape.officeLevel,
+      fecCommitteeId: tcrComplianceBaseShape.fecCommitteeId,
+      committeeType: tcrComplianceBaseShape.committeeType,
+      websiteUrl: z.string().url(),
+    })
+    .superRefine(tcrComplianceSuperRefine)
+    .transform(tcrComplianceTransform),
+) {}

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -655,7 +655,13 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
       peerly10DLCBrandSubmissionKey: 'brand-existing',
       peerlyVerificationId: 'cv-existing',
       stage: 'awaiting_pin',
-      pinDeliveryChannels: { email: input.email, phone: input.phone },
+      // Channels come from the persisted record, not the request input, so a
+      // retry with different contact details cannot misreport where Peerly
+      // sent the PIN.
+      pinDeliveryChannels: {
+        email: existingRecord.email,
+        phone: existingRecord.phone,
+      },
     })
   })
 
@@ -780,7 +786,7 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
       peerly10DLCBrandSubmissionKey: 'brand-winner',
       peerlyVerificationId: 'cv-winner',
       stage: 'awaiting_pin',
-      pinDeliveryChannels: { email: input.email, phone: input.phone },
+      pinDeliveryChannels: { email: winner.email, phone: winner.phone },
     })
   })
 
@@ -856,5 +862,35 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
       }),
     })
     expect(result.peerlyVerificationId).toBe('cv-existing-from-prior-run')
+  })
+
+  it('surfaces BadRequestException and rolls back claim when campaignCommittee is absent (real submit10DlcBrand guard)', async () => {
+    // The real PeerlyIdentityService.submit10DlcBrand throws this when
+    // campaign.details.campaignCommittee is missing. The rest of this suite
+    // mocks the helper away; this test forces the real production-path error
+    // so we exercise error propagation + claim rollback.
+    const missingCommitteeErr = new BadRequestException(
+      'Campaign committee is required to submit 10DLC brand',
+    )
+    mockPeerly.submit10DlcBrand.mockRejectedValueOnce(missingCommitteeErr)
+
+    await expect(
+      service.submitToPeerlyForAgent(user, campaign, input),
+    ).rejects.toBe(missingCommitteeErr)
+
+    // Two updateMany calls: claim, then rollback scoped to our own timestamp.
+    expect(mockTcrModel.updateMany).toHaveBeenCalledTimes(2)
+    const claimCall = mockTcrModel.updateMany.mock.calls[0][0]
+    const rollbackCall = mockTcrModel.updateMany.mock.calls[1][0]
+    expect(rollbackCall).toEqual({
+      where: {
+        id: existingRecord.id,
+        peerlyIdentityId: null,
+        peerlySubmissionStartedAt: claimCall.data.peerlySubmissionStartedAt,
+      },
+      data: { peerlySubmissionStartedAt: null },
+    })
+    // Final write never happens on the failure path.
+    expect(mockTcrModel.update).not.toHaveBeenCalled()
   })
 })

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -498,7 +498,7 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
   }
   let mockTcrModel: {
     findUnique: ReturnType<typeof vi.fn>
-    findUniqueOrThrow: ReturnType<typeof vi.fn>
+    update: ReturnType<typeof vi.fn>
     updateMany: ReturnType<typeof vi.fn>
   }
   let mockPrisma: {
@@ -576,11 +576,13 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
     }
     mockTcrModel = {
       findUnique: vi.fn().mockResolvedValue(existingRecord),
-      findUniqueOrThrow: vi
-        .fn()
-        .mockImplementation(({ where }) =>
-          Promise.resolve({ ...existingRecord, id: where.id }),
-        ),
+      update: vi.fn().mockImplementation(({ where, data }) =>
+        Promise.resolve({
+          ...existingRecord,
+          ...data,
+          id: where.id,
+        }),
+      ),
       updateMany: vi.fn().mockResolvedValue({ count: 1 }),
     }
     mockPrisma = {
@@ -677,6 +679,27 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
     )
   })
 
+  it('claims the submission slot atomically before calling Peerly', async () => {
+    await service.submitToPeerlyForAgent(user, campaign, input)
+
+    const firstUpdateMany = mockTcrModel.updateMany.mock.calls[0]
+    expect(firstUpdateMany[0]).toEqual({
+      where: {
+        id: existingRecord.id,
+        peerlyIdentityId: null,
+        OR: [
+          { peerlySubmissionStartedAt: null },
+          { peerlySubmissionStartedAt: { lt: expect.any(Date) } },
+        ],
+      },
+      data: { peerlySubmissionStartedAt: expect.any(Date) },
+    })
+    // Claim happens BEFORE Peerly is invoked
+    const claimCallOrder = mockTcrModel.updateMany.mock.invocationCallOrder[0]
+    const peerlyCallOrder = mockPeerly.getIdentities.mock.invocationCallOrder[0]
+    expect(claimCallOrder).toBeLessThan(peerlyCallOrder)
+  })
+
   it('submits to Peerly, persists results (including peerlyCvVerificationId), and returns awaiting_pin on the happy path', async () => {
     const result = await service.submitToPeerlyForAgent(user, campaign, input)
 
@@ -693,8 +716,8 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
       'janedoe.com',
     )
 
-    expect(mockTcrModel.updateMany).toHaveBeenCalledWith({
-      where: { id: existingRecord.id, peerlyIdentityId: null },
+    expect(mockTcrModel.update).toHaveBeenCalledWith({
+      where: { id: existingRecord.id },
       data: expect.objectContaining({
         peerlyIdentityId: 'peerly-id-1',
         peerlyIdentityProfileLink: 'https://peerly/profile/1',
@@ -717,7 +740,20 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
     })
   })
 
-  it('returns the parallel callers record when the write-time race guard reports count=0', async () => {
+  it('throws ConflictException when claim is taken and the in-flight call has not yet persisted peerlyIdentityId', async () => {
+    mockTcrModel.updateMany.mockResolvedValueOnce({ count: 0 })
+    mockTcrModel.findUnique
+      .mockResolvedValueOnce(existingRecord)
+      .mockResolvedValueOnce(existingRecord)
+
+    await expect(
+      service.submitToPeerlyForAgent(user, campaign, input),
+    ).rejects.toThrow('A Peerly submission is already in progress')
+
+    expect(mockPeerly.getIdentities).not.toHaveBeenCalled()
+  })
+
+  it('returns idempotent response when claim is taken because a concurrent call already completed', async () => {
     mockTcrModel.updateMany.mockResolvedValueOnce({ count: 0 })
     const winner = {
       ...existingRecord,
@@ -732,6 +768,7 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
 
     const result = await service.submitToPeerlyForAgent(user, campaign, input)
 
+    expect(mockPeerly.getIdentities).not.toHaveBeenCalled()
     expect(result).toEqual({
       tcrComplianceId: winner.id,
       peerlyIdentityId: 'peerly-winner',
@@ -741,5 +778,23 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
       stage: 'awaiting_pin',
       pinDeliveryChannels: { email: input.email, phone: input.phone },
     })
+  })
+
+  it('rolls back the claim and rethrows when the Peerly submission fails', async () => {
+    const peerlyErr = new BadGatewayException('Peerly down')
+    mockPeerly.createIdentity.mockRejectedValueOnce(peerlyErr)
+
+    await expect(
+      service.submitToPeerlyForAgent(user, campaign, input),
+    ).rejects.toBe(peerlyErr)
+
+    // Two updateMany calls: claim, then rollback
+    expect(mockTcrModel.updateMany).toHaveBeenCalledTimes(2)
+    expect(mockTcrModel.updateMany.mock.calls[1][0]).toEqual({
+      where: { id: existingRecord.id, peerlyIdentityId: null },
+      data: { peerlySubmissionStartedAt: null },
+    })
+    // Final write never happens on the failure path
+    expect(mockTcrModel.update).not.toHaveBeenCalled()
   })
 })

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -784,7 +784,7 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
     })
   })
 
-  it('rolls back the claim and rethrows when the Peerly submission fails', async () => {
+  it('rolls back only this callers own claim (matched by timestamp) and rethrows when Peerly fails', async () => {
     const peerlyErr = new BadGatewayException('Peerly down')
     mockPeerly.createIdentity.mockRejectedValueOnce(peerlyErr)
 
@@ -794,11 +794,40 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
 
     // Two updateMany calls: claim, then rollback
     expect(mockTcrModel.updateMany).toHaveBeenCalledTimes(2)
-    expect(mockTcrModel.updateMany.mock.calls[1][0]).toEqual({
-      where: { id: existingRecord.id, peerlyIdentityId: null },
+    const claimCall = mockTcrModel.updateMany.mock.calls[0][0]
+    const rollbackCall = mockTcrModel.updateMany.mock.calls[1][0]
+    const claimTimestamp = claimCall.data.peerlySubmissionStartedAt
+    expect(claimTimestamp).toBeInstanceOf(Date)
+    // Rollback scopes to the exact timestamp we wrote, so a TTL re-claim by
+    // another caller would NOT be cleared by our rollback.
+    expect(rollbackCall).toEqual({
+      where: {
+        id: existingRecord.id,
+        peerlyIdentityId: null,
+        peerlySubmissionStartedAt: claimTimestamp,
+      },
       data: { peerlySubmissionStartedAt: null },
     })
     // Final write never happens on the failure path
+    expect(mockTcrModel.update).not.toHaveBeenCalled()
+  })
+
+  it('throws UnprocessableEntityException when compliance stage is not awaiting_pin (website not yet live)', async () => {
+    mockComplianceState.findStateForCampaign.mockResolvedValueOnce({
+      stage: 'pending_website_live',
+      domain: null,
+      websiteId: null,
+      peerlyVerificationId: null,
+    })
+
+    await expect(
+      service.submitToPeerlyForAgent(user, campaign, input),
+    ).rejects.toThrow(
+      'Cannot submit TCR registration to Peerly until the candidate',
+    )
+
+    expect(mockPeerly.getIdentities).not.toHaveBeenCalled()
+    expect(mockTcrModel.updateMany).not.toHaveBeenCalled()
     expect(mockTcrModel.update).not.toHaveBeenCalled()
   })
 

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -5,6 +5,7 @@ import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import { PinoLogger } from 'nestjs-pino'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CampaignTcrComplianceService } from './campaignTcrCompliance.service'
+import { ComplianceStateService } from './complianceState.service'
 import { PeerlyIdentityService } from '../../../vendors/peerly/services/peerlyIdentity.service'
 import { WebsitesService } from '../../../websites/services/websites.service'
 import { CampaignsService } from '../../services/campaigns.service'
@@ -24,6 +25,9 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
   let mockWebsites: { findFirstOrThrow: ReturnType<typeof vi.fn> }
   let mockCampaigns: { updateJsonFields: ReturnType<typeof vi.fn> }
   let mockCrm: { trackCampaign: ReturnType<typeof vi.fn> }
+  let mockComplianceState: {
+    findStateForCampaign: ReturnType<typeof vi.fn>
+  }
   let mockQueue: { sendMessage: ReturnType<typeof vi.fn> }
   let mockModel: {
     findUnique: ReturnType<typeof vi.fn>
@@ -63,6 +67,7 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
       updateJsonFields: vi.fn().mockResolvedValue(campaign),
     }
     mockCrm = { trackCampaign: vi.fn().mockResolvedValue(undefined) }
+    mockComplianceState = { findStateForCampaign: vi.fn() }
     mockQueue = { sendMessage: vi.fn().mockResolvedValue(undefined) }
     mockModel = {
       findUnique: vi.fn().mockResolvedValue(null),
@@ -90,6 +95,7 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
         { provide: WebsitesService, useValue: mockWebsites },
         { provide: CampaignsService, useValue: mockCampaigns },
         { provide: CrmCampaignsService, useValue: mockCrm },
+        { provide: ComplianceStateService, useValue: mockComplianceState },
         { provide: QueueProducerService, useValue: mockQueue },
         { provide: PinoLogger, useValue: createMockLogger() },
         CampaignTcrComplianceService,
@@ -471,6 +477,269 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
 
       expect(mockQueue.sendMessage).not.toHaveBeenCalled()
       expect(mockModel.update).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
+  let service: CampaignTcrComplianceService
+  let mockPeerly: {
+    getTCRIdentityName: ReturnType<typeof vi.fn>
+    getIdentities: ReturnType<typeof vi.fn>
+    createIdentity: ReturnType<typeof vi.fn>
+    getIdentityProfile: ReturnType<typeof vi.fn>
+    submitIdentityProfile: ReturnType<typeof vi.fn>
+    submit10DlcBrand: ReturnType<typeof vi.fn>
+    getCampaignVerifyRequest: ReturnType<typeof vi.fn>
+    submitCampaignVerifyRequest: ReturnType<typeof vi.fn>
+  }
+  let mockComplianceState: {
+    findStateForCampaign: ReturnType<typeof vi.fn>
+  }
+  let mockTcrModel: {
+    findUnique: ReturnType<typeof vi.fn>
+    findUniqueOrThrow: ReturnType<typeof vi.fn>
+    updateMany: ReturnType<typeof vi.fn>
+  }
+  let mockPrisma: {
+    tcrCompliance: typeof mockTcrModel
+    $transaction: ReturnType<typeof vi.fn>
+  }
+
+  const user = createMockUser({ clerkId: 'user_clerk_xyz' })
+  const campaign = createMockCampaign({
+    userId: user.id,
+    formattedAddress: '123 Main St',
+    placeId: 'place-123',
+    details: { electionDate: '2026-11-03' },
+  })
+
+  const input = {
+    ein: '12-3456789',
+    committeeName: 'Jane for Springfield',
+    filingUrl: 'https://example.gov/filing/123',
+    email: 'jane@example.com',
+    phone: '5555555555',
+    officeLevel: OfficeLevel.state,
+    fecCommitteeId: undefined,
+    committeeType: CommitteeType.CANDIDATE,
+    websiteUrl: 'https://janedoe.com',
+  }
+
+  const existingRecord = {
+    id: 'tcr-existing',
+    campaignId: campaign.id,
+    ein: '00-0000000',
+    committeeName: 'Stub Committee',
+    websiteDomain: '',
+    filingUrl: 'https://stub.gov/filing',
+    phone: '0000000000',
+    email: 'stub@example.com',
+    officeLevel: OfficeLevel.state,
+    fecCommitteeId: null,
+    committeeType: CommitteeType.CANDIDATE,
+    status: TcrComplianceStatus.submitted,
+    peerlyIdentityId: null,
+    peerlyIdentityProfileLink: null,
+    peerly10DLCBrandSubmissionKey: null,
+    peerlyCvVerificationId: null,
+    postalAddress: '123 Main St',
+    kickoffSentAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    tdlcNumber: null,
+    peerlyRegistrationLink: null,
+  }
+
+  beforeEach(async () => {
+    mockPeerly = {
+      getTCRIdentityName: vi.fn().mockReturnValue('Jane Doe - 12-3456789'),
+      getIdentities: vi.fn().mockResolvedValue([]),
+      createIdentity: vi.fn().mockResolvedValue({ identity_id: 'peerly-id-1' }),
+      getIdentityProfile: vi.fn().mockResolvedValue(null),
+      submitIdentityProfile: vi
+        .fn()
+        .mockResolvedValue({ link: 'https://peerly/profile/1', profile: {} }),
+      submit10DlcBrand: vi.fn().mockResolvedValue('brand-key-1'),
+      getCampaignVerifyRequest: vi.fn().mockResolvedValue(null),
+      submitCampaignVerifyRequest: vi
+        .fn()
+        .mockResolvedValue({ verification_id: 'cv-verif-1', message: 'ok' }),
+    }
+    mockComplianceState = {
+      findStateForCampaign: vi.fn().mockResolvedValue({
+        stage: 'awaiting_pin',
+        domain: null,
+        websiteId: null,
+        peerlyVerificationId: null,
+      }),
+    }
+    mockTcrModel = {
+      findUnique: vi.fn().mockResolvedValue(existingRecord),
+      findUniqueOrThrow: vi
+        .fn()
+        .mockImplementation(({ where }) =>
+          Promise.resolve({ ...existingRecord, id: where.id }),
+        ),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    }
+    mockPrisma = {
+      tcrCompliance: mockTcrModel,
+      $transaction: vi.fn(),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: PeerlyIdentityService, useValue: mockPeerly },
+        {
+          provide: WebsitesService,
+          useValue: { findFirstOrThrow: vi.fn() },
+        },
+        {
+          provide: CampaignsService,
+          useValue: { updateJsonFields: vi.fn() },
+        },
+        {
+          provide: CrmCampaignsService,
+          useValue: { trackCampaign: vi.fn() },
+        },
+        { provide: ComplianceStateService, useValue: mockComplianceState },
+        {
+          provide: QueueProducerService,
+          useValue: { sendMessage: vi.fn() },
+        },
+        { provide: PinoLogger, useValue: createMockLogger() },
+        CampaignTcrComplianceService,
+      ],
+    }).compile()
+
+    service = module.get(CampaignTcrComplianceService)
+  })
+
+  it('throws NotFoundException when no TcrCompliance exists', async () => {
+    mockTcrModel.findUnique.mockResolvedValueOnce(null)
+
+    await expect(
+      service.submitToPeerlyForAgent(user, campaign, input),
+    ).rejects.toThrow(
+      `TcrCompliance record not found for campaignId=${campaign.id}`,
+    )
+
+    expect(mockPeerly.getIdentities).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent: returns existing record without calling Peerly when peerlyIdentityId is set', async () => {
+    mockTcrModel.findUnique.mockResolvedValueOnce({
+      ...existingRecord,
+      peerlyIdentityId: 'peerly-already-set',
+      peerlyIdentityProfileLink: 'https://peerly/profile/existing',
+      peerly10DLCBrandSubmissionKey: 'brand-existing',
+      peerlyCvVerificationId: 'cv-existing',
+    })
+
+    const result = await service.submitToPeerlyForAgent(user, campaign, input)
+
+    expect(mockPeerly.getIdentities).not.toHaveBeenCalled()
+    expect(mockPeerly.createIdentity).not.toHaveBeenCalled()
+    expect(mockPeerly.submit10DlcBrand).not.toHaveBeenCalled()
+    expect(mockPeerly.submitCampaignVerifyRequest).not.toHaveBeenCalled()
+    expect(mockTcrModel.updateMany).not.toHaveBeenCalled()
+
+    expect(result).toEqual({
+      tcrComplianceId: existingRecord.id,
+      peerlyIdentityId: 'peerly-already-set',
+      peerlyIdentityProfileLink: 'https://peerly/profile/existing',
+      peerly10DLCBrandSubmissionKey: 'brand-existing',
+      peerlyVerificationId: 'cv-existing',
+      stage: 'awaiting_pin',
+      pinDeliveryChannels: { email: input.email, phone: input.phone },
+    })
+  })
+
+  it('passes the parsed URL hostname to the Peerly helper (no DB lookup of Domain row required)', async () => {
+    await service.submitToPeerlyForAgent(user, campaign, {
+      ...input,
+      websiteUrl: 'https://www.janedoe.com/path?q=1',
+    })
+
+    expect(mockPeerly.submit10DlcBrand).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      campaign,
+      'www.janedoe.com',
+    )
+    expect(mockPeerly.submitCampaignVerifyRequest).toHaveBeenCalledWith(
+      expect.any(Object),
+      user,
+      campaign,
+      'www.janedoe.com',
+    )
+  })
+
+  it('submits to Peerly, persists results (including peerlyCvVerificationId), and returns awaiting_pin on the happy path', async () => {
+    const result = await service.submitToPeerlyForAgent(user, campaign, input)
+
+    expect(mockPeerly.submit10DlcBrand).toHaveBeenCalledWith(
+      'peerly-id-1',
+      expect.objectContaining({ websiteDomain: input.websiteUrl }),
+      campaign,
+      'janedoe.com',
+    )
+    expect(mockPeerly.submitCampaignVerifyRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ peerlyIdentityId: 'peerly-id-1' }),
+      user,
+      campaign,
+      'janedoe.com',
+    )
+
+    expect(mockTcrModel.updateMany).toHaveBeenCalledWith({
+      where: { id: existingRecord.id, peerlyIdentityId: null },
+      data: expect.objectContaining({
+        peerlyIdentityId: 'peerly-id-1',
+        peerlyIdentityProfileLink: 'https://peerly/profile/1',
+        peerly10DLCBrandSubmissionKey: 'brand-key-1',
+        peerlyCvVerificationId: 'cv-verif-1',
+        websiteDomain: input.websiteUrl,
+        email: input.email,
+        phone: input.phone,
+      }),
+    })
+
+    expect(result).toEqual({
+      tcrComplianceId: existingRecord.id,
+      peerlyIdentityId: 'peerly-id-1',
+      peerlyIdentityProfileLink: 'https://peerly/profile/1',
+      peerly10DLCBrandSubmissionKey: 'brand-key-1',
+      peerlyVerificationId: 'cv-verif-1',
+      stage: 'awaiting_pin',
+      pinDeliveryChannels: { email: input.email, phone: input.phone },
+    })
+  })
+
+  it('returns the parallel callers record when the write-time race guard reports count=0', async () => {
+    mockTcrModel.updateMany.mockResolvedValueOnce({ count: 0 })
+    const winner = {
+      ...existingRecord,
+      peerlyIdentityId: 'peerly-winner',
+      peerlyIdentityProfileLink: 'https://peerly/profile/winner',
+      peerly10DLCBrandSubmissionKey: 'brand-winner',
+      peerlyCvVerificationId: 'cv-winner',
+    }
+    mockTcrModel.findUnique
+      .mockResolvedValueOnce(existingRecord)
+      .mockResolvedValueOnce(winner)
+
+    const result = await service.submitToPeerlyForAgent(user, campaign, input)
+
+    expect(result).toEqual({
+      tcrComplianceId: winner.id,
+      peerlyIdentityId: 'peerly-winner',
+      peerlyIdentityProfileLink: 'https://peerly/profile/winner',
+      peerly10DLCBrandSubmissionKey: 'brand-winner',
+      peerlyVerificationId: 'cv-winner',
+      stage: 'awaiting_pin',
+      pinDeliveryChannels: { email: input.email, phone: input.phone },
     })
   })
 })

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -659,7 +659,7 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
     })
   })
 
-  it('passes the parsed URL hostname to the Peerly helper (no DB lookup of Domain row required)', async () => {
+  it('canonicalizes the input URL to the apex hostname (strips www., scheme, and path) for both Peerly fields and the DB', async () => {
     await service.submitToPeerlyForAgent(user, campaign, {
       ...input,
       websiteUrl: 'https://www.janedoe.com/path?q=1',
@@ -667,16 +667,20 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
 
     expect(mockPeerly.submit10DlcBrand).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expect.objectContaining({ websiteDomain: 'janedoe.com' }),
       campaign,
-      'www.janedoe.com',
+      'janedoe.com',
     )
     expect(mockPeerly.submitCampaignVerifyRequest).toHaveBeenCalledWith(
       expect.any(Object),
       user,
       campaign,
-      'www.janedoe.com',
+      'janedoe.com',
     )
+    expect(mockTcrModel.update).toHaveBeenCalledWith({
+      where: { id: existingRecord.id },
+      data: expect.objectContaining({ websiteDomain: 'janedoe.com' }),
+    })
   })
 
   it('claims the submission slot atomically before calling Peerly', async () => {
@@ -705,7 +709,7 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
 
     expect(mockPeerly.submit10DlcBrand).toHaveBeenCalledWith(
       'peerly-id-1',
-      expect.objectContaining({ websiteDomain: input.websiteUrl }),
+      expect.objectContaining({ websiteDomain: 'janedoe.com' }),
       campaign,
       'janedoe.com',
     )
@@ -723,7 +727,7 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
         peerlyIdentityProfileLink: 'https://peerly/profile/1',
         peerly10DLCBrandSubmissionKey: 'brand-key-1',
         peerlyCvVerificationId: 'cv-verif-1',
-        websiteDomain: input.websiteUrl,
+        websiteDomain: 'janedoe.com',
         email: input.email,
         phone: input.phone,
       }),
@@ -796,5 +800,32 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
     })
     // Final write never happens on the failure path
     expect(mockTcrModel.update).not.toHaveBeenCalled()
+  })
+
+  it('preserves persisted peerlyCvVerificationId when Peerly already has a CV request (existing-CV branch)', async () => {
+    // Existing record carries a CV id from a prior partial run.
+    const recordWithExistingCv = {
+      ...existingRecord,
+      peerlyCvVerificationId: 'cv-existing-from-prior-run',
+    }
+    mockTcrModel.findUnique.mockResolvedValueOnce(recordWithExistingCv)
+
+    // Peerly's GET shows an existing CV request, so the helper skips submit
+    // and returns null for cvVerificationId (the GET response shape carries
+    // no verification_id).
+    mockPeerly.getCampaignVerifyRequest.mockResolvedValueOnce({
+      verification_status: 'pending',
+    })
+
+    const result = await service.submitToPeerlyForAgent(user, campaign, input)
+
+    expect(mockPeerly.submitCampaignVerifyRequest).not.toHaveBeenCalled()
+    expect(mockTcrModel.update).toHaveBeenCalledWith({
+      where: { id: recordWithExistingCv.id },
+      data: expect.objectContaining({
+        peerlyCvVerificationId: 'cv-existing-from-prior-run',
+      }),
+    })
+    expect(result.peerlyVerificationId).toBe('cv-existing-from-prior-run')
   })
 })

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -40,7 +40,7 @@ import { CampaignsService } from '../../services/campaigns.service'
 import { CrmCampaignsService } from '../../services/crmCampaigns.service'
 import { ComplianceStateService } from './complianceState.service'
 import { SubmitToPeerlyDto } from '../schemas/submitToPeerlyDto.schema'
-import { SubmitToPeerlyOutput } from '@goodparty_org/contracts'
+import { ComplianceStage, SubmitToPeerlyOutput } from '@goodparty_org/contracts'
 
 const TCR_COMPLIANCE_CHECK_INTERVAL = process.env.TCR_COMPLIANCE_CHECK_INTERVAL
   ? parseInt(process.env.TCR_COMPLIANCE_CHECK_INTERVAL)
@@ -429,6 +429,20 @@ export class CampaignTcrComplianceService extends createPrismaBase(
       return this.buildSubmitToPeerlyResponse(existing, pinDeliveryChannels)
     }
 
+    // Stage gate: only proceed when the candidate's website is live + the
+    // domain is registered (derived stage = awaiting_pin with identity still
+    // null). Reject all earlier stages so an agent can't kick a Peerly brand
+    // submission for an unverified/unregistered domain.
+    const stateBeforeSubmit =
+      await this.complianceStateService.findStateForCampaign(campaign.id)
+    if (stateBeforeSubmit.stage !== ComplianceStage.awaiting_pin) {
+      throw new UnprocessableEntityException(
+        `Cannot submit TCR registration to Peerly until the candidate's ` +
+          `website is published and live. Current compliance stage: ` +
+          `${stateBeforeSubmit.stage}. Wait for stage = awaiting_pin.`,
+      )
+    }
+
     // Pre-Peerly claim: only one concurrent caller may proceed past this
     // point. The TTL allows re-claim if a prior caller crashed mid-flight
     // without clearing its claim.
@@ -436,6 +450,7 @@ export class CampaignTcrComplianceService extends createPrismaBase(
       new Date(),
       PEERLY_SUBMISSION_CLAIM_TTL_MINUTES,
     )
+    const claimTimestamp = new Date()
     const claim = await this.model.updateMany({
       where: {
         id: existing.id,
@@ -445,7 +460,7 @@ export class CampaignTcrComplianceService extends createPrismaBase(
           { peerlySubmissionStartedAt: { lt: staleBefore } },
         ],
       },
-      data: { peerlySubmissionStartedAt: new Date() },
+      data: { peerlySubmissionStartedAt: claimTimestamp },
     })
 
     if (claim.count === 0) {
@@ -484,11 +499,15 @@ export class CampaignTcrComplianceService extends createPrismaBase(
         hostname,
       )
     } catch (error) {
-      // Roll back the claim so a retry can re-enter the submission flow.
-      // Scope by peerlyIdentityId: null so a concurrently-completed call's
-      // record (which would only happen if the TTL fired) isn't disturbed.
+      // Roll back only this caller's claim by matching the exact timestamp we
+      // wrote. A TTL re-claimant (caller B, after our call exceeded TTL) will
+      // have a different timestamp, so its in-flight claim isn't disturbed.
       await this.model.updateMany({
-        where: { id: existing.id, peerlyIdentityId: null },
+        where: {
+          id: existing.id,
+          peerlyIdentityId: null,
+          peerlySubmissionStartedAt: claimTimestamp,
+        },
         data: { peerlySubmissionStartedAt: null },
       })
       throw error

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -1,6 +1,7 @@
 import {
   BadGatewayException,
   BadRequestException,
+  ConflictException,
   Injectable,
   NotFoundException,
   UnprocessableEntityException,
@@ -51,6 +52,18 @@ const AGENTIC_KICKOFF_SWEEP_INTERVAL = process.env
   : 10 * 60
 
 const AGENTIC_KICKOFF_STALENESS_MINUTES = 10
+
+// Pre-Peerly claim TTL: a claim older than this is treated as stale (failed
+// without rollback) and re-claimable. Bounds the Peerly call's normal duration
+// plus a comfortable margin; tune if Peerly latency drifts.
+const PEERLY_SUBMISSION_CLAIM_TTL_MINUTES = 5
+
+type PeerlySubmissionResult = {
+  peerlyIdentityId: string
+  peerlyIdentityProfileLink: string | null
+  peerly10DLCBrandSubmissionKey: string | null
+  cvVerificationId: string | null
+}
 
 @Injectable()
 export class CampaignTcrComplianceService extends createPrismaBase(
@@ -229,12 +242,7 @@ export class CampaignTcrComplianceService extends createPrismaBase(
     campaign: Campaign,
     tcrComplianceCreatePayload: CreateTcrCompliancePayload,
     domainName: string,
-  ): Promise<{
-    peerlyIdentityId: string
-    peerlyIdentityProfileLink: string | null
-    peerly10DLCBrandSubmissionKey: string | null
-    cvVerificationId: string | null
-  }> {
+  ): Promise<PeerlySubmissionResult> {
     const {
       ein,
       filingUrl,
@@ -418,45 +426,67 @@ export class CampaignTcrComplianceService extends createPrismaBase(
     const pinDeliveryChannels = { email: input.email, phone: input.phone }
 
     if (existing.peerlyIdentityId) {
-      this.logger.info(
-        `[TCR Compliance] submitToPeerlyForAgent idempotent return for ` +
-          `campaignId=${campaign.id}, ` +
-          `peerlyIdentityId=${existing.peerlyIdentityId}`,
-      )
-      const state = await this.complianceStateService.findStateForCampaign(
-        campaign.id,
-      )
-      return {
-        tcrComplianceId: existing.id,
-        peerlyIdentityId: existing.peerlyIdentityId,
-        peerlyIdentityProfileLink: existing.peerlyIdentityProfileLink,
-        peerly10DLCBrandSubmissionKey: existing.peerly10DLCBrandSubmissionKey,
-        peerlyVerificationId: existing.peerlyCvVerificationId,
-        stage: state.stage,
-        pinDeliveryChannels,
+      return this.buildSubmitToPeerlyResponse(existing, pinDeliveryChannels)
+    }
+
+    // Pre-Peerly claim: only one concurrent caller may proceed past this
+    // point. The TTL allows re-claim if a prior caller crashed mid-flight
+    // without clearing its claim.
+    const staleBefore = subMinutes(
+      new Date(),
+      PEERLY_SUBMISSION_CLAIM_TTL_MINUTES,
+    )
+    const claim = await this.model.updateMany({
+      where: {
+        id: existing.id,
+        peerlyIdentityId: null,
+        OR: [
+          { peerlySubmissionStartedAt: null },
+          { peerlySubmissionStartedAt: { lt: staleBefore } },
+        ],
+      },
+      data: { peerlySubmissionStartedAt: new Date() },
+    })
+
+    if (claim.count === 0) {
+      const current = await this.fetchByCampaignId(campaign.id)
+      if (current?.peerlyIdentityId) {
+        return this.buildSubmitToPeerlyResponse(current, pinDeliveryChannels)
       }
+      throw new ConflictException(
+        `A Peerly submission is already in progress for ` +
+          `campaignId=${campaign.id}; retry in a few seconds.`,
+      )
     }
 
     const hostname = new URL(input.websiteUrl).hostname
-
     const { websiteUrl, ...rest } = input
     const helperPayload: CreateTcrCompliancePayload = {
       ...rest,
       websiteDomain: websiteUrl,
     }
 
-    const peerlyResult = await this.submitToPeerly(
-      user,
-      campaign,
-      helperPayload,
-      hostname,
-    )
+    let peerlyResult: PeerlySubmissionResult
+    try {
+      peerlyResult = await this.submitToPeerly(
+        user,
+        campaign,
+        helperPayload,
+        hostname,
+      )
+    } catch (error) {
+      // Roll back the claim so a retry can re-enter the submission flow.
+      // Scope by peerlyIdentityId: null so a concurrently-completed call's
+      // record (which would only happen if the TTL fired) isn't disturbed.
+      await this.model.updateMany({
+        where: { id: existing.id, peerlyIdentityId: null },
+        data: { peerlySubmissionStartedAt: null },
+      })
+      throw error
+    }
 
-    // Race-safety: only land the write if peerlyIdentityId is still null.
-    // Combined with the helper's per-step Peerly de-dup by identity name,
-    // this keeps DB state consistent under overlapping retries.
-    const claim = await this.model.updateMany({
-      where: { id: existing.id, peerlyIdentityId: null },
+    const updated = await this.model.update({
+      where: { id: existing.id },
       data: {
         ein: input.ein,
         committeeName: input.committeeName,
@@ -476,53 +506,34 @@ export class CampaignTcrComplianceService extends createPrismaBase(
       },
     })
 
-    if (claim.count === 0) {
-      const winner = await this.fetchByCampaignId(campaign.id)
-      if (!winner) {
-        throw new NotFoundException(
-          `TcrCompliance record vanished mid-flight for ` +
-            `campaignId=${campaign.id}`,
-        )
-      }
-      const winnerState =
-        await this.complianceStateService.findStateForCampaign(campaign.id)
-      this.logger.info(
-        `[TCR Compliance] submitToPeerlyForAgent lost write race for ` +
-          `campaignId=${campaign.id}; returning record persisted by ` +
-          `parallel call (peerlyIdentityId=${winner.peerlyIdentityId})`,
-      )
-      return {
-        tcrComplianceId: winner.id,
-        peerlyIdentityId:
-          winner.peerlyIdentityId ?? peerlyResult.peerlyIdentityId,
-        peerlyIdentityProfileLink: winner.peerlyIdentityProfileLink,
-        peerly10DLCBrandSubmissionKey: winner.peerly10DLCBrandSubmissionKey,
-        peerlyVerificationId: winner.peerlyCvVerificationId,
-        stage: winnerState.stage,
-        pinDeliveryChannels,
-      }
-    }
-
-    const updated = await this.model.findUniqueOrThrow({
-      where: { id: existing.id },
-    })
-
-    const state = await this.complianceStateService.findStateForCampaign(
-      campaign.id,
-    )
-
     this.logger.info(
       `[TCR Compliance] submitToPeerlyForAgent complete for ` +
         `campaignId=${campaign.id}, tcrComplianceId=${updated.id}, ` +
-        `peerlyIdentityId=${updated.peerlyIdentityId}, stage=${state.stage}`,
+        `peerlyIdentityId=${updated.peerlyIdentityId}`,
     )
 
+    return this.buildSubmitToPeerlyResponse(updated, pinDeliveryChannels)
+  }
+
+  private async buildSubmitToPeerlyResponse(
+    record: TcrCompliance,
+    pinDeliveryChannels: { email: string; phone: string },
+  ): Promise<SubmitToPeerlyOutput> {
+    const state = await this.complianceStateService.findStateForCampaign(
+      record.campaignId,
+    )
+    if (!record.peerlyIdentityId) {
+      throw new BadGatewayException(
+        `Cannot build submit-to-peerly response for tcrComplianceId=` +
+          `${record.id}: peerlyIdentityId is unexpectedly null`,
+      )
+    }
     return {
-      tcrComplianceId: updated.id,
-      peerlyIdentityId: peerlyResult.peerlyIdentityId,
-      peerlyIdentityProfileLink: peerlyResult.peerlyIdentityProfileLink,
-      peerly10DLCBrandSubmissionKey: peerlyResult.peerly10DLCBrandSubmissionKey,
-      peerlyVerificationId: peerlyResult.cvVerificationId,
+      tcrComplianceId: record.id,
+      peerlyIdentityId: record.peerlyIdentityId,
+      peerlyIdentityProfileLink: record.peerlyIdentityProfileLink,
+      peerly10DLCBrandSubmissionKey: record.peerly10DLCBrandSubmissionKey,
+      peerlyVerificationId: record.peerlyCvVerificationId,
       stage: state.stage,
       pinDeliveryChannels,
     }

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -459,11 +459,20 @@ export class CampaignTcrComplianceService extends createPrismaBase(
       )
     }
 
-    const hostname = new URL(input.websiteUrl).hostname
-    const { websiteUrl, ...rest } = input
+    // Strip leading www. so Peerly's 10DLC brand `website` + `email` fields
+    // and the persisted websiteDomain all use the apex domain — matching the
+    // legacy create() path (which sources from Domain.name, an apex domain).
+    const hostname = new URL(input.websiteUrl).hostname.replace(/^www\./, '')
     const helperPayload: CreateTcrCompliancePayload = {
-      ...rest,
-      websiteDomain: websiteUrl,
+      ein: input.ein,
+      committeeName: input.committeeName,
+      filingUrl: input.filingUrl,
+      email: input.email,
+      phone: input.phone,
+      officeLevel: input.officeLevel,
+      fecCommitteeId: input.fecCommitteeId,
+      committeeType: input.committeeType,
+      websiteDomain: hostname,
     }
 
     let peerlyResult: PeerlySubmissionResult
@@ -496,13 +505,18 @@ export class CampaignTcrComplianceService extends createPrismaBase(
         officeLevel: input.officeLevel,
         fecCommitteeId: input.fecCommitteeId ?? null,
         committeeType: input.committeeType,
-        websiteDomain: input.websiteUrl,
+        websiteDomain: hostname,
         postalAddress: campaign.formattedAddress ?? existing.postalAddress,
         peerlyIdentityId: peerlyResult.peerlyIdentityId,
         peerlyIdentityProfileLink: peerlyResult.peerlyIdentityProfileLink,
         peerly10DLCBrandSubmissionKey:
           peerlyResult.peerly10DLCBrandSubmissionKey,
-        peerlyCvVerificationId: peerlyResult.cvVerificationId,
+        // Peerly's GET-CV-request response doesn't carry verification_id, so
+        // when the helper skipped CV submission (existing CV found), it
+        // returns null. Fall back to the persisted value so a real ID isn't
+        // overwritten on retry.
+        peerlyCvVerificationId:
+          peerlyResult.cvVerificationId ?? existing.peerlyCvVerificationId,
       },
     })
 

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -24,7 +24,6 @@ import {
 } from '../../../queue/queue.types'
 import { getUserFullName } from '../../../users/util/users.util'
 import {
-  PeerlyIdentity,
   PeerlyIdentityProfile,
   PeerlyIdentityProfileResponseBody,
   PeerlyIdentityUseCase,
@@ -38,6 +37,9 @@ import {
 } from '../campaignTcrCompliance.types'
 import { CampaignsService } from '../../services/campaigns.service'
 import { CrmCampaignsService } from '../../services/crmCampaigns.service'
+import { ComplianceStateService } from './complianceState.service'
+import { SubmitToPeerlyDto } from '../schemas/submitToPeerlyDto.schema'
+import { SubmitToPeerlyOutput } from '@goodparty_org/contracts'
 
 const TCR_COMPLIANCE_CHECK_INTERVAL = process.env.TCR_COMPLIANCE_CHECK_INTERVAL
   ? parseInt(process.env.TCR_COMPLIANCE_CHECK_INTERVAL)
@@ -59,6 +61,7 @@ export class CampaignTcrComplianceService extends createPrismaBase(
     private readonly websitesService: WebsitesService,
     private readonly campaignsService: CampaignsService,
     private readonly crmCampaignsService: CrmCampaignsService,
+    private readonly complianceStateService: ComplianceStateService,
     private queueService: QueueProducerService,
   ) {
     super()
@@ -172,25 +175,6 @@ export class CampaignTcrComplianceService extends createPrismaBase(
     campaign: Campaign,
     tcrComplianceCreatePayload: CreateTcrCompliancePayload,
   ) {
-    const {
-      ein,
-      filingUrl,
-      email,
-      phone,
-      officeLevel,
-      fecCommitteeId,
-      committeeType,
-    } = tcrComplianceCreatePayload
-
-    const userFullName = getUserFullName(user!)
-    const { ballotLevel } = campaign.details as { ballotLevel?: string }
-
-    this.logger.info(
-      `[TCR Compliance] Starting registration flow for ` +
-        `campaignId=${campaign.id}, userId=${user.id}, userName="${userFullName}", ` +
-        `ein=${ein}, ballotLevel=${ballotLevel || 'NOT_SET'}`,
-    )
-
     const { domain } = await this.websitesService.findFirstOrThrow({
       where: {
         campaignId: campaign.id,
@@ -204,9 +188,72 @@ export class CampaignTcrComplianceService extends createPrismaBase(
         'Campaign must have a domain to create TCR compliance',
       )
     }
-    let tcrComplianceIdentity: PeerlyIdentity | null = null,
-      peerlyIdentityProfileLink: string | null = null,
-      peerly10DLCBrandSubmissionKey: string | null = null
+
+    const peerlyResult = await this.submitToPeerly(
+      user,
+      campaign,
+      tcrComplianceCreatePayload,
+      domain.name,
+    )
+
+    const newTcrCompliance = {
+      ...tcrComplianceCreatePayload,
+      postalAddress: campaign.formattedAddress!,
+      campaignId: campaign.id,
+      peerlyIdentityId: peerlyResult.peerlyIdentityId,
+      peerlyIdentityProfileLink: peerlyResult.peerlyIdentityProfileLink,
+      peerly10DLCBrandSubmissionKey: peerlyResult.peerly10DLCBrandSubmissionKey,
+      peerlyCvVerificationId: peerlyResult.cvVerificationId,
+    }
+
+    this.logger.debug(
+      { newTcrCompliance },
+      '[TCR Compliance] Step 5: Creating TCR Compliance record:',
+    )
+
+    const createdTcrCompliance = await this.model.create({
+      data: newTcrCompliance,
+    })
+
+    this.logger.info(
+      `[TCR Compliance] Flow completed for campaignId=${campaign.id}, ` +
+        `tcrComplianceId=${createdTcrCompliance.id}, ` +
+        `peerlyIdentityId=${createdTcrCompliance.peerlyIdentityId}`,
+    )
+
+    return createdTcrCompliance
+  }
+
+  private async submitToPeerly(
+    user: User,
+    campaign: Campaign,
+    tcrComplianceCreatePayload: CreateTcrCompliancePayload,
+    domainName: string,
+  ): Promise<{
+    peerlyIdentityId: string
+    peerlyIdentityProfileLink: string | null
+    peerly10DLCBrandSubmissionKey: string | null
+    cvVerificationId: string | null
+  }> {
+    const {
+      ein,
+      filingUrl,
+      email,
+      phone,
+      officeLevel,
+      fecCommitteeId,
+      committeeType,
+    } = tcrComplianceCreatePayload
+
+    const userFullName = getUserFullName(user)
+    const { ballotLevel } = campaign.details as { ballotLevel?: string }
+
+    this.logger.info(
+      `[TCR Compliance] Starting registration flow for ` +
+        `campaignId=${campaign.id}, userId=${user.id}, ` +
+        `userName="${userFullName}", ein=${ein}, ` +
+        `ballotLevel=${ballotLevel || 'NOT_SET'}`,
+    )
 
     const tcrIdentityName = this.peerlyIdentityService.getTCRIdentityName(
       userFullName,
@@ -232,20 +279,25 @@ export class CampaignTcrComplianceService extends createPrismaBase(
       )
     }
 
-    tcrComplianceIdentity =
+    const tcrComplianceIdentity =
       existingIdentity ||
       (await this.peerlyIdentityService.createIdentity(
         tcrIdentityName,
         campaign,
-      )) ||
-      null
+      ))
+    if (!tcrComplianceIdentity) {
+      throw new BadGatewayException(
+        'Peerly did not return an identity after creation',
+      )
+    }
+    const peerlyIdentityId = tcrComplianceIdentity.identity_id
 
     let existingIdentityProfileResponse: PeerlyIdentityProfileResponseBody | null =
       null
     try {
       existingIdentityProfileResponse =
         await this.peerlyIdentityService.getIdentityProfile(
-          tcrComplianceIdentity!.identity_id,
+          peerlyIdentityId,
           campaign,
         )
     } catch (error) {
@@ -267,96 +319,213 @@ export class CampaignTcrComplianceService extends createPrismaBase(
     const peerlyIdentityProfileResponse: PeerlyIdentityProfileResponseBody | null =
       existingIdentityProfileResponse ||
       (await this.peerlyIdentityService.submitIdentityProfile(
-        tcrComplianceIdentity!.identity_id,
+        peerlyIdentityId,
         campaign,
       )) ||
       null
 
-    peerlyIdentityProfileLink = peerlyIdentityProfileResponse?.link || null
+    const peerlyIdentityProfileLink =
+      peerlyIdentityProfileResponse?.link || null
 
     const identityProfile: PeerlyIdentityProfile | null =
-      peerlyIdentityProfileResponse?.profile
-        ? peerlyIdentityProfileResponse?.profile
-        : null
+      peerlyIdentityProfileResponse?.profile ?? null
 
+    let peerly10DLCBrandSubmissionKey: string | null = null
     // Apparently, duck-typing whether `vertical` has been set or not, is the
     //  _only_ way to determine whether or not the given Identity has a 10DLC
     //  "brand" submitted for it or not. See Peerly Slack discussion here:
     //  https://goodpartyorg.slack.com/archives/C09H3K02LLV/p1759788426640679
     if (identityProfile?.vertical) {
       this.logger.debug(
-        `[TCR Compliance] Step 3: Existing 10DLC Brand derived from IdentityProfile (vertical=${identityProfile.vertical}), skipping creation`,
+        `[TCR Compliance] Step 3: Existing 10DLC Brand derived from ` +
+          `IdentityProfile (vertical=${identityProfile.vertical}), ` +
+          `skipping creation`,
       )
     } else {
       this.logger.debug(`[TCR Compliance] Step 3: Submitting 10DLC Brand`)
       peerly10DLCBrandSubmissionKey =
         (await this.peerlyIdentityService.submit10DlcBrand(
-          tcrComplianceIdentity!.identity_id,
+          peerlyIdentityId,
           tcrComplianceCreatePayload,
           campaign,
-          domain,
+          domainName,
         )) || null
     }
 
     const existingCampaignVerifyRequest =
       await this.peerlyIdentityService.getCampaignVerifyRequest(
-        tcrComplianceIdentity!.identity_id,
+        peerlyIdentityId,
         campaign,
       )
 
+    let cvVerificationId: string | null = null
     if (existingCampaignVerifyRequest?.verification_status) {
       this.logger.debug(
-        `[TCR Compliance] Step 4: Existing Campaign Verify Request found w/ status ${existingCampaignVerifyRequest?.verification_status}, skipping creation`,
+        `[TCR Compliance] Step 4: Existing Campaign Verify Request found ` +
+          `w/ status ${existingCampaignVerifyRequest.verification_status}, ` +
+          `skipping creation`,
       )
     } else {
       this.logger.debug(
-        `[TCR Compliance] Step 4: Submitting Campaign Verify Request for campaignId=${campaign.id}`,
+        `[TCR Compliance] Step 4: Submitting Campaign Verify Request for ` +
+          `campaignId=${campaign.id}`,
       )
 
-      await this.peerlyIdentityService.submitCampaignVerifyRequest(
-        {
-          ein,
-          filingUrl,
-          peerlyIdentityId: tcrComplianceIdentity!.identity_id,
-          email,
-          phone,
-          officeLevel,
-          fecCommitteeId: fecCommitteeId ?? null,
-          committeeType: committeeType,
-        },
-        user,
-        campaign,
-        domain!,
-      )
+      const cvResponse =
+        await this.peerlyIdentityService.submitCampaignVerifyRequest(
+          {
+            ein,
+            filingUrl,
+            peerlyIdentityId,
+            email,
+            phone,
+            officeLevel,
+            fecCommitteeId: fecCommitteeId ?? null,
+            committeeType: committeeType,
+          },
+          user,
+          campaign,
+          domainName,
+        )
+      cvVerificationId = cvResponse?.verification_id ?? null
       this.logger.info(
-        `[TCR Compliance] Step 4 SUCCESS: Campaign Verify Request submitted for campaignId=${campaign.id}`,
+        `[TCR Compliance] Step 4 SUCCESS: Campaign Verify Request submitted ` +
+          `for campaignId=${campaign.id}`,
       )
     }
 
-    const newTcrCompliance = {
-      ...tcrComplianceCreatePayload,
-      postalAddress: campaign.formattedAddress!,
-      campaignId: campaign.id,
-      peerlyIdentityId: tcrComplianceIdentity!.identity_id,
+    return {
+      peerlyIdentityId,
       peerlyIdentityProfileLink,
       peerly10DLCBrandSubmissionKey,
+      cvVerificationId,
+    }
+  }
+
+  async submitToPeerlyForAgent(
+    user: User,
+    campaign: Campaign,
+    input: SubmitToPeerlyDto,
+  ): Promise<SubmitToPeerlyOutput> {
+    const existing = await this.fetchByCampaignId(campaign.id)
+    if (!existing) {
+      throw new NotFoundException(
+        `TcrCompliance record not found for campaignId=${campaign.id}; ` +
+          `the agentic compliance flow must be initialized first`,
+      )
     }
 
-    this.logger.debug(
-      { newTcrCompliance },
-      '[TCR Compliance] Step 5: Creating TCR Compliance record:',
+    const pinDeliveryChannels = { email: input.email, phone: input.phone }
+
+    if (existing.peerlyIdentityId) {
+      this.logger.info(
+        `[TCR Compliance] submitToPeerlyForAgent idempotent return for ` +
+          `campaignId=${campaign.id}, ` +
+          `peerlyIdentityId=${existing.peerlyIdentityId}`,
+      )
+      const state = await this.complianceStateService.findStateForCampaign(
+        campaign.id,
+      )
+      return {
+        tcrComplianceId: existing.id,
+        peerlyIdentityId: existing.peerlyIdentityId,
+        peerlyIdentityProfileLink: existing.peerlyIdentityProfileLink,
+        peerly10DLCBrandSubmissionKey: existing.peerly10DLCBrandSubmissionKey,
+        peerlyVerificationId: existing.peerlyCvVerificationId,
+        stage: state.stage,
+        pinDeliveryChannels,
+      }
+    }
+
+    const hostname = new URL(input.websiteUrl).hostname
+
+    const { websiteUrl, ...rest } = input
+    const helperPayload: CreateTcrCompliancePayload = {
+      ...rest,
+      websiteDomain: websiteUrl,
+    }
+
+    const peerlyResult = await this.submitToPeerly(
+      user,
+      campaign,
+      helperPayload,
+      hostname,
     )
 
-    const createdTcrCompliance = await this.model.create({
-      data: newTcrCompliance,
+    // Race-safety: only land the write if peerlyIdentityId is still null.
+    // Combined with the helper's per-step Peerly de-dup by identity name,
+    // this keeps DB state consistent under overlapping retries.
+    const claim = await this.model.updateMany({
+      where: { id: existing.id, peerlyIdentityId: null },
+      data: {
+        ein: input.ein,
+        committeeName: input.committeeName,
+        filingUrl: input.filingUrl,
+        email: input.email,
+        phone: input.phone,
+        officeLevel: input.officeLevel,
+        fecCommitteeId: input.fecCommitteeId ?? null,
+        committeeType: input.committeeType,
+        websiteDomain: input.websiteUrl,
+        postalAddress: campaign.formattedAddress ?? existing.postalAddress,
+        peerlyIdentityId: peerlyResult.peerlyIdentityId,
+        peerlyIdentityProfileLink: peerlyResult.peerlyIdentityProfileLink,
+        peerly10DLCBrandSubmissionKey:
+          peerlyResult.peerly10DLCBrandSubmissionKey,
+        peerlyCvVerificationId: peerlyResult.cvVerificationId,
+      },
     })
 
-    this.logger.info(
-      `[TCR Compliance] Flow completed for campaignId=${campaign.id}, ` +
-        `tcrComplianceId=${createdTcrCompliance.id}, peerlyIdentityId=${createdTcrCompliance.peerlyIdentityId}`,
+    if (claim.count === 0) {
+      const winner = await this.fetchByCampaignId(campaign.id)
+      if (!winner) {
+        throw new NotFoundException(
+          `TcrCompliance record vanished mid-flight for ` +
+            `campaignId=${campaign.id}`,
+        )
+      }
+      const winnerState =
+        await this.complianceStateService.findStateForCampaign(campaign.id)
+      this.logger.info(
+        `[TCR Compliance] submitToPeerlyForAgent lost write race for ` +
+          `campaignId=${campaign.id}; returning record persisted by ` +
+          `parallel call (peerlyIdentityId=${winner.peerlyIdentityId})`,
+      )
+      return {
+        tcrComplianceId: winner.id,
+        peerlyIdentityId:
+          winner.peerlyIdentityId ?? peerlyResult.peerlyIdentityId,
+        peerlyIdentityProfileLink: winner.peerlyIdentityProfileLink,
+        peerly10DLCBrandSubmissionKey: winner.peerly10DLCBrandSubmissionKey,
+        peerlyVerificationId: winner.peerlyCvVerificationId,
+        stage: winnerState.stage,
+        pinDeliveryChannels,
+      }
+    }
+
+    const updated = await this.model.findUniqueOrThrow({
+      where: { id: existing.id },
+    })
+
+    const state = await this.complianceStateService.findStateForCampaign(
+      campaign.id,
     )
 
-    return createdTcrCompliance
+    this.logger.info(
+      `[TCR Compliance] submitToPeerlyForAgent complete for ` +
+        `campaignId=${campaign.id}, tcrComplianceId=${updated.id}, ` +
+        `peerlyIdentityId=${updated.peerlyIdentityId}, stage=${state.stage}`,
+    )
+
+    return {
+      tcrComplianceId: updated.id,
+      peerlyIdentityId: peerlyResult.peerlyIdentityId,
+      peerlyIdentityProfileLink: peerlyResult.peerlyIdentityProfileLink,
+      peerly10DLCBrandSubmissionKey: peerlyResult.peerly10DLCBrandSubmissionKey,
+      peerlyVerificationId: peerlyResult.cvVerificationId,
+      stage: state.stage,
+      pinDeliveryChannels,
+    }
   }
 
   async createAgentic(

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -423,10 +423,8 @@ export class CampaignTcrComplianceService extends createPrismaBase(
       )
     }
 
-    const pinDeliveryChannels = { email: input.email, phone: input.phone }
-
     if (existing.peerlyIdentityId) {
-      return this.buildSubmitToPeerlyResponse(existing, pinDeliveryChannels)
+      return this.buildSubmitToPeerlyResponse(existing)
     }
 
     // Stage gate: only proceed when the candidate's website is live + the
@@ -466,7 +464,7 @@ export class CampaignTcrComplianceService extends createPrismaBase(
     if (claim.count === 0) {
       const current = await this.fetchByCampaignId(campaign.id)
       if (current?.peerlyIdentityId) {
-        return this.buildSubmitToPeerlyResponse(current, pinDeliveryChannels)
+        return this.buildSubmitToPeerlyResponse(current)
       }
       throw new ConflictException(
         `A Peerly submission is already in progress for ` +
@@ -545,12 +543,11 @@ export class CampaignTcrComplianceService extends createPrismaBase(
         `peerlyIdentityId=${updated.peerlyIdentityId}`,
     )
 
-    return this.buildSubmitToPeerlyResponse(updated, pinDeliveryChannels)
+    return this.buildSubmitToPeerlyResponse(updated)
   }
 
   private async buildSubmitToPeerlyResponse(
     record: TcrCompliance,
-    pinDeliveryChannels: { email: string; phone: string },
   ): Promise<SubmitToPeerlyOutput> {
     const state = await this.complianceStateService.findStateForCampaign(
       record.campaignId,
@@ -568,7 +565,7 @@ export class CampaignTcrComplianceService extends createPrismaBase(
       peerly10DLCBrandSubmissionKey: record.peerly10DLCBrandSubmissionKey,
       peerlyVerificationId: record.peerlyCvVerificationId,
       stage: state.stage,
-      pinDeliveryChannels,
+      pinDeliveryChannels: { email: record.email, phone: record.phone },
     }
   }
 

--- a/src/campaigns/tcrCompliance/services/complianceState.service.ts
+++ b/src/campaigns/tcrCompliance/services/complianceState.service.ts
@@ -50,7 +50,7 @@ export class ComplianceStateService extends createPrismaBase(MODELS.Campaign) {
           }
         : null,
       websiteId: website?.id ?? null,
-      peerlyVerificationId: tcrCompliance?.peerlyIdentityId ?? null,
+      peerlyVerificationId: tcrCompliance?.peerlyCvVerificationId ?? null,
     }
   }
 }

--- a/src/vendors/peerly/services/peerlyIdentity.service.test.ts
+++ b/src/vendors/peerly/services/peerlyIdentity.service.test.ts
@@ -1,13 +1,6 @@
 import { BadRequestException } from '@nestjs/common'
 import { Test, TestingModule } from '@nestjs/testing'
-import {
-  Campaign,
-  CommitteeType,
-  Domain,
-  DomainStatus,
-  OfficeLevel,
-  User,
-} from '@prisma/client'
+import { Campaign, CommitteeType, OfficeLevel, User } from '@prisma/client'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { AreaCodeFromZipService } from '../../../ai/util/areaCodeFromZip.util'
 import { BallotReadyPositionLevel } from '@goodparty_org/contracts'
@@ -74,23 +67,6 @@ const createMockCampaign = (
   })
 }
 
-const createMockDomain = (overrides: Partial<Domain> = {}): Domain => {
-  return {
-    id: 1,
-    name: 'candidate.com',
-    websiteId: 1,
-    status: DomainStatus.active,
-    operationId: null,
-    price: null,
-    paymentId: null,
-    emailForwardingDomainId: null,
-    registrantVerifiedAt: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    ...overrides,
-  }
-}
-
 describe('PeerlyIdentityService', () => {
   let service: PeerlyIdentityService
   let module: TestingModule
@@ -120,7 +96,7 @@ describe('PeerlyIdentityService', () => {
   }
 
   const baseUser = createMockUser()
-  const baseDomain = createMockDomain()
+  const baseDomainName = 'candidate.com'
 
   beforeEach(async () => {
     resetAllCounters()
@@ -306,7 +282,7 @@ describe('PeerlyIdentityService', () => {
           tcrComplianceInput,
           baseUser,
           campaign,
-          baseDomain,
+          baseDomainName,
         )
 
         expect(lastSubmittedData.verification_type).toBe(
@@ -382,7 +358,7 @@ describe('PeerlyIdentityService', () => {
         },
         baseUser,
         campaign,
-        baseDomain,
+        baseDomainName,
       )
 
       expect(lastSubmittedData.city_county).toBe('Anytown')
@@ -424,7 +400,7 @@ describe('PeerlyIdentityService', () => {
           },
           baseUser,
           campaign,
-          baseDomain,
+          baseDomainName,
         ),
       ).rejects.toThrow(BadRequestException)
     })
@@ -452,7 +428,7 @@ describe('PeerlyIdentityService', () => {
         tcrComplianceInput,
         baseUser,
         campaign,
-        baseDomain,
+        baseDomainName,
       )
 
       // Verify email is the preferred verification method
@@ -492,7 +468,7 @@ describe('PeerlyIdentityService', () => {
           tcrComplianceInput,
           baseUser,
           campaign,
-          baseDomain,
+          baseDomainName,
         ),
       ).rejects.toThrow(BadRequestException)
     })
@@ -520,7 +496,7 @@ describe('PeerlyIdentityService', () => {
         'peerly-123',
         baseTcrPayload as never,
         campaign,
-        baseDomain,
+        baseDomainName,
       )
 
       expect(lastSubmittedData.jobAreas).toEqual([
@@ -543,7 +519,7 @@ describe('PeerlyIdentityService', () => {
         'peerly-123',
         baseTcrPayload as never,
         campaign,
-        baseDomain,
+        baseDomainName,
       )
 
       // jobAreas is present with didState even when no area codes resolved
@@ -562,7 +538,7 @@ describe('PeerlyIdentityService', () => {
         'peerly-123',
         baseTcrPayload as never,
         campaign,
-        baseDomain,
+        baseDomainName,
       )
 
       expect(lastSubmittedData.jobAreas).toEqual([{ didState: 'IL' }])
@@ -580,7 +556,7 @@ describe('PeerlyIdentityService', () => {
         'peerly-123',
         baseTcrPayload as never,
         campaign,
-        baseDomain,
+        baseDomainName,
       )
 
       // state at top level from extractAddressComponents
@@ -608,7 +584,7 @@ describe('PeerlyIdentityService', () => {
         'peerly-123',
         baseTcrPayload as never,
         campaign,
-        baseDomain,
+        baseDomainName,
       )
 
       expect(lastSubmittedData).not.toHaveProperty('jobAreas')
@@ -624,7 +600,7 @@ describe('PeerlyIdentityService', () => {
           'peerly-123',
           baseTcrPayload as never,
           campaign,
-          baseDomain,
+          baseDomainName,
         ),
       ).rejects.toThrow(BadRequestException)
     })
@@ -641,7 +617,7 @@ describe('PeerlyIdentityService', () => {
         'peerly-123',
         baseTcrPayload as never,
         campaign,
-        baseDomain,
+        baseDomainName,
       )
 
       expect(lastSubmittedData.ein).toBe('12-3456789')

--- a/src/vendors/peerly/services/peerlyIdentity.service.ts
+++ b/src/vendors/peerly/services/peerlyIdentity.service.ts
@@ -4,7 +4,7 @@ import {
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common'
-import { Campaign, Domain, TcrCompliance, User } from '@prisma/client'
+import { Campaign, TcrCompliance, User } from '@prisma/client'
 import { format } from '@redtea/format-axios-error'
 import { isAxiosError } from 'axios'
 import { parsePhoneNumberWithError } from 'libphonenumber-js'
@@ -208,7 +208,7 @@ export class PeerlyIdentityService extends PeerlyBaseConfig {
     peerlyIdentityId: string,
     tcrCompliancePayload: CreateTcrCompliancePayload,
     campaign: Campaign,
-    domain: Domain,
+    domainName: string,
   ) {
     const { details: campaignDetails, placeId } = campaign
     const { phone, websiteDomain, ein } = tcrCompliancePayload
@@ -247,7 +247,7 @@ export class PeerlyIdentityService extends PeerlyBaseConfig {
       state: state?.short_name,
       postalCode: postalCode?.long_name,
       website: websiteDomain.substring(0, 100), // Limit to 100 characters per Peerly API docs
-      email: `info@${domain.name}`.substring(0, 100), // Limit to 100 characters per Peerly API docs
+      email: `info@${domainName}`.substring(0, 100), // Limit to 100 characters per Peerly API docs
       ...(geography.didState !== P2P_JOB_DEFAULTS.DID_STATE
         ? {
             jobAreas: [
@@ -377,7 +377,7 @@ export class PeerlyIdentityService extends PeerlyBaseConfig {
     >,
     user: User,
     campaign: Campaign,
-    domain: Domain,
+    domainName: string,
   ): Promise<PeerlySubmitCVResponseBody | null> {
     const { details: campaignDetails, placeId } = campaign
     const { electionDate, ballotLevel } = campaignDetails
@@ -468,7 +468,7 @@ export class PeerlyIdentityService extends PeerlyBaseConfig {
       filing_phone_type: 'cell',
       filing_phone_number: phone,
       state: state?.short_name,
-      campaign_website: domain ? `https://${domain?.name}` : undefined,
+      campaign_website: domainName ? `https://${domainName}` : undefined,
       // Federal-specific fields
       ...(isFederal
         ? {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new Peerly submission API plus new DB fields and modifies the Peerly/TCR compliance flow; main risk is around concurrency/TTL claim logic and correctness of persisted Peerly IDs impacting compliance progression.
> 
> **Overview**
> Adds a new `POST /campaigns/tcr-compliance/submit-to-peerly` endpoint (with `SubmitToPeerlyDto` validation and `SubmitToPeerlyOutputSchema` response) to let the agentic compliance flow submit TCR/identity registration to Peerly and return the PIN delivery channels and updated compliance stage.
> 
> Extends `tcr_compliance` persistence with `peerly_cv_verification_id` and `peerly_submission_started_at`, refactors the existing Peerly submission helper to return/record the CV verification id, and updates Peerly service APIs to accept a `domainName` string instead of a `Domain` record. Implements idempotency + concurrency protection for agent submissions via an atomic “claim” (TTL-based) before calling Peerly, rollback on failure, and a fast-path when a concurrent winner already persisted results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc274ef25be56d97b5231293ca2e6879d923ef9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->