### PR TITLE
Prevent Clerk identity rebinding on existing users

### DIFF
--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -424,133 +424,80 @@ describe('UsersService', () => {
   })
 
   describe('findOrProvisionByClerk', () => {
+    const provision = (
+      clerkId: string,
+      email: string,
+      first = 'Test',
+      last = 'User',
+    ) =>
+      usersService.findOrProvisionByClerk({
+        clerkId,
+        email,
+        firstName: first,
+        lastName: last,
+      })
+
+    const createUser = (email: string, clerkId: string | null = null) =>
+      service.prisma.user.create({
+        data: { email, clerkId },
+      })
+
     it('returns existing user when found by clerkId', async () => {
-      const existing = await service.prisma.user.create({
-        data: {
-          email: 'clerk-existing@test.goodparty.org',
-          clerkId: 'user_existing_clerk',
-          firstName: 'Existing',
-          lastName: 'User',
-        },
-      })
-
-      const result = await usersService.findOrProvisionByClerk({
-        clerkId: 'user_existing_clerk',
-        email: 'clerk-existing@test.goodparty.org',
-        firstName: 'Existing',
-        lastName: 'User',
-      })
-
-      expect(result).not.toBeNull()
+      const existing = await createUser(
+        'clerk-existing@test.goodparty.org',
+        'user_existing',
+      )
+      const result = await provision(
+        'user_existing',
+        'clerk-existing@test.goodparty.org',
+      )
       expect(result?.id).toBe(existing.id)
     })
 
-    it('returns null when email matches a user that already has a clerkId', async () => {
-      await service.prisma.user.create({
-        data: {
-          email: 'victim@test.goodparty.org',
-          clerkId: 'user_victim_clerk',
-          firstName: 'Victim',
-          lastName: 'User',
-        },
-      })
-
-      const result = await usersService.findOrProvisionByClerk({
-        clerkId: 'user_attacker_clerk',
-        email: 'victim@test.goodparty.org',
-        firstName: 'Attacker',
-        lastName: 'User',
-      })
-
+    it('returns null and preserves clerkId when email matches a user that already has one', async () => {
+      const victim = await createUser(
+        'victim@test.goodparty.org',
+        'user_victim',
+      )
+      const result = await provision(
+        'user_attacker',
+        'victim@test.goodparty.org',
+      )
       expect(result).toBeNull()
-    })
-
-    it('does not overwrite clerkId on a user that already has one', async () => {
-      const victim = await service.prisma.user.create({
-        data: {
-          email: 'no-rebind@test.goodparty.org',
-          clerkId: 'user_original_clerk',
-          firstName: 'Original',
-          lastName: 'User',
-        },
-      })
-
-      await usersService.findOrProvisionByClerk({
-        clerkId: 'user_attacker_clerk',
-        email: 'no-rebind@test.goodparty.org',
-        firstName: 'Attacker',
-        lastName: 'User',
-      })
-
       const after = await service.prisma.user.findUnique({
         where: { id: victim.id },
       })
-      expect(after?.clerkId).toBe('user_original_clerk')
+      expect(after?.clerkId).toBe('user_victim')
     })
 
-    it('links legacy user with null clerkId to new Clerk identity', async () => {
-      const legacy = await service.prisma.user.create({
-        data: {
-          email: 'legacy@test.goodparty.org',
-          clerkId: null,
-          firstName: 'Legacy',
-          lastName: 'User',
-        },
-      })
-
-      const result = await usersService.findOrProvisionByClerk({
-        clerkId: 'user_new_clerk',
-        email: 'legacy@test.goodparty.org',
-        firstName: 'Legacy',
-        lastName: 'User',
-      })
-
-      expect(result).not.toBeNull()
+    it('links legacy user with null clerkId', async () => {
+      const legacy = await createUser('legacy@test.goodparty.org')
+      const result = await provision('user_new', 'legacy@test.goodparty.org')
       expect(result?.id).toBe(legacy.id)
-
       const after = await service.prisma.user.findUnique({
         where: { id: legacy.id },
       })
-      expect(after?.clerkId).toBe('user_new_clerk')
+      expect(after?.clerkId).toBe('user_new')
     })
 
-    it('creates a new user when no match by clerkId or email', async () => {
-      const result = await usersService.findOrProvisionByClerk({
-        clerkId: 'user_brand_new',
-        email: 'brand-new@test.goodparty.org',
-        firstName: 'Brand',
-        lastName: 'New',
-      })
-
-      expect(result).not.toBeNull()
+    it('creates a new user when no match', async () => {
+      const result = await provision(
+        'user_brand_new',
+        'brand-new@test.goodparty.org',
+      )
       expect(result?.clerkId).toBe('user_brand_new')
       expect(result?.email).toBe('brand-new@test.goodparty.org')
     })
 
-    it('returns user when updateMany count=0 but concurrent writer bound same clerkId', async () => {
-      const legacy = await service.prisma.user.create({
-        data: {
-          email: 'occ-same@test.goodparty.org',
-          clerkId: null,
-          firstName: 'OCC',
-          lastName: 'Same',
-        },
-      })
+    it('returns user when updateMany loses race to same clerkId', async () => {
+      const legacy = await createUser('occ-same@test.goodparty.org')
       await service.prisma.user.update({
         where: { id: legacy.id },
-        data: { clerkId: 'user_same_clerk' },
+        data: { clerkId: 'user_same' },
       })
-
-      const result = await usersService.findOrProvisionByClerk({
-        clerkId: 'user_same_clerk',
-        email: 'occ-same@test.goodparty.org',
-        firstName: 'OCC',
-        lastName: 'Same',
-      })
-
-      expect(result).not.toBeNull()
+      const result = await provision('user_same', 'occ-same@test.goodparty.org')
       expect(result?.id).toBe(legacy.id)
-      expect(result?.clerkId).toBe('user_same_clerk')
+      expect(result?.clerkId).toBe('user_same')
     })
 
     describe('P2002 race recovery', () => {
@@ -558,78 +505,39 @@ describe('UsersService', () => {
         'Unique constraint failed',
         { code: 'P2002', clientVersion: '5.0.0' },
       )
+      const stubP2002 = () =>
+        vi.spyOn(usersService.model, 'create').mockRejectedValueOnce(p2002)
 
-      it('returns user when P2002 and found by clerkId', async () => {
-        const existing = await service.prisma.user.create({
-          data: {
-            email: 'p2002-clerk@test.goodparty.org',
-            clerkId: 'user_p2002_winner',
-            firstName: 'P2002',
-            lastName: 'Winner',
-          },
-        })
-        vi.spyOn(
-          usersService.model,
-          'create',
-        ).mockRejectedValueOnce(p2002)
-
-        const result = await usersService.findOrProvisionByClerk({
-          clerkId: 'user_p2002_winner',
-          email: 'p2002-clerk@test.goodparty.org',
-          firstName: 'P2002',
-          lastName: 'Winner',
-        })
-
-        expect(result).not.toBeNull()
+      it('returns user found by clerkId', async () => {
+        const existing = await createUser(
+          'p2002-clerk@test.goodparty.org',
+          'user_p2002_winner',
+        )
+        stubP2002()
+        const result = await provision(
+          'user_p2002_winner',
+          'p2002-clerk@test.goodparty.org',
+        )
         expect(result?.id).toBe(existing.id)
       })
 
-      it('returns null when P2002 and email match has different clerkId', async () => {
-        await service.prisma.user.create({
-          data: {
-            email: 'p2002-diff@test.goodparty.org',
-            clerkId: 'user_p2002_other',
-            firstName: 'P2002',
-            lastName: 'Other',
-          },
-        })
-        vi.spyOn(
-          usersService.model,
-          'create',
-        ).mockRejectedValueOnce(p2002)
-
-        const result = await usersService.findOrProvisionByClerk({
-          clerkId: 'user_p2002_attacker',
-          email: 'p2002-diff@test.goodparty.org',
-          firstName: 'Attacker',
-          lastName: 'User',
-        })
-
+      it('returns null when email match has different clerkId', async () => {
+        await createUser('p2002-diff@test.goodparty.org', 'user_p2002_other')
+        stubP2002()
+        const result = await provision(
+          'user_p2002_attacker',
+          'p2002-diff@test.goodparty.org',
+        )
         expect(result).toBeNull()
       })
 
-      it('links legacy user when P2002 and email match has null clerkId', async () => {
-        const legacy = await service.prisma.user.create({
-          data: {
-            email: 'p2002-legacy@test.goodparty.org',
-            clerkId: null,
-            firstName: 'P2002',
-            lastName: 'Legacy',
-          },
-        })
-        vi.spyOn(
-          usersService.model,
-          'create',
-        ).mockRejectedValueOnce(p2002)
-
-        const result = await usersService.findOrProvisionByClerk({
-          clerkId: 'user_p2002_linker',
-          email: 'p2002-legacy@test.goodparty.org',
-          firstName: 'P2002',
-          lastName: 'Legacy',
-        })
-
-        expect(result).not.toBeNull()
+      it('links legacy user with null clerkId', async () => {
+        const legacy = await createUser('p2002-legacy@test.goodparty.org')
+        stubP2002()
+        const result = await provision(
+          'user_p2002_linker',
+          'p2002-legacy@test.goodparty.org',
+        )
         expect(result?.id).toBe(legacy.id)
         const after = await service.prisma.user.findUnique({
           where: { id: legacy.id },
@@ -637,19 +545,12 @@ describe('UsersService', () => {
         expect(after?.clerkId).toBe('user_p2002_linker')
       })
 
-      it('returns null when P2002 and neither lookup resolves', async () => {
-        vi.spyOn(
-          usersService.model,
-          'create',
-        ).mockRejectedValueOnce(p2002)
-
-        const result = await usersService.findOrProvisionByClerk({
-          clerkId: 'user_p2002_ghost',
-          email: 'p2002-ghost@test.goodparty.org',
-          firstName: 'Ghost',
-          lastName: 'User',
-        })
-
+      it('returns null when neither lookup resolves', async () => {
+        stubP2002()
+        const result = await provision(
+          'user_p2002_ghost',
+          'p2002-ghost@test.goodparty.org',
+        )
         expect(result).toBeNull()
       })
     })

--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -498,56 +498,6 @@ describe('UsersService', () => {
       expect(result?.id).toBe(legacy.id)
       expect(result?.clerkId).toBe('user_same')
     })
-
-    describe('P2002 race recovery', () => {
-      it('returns user found by clerkId', async () => {
-        const existing = await createUser(
-          'p2002-clerk@test.goodparty.org',
-          'user_p2002_winner',
-        )
-        vi.spyOn(usersService, 'findUserByEmail').mockResolvedValueOnce(null)
-        const result = await provision(
-          'user_p2002_winner',
-          'p2002-clerk@test.goodparty.org',
-        )
-        expect(result?.id).toBe(existing.id)
-      })
-
-      it('returns null when email match has different clerkId', async () => {
-        await createUser('p2002-diff@test.goodparty.org', 'user_p2002_other')
-        vi.spyOn(usersService, 'findUserByEmail').mockResolvedValueOnce(null)
-        const result = await provision(
-          'user_p2002_attacker',
-          'p2002-diff@test.goodparty.org',
-        )
-        expect(result).toBeNull()
-      })
-
-      it('links legacy user with null clerkId', async () => {
-        const legacy = await createUser('p2002-legacy@test.goodparty.org')
-        vi.spyOn(usersService, 'findUserByEmail').mockResolvedValueOnce(null)
-        const result = await provision(
-          'user_p2002_linker',
-          'p2002-legacy@test.goodparty.org',
-        )
-        expect(result?.id).toBe(legacy.id)
-        const after = await service.prisma.user.findUnique({
-          where: { id: legacy.id },
-        })
-        expect(after?.clerkId).toBe('user_p2002_linker')
-      })
-
-      it('returns null when neither lookup resolves', async () => {
-        await createUser('p2002-ghost@test.goodparty.org', 'user_p2002_taken')
-        vi.spyOn(usersService, 'findUserByEmail').mockResolvedValueOnce(null)
-        vi.spyOn(usersService, 'findUser').mockResolvedValueOnce(null)
-        const result = await provision(
-          'user_p2002_ghost',
-          'p2002-ghost@test.goodparty.org',
-        )
-        expect(result).toBeNull()
-      })
-    })
   })
 
   describe('deleteUser', () => {

--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -505,15 +505,13 @@ describe('UsersService', () => {
         'Unique constraint failed',
         { code: 'P2002', clientVersion: '5.0.0' },
       )
-      const stubP2002 = () =>
-        vi.spyOn(usersService.model, 'create').mockRejectedValueOnce(p2002)
 
       it('returns user found by clerkId', async () => {
         const existing = await createUser(
           'p2002-clerk@test.goodparty.org',
           'user_p2002_winner',
         )
-        stubP2002()
+        vi.spyOn(service.prisma.user, 'create').mockRejectedValueOnce(p2002)
         const result = await provision(
           'user_p2002_winner',
           'p2002-clerk@test.goodparty.org',
@@ -523,7 +521,7 @@ describe('UsersService', () => {
 
       it('returns null when email match has different clerkId', async () => {
         await createUser('p2002-diff@test.goodparty.org', 'user_p2002_other')
-        stubP2002()
+        vi.spyOn(service.prisma.user, 'create').mockRejectedValueOnce(p2002)
         const result = await provision(
           'user_p2002_attacker',
           'p2002-diff@test.goodparty.org',
@@ -533,7 +531,7 @@ describe('UsersService', () => {
 
       it('links legacy user with null clerkId', async () => {
         const legacy = await createUser('p2002-legacy@test.goodparty.org')
-        stubP2002()
+        vi.spyOn(service.prisma.user, 'create').mockRejectedValueOnce(p2002)
         const result = await provision(
           'user_p2002_linker',
           'p2002-legacy@test.goodparty.org',
@@ -546,7 +544,7 @@ describe('UsersService', () => {
       })
 
       it('returns null when neither lookup resolves', async () => {
-        stubP2002()
+        vi.spyOn(service.prisma.user, 'create').mockRejectedValueOnce(p2002)
         const result = await provision(
           'user_p2002_ghost',
           'p2002-ghost@test.goodparty.org',

--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -2,7 +2,6 @@ import { useTestService } from '@/test-service'
 import { CLERK_CLIENT_PROVIDER_TOKEN } from '@/vendors/clerk/providers/clerk-client.provider'
 import { ClerkClient } from '@clerk/backend'
 import { BadGatewayException, BadRequestException } from '@nestjs/common'
-import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { UsersService, type ResolvedActorIdentity } from './users.service'
 import { AnalyticsService } from '@/analytics/analytics.service'
@@ -501,17 +500,12 @@ describe('UsersService', () => {
     })
 
     describe('P2002 race recovery', () => {
-      const p2002 = new PrismaClientKnownRequestError(
-        'Unique constraint failed',
-        { code: 'P2002', clientVersion: '5.0.0' },
-      )
-
       it('returns user found by clerkId', async () => {
         const existing = await createUser(
           'p2002-clerk@test.goodparty.org',
           'user_p2002_winner',
         )
-        vi.spyOn(service.prisma.user, 'create').mockRejectedValueOnce(p2002)
+        vi.spyOn(usersService, 'findUserByEmail').mockResolvedValueOnce(null)
         const result = await provision(
           'user_p2002_winner',
           'p2002-clerk@test.goodparty.org',
@@ -521,7 +515,7 @@ describe('UsersService', () => {
 
       it('returns null when email match has different clerkId', async () => {
         await createUser('p2002-diff@test.goodparty.org', 'user_p2002_other')
-        vi.spyOn(service.prisma.user, 'create').mockRejectedValueOnce(p2002)
+        vi.spyOn(usersService, 'findUserByEmail').mockResolvedValueOnce(null)
         const result = await provision(
           'user_p2002_attacker',
           'p2002-diff@test.goodparty.org',
@@ -531,7 +525,7 @@ describe('UsersService', () => {
 
       it('links legacy user with null clerkId', async () => {
         const legacy = await createUser('p2002-legacy@test.goodparty.org')
-        vi.spyOn(service.prisma.user, 'create').mockRejectedValueOnce(p2002)
+        vi.spyOn(usersService, 'findUserByEmail').mockResolvedValueOnce(null)
         const result = await provision(
           'user_p2002_linker',
           'p2002-legacy@test.goodparty.org',
@@ -544,7 +538,9 @@ describe('UsersService', () => {
       })
 
       it('returns null when neither lookup resolves', async () => {
-        vi.spyOn(service.prisma.user, 'create').mockRejectedValueOnce(p2002)
+        await createUser('p2002-ghost@test.goodparty.org', 'user_p2002_taken')
+        vi.spyOn(usersService, 'findUserByEmail').mockResolvedValueOnce(null)
+        vi.spyOn(usersService, 'findUser').mockResolvedValueOnce(null)
         const result = await provision(
           'user_p2002_ghost',
           'p2002-ghost@test.goodparty.org',

--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -422,6 +422,111 @@ describe('UsersService', () => {
     })
   })
 
+  describe('findOrProvisionByClerk', () => {
+    it('returns existing user when found by clerkId', async () => {
+      const existing = await service.prisma.user.create({
+        data: {
+          email: 'clerk-existing@test.goodparty.org',
+          clerkId: 'user_existing_clerk',
+          firstName: 'Existing',
+          lastName: 'User',
+        },
+      })
+
+      const result = await usersService.findOrProvisionByClerk({
+        clerkId: 'user_existing_clerk',
+        email: 'clerk-existing@test.goodparty.org',
+        firstName: 'Existing',
+        lastName: 'User',
+      })
+
+      expect(result).not.toBeNull()
+      expect(result?.id).toBe(existing.id)
+    })
+
+    it('returns null when email matches a user that already has a clerkId', async () => {
+      await service.prisma.user.create({
+        data: {
+          email: 'victim@test.goodparty.org',
+          clerkId: 'user_victim_clerk',
+          firstName: 'Victim',
+          lastName: 'User',
+        },
+      })
+
+      const result = await usersService.findOrProvisionByClerk({
+        clerkId: 'user_attacker_clerk',
+        email: 'victim@test.goodparty.org',
+        firstName: 'Attacker',
+        lastName: 'User',
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it('does not overwrite clerkId on a user that already has one', async () => {
+      const victim = await service.prisma.user.create({
+        data: {
+          email: 'no-rebind@test.goodparty.org',
+          clerkId: 'user_original_clerk',
+          firstName: 'Original',
+          lastName: 'User',
+        },
+      })
+
+      await usersService.findOrProvisionByClerk({
+        clerkId: 'user_attacker_clerk',
+        email: 'no-rebind@test.goodparty.org',
+        firstName: 'Attacker',
+        lastName: 'User',
+      })
+
+      const after = await service.prisma.user.findUnique({
+        where: { id: victim.id },
+      })
+      expect(after?.clerkId).toBe('user_original_clerk')
+    })
+
+    it('links legacy user with null clerkId to new Clerk identity', async () => {
+      const legacy = await service.prisma.user.create({
+        data: {
+          email: 'legacy@test.goodparty.org',
+          clerkId: null,
+          firstName: 'Legacy',
+          lastName: 'User',
+        },
+      })
+
+      const result = await usersService.findOrProvisionByClerk({
+        clerkId: 'user_new_clerk',
+        email: 'legacy@test.goodparty.org',
+        firstName: 'Legacy',
+        lastName: 'User',
+      })
+
+      expect(result).not.toBeNull()
+      expect(result?.id).toBe(legacy.id)
+
+      const after = await service.prisma.user.findUnique({
+        where: { id: legacy.id },
+      })
+      expect(after?.clerkId).toBe('user_new_clerk')
+    })
+
+    it('creates a new user when no match by clerkId or email', async () => {
+      const result = await usersService.findOrProvisionByClerk({
+        clerkId: 'user_brand_new',
+        email: 'brand-new@test.goodparty.org',
+        firstName: 'Brand',
+        lastName: 'New',
+      })
+
+      expect(result).not.toBeNull()
+      expect(result?.clerkId).toBe('user_brand_new')
+      expect(result?.email).toBe('brand-new@test.goodparty.org')
+    })
+  })
+
   describe('deleteUser', () => {
     let clerkClient: ClerkClient
     let analyticsService: AnalyticsService

--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -2,6 +2,7 @@ import { useTestService } from '@/test-service'
 import { CLERK_CLIENT_PROVIDER_TOKEN } from '@/vendors/clerk/providers/clerk-client.provider'
 import { ClerkClient } from '@clerk/backend'
 import { BadGatewayException, BadRequestException } from '@nestjs/common'
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { UsersService, type ResolvedActorIdentity } from './users.service'
 import { AnalyticsService } from '@/analytics/analytics.service'
@@ -524,6 +525,133 @@ describe('UsersService', () => {
       expect(result).not.toBeNull()
       expect(result?.clerkId).toBe('user_brand_new')
       expect(result?.email).toBe('brand-new@test.goodparty.org')
+    })
+
+    it('returns user when updateMany count=0 but concurrent writer bound same clerkId', async () => {
+      const legacy = await service.prisma.user.create({
+        data: {
+          email: 'occ-same@test.goodparty.org',
+          clerkId: null,
+          firstName: 'OCC',
+          lastName: 'Same',
+        },
+      })
+      await service.prisma.user.update({
+        where: { id: legacy.id },
+        data: { clerkId: 'user_same_clerk' },
+      })
+
+      const result = await usersService.findOrProvisionByClerk({
+        clerkId: 'user_same_clerk',
+        email: 'occ-same@test.goodparty.org',
+        firstName: 'OCC',
+        lastName: 'Same',
+      })
+
+      expect(result).not.toBeNull()
+      expect(result?.id).toBe(legacy.id)
+      expect(result?.clerkId).toBe('user_same_clerk')
+    })
+
+    describe('P2002 race recovery', () => {
+      const p2002 = new PrismaClientKnownRequestError(
+        'Unique constraint failed',
+        { code: 'P2002', clientVersion: '5.0.0' },
+      )
+
+      it('returns user when P2002 and found by clerkId', async () => {
+        const existing = await service.prisma.user.create({
+          data: {
+            email: 'p2002-clerk@test.goodparty.org',
+            clerkId: 'user_p2002_winner',
+            firstName: 'P2002',
+            lastName: 'Winner',
+          },
+        })
+        vi.spyOn(
+          usersService.model,
+          'create',
+        ).mockRejectedValueOnce(p2002)
+
+        const result = await usersService.findOrProvisionByClerk({
+          clerkId: 'user_p2002_winner',
+          email: 'p2002-clerk@test.goodparty.org',
+          firstName: 'P2002',
+          lastName: 'Winner',
+        })
+
+        expect(result).not.toBeNull()
+        expect(result?.id).toBe(existing.id)
+      })
+
+      it('returns null when P2002 and email match has different clerkId', async () => {
+        await service.prisma.user.create({
+          data: {
+            email: 'p2002-diff@test.goodparty.org',
+            clerkId: 'user_p2002_other',
+            firstName: 'P2002',
+            lastName: 'Other',
+          },
+        })
+        vi.spyOn(
+          usersService.model,
+          'create',
+        ).mockRejectedValueOnce(p2002)
+
+        const result = await usersService.findOrProvisionByClerk({
+          clerkId: 'user_p2002_attacker',
+          email: 'p2002-diff@test.goodparty.org',
+          firstName: 'Attacker',
+          lastName: 'User',
+        })
+
+        expect(result).toBeNull()
+      })
+
+      it('links legacy user when P2002 and email match has null clerkId', async () => {
+        const legacy = await service.prisma.user.create({
+          data: {
+            email: 'p2002-legacy@test.goodparty.org',
+            clerkId: null,
+            firstName: 'P2002',
+            lastName: 'Legacy',
+          },
+        })
+        vi.spyOn(
+          usersService.model,
+          'create',
+        ).mockRejectedValueOnce(p2002)
+
+        const result = await usersService.findOrProvisionByClerk({
+          clerkId: 'user_p2002_linker',
+          email: 'p2002-legacy@test.goodparty.org',
+          firstName: 'P2002',
+          lastName: 'Legacy',
+        })
+
+        expect(result).not.toBeNull()
+        expect(result?.id).toBe(legacy.id)
+        const after = await service.prisma.user.findUnique({
+          where: { id: legacy.id },
+        })
+        expect(after?.clerkId).toBe('user_p2002_linker')
+      })
+
+      it('returns null when P2002 and neither lookup resolves', async () => {
+        vi.spyOn(
+          usersService.model,
+          'create',
+        ).mockRejectedValueOnce(p2002)
+
+        const result = await usersService.findOrProvisionByClerk({
+          clerkId: 'user_p2002_ghost',
+          email: 'p2002-ghost@test.goodparty.org',
+          firstName: 'Ghost',
+          lastName: 'User',
+        })
+
+        expect(result).toBeNull()
+      })
     })
   })
 

--- a/src/users/services/users.service.test.ts
+++ b/src/users/services/users.service.test.ts
@@ -498,6 +498,44 @@ describe('UsersService', () => {
       expect(result?.id).toBe(legacy.id)
       expect(result?.clerkId).toBe('user_same')
     })
+
+    describe('resolveAfterP2002 (race recovery)', () => {
+      const resolveAfterP2002 = (clerkId: string, email: string) =>
+        // @ts-expect-error accessing private method for test coverage
+        usersService.resolveAfterP2002({ clerkId, email }) as Promise<
+          Awaited<ReturnType<typeof usersService.findUser>>
+        >
+
+      it('returns null when email match has different clerkId', async () => {
+        await createUser('p2002-diff@test.goodparty.org', 'user_p2002_other')
+        const result = await resolveAfterP2002(
+          'user_p2002_attacker',
+          'p2002-diff@test.goodparty.org',
+        )
+        expect(result).toBeNull()
+      })
+
+      it('links legacy user with null clerkId', async () => {
+        const legacy = await createUser('p2002-legacy@test.goodparty.org')
+        const result = await resolveAfterP2002(
+          'user_p2002_linker',
+          'p2002-legacy@test.goodparty.org',
+        )
+        expect(result?.id).toBe(legacy.id)
+        const after = await service.prisma.user.findUnique({
+          where: { id: legacy.id },
+        })
+        expect(after?.clerkId).toBe('user_p2002_linker')
+      })
+
+      it('returns null when neither lookup resolves', async () => {
+        const result = await resolveAfterP2002(
+          'user_p2002_ghost',
+          'p2002-ghost@test.goodparty.org',
+        )
+        expect(result).toBeNull()
+      })
+    })
   })
 
   describe('deleteUser', () => {

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -229,7 +229,21 @@ export class UsersService extends createPrismaBase(MODELS.User) {
             existingClerkId: existingByEmail.clerkId,
             incomingClerkId: data.clerkId,
           },
-          'Refused clerkId rebind on user that already has a Clerk identity',
+          'Refused clerkId rebind: user already has a Clerk identity',
+        )
+        return null
+      }
+      const updated = await this.model.updateMany({
+        where: { id: existingByEmail.id, clerkId: null },
+        data: { clerkId: data.clerkId },
+      })
+      if (updated.count === 0) {
+        this.logger.warn(
+          {
+            userId: existingByEmail.id,
+            incomingClerkId: data.clerkId,
+          },
+          'Refused clerkId rebind: concurrent writer set clerkId first',
         )
         return null
       }
@@ -237,10 +251,7 @@ export class UsersService extends createPrismaBase(MODELS.User) {
         { userId: existingByEmail.id, clerkId: data.clerkId },
         'Linking legacy user to Clerk account',
       )
-      return this.updateUser(
-        { id: existingByEmail.id },
-        { clerkId: data.clerkId },
-      )
+      return this.findUser({ id: existingByEmail.id })
     }
 
     try {

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -238,6 +238,10 @@ export class UsersService extends createPrismaBase(MODELS.User) {
         data: { clerkId: data.clerkId },
       })
       if (updated.count === 0) {
+        const refetched = await this.findUser({
+          id: existingByEmail.id,
+        })
+        if (refetched?.clerkId === data.clerkId) return refetched
         this.logger.warn(
           {
             userId: existingByEmail.id,
@@ -278,25 +282,52 @@ export class UsersService extends createPrismaBase(MODELS.User) {
           { clerkId: data.clerkId },
           'Concurrent provisioning detected, fetching existing user',
         )
-        const byClerkId = await this.findUser({ clerkId: data.clerkId })
+        const byClerkId = await this.findUser({
+          clerkId: data.clerkId,
+        })
         if (byClerkId) return byClerkId
+
         const byEmail = await this.findUserByEmail(data.email)
-        if (byEmail?.clerkId && byEmail.clerkId !== data.clerkId) {
+        if (!byEmail) {
+          this.logger.error(
+            { clerkId: data.clerkId, email: data.email },
+            'P2002 race but user not found by clerkId or email',
+          )
+          return null
+        }
+        if (byEmail.clerkId && byEmail.clerkId !== data.clerkId) {
           this.logger.warn(
             {
               userId: byEmail.id,
               existingClerkId: byEmail.clerkId,
               incomingClerkId: data.clerkId,
             },
-            'P2002 race resolved to email match with different clerkId: refusing rebind',
+            'P2002 race: email match has different clerkId, refusing rebind',
           )
           return null
         }
-        if (!byEmail) {
-          this.logger.error(
-            { clerkId: data.clerkId, email: data.email },
-            'P2002 race but user not found by clerkId or email',
-          )
+        if (!byEmail.clerkId) {
+          const linked = await this.model.updateMany({
+            where: { id: byEmail.id, clerkId: null },
+            data: { clerkId: data.clerkId },
+          })
+          if (linked.count === 0) {
+            const refetched = await this.findUser({
+              id: byEmail.id,
+            })
+            if (refetched?.clerkId === data.clerkId) {
+              return refetched
+            }
+            this.logger.warn(
+              {
+                userId: byEmail.id,
+                incomingClerkId: data.clerkId,
+              },
+              'P2002 race: concurrent writer set clerkId first',
+            )
+            return null
+          }
+          return this.findUser({ id: byEmail.id })
         }
         return byEmail
       }

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -217,7 +217,9 @@ export class UsersService extends createPrismaBase(MODELS.User) {
     firstName: string
     lastName: string
   }): Promise<User | null> {
-    const existingByClerkId = await this.findUser({ clerkId: data.clerkId })
+    const existingByClerkId = await this.findUser({
+      clerkId: data.clerkId,
+    })
     if (existingByClerkId) return existingByClerkId
 
     const existingByEmail = await this.findUserByEmail(data.email)
@@ -233,29 +235,7 @@ export class UsersService extends createPrismaBase(MODELS.User) {
         )
         return null
       }
-      const updated = await this.model.updateMany({
-        where: { id: existingByEmail.id, clerkId: null },
-        data: { clerkId: data.clerkId },
-      })
-      if (updated.count === 0) {
-        const refetched = await this.findUser({
-          id: existingByEmail.id,
-        })
-        if (refetched?.clerkId === data.clerkId) return refetched
-        this.logger.warn(
-          {
-            userId: existingByEmail.id,
-            incomingClerkId: data.clerkId,
-          },
-          'Refused clerkId rebind: concurrent writer set clerkId first',
-        )
-        return null
-      }
-      this.logger.info(
-        { userId: existingByEmail.id, clerkId: data.clerkId },
-        'Linking legacy user to Clerk account',
-      )
-      return this.findUser({ id: existingByEmail.id })
+      return this.tryBindClerkId(existingByEmail.id, data.clerkId)
     }
 
     try {
@@ -278,61 +258,72 @@ export class UsersService extends createPrismaBase(MODELS.User) {
         err instanceof PrismaClientKnownRequestError &&
         err.code === 'P2002'
       ) {
-        this.logger.debug(
-          { clerkId: data.clerkId },
-          'Concurrent provisioning detected, fetching existing user',
-        )
-        const byClerkId = await this.findUser({
-          clerkId: data.clerkId,
-        })
-        if (byClerkId) return byClerkId
-
-        const byEmail = await this.findUserByEmail(data.email)
-        if (!byEmail) {
-          this.logger.error(
-            { clerkId: data.clerkId, email: data.email },
-            'P2002 race but user not found by clerkId or email',
-          )
-          return null
-        }
-        if (byEmail.clerkId && byEmail.clerkId !== data.clerkId) {
-          this.logger.warn(
-            {
-              userId: byEmail.id,
-              existingClerkId: byEmail.clerkId,
-              incomingClerkId: data.clerkId,
-            },
-            'P2002 race: email match has different clerkId, refusing rebind',
-          )
-          return null
-        }
-        if (!byEmail.clerkId) {
-          const linked = await this.model.updateMany({
-            where: { id: byEmail.id, clerkId: null },
-            data: { clerkId: data.clerkId },
-          })
-          if (linked.count === 0) {
-            const refetched = await this.findUser({
-              id: byEmail.id,
-            })
-            if (refetched?.clerkId === data.clerkId) {
-              return refetched
-            }
-            this.logger.warn(
-              {
-                userId: byEmail.id,
-                incomingClerkId: data.clerkId,
-              },
-              'P2002 race: concurrent writer set clerkId first',
-            )
-            return null
-          }
-          return this.findUser({ id: byEmail.id })
-        }
-        return byEmail
+        return this.resolveAfterP2002(data)
       }
       throw err
     }
+  }
+
+  private async tryBindClerkId(
+    userId: number,
+    clerkId: string,
+  ): Promise<User | null> {
+    const updated = await this.model.updateMany({
+      where: { id: userId, clerkId: null },
+      data: { clerkId },
+    })
+    if (updated.count === 0) {
+      const refetched = await this.findUser({ id: userId })
+      if (refetched?.clerkId === clerkId) return refetched
+      this.logger.warn(
+        { userId, incomingClerkId: clerkId },
+        'Refused clerkId rebind: concurrent writer set clerkId first',
+      )
+      return null
+    }
+    this.logger.info(
+      { userId, clerkId },
+      'Linking legacy user to Clerk account',
+    )
+    return this.findUser({ id: userId })
+  }
+
+  private async resolveAfterP2002(data: {
+    clerkId: string
+    email: string
+  }): Promise<User | null> {
+    this.logger.debug(
+      { clerkId: data.clerkId },
+      'Concurrent provisioning detected, fetching existing user',
+    )
+    const byClerkId = await this.findUser({
+      clerkId: data.clerkId,
+    })
+    if (byClerkId) return byClerkId
+
+    const byEmail = await this.findUserByEmail(data.email)
+    if (!byEmail) {
+      this.logger.error(
+        { clerkId: data.clerkId, email: data.email },
+        'P2002 race but user not found by clerkId or email',
+      )
+      return null
+    }
+    if (byEmail.clerkId && byEmail.clerkId !== data.clerkId) {
+      this.logger.warn(
+        {
+          userId: byEmail.id,
+          existingClerkId: byEmail.clerkId,
+          incomingClerkId: data.clerkId,
+        },
+        'P2002 race: email match has different clerkId, refusing rebind',
+      )
+      return null
+    }
+    if (!byEmail.clerkId) {
+      return this.tryBindClerkId(byEmail.id, data.clerkId)
+    }
+    return byEmail
   }
 
   async updateUser(where: Prisma.UserWhereUniqueInput, data: Partial<User>) {

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -222,9 +222,20 @@ export class UsersService extends createPrismaBase(MODELS.User) {
 
     const existingByEmail = await this.findUserByEmail(data.email)
     if (existingByEmail) {
+      if (existingByEmail.clerkId) {
+        this.logger.warn(
+          {
+            userId: existingByEmail.id,
+            existingClerkId: existingByEmail.clerkId,
+            incomingClerkId: data.clerkId,
+          },
+          'Refused clerkId rebind on user that already has a Clerk identity',
+        )
+        return null
+      }
       this.logger.info(
         { userId: existingByEmail.id, clerkId: data.clerkId },
-        'Linking existing user to Clerk account',
+        'Linking legacy user to Clerk account',
       )
       return this.updateUser(
         { id: existingByEmail.id },

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -278,16 +278,27 @@ export class UsersService extends createPrismaBase(MODELS.User) {
           { clerkId: data.clerkId },
           'Concurrent provisioning detected, fetching existing user',
         )
-        const existing =
-          (await this.findUser({ clerkId: data.clerkId })) ??
-          (await this.findUserByEmail(data.email))
-        if (!existing) {
+        const byClerkId = await this.findUser({ clerkId: data.clerkId })
+        if (byClerkId) return byClerkId
+        const byEmail = await this.findUserByEmail(data.email)
+        if (byEmail?.clerkId && byEmail.clerkId !== data.clerkId) {
+          this.logger.warn(
+            {
+              userId: byEmail.id,
+              existingClerkId: byEmail.clerkId,
+              incomingClerkId: data.clerkId,
+            },
+            'P2002 race resolved to email match with different clerkId: refusing rebind',
+          )
+          return null
+        }
+        if (!byEmail) {
           this.logger.error(
             { clerkId: data.clerkId, email: data.email },
             'P2002 race but user not found by clerkId or email',
           )
         }
-        return existing
+        return byEmail
       }
       throw err
     }


### PR DESCRIPTION
## Summary

Adds validation to prevent rebinding a Clerk identity to a user account that already has an associated Clerk ID. This protects against accidental or malicious identity conflicts during the user linking flow.

## Changes

- **Added rebind protection**: When linking a user by email, check if the existing user already has a `clerkId`. If so, log a warning and return `null` instead of proceeding with the update.
- **Improved logging**: Clarified the log message from "Linking existing user" to "Linking legacy user" to better reflect the scenario of connecting legacy accounts to Clerk for the first time.
- **Added context to warning**: The warning log includes the existing Clerk ID and incoming Clerk ID for debugging identity conflicts.

## Implementation Details

The check is placed early in the existing email-lookup flow, before any database updates occur. This ensures we fail safely and log the conflict for investigation without modifying user state.

https://claude.ai/code/session_014bW8faFSiYejrbdUCtDv5o

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Clerk provisioning in the session path, but the change is a fail-closed guard that prevents identity takeover rather than broadening access.
> 
> **Overview**
> **`findOrProvisionByClerk`** no longer overwrites **`clerkId`** when an email match finds a user who already has a Clerk identity. It logs a warning (user id, existing vs incoming Clerk id), returns **`null`**, and skips the DB update.
> 
> First-time email linking for users **without** a **`clerkId`** is unchanged; the info log text is clarified to **"Linking legacy user to Clerk account"**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a5393f76dba8c6d21fb708b05ec332b250d9c8d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->