### PR TITLE
feat(domains): enhance domain purchase functionality with maxPrice va…

### DIFF
--- a/src/websites/controllers/domains.controller.test.ts
+++ b/src/websites/controllers/domains.controller.test.ts
@@ -105,12 +105,11 @@ describe('DomainsController.purchaseDomain', () => {
         domain: {
           id: 99,
           name: 'voteforjane.run',
-          status: DomainStatus.pending,
+          status: DomainStatus.submitted,
           price: 8,
         },
         alreadyExisted: false,
-        message:
-          'Domain reserved; registration will complete after payment confirmation',
+        message: 'Domain registration submitted',
       }),
     }
 
@@ -136,22 +135,23 @@ describe('DomainsController.purchaseDomain', () => {
 
     const result = await controller.purchaseDomain(campaign, {
       domain: 'voteforjane.run',
+      maxPrice: 50,
     })
 
     expect(mockDomains.purchaseDomainForCampaign).toHaveBeenCalledWith(
       campaign,
       'voteforjane.run',
+      50,
     )
     expect(result).toEqual({
       domain: {
         id: 99,
         name: 'voteforjane.run',
-        status: DomainStatus.pending,
+        status: DomainStatus.submitted,
         price: 8,
       },
       alreadyExisted: false,
-      message:
-        'Domain reserved; registration will complete after payment confirmation',
+      message: 'Domain registration submitted',
     })
     expect(result).not.toHaveProperty('website')
   })
@@ -167,7 +167,10 @@ describe('DomainsController.purchaseDomain', () => {
     }
 
     await expect(
-      controller.purchaseDomain(campaign, { domain: 'voteforjane.run' }),
+      controller.purchaseDomain(campaign, {
+        domain: 'voteforjane.run',
+        maxPrice: 50,
+      }),
     ).rejects.toBeInstanceOf(ConflictException)
   })
 
@@ -194,7 +197,7 @@ describe('DomainsController.purchaseDomain', () => {
 
     const mcpMeta = reflector.get(MCP_TOOL_KEY, controller.purchaseDomain)
     expect(mcpMeta).toBeDefined()
-    expect(mcpMeta.description).toMatch(/Reserve a specific available domain/)
+    expect(mcpMeta.description).toMatch(/Purchase a specific available domain/)
   })
 })
 
