### PR TITLE
Secure signed upload URL generation with validation

### DIFF
--- a/src/users/schemas/GenerateSignedUploadUrlArgs.schema.test.ts
+++ b/src/users/schemas/GenerateSignedUploadUrlArgs.schema.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { GenerateSignedUploadUrlArgsSchema } from './GenerateSignedUploadUrlArgs.schema'
+
+const validPayload = {
+  bucket: 'uploads',
+  fileName: 'doc.pdf',
+  fileType: 'application/pdf' as const,
+}
+
+describe('GenerateSignedUploadUrlArgsSchema', () => {
+  it('accepts a valid payload', () => {
+    const result = GenerateSignedUploadUrlArgsSchema.safeParse(validPayload)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a bucket with subfolder', () => {
+    const result = GenerateSignedUploadUrlArgsSchema.safeParse({
+      ...validPayload,
+      bucket: 'ein-supporting-documents/test-folder',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  describe('bucket validation', () => {
+    it('rejects path traversal via ..', () => {
+      const result = GenerateSignedUploadUrlArgsSchema.safeParse({
+        ...validPayload,
+        bucket: 'uploads/../secrets',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects leading slash', () => {
+      const result = GenerateSignedUploadUrlArgsSchema.safeParse({
+        ...validPayload,
+        bucket: '/uploads',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects bucket not in allowlist', () => {
+      const result = GenerateSignedUploadUrlArgsSchema.safeParse({
+        ...validPayload,
+        bucket: 'arbitrary-bucket',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects empty bucket', () => {
+      const result = GenerateSignedUploadUrlArgsSchema.safeParse({
+        ...validPayload,
+        bucket: '',
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('fileName validation', () => {
+    it('rejects path traversal via ..', () => {
+      const result = GenerateSignedUploadUrlArgsSchema.safeParse({
+        ...validPayload,
+        fileName: '../index.html',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects forward slash', () => {
+      const result = GenerateSignedUploadUrlArgsSchema.safeParse({
+        ...validPayload,
+        fileName: 'path/to/file.pdf',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects backslash', () => {
+      const result = GenerateSignedUploadUrlArgsSchema.safeParse({
+        ...validPayload,
+        fileName: 'path\\file.pdf',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects empty fileName', () => {
+      const result = GenerateSignedUploadUrlArgsSchema.safeParse({
+        ...validPayload,
+        fileName: '',
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('fileType validation', () => {
+    it('rejects text/html', () => {
+      const result = GenerateSignedUploadUrlArgsSchema.safeParse({
+        ...validPayload,
+        fileType: 'text/html',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects application/javascript', () => {
+      const result = GenerateSignedUploadUrlArgsSchema.safeParse({
+        ...validPayload,
+        fileType: 'application/javascript',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts all allowed MIME types', () => {
+      const allowed = [
+        'application/pdf',
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+      ] as const
+
+      for (const fileType of allowed) {
+        const result = GenerateSignedUploadUrlArgsSchema.safeParse({
+          ...validPayload,
+          fileType,
+        })
+        expect(result.success).toBe(true)
+      }
+    })
+  })
+})

--- a/src/users/schemas/GenerateSignedUploadUrlArgs.schema.ts
+++ b/src/users/schemas/GenerateSignedUploadUrlArgs.schema.ts
@@ -1,10 +1,40 @@
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
+const ALLOWED_BUCKET_PREFIXES = ['ein-supporting-documents', 'uploads'] as const
+
+const ALLOWED_FILE_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+] as const
+
 export const GenerateSignedUploadUrlArgsSchema = z.object({
-  fileType: z.string(),
-  fileName: z.string(),
-  bucket: z.string(),
+  bucket: z
+    .string()
+    .min(1)
+    .refine(
+      (val) => !val.includes('..') && !val.startsWith('/'),
+      'Bucket must not contain path traversal',
+    )
+    .refine(
+      (val) =>
+        ALLOWED_BUCKET_PREFIXES.some(
+          (prefix) => val === prefix || val.startsWith(`${prefix}/`),
+        ),
+      'Bucket prefix not in allowlist',
+    ),
+  fileName: z
+    .string()
+    .min(1)
+    .max(255)
+    .refine(
+      (val) => !val.includes('..') && !val.includes('/') && !val.includes('\\'),
+      'File name must not contain path separators',
+    ),
+  fileType: z.enum(ALLOWED_FILE_TYPES),
 })
 
 export class GenerateSignedUploadUrlArgsDto extends createZodDto(

--- a/src/users/users.controller.test.ts
+++ b/src/users/users.controller.test.ts
@@ -471,6 +471,18 @@ describe('UsersController', () => {
         signedUploadUrl: 'https://s3.example.com/signed-url',
       })
     })
+
+    it('throws UnauthorizedException when user is null (M2M bypass)', async () => {
+      const args = {
+        bucket: 'uploads',
+        fileName: 'doc.pdf',
+        fileType: 'application/pdf' as const,
+      }
+
+      await expect(
+        controller.generateSignedUploadUrl(null as never, args),
+      ).rejects.toThrow(UnauthorizedException)
+    })
   })
 
   describe('updatePassword', () => {

--- a/src/users/users.controller.test.ts
+++ b/src/users/users.controller.test.ts
@@ -462,9 +462,9 @@ describe('UsersController', () => {
       const args = {
         bucket: 'uploads',
         fileName: 'doc.pdf',
-        fileType: 'application/pdf',
+        fileType: 'application/pdf' as const,
       }
-      const result = await controller.generateSignedUploadUrl(args)
+      const result = await controller.generateSignedUploadUrl(mockUser, args)
 
       expect(filesService.generateSignedUploadUrl).toHaveBeenCalledWith(args)
       expect(result).toEqual({

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -119,9 +119,12 @@ export class UsersController {
 
   @Put('files/generate-signed-upload-url')
   async generateSignedUploadUrl(
-    @ReqUser() _user: User,
+    @ReqUser() user: User,
     @Body() args: GenerateSignedUploadUrlArgsDto,
   ) {
+    if (!user) {
+      throw new UnauthorizedException('User session required')
+    }
     return {
       signedUploadUrl: await this.filesService.generateSignedUploadUrl(args),
     }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -118,7 +118,10 @@ export class UsersController {
   }
 
   @Put('files/generate-signed-upload-url')
-  async generateSignedUploadUrl(@Body() args: GenerateSignedUploadUrlArgsDto) {
+  async generateSignedUploadUrl(
+    @ReqUser() _user: User,
+    @Body() args: GenerateSignedUploadUrlArgsDto,
+  ) {
     return {
       signedUploadUrl: await this.filesService.generateSignedUploadUrl(args),
     }

--- a/src/vendors/aws/services/awsS3.service.ts
+++ b/src/vendors/aws/services/awsS3.service.ts
@@ -99,7 +99,7 @@ export class AwsS3Service extends AwsService {
   }
 
   async getSignedS3Url(bucket: string, fileName: string, fileType: string) {
-    const filePath = `${bucket}/${fileName}`
+    const filePath = this.getKey({ bucket, fileName })
 
     this.logger.debug(
       {


### PR DESCRIPTION
## Summary

Hardens the signed S3 upload URL generation endpoint by adding comprehensive input validation, enforcing an allowlist of bucket prefixes and MIME types, and requiring user authentication.

## Key changes

- **Schema validation**: Updated `GenerateSignedUploadUrlArgsSchema` to enforce:
  - Bucket: must be non-empty, reject path traversal (`..`, leading `/`), and match allowlisted prefixes (`ein-supporting-documents`, `uploads`)
  - File name: max 255 chars, reject path separators (`/`, `\`, `..`)
  - File type: enum of 5 allowed MIME types (PDF, JPEG, PNG, GIF, WebP) instead of arbitrary string
  
- **Authentication**: Added `@ReqUser()` decorator to `generateSignedUploadUrl` endpoint to require authenticated user context

- **S3 key generation**: Refactored `getSignedS3Url` to use `this.getKey({ bucket, fileName })` helper instead of string concatenation, ensuring consistent path handling

- **Tests**: Updated test to pass `mockUser` and cast `fileType` as const to match enum schema

## Implementation details

The allowlist constants are defined at module level for maintainability. Zod refinements provide clear, specific error messages for each validation failure. The bucket validation prevents both directory traversal attacks and access to unlisted storage locations.

https://claude.ai/code/session_01Dxm6BYdTf7aB58RX9r165Z

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens validation and authentication for the signed-upload endpoint, which may break existing clients that relied on arbitrary buckets/MIME types or unauthenticated access. Also changes S3 key construction for signed URLs, affecting where uploads land if callers depended on the previous raw concatenation behavior.
> 
> **Overview**
> **Hardens signed S3 upload URL generation** by adding strict Zod validation/allowlists for `bucket` (prefix-restricted + path-traversal checks), `fileName` (length + separator traversal checks), and `fileType` (restricted MIME enum).
> 
> The `PUT users/files/generate-signed-upload-url` controller now requires an authenticated `@ReqUser()` context, and `AwsS3Service.getSignedS3Url` switches to the shared `getKey()` helper for consistent key generation. Tests were updated to pass `mockUser` and align `fileType` typing with the new enum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 994bd327541eac817defc8ca88f6fb8c28ffa119. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->