### PR TITLE
Add campaign ID validation to position update/delete

### DIFF
--- a/src/campaigns/positions/campaignPositions.controller.ts
+++ b/src/campaigns/positions/campaignPositions.controller.ts
@@ -47,12 +47,13 @@ export class CampaignPositionsController {
   }
 
   @Put(':positionId')
-  update(
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async update(
     @Param('id', ParseIntPipe) id: number,
     @Param('positionId', ParseIntPipe) positionId: number,
     @Body() body: UpdateCampaignPositionSchema,
   ) {
-    return this.campaignPositionsService.update(positionId, id, body)
+    await this.campaignPositionsService.update(positionId, id, body)
   }
 
   @Delete(':positionId')

--- a/src/campaigns/positions/campaignPositions.controller.ts
+++ b/src/campaigns/positions/campaignPositions.controller.ts
@@ -48,15 +48,19 @@ export class CampaignPositionsController {
 
   @Put(':positionId')
   update(
+    @Param('id', ParseIntPipe) id: number,
     @Param('positionId', ParseIntPipe) positionId: number,
     @Body() body: UpdateCampaignPositionSchema,
   ) {
-    return this.campaignPositionsService.update(positionId, body)
+    return this.campaignPositionsService.update(positionId, id, body)
   }
 
   @Delete(':positionId')
   @HttpCode(HttpStatus.NO_CONTENT)
-  delete(@Param('positionId', ParseIntPipe) positionId: number) {
-    return this.campaignPositionsService.delete(positionId)
+  async delete(
+    @Param('id', ParseIntPipe) id: number,
+    @Param('positionId', ParseIntPipe) positionId: number,
+  ) {
+    await this.campaignPositionsService.delete(positionId, id)
   }
 }

--- a/src/campaigns/positions/campaignPositions.service.test.ts
+++ b/src/campaigns/positions/campaignPositions.service.test.ts
@@ -1,0 +1,72 @@
+import { NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CampaignPositionsService } from './campaignPositions.service'
+
+const mockUpdateMany = vi.fn()
+const mockDeleteMany = vi.fn()
+
+vi.mock('src/prisma/util/prisma.util', () => ({
+  MODELS: { CampaignPosition: 'CampaignPosition' },
+  createPrismaBase: () =>
+    class {
+      model = {
+        updateMany: mockUpdateMany,
+        deleteMany: mockDeleteMany,
+      }
+    },
+}))
+
+describe('CampaignPositionsService', () => {
+  let service: CampaignPositionsService
+
+  beforeEach(() => {
+    service = new CampaignPositionsService()
+  })
+
+  describe('update', () => {
+    it('updates when position belongs to campaign', async () => {
+      mockUpdateMany.mockResolvedValue({ count: 1 })
+
+      await expect(
+        service.update(10, 1, {
+          description: 'new',
+          order: 2,
+        }),
+      ).resolves.toBeUndefined()
+
+      expect(mockUpdateMany).toHaveBeenCalledWith({
+        where: { id: 10, campaignId: 1 },
+        data: { description: 'new', order: 2 },
+      })
+    })
+
+    it('throws NotFoundException when position does not belong to campaign', async () => {
+      mockUpdateMany.mockResolvedValue({ count: 0 })
+
+      await expect(
+        service.update(10, 999, {
+          description: 'new',
+          order: 2,
+        }),
+      ).rejects.toThrow(NotFoundException)
+    })
+  })
+
+  describe('delete', () => {
+    it('deletes when position belongs to campaign', async () => {
+      mockDeleteMany.mockResolvedValue({ count: 1 })
+
+      await expect(service.delete(10, 1)).resolves.toBeUndefined()
+
+      expect(mockDeleteMany).toHaveBeenCalledWith({
+        where: { id: 10, campaignId: 1 },
+      })
+    })
+
+    it('throws NotFoundException when position does not belong to campaign', async () => {
+      mockDeleteMany.mockResolvedValue({ count: 0 })
+
+      await expect(service.delete(10, 999)).rejects.toThrow(NotFoundException)
+    })
+  })
+})

--- a/src/campaigns/positions/campaignPositions.service.ts
+++ b/src/campaigns/positions/campaignPositions.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, NotFoundException } from '@nestjs/common'
 import { CreateCampaignPositionSchema } from './schemas/CreateCampaignPosition.schema'
 import { UpdateCampaignPositionSchema } from './schemas/UpdateCampaignPosition.schema'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
@@ -26,17 +26,29 @@ export class CampaignPositionsService extends createPrismaBase(
     return this.model.create({ data })
   }
 
-  update(id: number, { description, order }: UpdateCampaignPositionSchema) {
-    return this.model.update({
-      where: { id },
+  async update(
+    id: number,
+    campaignId: number,
+    { description, order }: UpdateCampaignPositionSchema,
+  ) {
+    const { count } = await this.model.updateMany({
+      where: { id, campaignId },
       data: {
         description,
         order,
       },
     })
+    if (count === 0) {
+      throw new NotFoundException()
+    }
   }
 
-  delete(id: number) {
-    return this.model.delete({ where: { id } })
+  async delete(id: number, campaignId: number) {
+    const { count } = await this.model.deleteMany({
+      where: { id, campaignId },
+    })
+    if (count === 0) {
+      throw new NotFoundException()
+    }
   }
 }


### PR DESCRIPTION
## Summary

Add campaign ID parameter to campaign position update and delete operations to enforce ownership validation. This ensures positions can only be modified/deleted within their parent campaign context.

## Changes

- **Service layer** (`campaignPositions.service.ts`):
  - Import `NotFoundException` from `@nestjs/common`
  - Update `update()` to accept `campaignId` parameter and use `updateMany()` with both `id` and `campaignId` in the where clause
  - Update `delete()` to accept `campaignId` parameter and use `deleteMany()` with both `id` and `campaignId` in the where clause
  - Add `NotFoundException` throws when `count === 0` (no matching record found) in both methods
  - Make both methods `async`

- **Controller layer** (`campaignPositions.controller.ts`):
  - Add `@Param('id', ParseIntPipe) id: number` to `update()` method to extract campaign ID from route
  - Pass campaign ID to service `update()` call
  - Add `@Param('id', ParseIntPipe) id: number` to `delete()` method to extract campaign ID from route
  - Make `delete()` method `async` and `await` the service call
  - Pass campaign ID to service `delete()` call

## Implementation Details

- Uses Prisma's `updateMany()` and `deleteMany()` instead of `update()` and `delete()` to support multi-field where clauses and return a count
- Throws `NotFoundException` when no records match the combined `id` + `campaignId` criteria, preventing silent failures
- Maintains strict scope: only the campaign position endpoints are modified

https://claude.ai/code/session_01QdG3quEjBim3AskD1FscVy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens authorization boundaries on campaign-owned resources; behavior change for clients that previously called update/delete with only a position id that belonged to another campaign.
> 
> **Overview**
> **Campaign position update and delete are now scoped to the campaign in the URL**, matching how create already injects `campaignId` from the route instead of trusting only the position id.
> 
> The controller passes the route `id` (campaign) into `update` and `delete`. The service uses `updateMany` / `deleteMany` with `where: { id, campaignId }` and throws **`NotFoundException`** when nothing matches, so a valid position id under another campaign cannot be changed or removed through this endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01606299f5e251d7dfd2192b671ab0506d8ffa58. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->