### PR TITLE
feat(domains): implement purchase domain functionality in DomainsCont…

### DIFF
--- a/src/websites/controllers/domains.controller.test.ts
+++ b/src/websites/controllers/domains.controller.test.ts
@@ -1,16 +1,30 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { Reflector } from '@nestjs/core'
-import { RequestMethod } from '@nestjs/common'
+import { DiscoveryModule, HttpAdapterHost, Reflector } from '@nestjs/core'
+import {
+  ConflictException,
+  HttpStatus,
+  ModuleMetadata,
+  RequestMethod,
+} from '@nestjs/common'
+import { DomainStatus } from '@prisma/client'
+import { PinoLogger } from 'nestjs-pino'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DomainsController } from './domains.controller'
 import { DomainsService } from '../services/domains.service'
 import { WebsitesService } from '../services/websites.service'
 import { UseCampaignGuard } from 'src/campaigns/guards/UseCampaign.guard'
 import { REQUIRE_CAMPAIGN_META_KEY } from 'src/campaigns/decorators/UseCampaign.decorator'
+import { MCP_TOOL_KEY } from '@/mcp/decorators/McpTool.decorator'
+import { McpServerService } from '@/mcp/services/mcpServer.service'
+import {
+  PurchaseDomainBodySchema,
+  PurchaseDomainResponseSchema,
+} from '../schemas/PurchaseDomain.schema'
 import {
   createMockCampaign,
   createMockUser,
 } from '@/shared/test-utils/mockData.util'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
 
 describe('DomainsController.searchDomains', () => {
   let controller: DomainsController
@@ -72,5 +86,165 @@ describe('DomainsController.searchDomains', () => {
     )
     expect(meta).toBeDefined()
     expect(meta.include).toEqual({ user: true })
+  })
+})
+
+describe('DomainsController.purchaseDomain', () => {
+  let controller: DomainsController
+  let mockDomains: { purchaseDomainForCampaign: ReturnType<typeof vi.fn> }
+
+  beforeEach(async () => {
+    mockDomains = {
+      purchaseDomainForCampaign: vi.fn().mockResolvedValue({
+        website: {
+          id: 42,
+          vanityPath: 'jane-for-senate',
+          status: 'unpublished',
+          campaignId: 7,
+        },
+        domain: {
+          id: 99,
+          name: 'voteforjane.run',
+          status: DomainStatus.pending,
+          price: 8,
+        },
+        alreadyExisted: false,
+        message:
+          'Domain reserved; registration will complete after payment confirmation',
+      }),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DomainsController],
+      providers: [
+        { provide: DomainsService, useValue: mockDomains },
+        { provide: WebsitesService, useValue: {} },
+      ],
+    })
+      .overrideGuard(UseCampaignGuard)
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    controller = module.get<DomainsController>(DomainsController)
+  })
+
+  it('delegates to DomainsService.purchaseDomainForCampaign and narrows the response (drops website)', async () => {
+    const campaign = {
+      ...createMockCampaign({ details: { electionDate: '2026-11-03' } }),
+      user: createMockUser({ firstName: 'Jane', lastName: 'Doe' }),
+    }
+
+    const result = await controller.purchaseDomain(campaign, {
+      domain: 'voteforjane.run',
+    })
+
+    expect(mockDomains.purchaseDomainForCampaign).toHaveBeenCalledWith(
+      campaign,
+      'voteforjane.run',
+    )
+    expect(result).toEqual({
+      domain: {
+        id: 99,
+        name: 'voteforjane.run',
+        status: DomainStatus.pending,
+        price: 8,
+      },
+      alreadyExisted: false,
+      message:
+        'Domain reserved; registration will complete after payment confirmation',
+    })
+    expect(result).not.toHaveProperty('website')
+  })
+
+  it('propagates ConflictException from the service when the domain is no longer available', async () => {
+    mockDomains.purchaseDomainForCampaign.mockRejectedValueOnce(
+      new ConflictException('Domain voteforjane.run is no longer available'),
+    )
+
+    const campaign = {
+      ...createMockCampaign({ details: { electionDate: '2026-11-03' } }),
+      user: createMockUser({ firstName: 'Jane', lastName: 'Doe' }),
+    }
+
+    await expect(
+      controller.purchaseDomain(campaign, { domain: 'voteforjane.run' }),
+    ).rejects.toBeInstanceOf(ConflictException)
+  })
+
+  it('handler is registered for POST /purchase with @UseCampaign() including user, @HttpCode(202), and @McpTool description', () => {
+    const reflector = new Reflector()
+
+    const path = Reflect.getMetadata('path', controller.purchaseDomain)
+    const method = Reflect.getMetadata('method', controller.purchaseDomain)
+    expect(path).toBe('purchase')
+    expect(method).toBe(RequestMethod.POST)
+
+    const statusCode = Reflect.getMetadata(
+      '__httpCode__',
+      controller.purchaseDomain,
+    )
+    expect(statusCode).toBe(HttpStatus.ACCEPTED)
+
+    const useCampaignMeta = reflector.get(
+      REQUIRE_CAMPAIGN_META_KEY,
+      controller.purchaseDomain,
+    )
+    expect(useCampaignMeta).toBeDefined()
+    expect(useCampaignMeta.include).toEqual({ user: true })
+
+    const mcpMeta = reflector.get(MCP_TOOL_KEY, controller.purchaseDomain)
+    expect(mcpMeta).toBeDefined()
+    expect(mcpMeta.description).toMatch(/Reserve a specific available domain/)
+  })
+})
+
+describe('DomainsController.purchaseDomain MCP discoverability', () => {
+  const buildModule = (): ModuleMetadata => ({
+    imports: [DiscoveryModule],
+    controllers: [DomainsController],
+    providers: [
+      McpServerService,
+      { provide: DomainsService, useValue: {} },
+      { provide: WebsitesService, useValue: {} },
+      {
+        provide: HttpAdapterHost,
+        useValue: {
+          httpAdapter: {
+            getInstance: () => ({
+              inject: async () => ({
+                statusCode: 200,
+                body: '{}',
+                headers: {},
+              }),
+            }),
+          },
+        },
+      },
+      { provide: PinoLogger, useValue: createMockLogger() },
+    ],
+  })
+
+  it('appears in gatherTools() output with name POST_domains_purchase, full input/output schemas, and accurate description', async () => {
+    const moduleRef = await Test.createTestingModule(buildModule())
+      .overrideGuard(UseCampaignGuard)
+      .useValue({ canActivate: () => true })
+      .compile()
+    await moduleRef.init()
+
+    const tools = moduleRef.get(McpServerService).getTools()
+    const purchase = tools.find((t) => t.toolName === 'POST_domains_purchase')
+
+    expect(purchase).toBeDefined()
+    expect(purchase!.description).toMatch(/Reserve a specific available domain/)
+    expect(purchase!.description).toMatch(
+      /poll GET \/v1\/websites\/domains\/status/,
+    )
+    expect(purchase!.outputSchema).toBe(PurchaseDomainResponseSchema)
+    expect(purchase!.inputDeclarations.body.declared).toBe(true)
+    expect(purchase!.inputDeclarations.body.schema).toBe(
+      PurchaseDomainBodySchema.schema,
+    )
+    expect(purchase!.inputDeclarations.query.declared).toBe(false)
+    expect(purchase!.inputDeclarations.params.declared).toBe(false)
   })
 })

