### PR TITLE
Validate website status before enriching campaign user

### DIFF
--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -48,7 +48,8 @@ describe('WebsitesController', () => {
   }
   let mockWebsitesService: {
     findUniqueOrThrow: ReturnType<typeof vi.fn>
-    findByDomainName: ReturnType<typeof vi.fn>
+    findUnique: ReturnType<typeof vi.fn>
+    getWebsiteIdByDomain: ReturnType<typeof vi.fn>
     update: ReturnType<typeof vi.fn>
   }
   let mockClerkEnricher: ReturnType<typeof createMockClerkEnricher>
@@ -63,7 +64,8 @@ describe('WebsitesController', () => {
         content: completeContent,
         hasEverBeenPublished: false,
       }),
-      findByDomainName: vi.fn(),
+      findUnique: vi.fn(),
+      getWebsiteIdByDomain: vi.fn(),
       update: vi.fn().mockResolvedValue({
         id: 1,
         content: completeContent,
@@ -462,8 +464,12 @@ describe('WebsitesController', () => {
     const domain = 'example-candidate.com'
     const websiteId = 42
 
+    beforeEach(() => {
+      mockWebsitesService.getWebsiteIdByDomain.mockResolvedValue(websiteId)
+    })
+
     it('throws NotFoundException when website is null', async () => {
-      mockWebsitesService.findByDomainName.mockResolvedValue(null)
+      mockWebsitesService.findUnique.mockResolvedValue(null)
 
       await expect(controller.getWebsiteByDomain(domain)).rejects.toThrow(
         NotFoundException,
@@ -471,7 +477,7 @@ describe('WebsitesController', () => {
     })
 
     it('throws NotFoundException when unpublished', async () => {
-      mockWebsitesService.findByDomainName.mockResolvedValue({
+      mockWebsitesService.findUnique.mockResolvedValue({
         id: websiteId,
         status: WebsiteStatus.unpublished,
         content: completeContent,
@@ -483,26 +489,26 @@ describe('WebsitesController', () => {
     })
 
     it('returns published website and enriches user', async () => {
-      const mockUser = {
+      const mockDomainUser = {
         clerkId: 'clerk_123',
         firstName: 'Jane',
         lastName: 'Doe',
       }
-      mockWebsitesService.findByDomainName.mockResolvedValue({
+      mockWebsitesService.findUnique.mockResolvedValue({
         id: websiteId,
         status: WebsiteStatus.published,
         content: completeContent,
-        campaign: { user: mockUser },
+        campaign: { user: mockDomainUser },
       })
 
       const result = await controller.getWebsiteByDomain(domain)
 
       expect(result.id).toBe(websiteId)
-      expect(mockClerkEnricher.enrichUser).toHaveBeenCalledWith(mockUser)
+      expect(mockClerkEnricher.enrichUser).toHaveBeenCalledWith(mockDomainUser)
     })
 
     it('skips enrichment when no user', async () => {
-      mockWebsitesService.findByDomainName.mockResolvedValue({
+      mockWebsitesService.findUnique.mockResolvedValue({
         id: websiteId,
         status: WebsiteStatus.published,
         content: completeContent,

--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -469,74 +469,62 @@ describe('WebsitesController', () => {
     const websiteId = 42
 
     beforeEach(() => {
-      mockWebsitesService.client.domain.findUniqueOrThrow
-        .mockResolvedValue({ websiteId })
+      mockWebsitesService.client.domain.findUniqueOrThrow.mockResolvedValue({
+        websiteId,
+      })
     })
 
     it('throws NotFoundException when website is null', async () => {
       mockWebsitesService.findUnique.mockResolvedValue(null)
 
-      await expect(
-        controller.getWebsiteByDomain(domain),
-      ).rejects.toThrow(NotFoundException)
+      await expect(controller.getWebsiteByDomain(domain)).rejects.toThrow(
+        NotFoundException,
+      )
     })
 
-    it(
-      'throws NotFoundException when website is unpublished',
-      async () => {
-        mockWebsitesService.findUnique.mockResolvedValue({
-          id: websiteId,
-          status: WebsiteStatus.unpublished,
-          content: completeContent,
-        })
+    it('throws NotFoundException when website is unpublished', async () => {
+      mockWebsitesService.findUnique.mockResolvedValue({
+        id: websiteId,
+        status: WebsiteStatus.unpublished,
+        content: completeContent,
+      })
 
-        await expect(
-          controller.getWebsiteByDomain(domain),
-        ).rejects.toThrow(NotFoundException)
-      },
-    )
+      await expect(controller.getWebsiteByDomain(domain)).rejects.toThrow(
+        NotFoundException,
+      )
+    })
 
-    it(
-      'returns published website with enriched user',
-      async () => {
-        mockWebsitesService.findUnique.mockResolvedValue({
-          id: websiteId,
-          status: WebsiteStatus.published,
-          content: completeContent,
-          campaign: {
-            user: {
-              clerkId: 'clerk_123',
-              firstName: 'Jane',
-              lastName: 'Doe',
-            },
+    it('returns published website with enriched user', async () => {
+      mockWebsitesService.findUnique.mockResolvedValue({
+        id: websiteId,
+        status: WebsiteStatus.published,
+        content: completeContent,
+        campaign: {
+          user: {
+            clerkId: 'clerk_123',
+            firstName: 'Jane',
+            lastName: 'Doe',
           },
-        })
+        },
+      })
 
-        const result =
-          await controller.getWebsiteByDomain(domain)
+      const result = await controller.getWebsiteByDomain(domain)
 
-        expect(result.id).toBe(websiteId)
-        expect(result.status).toBe(
-          WebsiteStatus.published,
-        )
-      },
-    )
+      expect(result.id).toBe(websiteId)
+      expect(result.status).toBe(WebsiteStatus.published)
+    })
 
-    it(
-      'returns published website without user enrichment',
-      async () => {
-        mockWebsitesService.findUnique.mockResolvedValue({
-          id: websiteId,
-          status: WebsiteStatus.published,
-          content: completeContent,
-          campaign: { user: null },
-        })
+    it('returns published website without user enrichment', async () => {
+      mockWebsitesService.findUnique.mockResolvedValue({
+        id: websiteId,
+        status: WebsiteStatus.published,
+        content: completeContent,
+        campaign: { user: null },
+      })
 
-        const result =
-          await controller.getWebsiteByDomain(domain)
+      const result = await controller.getWebsiteByDomain(domain)
 
-        expect(result.id).toBe(websiteId)
-      },
-    )
+      expect(result.id).toBe(websiteId)
+    })
   })
 })

--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -48,14 +48,10 @@ describe('WebsitesController', () => {
   }
   let mockWebsitesService: {
     findUniqueOrThrow: ReturnType<typeof vi.fn>
-    findUnique: ReturnType<typeof vi.fn>
+    findByDomainName: ReturnType<typeof vi.fn>
     update: ReturnType<typeof vi.fn>
-    client: {
-      domain: {
-        findUniqueOrThrow: ReturnType<typeof vi.fn>
-      }
-    }
   }
+  let mockClerkEnricher: ReturnType<typeof createMockClerkEnricher>
 
   beforeEach(async () => {
     mockAnalytics = {
@@ -67,16 +63,11 @@ describe('WebsitesController', () => {
         content: completeContent,
         hasEverBeenPublished: false,
       }),
-      findUnique: vi.fn(),
+      findByDomainName: vi.fn(),
       update: vi.fn().mockResolvedValue({
         id: 1,
         content: completeContent,
       }),
-      client: {
-        domain: {
-          findUniqueOrThrow: vi.fn(),
-        },
-      },
     }
     mockFilesService = {
       uploadFile: vi.fn().mockResolvedValue('uploaded-file-url'),
@@ -93,7 +84,10 @@ describe('WebsitesController', () => {
         { provide: AnalyticsService, useValue: mockAnalytics },
         {
           provide: ClerkUserEnricherService,
-          useValue: createMockClerkEnricher(),
+          useFactory: () => {
+            mockClerkEnricher = createMockClerkEnricher()
+            return mockClerkEnricher
+          },
         },
         { provide: PinoLogger, useValue: createMockLogger() },
         WebsitesController,
@@ -468,22 +462,16 @@ describe('WebsitesController', () => {
     const domain = 'example-candidate.com'
     const websiteId = 42
 
-    beforeEach(() => {
-      mockWebsitesService.client.domain.findUniqueOrThrow.mockResolvedValue({
-        websiteId,
-      })
-    })
-
     it('throws NotFoundException when website is null', async () => {
-      mockWebsitesService.findUnique.mockResolvedValue(null)
+      mockWebsitesService.findByDomainName.mockResolvedValue(null)
 
       await expect(controller.getWebsiteByDomain(domain)).rejects.toThrow(
         NotFoundException,
       )
     })
 
-    it('throws NotFoundException when website is unpublished', async () => {
-      mockWebsitesService.findUnique.mockResolvedValue({
+    it('throws NotFoundException when unpublished', async () => {
+      mockWebsitesService.findByDomainName.mockResolvedValue({
         id: websiteId,
         status: WebsiteStatus.unpublished,
         content: completeContent,
@@ -494,28 +482,27 @@ describe('WebsitesController', () => {
       )
     })
 
-    it('returns published website with enriched user', async () => {
-      mockWebsitesService.findUnique.mockResolvedValue({
+    it('returns published website and enriches user', async () => {
+      const mockUser = {
+        clerkId: 'clerk_123',
+        firstName: 'Jane',
+        lastName: 'Doe',
+      }
+      mockWebsitesService.findByDomainName.mockResolvedValue({
         id: websiteId,
         status: WebsiteStatus.published,
         content: completeContent,
-        campaign: {
-          user: {
-            clerkId: 'clerk_123',
-            firstName: 'Jane',
-            lastName: 'Doe',
-          },
-        },
+        campaign: { user: mockUser },
       })
 
       const result = await controller.getWebsiteByDomain(domain)
 
       expect(result.id).toBe(websiteId)
-      expect(result.status).toBe(WebsiteStatus.published)
+      expect(mockClerkEnricher.enrichUser).toHaveBeenCalledWith(mockUser)
     })
 
-    it('returns published website without user enrichment', async () => {
-      mockWebsitesService.findUnique.mockResolvedValue({
+    it('skips enrichment when no user', async () => {
+      mockWebsitesService.findByDomainName.mockResolvedValue({
         id: websiteId,
         status: WebsiteStatus.published,
         content: completeContent,
@@ -525,6 +512,7 @@ describe('WebsitesController', () => {
       const result = await controller.getWebsiteByDomain(domain)
 
       expect(result.id).toBe(websiteId)
+      expect(mockClerkEnricher.enrichUser).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { HttpStatus } from '@nestjs/common'
+import { HttpStatus, NotFoundException } from '@nestjs/common'
 import { WebsiteStatus } from '@prisma/client'
 import { AnalyticsService } from 'src/analytics/analytics.service'
 import { EVENTS } from 'src/vendors/segment/segment.types'
@@ -48,7 +48,13 @@ describe('WebsitesController', () => {
   }
   let mockWebsitesService: {
     findUniqueOrThrow: ReturnType<typeof vi.fn>
+    findUnique: ReturnType<typeof vi.fn>
     update: ReturnType<typeof vi.fn>
+    client: {
+      domain: {
+        findUniqueOrThrow: ReturnType<typeof vi.fn>
+      }
+    }
   }
 
   beforeEach(async () => {
@@ -61,7 +67,16 @@ describe('WebsitesController', () => {
         content: completeContent,
         hasEverBeenPublished: false,
       }),
-      update: vi.fn().mockResolvedValue({ id: 1, content: completeContent }),
+      findUnique: vi.fn(),
+      update: vi.fn().mockResolvedValue({
+        id: 1,
+        content: completeContent,
+      }),
+      client: {
+        domain: {
+          findUniqueOrThrow: vi.fn(),
+        },
+      },
     }
     mockFilesService = {
       uploadFile: vi.fn().mockResolvedValue('uploaded-file-url'),
@@ -447,5 +462,81 @@ describe('WebsitesController', () => {
       expect(mockFilesService.uploadFile).not.toHaveBeenCalled()
       expect(mockWebsitesService.update).not.toHaveBeenCalled()
     })
+  })
+
+  describe('getWebsiteByDomain', () => {
+    const domain = 'example-candidate.com'
+    const websiteId = 42
+
+    beforeEach(() => {
+      mockWebsitesService.client.domain.findUniqueOrThrow
+        .mockResolvedValue({ websiteId })
+    })
+
+    it('throws NotFoundException when website is null', async () => {
+      mockWebsitesService.findUnique.mockResolvedValue(null)
+
+      await expect(
+        controller.getWebsiteByDomain(domain),
+      ).rejects.toThrow(NotFoundException)
+    })
+
+    it(
+      'throws NotFoundException when website is unpublished',
+      async () => {
+        mockWebsitesService.findUnique.mockResolvedValue({
+          id: websiteId,
+          status: WebsiteStatus.unpublished,
+          content: completeContent,
+        })
+
+        await expect(
+          controller.getWebsiteByDomain(domain),
+        ).rejects.toThrow(NotFoundException)
+      },
+    )
+
+    it(
+      'returns published website with enriched user',
+      async () => {
+        mockWebsitesService.findUnique.mockResolvedValue({
+          id: websiteId,
+          status: WebsiteStatus.published,
+          content: completeContent,
+          campaign: {
+            user: {
+              clerkId: 'clerk_123',
+              firstName: 'Jane',
+              lastName: 'Doe',
+            },
+          },
+        })
+
+        const result =
+          await controller.getWebsiteByDomain(domain)
+
+        expect(result.id).toBe(websiteId)
+        expect(result.status).toBe(
+          WebsiteStatus.published,
+        )
+      },
+    )
+
+    it(
+      'returns published website without user enrichment',
+      async () => {
+        mockWebsitesService.findUnique.mockResolvedValue({
+          id: websiteId,
+          status: WebsiteStatus.published,
+          content: completeContent,
+          campaign: { user: null },
+        })
+
+        const result =
+          await controller.getWebsiteByDomain(domain)
+
+        expect(result.id).toBe(websiteId)
+      },
+    )
   })
 })

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -3,6 +3,7 @@ import {
   Body,
   Controller,
   Get,
+  NotFoundException,
   Param,
   Post,
   Put,
@@ -391,7 +392,10 @@ export class WebsitesController {
       where: { id: websiteId },
       include: WEBSITE_CONTENT_INCLUDES,
     })
-    if (website?.campaign?.user) {
+    if (!website || website.status !== WebsiteStatus.published) {
+      throw new NotFoundException()
+    }
+    if (website.campaign?.user) {
       website.campaign.user = await this.clerkEnricher.enrichUser(
         website.campaign.user,
       )

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -385,10 +385,11 @@ export class WebsitesController {
   @Get('by-domain/:domain')
   @PublicAccess()
   async getWebsiteByDomain(@Param('domain') domain: string) {
-    const website = await this.websites.findByDomainName(
-      domain,
-      WEBSITE_CONTENT_INCLUDES,
-    )
+    const websiteId = await this.websites.getWebsiteIdByDomain(domain)
+    const website = await this.websites.findUnique({
+      where: { id: websiteId },
+      include: WEBSITE_CONTENT_INCLUDES,
+    })
     if (!website || website.status !== WebsiteStatus.published) {
       throw new NotFoundException()
     }

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -385,13 +385,10 @@ export class WebsitesController {
   @Get('by-domain/:domain')
   @PublicAccess()
   async getWebsiteByDomain(@Param('domain') domain: string) {
-    const { websiteId } = await this.websites.client.domain.findUniqueOrThrow({
-      where: { name: domain },
-    })
-    const website = await this.websites.findUnique({
-      where: { id: websiteId },
-      include: WEBSITE_CONTENT_INCLUDES,
-    })
+    const website = await this.websites.findByDomainName(
+      domain,
+      WEBSITE_CONTENT_INCLUDES,
+    )
     if (!website || website.status !== WebsiteStatus.published) {
       throw new NotFoundException()
     }

--- a/src/websites/services/websites.service.ts
+++ b/src/websites/services/websites.service.ts
@@ -48,10 +48,7 @@ export class WebsitesService extends createPrismaBase(MODELS.Website) {
     return this.model.update(args)
   }
 
-  async findByDomainName<I extends Prisma.WebsiteInclude>(
-    domainName: string,
-    include?: I,
-  ) {
+  async findByDomainName(domainName: string, include?: Prisma.WebsiteInclude) {
     const domainRecord = await this.client.domain.findUniqueOrThrow({
       where: { name: domainName },
       include: {
@@ -61,8 +58,13 @@ export class WebsitesService extends createPrismaBase(MODELS.Website) {
       },
     })
 
-    return domainRecord.website as Prisma.WebsiteGetPayload<{
-      include: I
-    }> | null
+    return domainRecord.website
+  }
+
+  async getWebsiteIdByDomain(domainName: string) {
+    const { websiteId } = await this.client.domain.findUniqueOrThrow({
+      where: { name: domainName },
+    })
+    return websiteId
   }
 }

--- a/src/websites/services/websites.service.ts
+++ b/src/websites/services/websites.service.ts
@@ -48,7 +48,10 @@ export class WebsitesService extends createPrismaBase(MODELS.Website) {
     return this.model.update(args)
   }
 
-  async findByDomainName(domainName: string, include?: Prisma.WebsiteInclude) {
+  async findByDomainName<I extends Prisma.WebsiteInclude>(
+    domainName: string,
+    include?: I,
+  ) {
     const domainRecord = await this.client.domain.findUniqueOrThrow({
       where: { name: domainName },
       include: {
@@ -58,6 +61,8 @@ export class WebsitesService extends createPrismaBase(MODELS.Website) {
       },
     })
 
-    return domainRecord.website
+    return domainRecord.website as Prisma.WebsiteGetPayload<{
+      include: I
+    }> | null
   }
 }


### PR DESCRIPTION
## Summary

Add validation to the website retrieval endpoint to ensure the website exists and is published before processing it. This prevents returning unpublished or non-existent websites and ensures the campaign user enrichment only occurs on valid published websites.

## Changes

- Import `NotFoundException` from `@nestjs/common`
- Add explicit check that website exists and has `published` status
- Throw `NotFoundException` if website is missing or not published
- Simplify the campaign user enrichment condition by removing the optional chaining check (now guaranteed to exist if we reach that point)

## Implementation details

The validation is placed immediately after the database query, before any user enrichment logic. This follows the fail-fast pattern and ensures downstream code can safely assume the website is valid and published.

https://claude.ai/code/session_018YhuZnuKGbUU91ubVcGRUn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard on a public read endpoint; aligns with existing published checks on vanity routes and reduces exposure of draft sites.
> 
> **Overview**
> The public **`GET websites/by-domain/:domain`** handler (used from candidates.goodparty.org) now **fails fast** when the linked website record is missing or not **`published`**, responding with **`NotFoundException`** instead of returning partial data.
> 
> Clerk **campaign user enrichment** only runs after that check, matching the pattern used on other public website read routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9709749532fc87bb7d511fd46fdd65f2626439ff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->