### PR TITLE
feat(tcrCompliance): implement agentic compliance kickoff handling

### DIFF
--- a/src/agentExperiments/agentExperiments.module.ts
+++ b/src/agentExperiments/agentExperiments.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { AwsModule } from '@/vendors/aws/aws.module'
 import { ExperimentRunsService } from './services/experimentRuns.service'
+import './complianceSetupContract'
 
 @Module({
   imports: [AwsModule],

--- a/src/agentExperiments/complianceSetupContract.ts
+++ b/src/agentExperiments/complianceSetupContract.ts
@@ -1,0 +1,17 @@
+import '@/generated/agent-job-contracts'
+
+// TODO(ENG-7535): Drop this augmentation once compliance_setup is registered
+// in the PMF engine's EXPERIMENT_REGISTRY and its manifest is published to the
+// agent-experiment-metadata-{env} bucket — the codegen at
+// scripts/generate-agent-job-types.ts will then produce this entry directly.
+declare module '@/generated/agent-job-contracts' {
+  interface AgentJobContracts {
+    compliance_setup: {
+      Input: {
+        campaignId: number
+        tcrComplianceId: string
+      }
+      Output: Record<string, never>
+    }
+  }
+}

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -1,5 +1,6 @@
 import { OrganizationsModule } from '@/organizations/organizations.module'
 import { ClerkModule } from '@/vendors/clerk/clerk.module'
+import { AgentExperimentsModule } from '@/agentExperiments/agentExperiments.module'
 import { forwardRef, Global, Module } from '@nestjs/common'
 import { AwsModule } from 'src/vendors/aws/aws.module'
 import { ElectionsModule } from 'src/elections/elections.module'
@@ -57,6 +58,7 @@ import { CampaignUpdateHistoryService } from './updateHistory/campaignUpdateHist
     WebsitesModule,
     QueueProducerModule,
     SlackModule,
+    AgentExperimentsModule,
   ],
   controllers: [
     CampaignsController,

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -1,6 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { BadGatewayException, BadRequestException } from '@nestjs/common'
-import { CommitteeType, OfficeLevel, TcrComplianceStatus } from '@prisma/client'
+import {
+  CommitteeType,
+  ExperimentRunStatus,
+  OfficeLevel,
+  TcrComplianceStatus,
+} from '@prisma/client'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import { PinoLogger } from 'nestjs-pino'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -11,6 +16,7 @@ import { WebsitesService } from '../../../websites/services/websites.service'
 import { CampaignsService } from '../../services/campaigns.service'
 import { CrmCampaignsService } from '../../services/crmCampaigns.service'
 import { QueueProducerService } from '../../../queue/producer/queueProducer.service'
+import { ExperimentRunsService } from '../../../agentExperiments/services/experimentRuns.service'
 import { PrismaService } from '@/prisma/prisma.service'
 import { MessageGroup, QueueType } from '../../../queue/queue.types'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
@@ -23,12 +29,19 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
   let service: CampaignTcrComplianceService
   let mockPeerly: { getIdentities: ReturnType<typeof vi.fn> }
   let mockWebsites: { findFirstOrThrow: ReturnType<typeof vi.fn> }
-  let mockCampaigns: { updateJsonFields: ReturnType<typeof vi.fn> }
+  let mockCampaigns: {
+    updateJsonFields: ReturnType<typeof vi.fn>
+    findUnique: ReturnType<typeof vi.fn>
+  }
   let mockCrm: { trackCampaign: ReturnType<typeof vi.fn> }
   let mockComplianceState: {
     findStateForCampaign: ReturnType<typeof vi.fn>
   }
   let mockQueue: { sendMessage: ReturnType<typeof vi.fn> }
+  let mockExperimentRuns: {
+    findFirst: ReturnType<typeof vi.fn>
+    dispatchRun: ReturnType<typeof vi.fn>
+  }
   let mockModel: {
     findUnique: ReturnType<typeof vi.fn>
     findMany: ReturnType<typeof vi.fn>
@@ -65,10 +78,15 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
     mockWebsites = { findFirstOrThrow: vi.fn() }
     mockCampaigns = {
       updateJsonFields: vi.fn().mockResolvedValue(campaign),
+      findUnique: vi.fn().mockResolvedValue(campaign),
     }
     mockCrm = { trackCampaign: vi.fn().mockResolvedValue(undefined) }
     mockComplianceState = { findStateForCampaign: vi.fn() }
     mockQueue = { sendMessage: vi.fn().mockResolvedValue(undefined) }
+    mockExperimentRuns = {
+      findFirst: vi.fn().mockResolvedValue(null),
+      dispatchRun: vi.fn().mockResolvedValue(undefined),
+    }
     mockModel = {
       findUnique: vi.fn().mockResolvedValue(null),
       findMany: vi.fn().mockResolvedValue([]),
@@ -97,6 +115,7 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
         { provide: CrmCampaignsService, useValue: mockCrm },
         { provide: ComplianceStateService, useValue: mockComplianceState },
         { provide: QueueProducerService, useValue: mockQueue },
+        { provide: ExperimentRunsService, useValue: mockExperimentRuns },
         { provide: PinoLogger, useValue: createMockLogger() },
         CampaignTcrComplianceService,
       ],
@@ -481,6 +500,149 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
   })
 })
 
