### PR TITLE
hotfix: allow website updates without registrant verification gate

### DIFF
--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -166,8 +166,8 @@ describe('WebsitesController', () => {
     })
   })
 
-  describe('updateWebsite - domain registrant verification gate', () => {
-    it('blocks publishing when an attached domain has not been registrant-verified', async () => {
+  describe('updateWebsite - domain publishing compatibility', () => {
+    it('allows publishing when an attached domain is not registrant-verified', async () => {
       mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
         content: {},
         hasEverBeenPublished: false,
@@ -177,11 +177,9 @@ describe('WebsitesController', () => {
       const body = new UpdateWebsiteSchema()
       body.status = WebsiteStatus.published
 
-      await expect(
-        controller.updateWebsite(mockUser, mockCampaign, body),
-      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST })
+      await controller.updateWebsite(mockUser, mockCampaign, body)
 
-      expect(mockWebsitesService.update).not.toHaveBeenCalled()
+      expect(mockWebsitesService.update).toHaveBeenCalled()
     })
 
     it('allows publishing when the attached domain has been registrant-verified', async () => {

--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { HttpStatus } from '@nestjs/common'
 import { WebsiteStatus } from '@prisma/client'
 import { AnalyticsService } from 'src/analytics/analytics.service'
 import { EVENTS } from 'src/vendors/segment/segment.types'

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -173,28 +173,26 @@ export class WebsitesController {
     const logoFile = files?.find((file) => file.fieldname === LOGO_FIELDNAME)
     const heroFile = files?.find((file) => file.fieldname === HERO_FIELDNAME)
 
-    const {
-      content: currentContent,
-      domain,
-      hasEverBeenPublished,
-    } = await this.websites.findUniqueOrThrow({
-      where: { campaignId },
-      select: {
-        content: true,
-        domain: true,
-        hasEverBeenPublished: true,
-      },
-    })
+    const { content: currentContent, hasEverBeenPublished } =
+      await this.websites.findUniqueOrThrow({
+        where: { campaignId },
+        select: {
+          content: true,
+          hasEverBeenPublished: true,
+        },
+      })
 
-    if (
-      body.status === WebsiteStatus.published &&
-      domain &&
-      !domain.registrantVerifiedAt
-    ) {
-      throw new BadRequestException(
-        'Domain registrant verification is not yet complete. The site cannot be published until Vercel confirms domain ownership.',
-      )
-    }
+    // TODO: Restore this gate when registrant verification is required
+    // for the new publish flow.
+    // if (
+    //   body.status === WebsiteStatus.published &&
+    //   domain &&
+    //   !domain.registrantVerifiedAt
+    // ) {
+    //   throw new BadRequestException(
+    //     'Domain registrant verification is not yet complete. The site cannot be published until Vercel confirms domain ownership.',
+    //   )
+    // }
 
     const updatedContent: PrismaJson.WebsiteContent = merge(
       currentContent || {},


### PR DESCRIPTION
## Summary
- keep website publish/update backward compatible by disabling the registrant verification gate for now
- preserve the future-flow logic as commented code with a TODO in `WebsitesController`
- update tests to assert publishing remains allowed when `registrantVerifiedAt` is missing and remove now-unused imports

## Test plan
- [x] `npx vitest run src/websites/controllers/websites.controller.test.ts`
- [x] `npx eslint src/websites/controllers/websites.controller.ts src/websites/controllers/websites.controller.test.ts`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a publish-time validation that previously blocked publishing when `domain.registrantVerifiedAt` was missing, which can allow publishing with unverified domains until the gate is reinstated.
> 
> **Overview**
> **Disables the domain registrant-verification publish gate** in `WebsitesController.updateWebsite`, removing the `BadRequestException` path and no longer selecting `domain` for this check (leaving the prior logic commented with a TODO).
> 
> Updates controller tests to assert publishing/updates proceed even when an attached domain is *not* registrant-verified, and drops the now-unused `HttpStatus` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed96265d263e9e6262ddc158eb1298bdb7ec5026. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->