### PR TITLE
Prevent prototype pollution in multipart form handling

### DIFF
--- a/src/campaigns/ai/schemas/forbiddenKeys.ts
+++ b/src/campaigns/ai/schemas/forbiddenKeys.ts
@@ -1,1 +1,1 @@
-export const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+export { FORBIDDEN_KEYS } from '@/shared/constants/forbiddenKeys'

--- a/src/files/interceptors/files.interceptor.test.ts
+++ b/src/files/interceptors/files.interceptor.test.ts
@@ -1,0 +1,128 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common'
+import { describe, expect, it, vi } from 'vitest'
+import { of } from 'rxjs'
+import { Headers, MimeTypes } from 'http-constants-ts'
+import { FilesInterceptor, setNestedProperty } from './files.interceptor'
+
+const FORBIDDEN = ['__proto__', 'constructor', 'prototype'] as const
+
+describe('setNestedProperty', () => {
+  it.each(FORBIDDEN)('rejects flat forbidden key: %s', (key) => {
+    const obj = {}
+    setNestedProperty(obj, key, 'evil')
+    expect(obj).toEqual({})
+  })
+
+  it.each(FORBIDDEN)(
+    'rejects bracket-notation forbidden key: %s[value]',
+    (key) => {
+      const obj = {}
+      setNestedProperty(obj, `${key}[isAdmin]`, 'true')
+      expect(obj).toEqual({})
+    },
+  )
+
+  it.each(FORBIDDEN)('rejects nested forbidden key: data[%s]', (key) => {
+    const obj = {}
+    setNestedProperty(obj, `data[${key}]`, 'true')
+    expect(obj).toEqual({})
+  })
+
+  it('allows normal flat keys', () => {
+    const obj = {}
+    setNestedProperty(obj, 'name', 'alice')
+    expect(obj).toEqual({ name: 'alice' })
+  })
+
+  it('allows normal bracket-notation keys', () => {
+    const obj = {}
+    setNestedProperty(obj, 'user[name]', 'alice')
+    expect(obj).toEqual({ user: { name: 'alice' } })
+  })
+
+  it('does not pollute Object.prototype', () => {
+    const before = { ...Object.prototype }
+    const obj = {}
+    setNestedProperty(obj, '__proto__[polluted]', 'yes')
+    setNestedProperty(obj, 'constructor[polluted]', 'yes')
+    setNestedProperty(obj, 'prototype[polluted]', 'yes')
+    expect(Object.prototype).toEqual(before)
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined()
+  })
+})
+
+describe('FilesInterceptor forbidden field guard', () => {
+  const createMockContext = (
+    parts: Array<{ type: 'field'; fieldname: string; value: string }>,
+  ) => {
+    const body: Record<string, unknown> = {}
+    const req = {
+      headers: {
+        [Headers.CONTENT_TYPE.toLowerCase()]: MimeTypes.IMAGE_FORM_DATA,
+      },
+      body,
+      parts: () => ({
+        async *[Symbol.asyncIterator]() {
+          for (const part of parts) {
+            yield part
+          }
+        },
+      }),
+    }
+
+    const ctx = {
+      switchToHttp: () => ({ getRequest: () => req }),
+      getHandler: vi.fn(),
+      getClass: vi.fn(),
+    } as unknown as ExecutionContext
+
+    const next: CallHandler = { handle: () => of(undefined) }
+
+    return { ctx, next, req }
+  }
+
+  it.each(FORBIDDEN)('drops flat forbidden field: %s', async (key) => {
+    const { ctx, next, req } = createMockContext([
+      { type: 'field', fieldname: key, value: 'evil' },
+    ])
+    const Interceptor = FilesInterceptor('file')
+    const instance = new Interceptor()
+    await instance.intercept(ctx, next)
+    expect(req.body).toEqual({})
+  })
+
+  it.each(FORBIDDEN)(
+    'drops bracket-notation forbidden field: %s[x]',
+    async (key) => {
+      const { ctx, next, req } = createMockContext([
+        {
+          type: 'field',
+          fieldname: `${key}[isAdmin]`,
+          value: 'true',
+        },
+      ])
+      const Interceptor = FilesInterceptor('file')
+      const instance = new Interceptor()
+      await instance.intercept(ctx, next)
+      expect(req.body).toEqual({})
+    },
+  )
+
+  it('allows legitimate fields through', async () => {
+    const { ctx, next, req } = createMockContext([
+      { type: 'field', fieldname: 'name', value: 'alice' },
+      {
+        type: 'field',
+        fieldname: 'address[city]',
+        value: 'NYC',
+      },
+    ])
+    const Interceptor = FilesInterceptor('file')
+    const instance = new Interceptor()
+    await instance.intercept(ctx, next)
+    expect(req.body).toEqual({
+      name: 'alice',
+      address: { city: 'NYC' },
+    })
+  })
+})