+describe('CampaignTcrComplianceService - handleAgenticKickoff', () => {
+  let service: CampaignTcrComplianceService
+  let mockCampaigns: { findUnique: ReturnType<typeof vi.fn> }
+  let mockExperimentRuns: {
+    findFirst: ReturnType<typeof vi.fn>
+    dispatchRun: ReturnType<typeof vi.fn>
+  }
+  let mockModel: { findUnique: ReturnType<typeof vi.fn> }
+  let mockPrisma: { tcrCompliance: typeof mockModel }
+
+  const kickoff = {
+    campaignId: 123,
+    tcrComplianceId: 'tcr-abc',
+    clerkUserId: 'user_clerk_abc',
+  }
+  const tcrRecord = {
+    id: kickoff.tcrComplianceId,
+    campaignId: kickoff.campaignId,
+  }
+  const campaign = createMockCampaign({
+    id: kickoff.campaignId,
+    organizationSlug: 'org-jane-for-springfield',
+  })
+
+  beforeEach(async () => {
+    mockCampaigns = { findUnique: vi.fn().mockResolvedValue(campaign) }
+    mockExperimentRuns = {
+      findFirst: vi.fn().mockResolvedValue(null),
+      dispatchRun: vi.fn().mockResolvedValue(undefined),
+    }
+    mockModel = { findUnique: vi.fn().mockResolvedValue(tcrRecord) }
+    mockPrisma = { tcrCompliance: mockModel }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: PeerlyIdentityService, useValue: {} },
+        { provide: WebsitesService, useValue: {} },
+        { provide: CampaignsService, useValue: mockCampaigns },
+        { provide: CrmCampaignsService, useValue: {} },
+        { provide: ComplianceStateService, useValue: {} },
+        { provide: QueueProducerService, useValue: { sendMessage: vi.fn() } },
+        { provide: ExperimentRunsService, useValue: mockExperimentRuns },
+        { provide: PinoLogger, useValue: createMockLogger() },
+        CampaignTcrComplianceService,
+      ],
+    }).compile()
+
+    service = module.get(CampaignTcrComplianceService)
+
+    vi.clearAllMocks()
+    mockCampaigns.findUnique.mockResolvedValue(campaign)
+    mockExperimentRuns.findFirst.mockResolvedValue(null)
+    mockExperimentRuns.dispatchRun.mockResolvedValue(undefined)
+    mockModel.findUnique.mockResolvedValue(tcrRecord)
+  })
+
+  it('dispatches a compliance_setup run with the campaign and record ids', async () => {
+    await service.handleAgenticKickoff(kickoff)
+
+    expect(mockExperimentRuns.findFirst).toHaveBeenCalledWith({
+      where: {
+        experimentType: 'compliance_setup',
+        params: {
+          path: ['tcrComplianceId'],
+          equals: kickoff.tcrComplianceId,
+        },
+      },
+    })
+    expect(mockExperimentRuns.dispatchRun).toHaveBeenCalledWith({
+      type: 'compliance_setup',
+      organizationSlug: campaign.organizationSlug,
+      clerkUserId: kickoff.clerkUserId,
+      params: {
+        campaignId: kickoff.campaignId,
+        tcrComplianceId: kickoff.tcrComplianceId,
+      },
+    })
+  })
+
+  it('does not include actor_token_url in the dispatch params', async () => {
+    await service.handleAgenticKickoff(kickoff)
+
+    const dispatchCall = mockExperimentRuns.dispatchRun.mock.calls[0][0]
+    expect(JSON.stringify(dispatchCall)).not.toContain('actor_token_url')
+    expect(JSON.stringify(dispatchCall)).not.toContain('actorTokenUrl')
+  })
+
+  it.each([
+    ExperimentRunStatus.RUNNING,
+    ExperimentRunStatus.COMPLETED,
+    ExperimentRunStatus.FAILED,
+  ])(
+    'skips dispatch when a %s run already exists for the record',
+    async (status) => {
+      mockExperimentRuns.findFirst.mockResolvedValueOnce({
+        runId: 'run-existing',
+        status,
+      })
+
+      await service.handleAgenticKickoff(kickoff)
+
+      expect(mockExperimentRuns.dispatchRun).not.toHaveBeenCalled()
+    },
+  )
+
+  it('drops silently when the TcrCompliance record does not exist', async () => {
+    mockModel.findUnique.mockResolvedValueOnce(null)
+
+    await service.handleAgenticKickoff(kickoff)
+
+    expect(mockExperimentRuns.findFirst).not.toHaveBeenCalled()
+    expect(mockExperimentRuns.dispatchRun).not.toHaveBeenCalled()
+  })
+
+  it('drops silently when the record belongs to a different campaign', async () => {
+    mockModel.findUnique.mockResolvedValueOnce({
+      ...tcrRecord,
+      campaignId: tcrRecord.campaignId + 1,
+    })
+
+    await service.handleAgenticKickoff(kickoff)
+
+    expect(mockExperimentRuns.findFirst).not.toHaveBeenCalled()
+    expect(mockExperimentRuns.dispatchRun).not.toHaveBeenCalled()
+  })
+
+  it('drops silently when the campaign does not exist', async () => {
+    mockCampaigns.findUnique.mockResolvedValueOnce(null)
+
+    await service.handleAgenticKickoff(kickoff)
+
+    expect(mockExperimentRuns.dispatchRun).not.toHaveBeenCalled()
+  })
+
+  it('propagates BadGatewayException from dispatchRun so the message redelivers', async () => {
+    const err = new BadGatewayException('SQS dispatch failed')
+    mockExperimentRuns.dispatchRun.mockRejectedValueOnce(err)
+
+    await expect(service.handleAgenticKickoff(kickoff)).rejects.toBe(err)
+  })
+})
+
 describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
   let service: CampaignTcrComplianceService
   let mockPeerly: {
@@ -610,6 +772,10 @@ describe('CampaignTcrComplianceService - submitToPeerlyForAgent', () => {
         {
           provide: QueueProducerService,
           useValue: { sendMessage: vi.fn() },
+        },
+        {
+          provide: ExperimentRunsService,
+          useValue: { findFirst: vi.fn(), dispatchRun: vi.fn() },
         },
         { provide: PinoLogger, useValue: createMockLogger() },
         CampaignTcrComplianceService,

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -524,11 +524,13 @@ describe('CampaignTcrComplianceService - handleAgenticKickoff', () => {
     organizationSlug: 'org-jane-for-springfield',
   })
 
+  const dispatchedRun = { runId: 'run-dispatched-xyz' }
+
   beforeEach(async () => {
     mockCampaigns = { findUnique: vi.fn().mockResolvedValue(campaign) }
     mockExperimentRuns = {
       findFirst: vi.fn().mockResolvedValue(null),
-      dispatchRun: vi.fn().mockResolvedValue(undefined),
+      dispatchRun: vi.fn().mockResolvedValue(dispatchedRun),
     }
     mockModel = { findUnique: vi.fn().mockResolvedValue(tcrRecord) }
     mockPrisma = { tcrCompliance: mockModel }
@@ -553,7 +555,7 @@ describe('CampaignTcrComplianceService - handleAgenticKickoff', () => {
     vi.clearAllMocks()
     mockCampaigns.findUnique.mockResolvedValue(campaign)
     mockExperimentRuns.findFirst.mockResolvedValue(null)
-    mockExperimentRuns.dispatchRun.mockResolvedValue(undefined)
+    mockExperimentRuns.dispatchRun.mockResolvedValue(dispatchedRun)
     mockModel.findUnique.mockResolvedValue(tcrRecord)
   })
 
@@ -639,6 +641,14 @@ describe('CampaignTcrComplianceService - handleAgenticKickoff', () => {
     mockExperimentRuns.dispatchRun.mockRejectedValueOnce(err)
 
     await expect(service.handleAgenticKickoff(kickoff)).rejects.toBe(err)
+  })
+
+  it('throws when dispatchRun returns no run (queue not configured in env)', async () => {
+    mockExperimentRuns.dispatchRun.mockResolvedValueOnce(undefined)
+
+    await expect(service.handleAgenticKickoff(kickoff)).rejects.toThrow(
+      /Agent dispatch queue not configured/,
+    )
   })
 })
 

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -643,12 +643,11 @@ describe('CampaignTcrComplianceService - handleAgenticKickoff', () => {
     await expect(service.handleAgenticKickoff(kickoff)).rejects.toBe(err)
   })
 
-  it('throws when dispatchRun returns no run (queue not configured in env)', async () => {
+  it('logs and acks (does not throw) when dispatchRun returns no run', async () => {
     mockExperimentRuns.dispatchRun.mockResolvedValueOnce(undefined)
 
-    await expect(service.handleAgenticKickoff(kickoff)).rejects.toThrow(
-      /Agent dispatch queue not configured/,
-    )
+    await expect(service.handleAgenticKickoff(kickoff)).resolves.toBeUndefined()
+    expect(mockExperimentRuns.dispatchRun).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -563,6 +563,9 @@ describe('CampaignTcrComplianceService - handleAgenticKickoff', () => {
     expect(mockExperimentRuns.findFirst).toHaveBeenCalledWith({
       where: {
         experimentType: 'compliance_setup',
+        status: {
+          in: [ExperimentRunStatus.RUNNING, ExperimentRunStatus.COMPLETED],
+        },
         params: {
           path: ['tcrComplianceId'],
           equals: kickoff.tcrComplianceId,
@@ -588,11 +591,7 @@ describe('CampaignTcrComplianceService - handleAgenticKickoff', () => {
     expect(JSON.stringify(dispatchCall)).not.toContain('actorTokenUrl')
   })
 
-  it.each([
-    ExperimentRunStatus.RUNNING,
-    ExperimentRunStatus.COMPLETED,
-    ExperimentRunStatus.FAILED,
-  ])(
+  it.each([ExperimentRunStatus.RUNNING, ExperimentRunStatus.COMPLETED])(
     'skips dispatch when a %s run already exists for the record',
     async (status) => {
       mockExperimentRuns.findFirst.mockResolvedValueOnce({

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -781,11 +781,17 @@ export class CampaignTcrComplianceService extends createPrismaBase(
     })
 
     if (!run) {
-      throw new Error(
-        `[TCR Compliance] Agent dispatch queue not configured; ` +
-          `cannot kick off compliance_setup for tcrComplianceId=` +
-          `${tcrComplianceId}`,
+      // AGENT_DISPATCH_QUEUE_NAME is unset (preview envs by design — see
+      // src/agentExperiments/CLAUDE.md). The misconfiguration is permanent
+      // for the lifetime of this env, so retrying is futile. Log loudly and
+      // ack so the message doesn't churn through redrives until DLQ.
+      this.logger.error(
+        { campaignId, tcrComplianceId },
+        '[TCR Compliance] Agent dispatch queue not configured; ' +
+          'discarding kickoff message ' +
+          '(set AGENT_DISPATCH_QUEUE_NAME to enable)',
       )
+      return
     }
 
     this.logger.info(

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -744,6 +744,11 @@ export class CampaignTcrComplianceService extends createPrismaBase(
       return
     }
 
+    // Idempotency filter intentionally excludes FAILED. Per CLAUDE.md
+    // "Idempotency check breadth", FAILED runs must remain eligible for
+    // re-dispatch — sweepStaleRuns flips RUNNING→FAILED at 45min, and
+    // dispatchRun writes RUNNING then flips to FAILED on SQS-send failure;
+    // including FAILED here would permanently strand both.
     const existingRun = await this.experimentRunsService.findFirst({
       where: {
         experimentType: 'compliance_setup',
@@ -768,15 +773,23 @@ export class CampaignTcrComplianceService extends createPrismaBase(
       return
     }
 
-    await this.experimentRunsService.dispatchRun({
+    const run = await this.experimentRunsService.dispatchRun({
       type: 'compliance_setup',
       organizationSlug: campaign.organizationSlug,
       clerkUserId,
       params: { campaignId, tcrComplianceId },
     })
 
+    if (!run) {
+      throw new Error(
+        `[TCR Compliance] Agent dispatch queue not configured; ` +
+          `cannot kick off compliance_setup for tcrComplianceId=` +
+          `${tcrComplianceId}`,
+      )
+    }
+
     this.logger.info(
-      { campaignId, tcrComplianceId },
+      { campaignId, tcrComplianceId, runId: run.runId },
       '[TCR Compliance] Dispatched compliance_setup agent run',
     )
   }

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -41,6 +41,8 @@ import { CrmCampaignsService } from '../../services/crmCampaigns.service'
 import { ComplianceStateService } from './complianceState.service'
 import { SubmitToPeerlyDto } from '../schemas/submitToPeerlyDto.schema'
 import { ComplianceStage, SubmitToPeerlyOutput } from '@goodparty_org/contracts'
+import { ExperimentRunsService } from '../../../agentExperiments/services/experimentRuns.service'
+import { AgenticComplianceKickoffMessage } from '../../../queue/queue.types'
 
 const TCR_COMPLIANCE_CHECK_INTERVAL = process.env.TCR_COMPLIANCE_CHECK_INTERVAL
   ? parseInt(process.env.TCR_COMPLIANCE_CHECK_INTERVAL)
@@ -76,6 +78,7 @@ export class CampaignTcrComplianceService extends createPrismaBase(
     private readonly crmCampaignsService: CrmCampaignsService,
     private readonly complianceStateService: ComplianceStateService,
     private queueService: QueueProducerService,
+    private readonly experimentRunsService: ExperimentRunsService,
   ) {
     super()
   }
@@ -713,6 +716,65 @@ export class CampaignTcrComplianceService extends createPrismaBase(
     )
 
     return { record, created: true }
+  }
+
+  async handleAgenticKickoff(message: AgenticComplianceKickoffMessage) {
+    const { campaignId, tcrComplianceId, clerkUserId } = message
+
+    const record = await this.model.findUnique({
+      where: { id: tcrComplianceId },
+    })
+    if (!record || record.campaignId !== campaignId) {
+      this.logger.warn(
+        { campaignId, tcrComplianceId },
+        '[TCR Compliance] Kickoff for unknown or mismatched record; dropping',
+      )
+      return
+    }
+
+    const campaign = await this.campaignsService.findUnique({
+      where: { id: campaignId },
+    })
+    if (!campaign) {
+      this.logger.warn(
+        { campaignId, tcrComplianceId },
+        '[TCR Compliance] Kickoff for unknown campaign; dropping',
+      )
+      return
+    }
+
+    const existingRun = await this.experimentRunsService.findFirst({
+      where: {
+        experimentType: 'compliance_setup',
+        params: {
+          path: ['tcrComplianceId'],
+          equals: tcrComplianceId,
+        },
+      },
+    })
+    if (existingRun) {
+      this.logger.info(
+        {
+          tcrComplianceId,
+          existingRunId: existingRun.runId,
+          status: existingRun.status,
+        },
+        '[TCR Compliance] Agent run already dispatched for record; skipping',
+      )
+      return
+    }
+
+    await this.experimentRunsService.dispatchRun({
+      type: 'compliance_setup',
+      organizationSlug: campaign.organizationSlug,
+      clerkUserId,
+      params: { campaignId, tcrComplianceId },
+    })
+
+    this.logger.info(
+      { campaignId, tcrComplianceId },
+      '[TCR Compliance] Dispatched compliance_setup agent run',
+    )
   }
 
   async delete(id: string) {

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -43,6 +43,7 @@ import { SubmitToPeerlyDto } from '../schemas/submitToPeerlyDto.schema'
 import { ComplianceStage, SubmitToPeerlyOutput } from '@goodparty_org/contracts'
 import { ExperimentRunsService } from '../../../agentExperiments/services/experimentRuns.service'
 import { AgenticComplianceKickoffMessage } from '../../../queue/queue.types'
+import { ExperimentRunStatus } from '@prisma/client'
 
 const TCR_COMPLIANCE_CHECK_INTERVAL = process.env.TCR_COMPLIANCE_CHECK_INTERVAL
   ? parseInt(process.env.TCR_COMPLIANCE_CHECK_INTERVAL)
@@ -746,6 +747,9 @@ export class CampaignTcrComplianceService extends createPrismaBase(
     const existingRun = await this.experimentRunsService.findFirst({
       where: {
         experimentType: 'compliance_setup',
+        status: {
+          in: [ExperimentRunStatus.RUNNING, ExperimentRunStatus.COMPLETED],
+        },
         params: {
           path: ['tcrComplianceId'],
           equals: tcrComplianceId,

--- a/src/queue/consumer/queueConsumer.service.test.ts
+++ b/src/queue/consumer/queueConsumer.service.test.ts
@@ -1076,7 +1076,12 @@ describe('QueueConsumerService - message type routing', () => {
             addEventTasks: vi.fn().mockResolvedValue(undefined),
           },
         },
-        { provide: CampaignTcrComplianceService, useValue: {} },
+        {
+          provide: CampaignTcrComplianceService,
+          useValue: {
+            handleAgenticKickoff: vi.fn().mockResolvedValue(undefined),
+          },
+        },
         { provide: ContactsService, useValue: {} },
         { provide: DomainsService, useValue: {} },
         { provide: ElectedOfficeService, useValue: {} },
@@ -1209,6 +1214,57 @@ describe('QueueConsumerService - message type routing', () => {
     const result = await service.processMessage(message)
 
     expect(result).toBe(true)
+    expect(handleSpy).not.toHaveBeenCalled()
+  })
+
+  it('routes agenticComplianceKickoff messages to the TCR compliance handler', async () => {
+    const tcr = module.get(CampaignTcrComplianceService)
+    const handleSpy = vi
+      .spyOn(tcr, 'handleAgenticKickoff')
+      .mockResolvedValue(undefined)
+
+    const message: Message = {
+      MessageId: 'msg-kickoff-ok',
+      Body: JSON.stringify({
+        type: QueueType.AGENTIC_COMPLIANCE_KICKOFF,
+        data: {
+          campaignId: 42,
+          tcrComplianceId: 'tcr-abc',
+          clerkUserId: 'user_clerk_xyz',
+        },
+      }),
+    }
+
+    const result = await service.processMessage(message)
+
+    expect(result).toBe(true)
+    expect(handleSpy).toHaveBeenCalledOnce()
+    expect(handleSpy).toHaveBeenCalledWith({
+      campaignId: 42,
+      tcrComplianceId: 'tcr-abc',
+      clerkUserId: 'user_clerk_xyz',
+    })
+  })
+
+  it('rejects agenticComplianceKickoff with invalid payload and does not call handler', async () => {
+    const tcr = module.get(CampaignTcrComplianceService)
+    const handleSpy = vi
+      .spyOn(tcr, 'handleAgenticKickoff')
+      .mockResolvedValue(undefined)
+
+    const message: Message = {
+      MessageId: 'msg-kickoff-invalid',
+      Body: JSON.stringify({
+        type: QueueType.AGENTIC_COMPLIANCE_KICKOFF,
+        data: {
+          campaignId: 'not-a-number',
+          tcrComplianceId: '',
+        },
+      }),
+    }
+
+    await service.processMessage(message)
+
     expect(handleSpy).not.toHaveBeenCalled()
   })
 

--- a/src/queue/consumer/queueConsumer.service.test.ts
+++ b/src/queue/consumer/queueConsumer.service.test.ts
@@ -1223,13 +1223,14 @@ describe('QueueConsumerService - message type routing', () => {
       .spyOn(tcr, 'handleAgenticKickoff')
       .mockResolvedValue(undefined)
 
+    const validTcrCuid = 'ckpqr7s3z00010o9k1234abcd'
     const message: Message = {
       MessageId: 'msg-kickoff-ok',
       Body: JSON.stringify({
         type: QueueType.AGENTIC_COMPLIANCE_KICKOFF,
         data: {
           campaignId: 42,
-          tcrComplianceId: 'tcr-abc',
+          tcrComplianceId: validTcrCuid,
           clerkUserId: 'user_clerk_xyz',
         },
       }),
@@ -1241,12 +1242,12 @@ describe('QueueConsumerService - message type routing', () => {
     expect(handleSpy).toHaveBeenCalledOnce()
     expect(handleSpy).toHaveBeenCalledWith({
       campaignId: 42,
-      tcrComplianceId: 'tcr-abc',
+      tcrComplianceId: validTcrCuid,
       clerkUserId: 'user_clerk_xyz',
     })
   })
 
-  it('rejects agenticComplianceKickoff with invalid payload and does not call handler', async () => {
+  it('discards agenticComplianceKickoff with invalid payload and does not call handler', async () => {
     const tcr = module.get(CampaignTcrComplianceService)
     const handleSpy = vi
       .spyOn(tcr, 'handleAgenticKickoff')
@@ -1257,14 +1258,16 @@ describe('QueueConsumerService - message type routing', () => {
       Body: JSON.stringify({
         type: QueueType.AGENTIC_COMPLIANCE_KICKOFF,
         data: {
-          campaignId: 'not-a-number',
-          tcrComplianceId: '',
+          campaignId: 42,
+          tcrComplianceId: 'not-a-cuid',
+          clerkUserId: 'user_clerk_xyz',
         },
       }),
     }
 
-    await service.processMessage(message)
+    const result = await service.processMessage(message)
 
+    expect(result).toBe(true)
     expect(handleSpy).not.toHaveBeenCalled()
   })
 

--- a/src/queue/consumer/queueConsumer.service.ts
+++ b/src/queue/consumer/queueConsumer.service.ts
@@ -47,6 +47,7 @@ import { PeerlyCvVerificationStatus } from '../../vendors/peerly/peerly.types'
 import { EVENTS } from '../../vendors/segment/segment.types'
 import { DomainsService } from '../../websites/services/domains.service'
 import {
+  AgenticComplianceKickoffMessageSchema,
   CampaignPlanCompleteMessage,
   CampaignPlanCompleteMessageSchema,
   AgentExperimentResultSchema,
@@ -375,11 +376,14 @@ export class QueueConsumerService {
           AgentExperimentResultSchema.parse(queueMessage.data),
         )
       case QueueType.AGENTIC_COMPLIANCE_KICKOFF:
-        this.logger.warn(
-          { messageId: message.MessageId, data: queueMessage.data },
-          'AGENTIC_COMPLIANCE_KICKOFF handler not yet implemented — discarding message',
-        )
-        return true
+        this.logger.info('received agenticComplianceKickoff message')
+        return await this.withLegacyErrorSwallowing(message, async () => {
+          const kickoff = AgenticComplianceKickoffMessageSchema.parse(
+            queueMessage.data,
+          )
+          await this.tcrComplianceService.handleAgenticKickoff(kickoff)
+          return true
+        })
       case QueueType.OCR_ATTACHMENT:
         return await this.withLegacyErrorSwallowing(message, async () => {
           const { attachmentId } = OcrAttachmentMessageSchema.parse(

--- a/src/queue/queue.types.ts
+++ b/src/queue/queue.types.ts
@@ -68,7 +68,7 @@ export type DomainEmailForwardingMessage = {
 
 export const AgenticComplianceKickoffMessageSchema = z.object({
   campaignId: z.number().int(),
-  tcrComplianceId: z.string().min(1),
+  tcrComplianceId: z.string().cuid(),
   clerkUserId: z.string().min(1),
 })
 

--- a/src/queue/queue.types.ts
+++ b/src/queue/queue.types.ts
@@ -66,11 +66,15 @@ export type DomainEmailForwardingMessage = {
   domainId: number
 }
 
-export type AgenticComplianceKickoffMessage = {
-  campaignId: number
-  tcrComplianceId: string
-  clerkUserId: string
-}
+export const AgenticComplianceKickoffMessageSchema = z.object({
+  campaignId: z.number().int(),
+  tcrComplianceId: z.string().min(1),
+  clerkUserId: z.string().min(1),
+})
+
+export type AgenticComplianceKickoffMessage = z.infer<
+  typeof AgenticComplianceKickoffMessageSchema
+>
 
 export const CampaignPlanCompleteMessageSchema = z.discriminatedUnion(
   'status',


### PR DESCRIPTION
- Integrated the AgentExperimentsModule into the CampaignsModule to facilitate compliance setup runs.
- Enhanced the CampaignTcrComplianceService with a new method to handle agentic compliance kickoff messages, ensuring proper validation and dispatch of experiment runs.
- Updated the QueueConsumerService to route agentic compliance kickoff messages to the new handler, improving message processing and error handling.
- Added tests to validate the new functionality and ensure correct behavior under various scenarios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes SQS message routing/validation and introduces new experiment-run dispatch behavior that can affect compliance automation and retries.
> 
> **Overview**
> **Adds end-to-end handling for agentic compliance kickoffs.** `QueueConsumerService` now validates `agenticComplianceKickoff` payloads with a new Zod schema and routes them to `CampaignTcrComplianceService.handleAgenticKickoff` instead of discarding.
> 
> **Dispatches the `compliance_setup` experiment run on kickoff.** `CampaignTcrComplianceService` now checks the TCR record + campaign, de-dupes by existing `ExperimentRun` for the `tcrComplianceId`, and dispatches via `ExperimentRunsService` (propagating `BadGatewayException` to trigger redelivery).
> 
> **Wires and types the new experiment contract.** `CampaignsModule` imports `AgentExperimentsModule`, and `AgentExperimentsModule` adds a temporary `compliance_setup` contract type augmentation until codegen supports it; tests were expanded to cover routing and dispatch/skip/drop scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02b8d75317f7968871455e69cfaf06b824c17065. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->