### PR TITLE
hotfix: allow website updates without registrant verification gate

### DIFF
--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { HttpStatus } from '@nestjs/common'
 import { WebsiteStatus } from '@prisma/client'
 import { AnalyticsService } from 'src/analytics/analytics.service'
 import { EVENTS } from 'src/vendors/segment/segment.types'

--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { HttpStatus } from '@nestjs/common'
 import { WebsiteStatus } from '@prisma/client'
 import { AnalyticsService } from 'src/analytics/analytics.service'
 import { EVENTS } from 'src/vendors/segment/segment.types'

--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -186,8 +186,8 @@ describe('WebsitesController', () => {
     })
   })
 
-  describe('updateWebsite - domain registrant verification gate', () => {
-    it('blocks publishing when an attached domain has not been registrant-verified', async () => {
+  describe('updateWebsite - domain publishing compatibility', () => {
+    it('allows publishing when an attached domain is not registrant-verified', async () => {
       mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
         content: completeContent,
         hasEverBeenPublished: false,
@@ -197,11 +197,9 @@ describe('WebsitesController', () => {
       const body = new UpdateWebsiteSchema()
       body.status = WebsiteStatus.published
 
-      await expect(
-        controller.updateWebsite(mockUser, mockCampaign, body),
-      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST })
+      await controller.updateWebsite(mockUser, mockCampaign, body)
 
-      expect(mockWebsitesService.update).not.toHaveBeenCalled()
+      expect(mockWebsitesService.update).toHaveBeenCalled()
     })
 
     it('allows publishing when the attached domain has been registrant-verified', async () => {

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -220,28 +220,26 @@ export class WebsitesController {
     const logoFile = files?.find((file) => file.fieldname === LOGO_FIELDNAME)
     const heroFile = files?.find((file) => file.fieldname === HERO_FIELDNAME)
 
-    const {
-      content: currentContent,
-      domain,
-      hasEverBeenPublished,
-    } = await this.websites.findUniqueOrThrow({
-      where: { campaignId },
-      select: {
-        content: true,
-        domain: true,
-        hasEverBeenPublished: true,
-      },
-    })
+    const { content: currentContent, hasEverBeenPublished } =
+      await this.websites.findUniqueOrThrow({
+        where: { campaignId },
+        select: {
+          content: true,
+          hasEverBeenPublished: true,
+        },
+      })
 
-    if (
-      body.status === WebsiteStatus.published &&
-      domain &&
-      !domain.registrantVerifiedAt
-    ) {
-      throw new BadRequestException(
-        'Domain registrant verification is not yet complete. The site cannot be published until Vercel confirms domain ownership.',
-      )
-    }
+    // TODO: Restore this gate when registrant verification is required
+    // for the new publish flow.
+    // if (
+    //   body.status === WebsiteStatus.published &&
+    //   domain &&
+    //   !domain.registrantVerifiedAt
+    // ) {
+    //   throw new BadRequestException(
+    //     'Domain registrant verification is not yet complete. The site cannot be published until Vercel confirms domain ownership.',
+    //   )
+    // }
 
     const updatedContent: PrismaJson.WebsiteContent = merge(
       currentContent || {},


### PR DESCRIPTION
## Summary
- keep website publish/update backward compatible by disabling the registrant verification gate for now
- preserve the future-flow logic as commented code with a TODO in `WebsitesController`
- align imports for `develop` so existing publish validation tests and controller paths still compile

## Test plan
- [x] `npx vitest run src/websites/controllers/websites.controller.test.ts`
- [x] `npx eslint src/websites/controllers/websites.controller.ts src/websites/controllers/websites.controller.test.ts`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it relaxes a publishing validation gate, potentially allowing domains to be published before ownership verification; change is small and covered by updated controller tests.
> 
> **Overview**
> Publishing via `PUT /websites/mine` no longer blocks when a custom domain’s `registrantVerifiedAt` is missing; the controller now only fetches `content`/`hasEverBeenPublished` and leaves the prior registrant-verification gate commented out with a TODO.
> 
> Controller tests are updated to assert publishing proceeds (and `websites.update` is called) whether the domain is unverified, verified, or absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099259c2f180a1ba009cf5389c282b88b6b14f7b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->