--- a/src/files/interceptors/files.interceptor.test.ts
+++ b/src/files/interceptors/files.interceptor.test.ts
@@ -3,8 +3,9 @@ import { describe, expect, it, vi } from 'vitest'
 import { of } from 'rxjs'
 import { Headers, MimeTypes } from 'http-constants-ts'
 import { FilesInterceptor, setNestedProperty } from './files.interceptor'
+import { FORBIDDEN_KEYS } from '@/shared/constants/forbiddenKeys'
 
-const FORBIDDEN = ['__proto__', 'constructor', 'prototype'] as const
+const FORBIDDEN = [...FORBIDDEN_KEYS]
 
 describe('setNestedProperty', () => {
   it.each(FORBIDDEN)('rejects flat forbidden key: %s', (key) => {

--- a/src/files/interceptors/files.interceptor.ts
+++ b/src/files/interceptors/files.interceptor.ts
@@ -11,6 +11,7 @@ import { omit } from 'es-toolkit'
 import { PassThrough } from 'stream'
 import { Headers, MimeTypes } from 'http-constants-ts'
 import { Prisma } from '@prisma/client'
+import { FORBIDDEN_KEYS } from '@/shared/constants/forbiddenKeys'
 
 type FilesInterceptorOpts = {
   /**
@@ -138,8 +139,6 @@ export function FilesInterceptor(
     }
   }
 }
-
-const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 
 /**
  * Helper function to set nested object properties

--- a/src/files/interceptors/files.interceptor.ts
+++ b/src/files/interceptors/files.interceptor.ts
@@ -139,11 +139,7 @@ export function FilesInterceptor(
   }
 }
 
-const FORBIDDEN_KEYS = new Set([
-  '__proto__',
-  'constructor',
-  'prototype',
-])
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 
 /**
  * Helper function to set nested object properties
@@ -162,9 +158,7 @@ function setNestedProperty(
     return
   }
 
-  const keys = path
-    .split(/[\[\]]/)
-    .filter((key) => key !== '')
+  const keys = path.split(/[\[\]]/).filter((key) => key !== '')
 
   if (keys.some((k) => FORBIDDEN_KEYS.has(k))) return
 
@@ -180,15 +174,9 @@ function setNestedProperty(
       current[key] = isNextKeyNumeric ? [] : {}
     } else if (typeof current[key] !== 'object') {
       current[key] = isNextKeyNumeric ? [] : {}
-    } else if (
-      isNextKeyNumeric &&
-      !Array.isArray(current[key])
-    ) {
+    } else if (isNextKeyNumeric && !Array.isArray(current[key])) {
       current[key] = []
-    } else if (
-      !isNextKeyNumeric &&
-      Array.isArray(current[key])
-    ) {
+    } else if (!isNextKeyNumeric && Array.isArray(current[key])) {
       current[key] = {}
     }
 

--- a/src/files/interceptors/files.interceptor.ts
+++ b/src/files/interceptors/files.interceptor.ts
@@ -146,7 +146,7 @@ export function FilesInterceptor(
  * @param path The field name with bracket notation (e.g., 'user[name]', 'items[0]')
  * @param value The value to set
  */
-function setNestedProperty(
+export function setNestedProperty(
   obj: Prisma.JsonObject,
   path: string,
   value: Prisma.JsonValue,

--- a/src/files/interceptors/files.interceptor.ts
+++ b/src/files/interceptors/files.interceptor.ts
@@ -126,7 +126,7 @@ export function FilesInterceptor(
               // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
               part.value as Prisma.JsonValue,
             )
-          } else {
+          } else if (!FORBIDDEN_KEYS.has(part.fieldname)) {
             // Multipart form value to Prisma JSON — no shared type between fastify and Prisma
             // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
             req.body[part.fieldname] = part.value as Prisma.JsonValue
@@ -138,6 +138,12 @@ export function FilesInterceptor(
     }
   }
 }
+
+const FORBIDDEN_KEYS = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+])
 
 /**
  * Helper function to set nested object properties
@@ -151,11 +157,16 @@ function setNestedProperty(
   value: Prisma.JsonValue,
 ) {
   if (!path.includes('[') || !path.includes(']')) {
+    if (FORBIDDEN_KEYS.has(path)) return
     obj[path] = value
     return
   }
 
-  const keys = path.split(/[\[\]]/).filter((key) => key !== '')
+  const keys = path
+    .split(/[\[\]]/)
+    .filter((key) => key !== '')
+
+  if (keys.some((k) => FORBIDDEN_KEYS.has(k))) return
 
   let current = obj
 
@@ -169,9 +180,15 @@ function setNestedProperty(
       current[key] = isNextKeyNumeric ? [] : {}
     } else if (typeof current[key] !== 'object') {
       current[key] = isNextKeyNumeric ? [] : {}
-    } else if (isNextKeyNumeric && !Array.isArray(current[key])) {
+    } else if (
+      isNextKeyNumeric &&
+      !Array.isArray(current[key])
+    ) {
       current[key] = []
-    } else if (!isNextKeyNumeric && Array.isArray(current[key])) {
+    } else if (
+      !isNextKeyNumeric &&
+      Array.isArray(current[key])
+    ) {
       current[key] = {}
     }
 

--- a/src/shared/constants/forbiddenKeys.ts
+++ b/src/shared/constants/forbiddenKeys.ts
@@ -1,0 +1,1 @@
+export const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])


### PR DESCRIPTION
## Summary

Add protection against prototype pollution attacks in the `FilesInterceptor` by blocking assignment to forbidden keys (`__proto__`, `constructor`, `prototype`) in both direct form fields and nested object paths.

## Changes

- **Forbidden keys set**: Created `FORBIDDEN_KEYS` constant containing `__proto__`, `constructor`, and `prototype`
- **Direct field filtering**: Updated the multipart form value assignment to skip forbidden keys via `else if (!FORBIDDEN_KEYS.has(part.fieldname))`
- **Nested path validation**: Added two guards in `setNestedProperty()`:
  - Check for forbidden keys in simple (non-nested) paths
  - Check for forbidden keys anywhere in the split path array for nested assignments
- **Code formatting**: Reformatted multi-line conditionals for readability (no logic change)

## Implementation Details

The protection is applied at two levels:
1. When assigning form fields directly to `req.body`
2. When setting nested properties via bracket notation (e.g., `obj[key][subkey]`)

This prevents attackers from polluting the prototype chain through either direct field names or nested path components.

https://claude.ai/code/session_01Sc4ow1GZrVnwr9wSQr4TDF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security fix on a shared request interceptor that shapes `req.body` for all multipart uploads; behavior change only for malicious or forbidden key names, with no new tests in the diff.
> 
> **Overview**
> Hardens **`FilesInterceptor`** so multipart field names cannot pollute `Object.prototype` when values are merged into `req.body`.
> 
> A local **`FORBIDDEN_KEYS`** set (`__proto__`, `constructor`, `prototype`) now blocks **top-level** field assignment unless the name is allowed, and **`setNestedProperty`** silently skips writes when any path segment (including simple keys) matches that set. Unrelated formatting-only tweaks to multi-line `if` conditions in the same helper.
> 
> This closes the gap where bracket notation (e.g. `foo[__proto__][polluted]`) could previously set dangerous keys on nested objects built from form data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e4094cb657833ec86423b380e4d944e8a64dab1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->