### PR TITLE
Add admin role requirement to positions endpoints

### DIFF
--- a/src/topIssues/positions/positions.controller.test.ts
+++ b/src/topIssues/positions/positions.controller.test.ts
@@ -1,0 +1,56 @@
+import { ROLES_KEY } from '@/authentication/decorators/Roles.decorator'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { UserRole } from '@prisma/client'
+import { describe, expect, it, vi } from 'vitest'
+import { PositionsController } from './positions.controller'
+import { PositionsService } from './positions.service'
+
+function getRoles(
+  methodName: keyof PositionsController,
+): UserRole[] | undefined {
+  return Reflect.getMetadata(
+    ROLES_KEY,
+    PositionsController.prototype[methodName],
+  )
+}
+
+describe('PositionsController', () => {
+  const positionsService = {
+    findAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as PositionsService
+
+  const controller = new PositionsController(
+    positionsService,
+    createMockLogger(),
+  )
+
+  describe('role guards', () => {
+    it('does not require a role for list', () => {
+      expect(getRoles('list')).toBeUndefined()
+    })
+
+    it('requires admin role for create', () => {
+      expect(getRoles('create')).toEqual([UserRole.admin])
+    })
+
+    it('requires admin role for update', () => {
+      expect(getRoles('update')).toEqual([UserRole.admin])
+    })
+
+    it('requires admin role for delete', () => {
+      expect(getRoles('delete')).toEqual([UserRole.admin])
+    })
+  })
+
+  describe('delete', () => {
+    it('awaits the service and returns undefined', async () => {
+      positionsService.delete = vi.fn().mockResolvedValue({})
+      const result = await controller.delete(1)
+      expect(result).toBeUndefined()
+      expect(positionsService.delete).toHaveBeenCalledWith(1)
+    })
+  })
+})

--- a/src/topIssues/positions/positions.controller.ts
+++ b/src/topIssues/positions/positions.controller.ts
@@ -52,7 +52,7 @@ export class PositionsController {
   @Delete(':id')
   @Roles(UserRole.admin)
   @HttpCode(HttpStatus.NO_CONTENT)
-  delete(@Param('id', ParseIntPipe) id: number) {
-    return this.positionsService.delete(id)
+  async delete(@Param('id', ParseIntPipe) id: number) {
+    await this.positionsService.delete(id)
   }
 }

--- a/src/topIssues/positions/positions.controller.ts
+++ b/src/topIssues/positions/positions.controller.ts
@@ -11,7 +11,9 @@ import {
   Put,
   UsePipes,
 } from '@nestjs/common'
+import { UserRole } from '@prisma/client'
 import { ZodValidationPipe } from 'nestjs-zod'
+import { Roles } from '@/authentication/decorators/Roles.decorator'
 import { PositionsService } from './positions.service'
 import { CreatePositionSchema } from './schemas/CreatePosition.schema'
 import { UpdatePositionSchema } from './schemas/UpdatePosition.schema'
@@ -33,11 +35,13 @@ export class PositionsController {
   }
 
   @Post()
+  @Roles(UserRole.admin)
   create(@Body() body: CreatePositionSchema) {
     return this.positionsService.create(body)
   }
 
   @Put(':id')
+  @Roles(UserRole.admin)
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() body: UpdatePositionSchema,
@@ -46,6 +50,7 @@ export class PositionsController {
   }
 
   @Delete(':id')
+  @Roles(UserRole.admin)
   @HttpCode(HttpStatus.NO_CONTENT)
   delete(@Param('id', ParseIntPipe) id: number) {
     return this.positionsService.delete(id)


### PR DESCRIPTION
## Summary

Restrict create, update, and delete operations on positions to admin users only by adding the `@Roles(UserRole.admin)` decorator to the corresponding controller endpoints.

## Changes

- Added `UserRole` import from `@prisma/client`
- Added `Roles` decorator import from authentication module
- Applied `@Roles(UserRole.admin)` to:
  - `POST /positions` (create)
  - `PUT /positions/:id` (update)
  - `DELETE /positions/:id` (delete)

## Implementation Details

The `@Roles` decorator is applied before the route handler methods, ensuring role validation occurs before business logic execution. Read-only endpoints (`GET`) remain unrestricted.

https://claude.ai/code/session_01AJwhZ2JbMqeF2iWuoCc2fj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization for `POST`/`PUT`/`DELETE` `positions` routes, which can break existing clients or workflows that relied on non-admin access. Low implementation risk (decorator-only) but impacts access control behavior in production.
> 
> **Overview**
> Restricts write access to positions by requiring `UserRole.admin` on `POST /positions`, `PUT /positions/:id`, and `DELETE /positions/:id` via the `@Roles()` decorator.
> 
> Read-only listing (`GET /positions`) remains unchanged and unrestricted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 264f59d31a46a4a8d72757124fb56c9bd63d8972. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->