### PR TITLE
Hotfix/website publish compat

### DIFF
--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -166,8 +166,8 @@ describe('WebsitesController', () => {
     })
   })
 
-  describe('updateWebsite - domain registrant verification gate', () => {
-    it('blocks publishing when an attached domain has not been registrant-verified', async () => {
+  describe('updateWebsite - domain publishing compatibility', () => {
+    it('allows publishing when an attached domain is not registrant-verified', async () => {
       mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
         content: {},
         hasEverBeenPublished: false,
@@ -177,11 +177,9 @@ describe('WebsitesController', () => {
       const body = new UpdateWebsiteSchema()
       body.status = WebsiteStatus.published
 
-      await expect(
-        controller.updateWebsite(mockUser, mockCampaign, body),
-      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST })
+      await controller.updateWebsite(mockUser, mockCampaign, body)
 
-      expect(mockWebsitesService.update).not.toHaveBeenCalled()
+      expect(mockWebsitesService.update).toHaveBeenCalled()
     })
 
     it('allows publishing when the attached domain has been registrant-verified', async () => {

--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { HttpStatus } from '@nestjs/common'
 import { WebsiteStatus } from '@prisma/client'
 import { AnalyticsService } from 'src/analytics/analytics.service'
 import { EVENTS } from 'src/vendors/segment/segment.types'

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -173,28 +173,26 @@ export class WebsitesController {
     const logoFile = files?.find((file) => file.fieldname === LOGO_FIELDNAME)
     const heroFile = files?.find((file) => file.fieldname === HERO_FIELDNAME)
 
-    const {
-      content: currentContent,
-      domain,
-      hasEverBeenPublished,
-    } = await this.websites.findUniqueOrThrow({
-      where: { campaignId },
-      select: {
-        content: true,
-        domain: true,
-        hasEverBeenPublished: true,
-      },
-    })
+    const { content: currentContent, hasEverBeenPublished } =
+      await this.websites.findUniqueOrThrow({
+        where: { campaignId },
+        select: {
+          content: true,
+          hasEverBeenPublished: true,
+        },
+      })
 
-    if (
-      body.status === WebsiteStatus.published &&
-      domain &&
-      !domain.registrantVerifiedAt
-    ) {
-      throw new BadRequestException(
-        'Domain registrant verification is not yet complete. The site cannot be published until Vercel confirms domain ownership.',
-      )
-    }
+    // TODO: Restore this gate when registrant verification is required
+    // for the new publish flow.
+    // if (
+    //   body.status === WebsiteStatus.published &&
+    //   domain &&
+    //   !domain.registrantVerifiedAt
+    // ) {
+    //   throw new BadRequestException(
+    //     'Domain registrant verification is not yet complete. The site cannot be published until Vercel confirms domain ownership.',
+    //   )
+    // }
 
     const updatedContent: PrismaJson.WebsiteContent = merge(
       currentContent || {},


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Removes a publish-time guard that previously blocked publishing when a custom domain lacked `registrantVerifiedAt`, which changes production publishing behavior and could expose sites on unverified domains.
> 
> **Overview**
> Removes the `updateWebsite` publishing gate that threw `BadRequestException` when an attached custom domain was not registrant-verified, allowing publish status transitions to proceed regardless of `domain.registrantVerifiedAt` (with a TODO to restore later).
> 
> Updates controller tests to expect publishing to succeed and `websites.update` to be called even when the attached domain is unverified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e96d26877cb4009829513809e310def1ad8fdbc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->