@@ -235,7 +238,9 @@ describe('DomainsController.purchaseDomain MCP discoverability', () => {
     const purchase = tools.find((t) => t.toolName === 'POST_domains_purchase')
 
     expect(purchase).toBeDefined()
-    expect(purchase!.description).toMatch(/Reserve a specific available domain/)
+    expect(purchase!.description).toMatch(
+      /Purchase a specific available domain/,
+    )
     expect(purchase!.description).toMatch(/Poll GET \/v1\/domains\/status/)
     expect(purchase!.outputSchema).toBe(PurchaseDomainResponseSchema)
     expect(purchase!.inputDeclarations.body.declared).toBe(true)

--- a/src/websites/controllers/domains.controller.test.ts
+++ b/src/websites/controllers/domains.controller.test.ts
@@ -199,6 +199,20 @@ describe('DomainsController.purchaseDomain', () => {
     expect(mcpMeta).toBeDefined()
     expect(mcpMeta.description).toMatch(/Purchase a specific available domain/)
   })
+
+  it('PurchaseDomainBodySchema enforces server-side maxPrice ceiling', () => {
+    const validResult = PurchaseDomainBodySchema.schema.safeParse({
+      domain: 'voteforjane.run',
+      maxPrice: 50,
+    })
+    expect(validResult.success).toBe(true)
+
+    const overCeilingResult = PurchaseDomainBodySchema.schema.safeParse({
+      domain: 'voteforjane.run',
+      maxPrice: 200,
+    })
+    expect(overCeilingResult.success).toBe(false)
+  })
 })
 
 describe('DomainsController.purchaseDomain MCP discoverability', () => {

--- a/src/websites/controllers/domains.controller.ts
+++ b/src/websites/controllers/domains.controller.ts
@@ -86,24 +86,28 @@ export class DomainsController {
   @ResponseSchema(PurchaseDomainResponseSchema)
   @McpTool({
     description:
-      'Reserve a specific available domain for the calling campaign. ' +
+      'Purchase a specific available domain for the calling campaign. ' +
       'Call AFTER searchDomains has returned a candidate and the agent ' +
-      'has chosen one under the price cap. Idempotent per campaign via ' +
-      'a Postgres advisory transaction lock — safe to retry on ' +
-      'transient errors; a repeated call for the same domain returns ' +
+      'has chosen one. Pass the same maxPrice that searchDomains was ' +
+      'called with; the server re-checks the live price against this ' +
+      'cap and rejects with 409 if Vercel returned a higher price ' +
+      'between search and purchase. Idempotent per campaign via a ' +
+      'Postgres advisory transaction lock — safe to retry on transient ' +
+      'errors; a repeated call for the same domain returns ' +
       'alreadyExisted: true. Conflicts (a different in-progress domain ' +
       'for the campaign, or the domain is no longer available) return ' +
-      '4xx. On success the domain is created in DomainStatus.pending; ' +
-      'registration completion is handled by a separate post-purchase ' +
-      'pipeline. Poll GET /v1/domains/status to observe progression.',
+      '4xx. On success the domain reaches DomainStatus.submitted. ' +
+      'Poll GET /v1/domains/status to observe progression to ' +
+      'registered / active.',
   })
   async purchaseDomain(
     @ReqCampaign() campaign: Campaign & { user: User },
-    @Body() { domain }: PurchaseDomainBodySchema,
+    @Body() { domain, maxPrice }: PurchaseDomainBodySchema,
   ) {
     const result = await this.domains.purchaseDomainForCampaign(
       campaign,
       domain,
+      maxPrice,
     )
     return {
       domain: result.domain,

--- a/src/websites/schemas/PurchaseDomain.schema.ts
+++ b/src/websites/schemas/PurchaseDomain.schema.ts
@@ -9,6 +9,7 @@ export class PurchaseDomainBodySchema extends createZodDto(
       message:
         'Invalid domain format. Must be a Fully Qualified Domain Name (e.g., example.com or foo.example.com)',
     }),
+    maxPrice: z.number().positive(),
   }),
 ) {}
 

--- a/src/websites/schemas/PurchaseDomain.schema.ts
+++ b/src/websites/schemas/PurchaseDomain.schema.ts
@@ -9,7 +9,11 @@ export class PurchaseDomainBodySchema extends createZodDto(
       message:
         'Invalid domain format. Must be a Fully Qualified Domain Name (e.g., example.com or foo.example.com)',
     }),
-    maxPrice: z.number().positive(),
+    // Defense-in-depth ceiling: caller-supplied cap can't be larger than this.
+    // Standard campaign domains run ~$10–30; premium TLDs occasionally $50–90.
+    // $100 leaves headroom while bounding the blast radius of a compromised
+    // or misconfigured caller passing maxPrice: 999999.
+    maxPrice: z.number().positive().max(100),
   }),
 ) {}
 

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -861,6 +861,45 @@ describe('DomainsService', () => {
       expect(mockPrisma.$transaction).not.toHaveBeenCalled()
       expect(completeSpy).not.toHaveBeenCalled()
     })