--- a/src/websites/controllers/domains.controller.test.ts
+++ b/src/websites/controllers/domains.controller.test.ts
@@ -236,9 +236,7 @@ describe('DomainsController.purchaseDomain MCP discoverability', () => {
 
     expect(purchase).toBeDefined()
     expect(purchase!.description).toMatch(/Reserve a specific available domain/)
-    expect(purchase!.description).toMatch(
-      /poll GET \/v1\/websites\/domains\/status/,
-    )
+    expect(purchase!.description).toMatch(/Poll GET \/v1\/domains\/status/)
     expect(purchase!.outputSchema).toBe(PurchaseDomainResponseSchema)
     expect(purchase!.inputDeclarations.body.declared).toBe(true)
     expect(purchase!.inputDeclarations.body.schema).toBe(

--- a/src/websites/controllers/domains.controller.ts
+++ b/src/websites/controllers/domains.controller.ts
@@ -19,6 +19,10 @@ import {
   SearchDomainsBodySchema,
   SearchDomainsResponseSchema,
 } from '../schemas/SearchDomains.schema'
+import {
+  PurchaseDomainBodySchema,
+  PurchaseDomainResponseSchema,
+} from '../schemas/PurchaseDomain.schema'
 import { UseCampaign } from 'src/campaigns/decorators/UseCampaign.decorator'
 import { ReqCampaign } from 'src/campaigns/decorators/ReqCampaign.decorator'
 import { Campaign, DomainStatus, User, UserRole } from '@prisma/client'
@@ -74,6 +78,37 @@ export class DomainsController {
     @Body() { patterns, maxPrice }: SearchDomainsBodySchema,
   ): Promise<PatternedDomainSearchResult> {
     return this.domains.searchDomainsForCampaign(campaign, patterns, maxPrice)
+  }
+
+  @Post('purchase')
+  @UseCampaign({ include: { user: true } })
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ResponseSchema(PurchaseDomainResponseSchema)
+  @McpTool({
+    description:
+      'Reserve a specific available domain for the calling campaign. ' +
+      'Call AFTER searchDomains has returned a candidate and the agent ' +
+      'has chosen one under the price cap. Idempotent per campaign via ' +
+      'a Postgres advisory transaction lock — safe to retry on ' +
+      'transient errors; a repeated call for the same domain returns ' +
+      'alreadyExisted: true. Conflicts (a different in-progress domain ' +
+      'for the campaign, or the domain is no longer available) return ' +
+      '4xx. On success the domain is created in DomainStatus.pending; ' +
+      'poll GET /v1/websites/domains/status to observe progression.',
+  })
+  async purchaseDomain(
+    @ReqCampaign() campaign: Campaign & { user: User },
+    @Body() { domain }: PurchaseDomainBodySchema,
+  ) {
+    const result = await this.domains.purchaseDomainForCampaign(
+      campaign,
+      domain,
+    )
+    return {
+      domain: result.domain,
+      alreadyExisted: result.alreadyExisted,
+      message: result.message,
+    }
   }
 
   @Get('status')

--- a/src/websites/controllers/domains.controller.ts
+++ b/src/websites/controllers/domains.controller.ts
@@ -94,7 +94,8 @@ export class DomainsController {
       'alreadyExisted: true. Conflicts (a different in-progress domain ' +
       'for the campaign, or the domain is no longer available) return ' +
       '4xx. On success the domain is created in DomainStatus.pending; ' +
-      'poll GET /v1/websites/domains/status to observe progression.',
+      'registration completion is handled by a separate post-purchase ' +
+      'pipeline. Poll GET /v1/domains/status to observe progression.',
   })
   async purchaseDomain(
     @ReqCampaign() campaign: Campaign & { user: User },

--- a/src/websites/schemas/PurchaseDomain.schema.ts
+++ b/src/websites/schemas/PurchaseDomain.schema.ts
@@ -1,10 +1,14 @@
 import { DomainStatus } from '@prisma/client'
 import { createZodDto } from 'nestjs-zod'
+import { isFQDN } from 'validator'
 import { z } from 'zod'
 
 export class PurchaseDomainBodySchema extends createZodDto(
   z.object({
-    domain: z.string().min(1).max(253),
+    domain: z.string().refine((v) => isFQDN(v), {
+      message:
+        'Invalid domain format. Must be a Fully Qualified Domain Name (e.g., example.com or foo.example.com)',
+    }),
   }),
 ) {}
 

--- a/src/websites/schemas/PurchaseDomain.schema.ts
+++ b/src/websites/schemas/PurchaseDomain.schema.ts
@@ -1,0 +1,20 @@
+import { DomainStatus } from '@prisma/client'
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+export class PurchaseDomainBodySchema extends createZodDto(
+  z.object({
+    domain: z.string().min(1).max(253),
+  }),
+) {}
+
+export const PurchaseDomainResponseSchema = z.object({
+  domain: z.object({
+    id: z.number().int(),
+    name: z.string(),
+    status: z.nativeEnum(DomainStatus),
+    price: z.number().nullable(),
+  }),
+  alreadyExisted: z.boolean(),
+  message: z.string(),
+})


### PR DESCRIPTION
…roller

- Added a new endpoint for purchasing domains, allowing campaigns to reserve specific available domains.
- Implemented request handling with appropriate validation and response schemas.
- Enhanced test coverage for the purchaseDomain method, including success and error scenarios.
- Registered metadata for the new endpoint to ensure proper discoverability in the MCP tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new purchase/reservation API on the domain flow (pending status, conflicts, idempotency) though most business logic stays in the existing service layer.
> 
> **Overview**
> Adds **campaign domain purchase** as `POST /domains/purchase` (HTTP **202**), letting callers reserve a chosen domain name after search. The handler uses `@UseCampaign({ include: { user: true } })`, validates `{ domain }` via new Zod DTOs, and returns only `domain`, `alreadyExisted`, and `message`—omitting `website` from the service payload.
> 
> New **`PurchaseDomain`** request/response schemas back `@ResponseSchema` and MCP agent docs (`POST_domains_purchase`), including guidance to poll domain status after a pending reservation.
> 
> Tests cover service delegation, `ConflictException` passthrough, route/metadata (`@HttpCode`, `@McpTool`), and MCP tool registration with the correct input/output schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a2fe00e5bed105e831177776f82bfbb0498fc1a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->