+
+    it('marks the Domain row inactive and re-throws when inline registration fails', async () => {
+      mockPrisma.website.findUnique.mockResolvedValue(baseWebsite)
+      mockPrisma.website.findUniqueOrThrow.mockResolvedValue({
+        content: { contact: {} },
+      })
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 12 })
+      const created = {
+        ...mockDomain,
+        id: 555,
+        name: domainName,
+        paymentId: null,
+        price: new Decimal(12),
+      }
+      mockPrisma.domain.create.mockResolvedValue(created)
+      const registrationError = new Error(
+        'Error getting domain details from Vercel:',
+      )
+      vi.spyOn(service, 'completeDomainRegistration').mockRejectedValue(
+        registrationError,
+      )
+
+      await expect(
+        service.purchaseDomainForCampaign(
+          campaignWithUser,
+          domainName,
+          maxPrice,
+        ),
+      ).rejects.toBe(registrationError)
+
+      expect(mockPrisma.domain.update).toHaveBeenCalledWith({
+        where: { id: created.id },
+        data: { status: DomainStatus.inactive },
+      })
+      expect(mockPrisma.domain.findUniqueOrThrow).not.toHaveBeenCalled()
+    })
   })
 
   describe('completeDomainRegistration', () => {

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -485,6 +485,7 @@ describe('DomainsService', () => {
     const campaign = createMockCampaign({ id: 42 })
     const campaignWithUser = { ...campaign, user: mockUser }
     const domainName = 'vote-oneill.run'
+    const maxPrice = 50
 
     const baseWebsite = {
       id: 10,
@@ -499,7 +500,11 @@ describe('DomainsService', () => {
       mockPrisma.website.findUnique.mockResolvedValue(null)
 
       await expect(
-        service.purchaseDomainForCampaign(campaignWithUser, domainName),
+        service.purchaseDomainForCampaign(
+          campaignWithUser,
+          domainName,
+          maxPrice,
+        ),
       ).rejects.toBeInstanceOf(NotFoundException)
 
       expect(mockRoute53.checkDomainAvailability).not.toHaveBeenCalled()
@@ -521,6 +526,7 @@ describe('DomainsService', () => {
         const result = await service.purchaseDomainForCampaign(
           campaignWithUser,
           mockDomain.name,
+          maxPrice,
         )
 
         expect(result.alreadyExisted).toBe(true)
@@ -551,7 +557,11 @@ describe('DomainsService', () => {
         })
 
         await expect(
-          service.purchaseDomainForCampaign(campaignWithUser, domainName),
+          service.purchaseDomainForCampaign(
+            campaignWithUser,
+            domainName,
+            maxPrice,
+          ),
         ).rejects.toBeInstanceOf(ConflictException)
 
         expect(mockRoute53.checkDomainAvailability).not.toHaveBeenCalled()
@@ -588,7 +598,11 @@ describe('DomainsService', () => {
         message: 'Disabled',
       })
 
-      await service.purchaseDomainForCampaign(campaignWithUser, domainName)
+      await service.purchaseDomainForCampaign(
+        campaignWithUser,
+        domainName,
+        maxPrice,
+      )
 
       expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1)
       expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1)
@@ -625,7 +639,11 @@ describe('DomainsService', () => {
         message: 'Disabled',
       })
 
-      await service.purchaseDomainForCampaign(campaignWithUser, domainName)
+      await service.purchaseDomainForCampaign(
+        campaignWithUser,
+        domainName,
+        maxPrice,
+      )
 
       const route53Order =
         mockRoute53.checkDomainAvailability.mock.invocationCallOrder[0]
@@ -678,6 +696,7 @@ describe('DomainsService', () => {
       const result = await service.purchaseDomainForCampaign(
         campaignWithUser,
         domainName,
+        maxPrice,
       )
 
       expect(mockPrisma.domain.delete).toHaveBeenCalledWith({
@@ -706,7 +725,11 @@ describe('DomainsService', () => {
       })
 
       await expect(
-        service.purchaseDomainForCampaign(campaignWithUser, domainName),
+        service.purchaseDomainForCampaign(
+          campaignWithUser,
+          domainName,
+          maxPrice,
+        ),
       ).rejects.toBeInstanceOf(ConflictException)
 
       expect(mockPrisma.domain.create).not.toHaveBeenCalled()
@@ -719,13 +742,17 @@ describe('DomainsService', () => {
       })
 
       await expect(
-        service.purchaseDomainForCampaign(campaignWithUser, domainName),
+        service.purchaseDomainForCampaign(
+          campaignWithUser,
+          domainName,
+          maxPrice,
+        ),
       ).rejects.toBeInstanceOf(ConflictException)
 
       expect(mockRoute53.getDomainSuggestions).not.toHaveBeenCalled()
     })
 
-    it('creates a Domain row with paymentId=null on the happy path', async () => {
+    it('creates a Domain row with paymentId=null and returns post-registration status on the happy path', async () => {
       mockPrisma.website.findUnique.mockResolvedValue(baseWebsite)
       mockPrisma.website.findUniqueOrThrow.mockResolvedValue({
         content: { contact: {} },
@@ -754,12 +781,12 @@ describe('DomainsService', () => {
       const result = await service.purchaseDomainForCampaign(
         campaignWithUser,
         domainName,
+        maxPrice,
       )
 
       expect(result.alreadyExisted).toBe(false)
       expect(result.domain.name).toBe(domainName)
-      expect(result.domain.status).toBe(DomainStatus.pending)
-      expect(result.website.campaignId).toBe(campaign.id)
+      expect(result.domain.status).toBe(DomainStatus.submitted)
       expect(result.website.campaignId).toBe(campaign.id)
       expect(mockPrisma.domain.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
@@ -769,6 +796,70 @@ describe('DomainsService', () => {
           status: DomainStatus.pending,
         }),
       })
+    })
+
+    it('invokes completeDomainRegistration with skipPaymentVerification after reservation', async () => {
+      mockPrisma.website.findUnique.mockResolvedValue(baseWebsite)
+      mockPrisma.website.findUniqueOrThrow.mockResolvedValue({
+        content: { contact: {} },
+      })
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 12 })
+      const created = {
+        ...mockDomain,
+        name: domainName,
+        paymentId: null,
+        price: new Decimal(12),
+      }
+      mockPrisma.domain.create.mockResolvedValue(created)
+      mockPrisma.domain.findUniqueOrThrow.mockResolvedValue({
+        ...created,
+        status: DomainStatus.submitted,
+      })
+      const completeSpy = vi
+        .spyOn(service, 'completeDomainRegistration')
+        .mockResolvedValue({
+          vercelResult: null,
+          projectResult: null,
+          message: 'Disabled',
+        })
+
+      await service.purchaseDomainForCampaign(
+        campaignWithUser,
+        domainName,
+        maxPrice,
+      )
+
+      expect(completeSpy).toHaveBeenCalledTimes(1)
+      const [websiteIdArg, , optionsArg] = completeSpy.mock.calls[0]
+      expect(websiteIdArg).toBe(baseWebsite.id)
+      expect(optionsArg).toEqual({ skipPaymentVerification: true })
+      const completeOrder = completeSpy.mock.invocationCallOrder[0]
+      const createOrder = mockPrisma.domain.create.mock.invocationCallOrder[0]
+      expect(completeOrder).toBeGreaterThan(createOrder)
+    })
+
+    it('throws ConflictException when looked-up price exceeds maxPrice; no Domain row created', async () => {
+      mockPrisma.website.findUnique.mockResolvedValue(baseWebsite)
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 75 })
+      const completeSpy = vi.spyOn(service, 'completeDomainRegistration')
+
+      await expect(
+        service.purchaseDomainForCampaign(
+          campaignWithUser,
+          domainName,
+          maxPrice,
+        ),
+      ).rejects.toBeInstanceOf(ConflictException)
+
+      expect(mockPrisma.domain.create).not.toHaveBeenCalled()
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled()
+      expect(completeSpy).not.toHaveBeenCalled()
     })
   })
 
@@ -815,6 +906,42 @@ describe('DomainsService', () => {
         errorCode: 'BILLING_DOMAIN_PAYMENT_ID_MISSING',
       })
       expect(mockPayments.retrievePayment).not.toHaveBeenCalled()
+    })
+
+    it('skips the payment guard when skipPaymentVerification is true', async () => {
+      Object.assign(mockPrisma.domain, {
+        findFirst: vi.fn(),
+        findFirstOrThrow: vi.fn(),
+        findUnique: vi.fn(),
+        count: vi.fn(),
+      })
+      service.onModuleInit()
+      vi.spyOn(service, 'shouldEnableDomainPurchase').mockReturnValue(true)
+      const purchaseDomainMock = vi.fn().mockResolvedValue({})
+      Object.assign(mockVercel, {
+        getDomainDetails: vi.fn().mockRejectedValue(new Error('not found')),
+        isVercelNotFoundError: vi.fn().mockReturnValue(true),
+        purchaseDomain: purchaseDomainMock,
+        getProjectDomain: vi.fn().mockRejectedValue(new Error('not found')),
+        addDomainToProject: vi.fn().mockResolvedValue({}),
+      })
+      mockPrisma.domain.findUniqueOrThrow.mockResolvedValue({
+        ...mockDomain,
+        paymentId: null,
+        price: new Decimal(12),
+      })
+
+      await service.completeDomainRegistration(10, contact, {
+        skipPaymentVerification: true,
+      })
+
+      expect(mockPayments.retrievePayment).not.toHaveBeenCalled()
+      expect(purchaseDomainMock).toHaveBeenCalled()
+      expect(mockPrisma.domain.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: DomainStatus.submitted }),
+        }),
+      )
     })
   })
 

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   HttpStatus,
   NotFoundException,
 } from '@nestjs/common'
@@ -482,7 +483,7 @@ describe('DomainsService', () => {
   })
 
   describe('purchaseDomainForCampaign', () => {
-    const campaign = createMockCampaign({ id: 42 })
+    const campaign = createMockCampaign({ id: 42, isPro: true })
     const campaignWithUser = { ...campaign, user: mockUser }
     const domainName = 'vote-oneill.run'
     const maxPrice = 50
@@ -507,6 +508,24 @@ describe('DomainsService', () => {
         ),
       ).rejects.toBeInstanceOf(NotFoundException)
 
+      expect(mockRoute53.checkDomainAvailability).not.toHaveBeenCalled()
+    })
+
+    it('throws ForbiddenException when the campaign is not Pro', async () => {
+      const nonProCampaign = {
+        ...createMockCampaign({ id: 42, isPro: false }),
+        user: mockUser,
+      }
+
+      await expect(
+        service.purchaseDomainForCampaign(
+          nonProCampaign,
+          domainName,
+          maxPrice,
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenException)
+
+      expect(mockPrisma.website.findUnique).not.toHaveBeenCalled()
       expect(mockRoute53.checkDomainAvailability).not.toHaveBeenCalled()
     })
 

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -708,12 +708,12 @@ export class DomainsService
     // billed to GP's Vercel team account; the maxPrice check above is the
     // safety bound). Browser purchases flow through handleDomainPostPurchase,
     // which sets paymentId so completeDomainRegistration's default guard fires.
-    const website = await this.client.website.findUniqueOrThrow({
-      where: { id: websiteSummary.id },
-      select: { content: true },
-    })
-    const contactInfo = this.buildContactInfo(campaign.user, website.content)
     try {
+      const website = await this.client.website.findUniqueOrThrow({
+        where: { id: websiteSummary.id },
+        select: { content: true },
+      })
+      const contactInfo = this.buildContactInfo(campaign.user, website.content)
       await this.completeDomainRegistration(websiteSummary.id, contactInfo, {
         skipPaymentVerification: true,
       })
@@ -721,9 +721,9 @@ export class DomainsService
       // Mark inactive so preflight on retry falls through to a fresh reservation
       // instead of returning alreadyExisted: true for a stuck pending row.
       // completeDomainRegistration's Vercel-failure path sets this itself, but
-      // other failure modes (top-level findUniqueOrThrow, !domain.price,
-      // getDomainDetails rethrow, final status update) do not — this is the
-      // safety net for those.
+      // other failure modes (the website lookup above, top-level
+      // findUniqueOrThrow, !domain.price, getDomainDetails rethrow, final
+      // status update) do not — this is the safety net for those.
       await this.model.update({
         where: { id: createdDomain.id },
         data: { status: DomainStatus.inactive },

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -720,6 +720,10 @@ export class DomainsService
     } catch (error) {
       // Mark inactive so preflight on retry falls through to a fresh reservation
       // instead of returning alreadyExisted: true for a stuck pending row.
+      // completeDomainRegistration's Vercel-failure path sets this itself, but
+      // other failure modes (top-level findUniqueOrThrow, !domain.price,
+      // getDomainDetails rethrow, final status update) do not — this is the
+      // safety net for those.
       await this.model.update({
         where: { id: createdDomain.id },
         data: { status: DomainStatus.inactive },
@@ -727,17 +731,15 @@ export class DomainsService
       throw error
     }
 
-    const registered = await this.model.findUniqueOrThrow({
-      where: { id: createdDomain.id },
-    })
-
+    // completeDomainRegistration unconditionally sets status=submitted; reuse
+    // the reservation row's fields rather than re-reading from the DB.
     return {
       website: websiteSummary,
       domain: {
-        id: registered.id,
-        name: registered.name,
-        status: registered.status,
-        price: registered.price?.toNumber() ?? null,
+        id: createdDomain.id,
+        name: createdDomain.name,
+        status: DomainStatus.submitted,
+        price: createdDomain.price?.toNumber() ?? null,
       },
       alreadyExisted: false,
       message: 'Domain registration submitted',

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -713,9 +713,19 @@ export class DomainsService
       select: { content: true },
     })
     const contactInfo = this.buildContactInfo(campaign.user, website.content)
-    await this.completeDomainRegistration(websiteSummary.id, contactInfo, {
-      skipPaymentVerification: true,
-    })
+    try {
+      await this.completeDomainRegistration(websiteSummary.id, contactInfo, {
+        skipPaymentVerification: true,
+      })
+    } catch (error) {
+      // Mark inactive so preflight on retry falls through to a fresh reservation
+      // instead of returning alreadyExisted: true for a stuck pending row.
+      await this.model.update({
+        where: { id: createdDomain.id },
+        data: { status: DomainStatus.inactive },
+      })
+      throw error
+    }
 
     const registered = await this.model.findUniqueOrThrow({
       where: { id: createdDomain.id },

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -644,6 +644,7 @@ export class DomainsService
   async purchaseDomainForCampaign(
     campaign: Campaign & { user: User },
     domainName: string,
+    maxPrice: number,
   ): Promise<{
     website: Pick<Website, 'id' | 'vanityPath' | 'status' | 'campaignId'>
     domain: Pick<Domain, 'id' | 'name' | 'status'> & { price: number | null }
@@ -680,6 +681,12 @@ export class DomainsService
 
     const price = await this.lookupDomainPrice(domainName)
 
+    if (price > maxPrice) {
+      throw new ConflictException(
+        `Domain ${domainName} price ${price} exceeds maxPrice ${maxPrice}`,
+      )
+    }
+
     const locked = await this.reserveDomainForCampaign(
       campaign.id,
       domainName,
@@ -697,24 +704,33 @@ export class DomainsService
 
     const { websiteSummary, domain: createdDomain } = locked
 
-    // NOTE: this method only reserves the Domain row (status=pending) and
-    // does NOT call completeDomainRegistration — that requires a non-null
-    // paymentId and must be invoked after payment is confirmed (e.g. via a
-    // Stripe webhook). No HTTP route should call this method directly until
-    // that payment-confirmation leg is wired up, or domains will stall in
-    // DomainStatus.pending with no recovery path.
+    // Agent purchases handle registration inline (no Stripe charge — domain
+    // billed to GP's Vercel team account; the maxPrice check above is the
+    // safety bound). Browser purchases flow through handleDomainPostPurchase,
+    // which sets paymentId so completeDomainRegistration's default guard fires.
+    const website = await this.client.website.findUniqueOrThrow({
+      where: { id: websiteSummary.id },
+      select: { content: true },
+    })
+    const contactInfo = this.buildContactInfo(campaign.user, website.content)
+    await this.completeDomainRegistration(websiteSummary.id, contactInfo, {
+      skipPaymentVerification: true,
+    })
+
+    const registered = await this.model.findUniqueOrThrow({
+      where: { id: createdDomain.id },
+    })
 
     return {
       website: websiteSummary,
       domain: {
-        id: createdDomain.id,
-        name: createdDomain.name,
-        status: createdDomain.status,
-        price: createdDomain.price?.toNumber() ?? null,
+        id: registered.id,
+        name: registered.name,
+        status: registered.status,
+        price: registered.price?.toNumber() ?? null,
       },
       alreadyExisted: false,
-      message:
-        'Domain reserved; registration will complete after payment confirmation',
+      message: 'Domain registration submitted',
     }
   }
 
@@ -957,26 +973,31 @@ export class DomainsService
   async completeDomainRegistration(
     websiteId: number,
     contact: RegisterDomainSchema,
+    options: { skipPaymentVerification?: boolean } = {},
   ) {
     const domain = await this.findUniqueOrThrow({
       where: { websiteId },
     })
 
-    if (!domain.paymentId) {
-      throw new BadRequestException({
-        message: 'No payment ID found for domain',
-        errorCode: 'BILLING_DOMAIN_PAYMENT_ID_MISSING',
-      })
-    }
+    if (!options.skipPaymentVerification) {
+      if (!domain.paymentId) {
+        throw new BadRequestException({
+          message: 'No payment ID found for domain',
+          errorCode: 'BILLING_DOMAIN_PAYMENT_ID_MISSING',
+        })
+      }
 
-    const paymentIntent = await this.payments.retrievePayment(domain.paymentId)
-
-    // Stripe SDK uses broad union types — cannot narrow without runtime expandable-field check
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    if ((paymentIntent.status as PaymentStatus) !== PaymentStatus.SUCCEEDED) {
-      throw new BadRequestException(
-        `Payment not completed. Current status: ${paymentIntent.status}`,
+      const paymentIntent = await this.payments.retrievePayment(
+        domain.paymentId,
       )
+
+      // Stripe SDK uses broad union types — cannot narrow without runtime expandable-field check
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      if ((paymentIntent.status as PaymentStatus) !== PaymentStatus.SUCCEEDED) {
+        throw new BadRequestException(
+          `Payment not completed. Current status: ${paymentIntent.status}`,
+        )
+      }
     }
 
     if (!domain.price) {

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -3,6 +3,7 @@ import {
   BadGatewayException,
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   HttpStatus,
   Injectable,
   NotFoundException,
@@ -651,6 +652,17 @@ export class DomainsService
     alreadyExisted: boolean
     message: string
   }> {
+    // The skip-payment branch below bills GP's Vercel team account; gate to
+    // Pro campaigns so non-Pro browser callers can't bypass Stripe Checkout.
+    // (Pro covers the bundled domain per the product design.) Strict
+    // agent-only discrimination would require an actor-token claim from the
+    // broker — tracked separately.
+    if (!campaign.isPro) {
+      throw new ForbiddenException(
+        'Domain purchase requires an active Pro subscription',
+      )
+    }
+
     const preflightHit = await this.preflightDomainPurchase(
       campaign.id,
       domainName,


### PR DESCRIPTION
…lidation

- Updated the purchaseDomain method to accept a maxPrice parameter, ensuring that domain prices do not exceed the specified limit.
- Changed domain status from 'pending' to 'submitted' upon successful purchase.
- Modified response messages to reflect the new registration process.
- Enhanced tests to cover scenarios involving maxPrice validation and updated assertions accordingly.
- Updated metadata descriptions for clarity in the MCP tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes domain purchase and registration flow, adds a payment-bypass path for agent purchases, and spends against GP’s Vercel account bounded only by maxPrice.
> 
> **Overview**
> **POST `/domains/purchase`** now requires **`maxPrice`** (same cap as search). After availability checks, the service re-prices via Vercel and returns **409** if the live price is above `maxPrice`—no DB reservation or registration runs in that case.
> 
> Agent/campaign purchases are no longer “reserve pending, finish after Stripe.” On success they **run `completeDomainRegistration` inline** with **`skipPaymentVerification: true`** (GP-billed Vercel path; `maxPrice` is the spend guard). Responses and MCP copy move from **reserve / `pending`** to **purchase / `submitted`** with message **“Domain registration submitted.”** Browser checkout still uses payment-gated registration via `handleDomainPostPurchase`.
> 
> Tests cover `maxPrice` delegation, over-cap conflicts, and the skip-payment registration path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17aa3ef9b6e7f697a1d9bd45c594b35add6d1c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->