### PR TITLE
Decouple meeting_schedule and meeting_briefings

### DIFF
--- a/prisma/schema/meetingBriefing.jsonTypes.d.ts
+++ b/prisma/schema/meetingBriefing.jsonTypes.d.ts
@@ -12,6 +12,8 @@ declare global {
         | 'no_meeting_found'
         | 'error'
       meeting_date?: string
+      meeting_time?: string
+      meeting_timezone?: string
       meeting_name?: string
       location?: string
       [key: string]: Prisma.JsonValue | undefined

--- a/src/generated/agent-job-contracts.ts
+++ b/src/generated/agent-job-contracts.ts
@@ -315,7 +315,239 @@ export interface MeetingBriefingFull {
    */
   disclosure: string
   estimated_read_minutes: number
-  executive_summary: string
+  executive_summary: {
+    /**
+     * One entry per featured item in top-level items[], in the same order. Empty when no items qualify as featured (and for placeholder briefing_status values).
+     *
+     * @maxItems 5
+     */
+    items:
+      | []
+      | [
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+        ]
+      | [
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+        ]
+      | [
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+        ]
+      | [
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+        ]
+      | [
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+        ]
+    /**
+     * Single framing sentence at the top of the briefing. For briefing_ready artifacts: defaults to 'The following items on your agenda require action and/or have a vote:' (with trailing colon when items follow). For awaiting_agenda / no_meeting_found / error: a check-back or no-meeting message; items[] is empty.
+     */
+    lead_in: string
+  }
   /**
    * Experiment id, echoed from PARAMS.
    */
@@ -829,6 +1061,14 @@ export interface MeetingBriefingFull {
    * Official name of the meeting body as the source refers to it (e.g. 'City Council', 'Planning Board'). Used as the list-row title in the candidate dashboard. Mirrors meeting_schedule.meeting_name when a schedule exists.
    */
   meeting_name: string
+  /**
+   * Start time of the meeting in 24-hour HH:MM format, in the local timezone given by meeting_timezone. Briefings own this independently of meeting_schedule so the row is self-sufficient.
+   */
+  meeting_time: string
+  /**
+   * IANA timezone name for meeting_time (e.g. 'America/Chicago'). Use the timezone the governing body publishes the meeting in, not UTC.
+   */
+  meeting_timezone: string
   official_name: string
   required_data_points: {
     allowed_source_types?: (
@@ -912,7 +1152,239 @@ export interface MeetingBriefingPlaceholder {
    */
   disclosure: string
   estimated_read_minutes: number
-  executive_summary: string
+  executive_summary: {
+    /**
+     * One entry per featured item in top-level items[], in the same order. Empty when no items qualify as featured (and for placeholder briefing_status values).
+     *
+     * @maxItems 5
+     */
+    items:
+      | []
+      | [
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+        ]
+      | [
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+        ]
+      | [
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+        ]
+      | [
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+        ]
+      | [
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+          {
+            /**
+             * Must resolve to an entry in top-level items[] with tier='featured'. UI uses this to link the entry to the corresponding deep-dive panel.
+             */
+            item_id: string
+            /**
+             * One-sentence distillation of items[item_id].display.summary (the Step 9 Overview) — same facts, tighter framing.
+             */
+            overview: string
+            /**
+             * Item title shown before the em-dash. Must verbatim equal items[item_id].title (denormalized for renderer convenience).
+             */
+            title: string
+          },
+        ]
+    /**
+     * Single framing sentence at the top of the briefing. For briefing_ready artifacts: defaults to 'The following items on your agenda require action and/or have a vote:' (with trailing colon when items follow). For awaiting_agenda / no_meeting_found / error: a check-back or no-meeting message; items[] is empty.
+     */
+    lead_in: string
+  }
   /**
    * Experiment id, echoed from PARAMS.
    */
@@ -992,6 +1464,14 @@ export interface MeetingBriefingPlaceholder {
    * Official name of the meeting body (e.g. 'City Council'). Required-but-may-be-empty: populate when the meeting is identified (awaiting_agenda), emit an empty string when no_meeting_found or error.
    */
   meeting_name: string
+  /**
+   * Start time of the meeting in 24-hour HH:MM format, in the local timezone given by meeting_timezone. Required-but-may-be-empty: populate when the meeting is identified (awaiting_agenda), emit an empty string when no_meeting_found or error.
+   */
+  meeting_time: string
+  /**
+   * IANA timezone name for meeting_time (e.g. 'America/Chicago'). Required-but-may-be-empty: populate when the meeting is identified, emit an empty string when no_meeting_found or error.
+   */
+  meeting_timezone: string
   official_name: string
   required_data_points: {
     allowed_source_types?: (

--- a/src/meetings/CLAUDE.md
+++ b/src/meetings/CLAUDE.md
@@ -12,28 +12,28 @@ This module is intentionally a thin orchestration layer over `agentExperiments`.
 
 Eight Prisma models + two enums participate. File paths are under `prisma/schema/`.
 
-| Model                       | File                              | Role                                                                                                      |
-| --------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `MeetingBriefing`           | `meetingBriefing.prisma`          | One row per `(electedOfficeId, meetingDate)`. Points at the S3 artifact and caches a typed copy in JSONB. |
-| `ExperimentRun`             | `experimentRun.prisma`            | Dispatch + result row for both `meeting_schedule` and `meeting_briefing` agent runs.                      |
-| `Annotation`                | `annotation.prisma`               | A user marker on a briefing — a note, a chat anchor, or a bug report. Joined to the briefing via `resourceId` + `resourceType=briefing`. |
-| `AnnotationNote`            | `annotationNote.prisma`           | Optional `body` (typed text) for `kind=note` annotations. Owns attachments.                               |
-| `AnnotationNoteAttachment`  | `annotationNoteAttachment.prisma` | File uploads on a note (image / pdf / docx / plaintext). Carries OCR status + extracted text.             |
-| `ChatConversation`          | `chatConversation.prisma`         | Persistent conversation owned by a user. Linked 1:1 to an `Annotation` of `kind=chat`.                    |
-| `ChatMessage`               | `chatMessage.prisma`              | Individual user/assistant/system/tool message in a conversation.                                          |
-| `ArtifactFeedback`          | `artifactFeedback.prisma`         | Per-user thumbs up/down on an item inside the briefing artifact (currently agenda items only).            |
+| Model                      | File                              | Role                                                                                                                                     |
+| -------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `MeetingBriefing`          | `meetingBriefing.prisma`          | One row per `(electedOfficeId, meetingDate)`. Points at the S3 artifact and caches a typed copy in JSONB.                                |
+| `ExperimentRun`            | `experimentRun.prisma`            | Dispatch + result row for both `meeting_schedule` and `meeting_briefing` agent runs.                                                     |
+| `Annotation`               | `annotation.prisma`               | A user marker on a briefing — a note, a chat anchor, or a bug report. Joined to the briefing via `resourceId` + `resourceType=briefing`. |
+| `AnnotationNote`           | `annotationNote.prisma`           | Optional `body` (typed text) for `kind=note` annotations. Owns attachments.                                                              |
+| `AnnotationNoteAttachment` | `annotationNoteAttachment.prisma` | File uploads on a note (image / pdf / docx / plaintext). Carries OCR status + extracted text.                                            |
+| `ChatConversation`         | `chatConversation.prisma`         | Persistent conversation owned by a user. Linked 1:1 to an `Annotation` of `kind=chat`.                                                   |
+| `ChatMessage`              | `chatMessage.prisma`              | Individual user/assistant/system/tool message in a conversation.                                                                         |
+| `ArtifactFeedback`         | `artifactFeedback.prisma`         | Per-user thumbs up/down on an item inside the briefing artifact (currently agenda items only).                                           |
 
 Enums:
 
-| Enum                     | Values                                                          | Used by                       |
-| ------------------------ | --------------------------------------------------------------- | ----------------------------- |
-| `AnnotationKind`         | `note`, `chat`, `bug_report`                                    | `Annotation.kind`             |
-| `AnnotationResourceType` | `briefing` (only value today)                                   | `Annotation.resourceType`     |
-| `OcrStatus`              | `pending`, `processing`, `completed`, `failed`, `skipped`       | `AnnotationNoteAttachment.ocrStatus` |
-| `ChatMessageRole`        | `user`, `assistant`, `system`, `tool`                           | `ChatMessage.role`            |
-| `ArtifactResourceType`   | `agenda_item`                                                   | `ArtifactFeedback.artifactType` |
-| `ArtifactFeedbackKind`   | `positive`, `negative`                                          | `ArtifactFeedback.feedback`   |
-| `ExperimentRunStatus`    | `RUNNING`, `COMPLETED`, `FAILED`                                | `ExperimentRun.status`        |
+| Enum                     | Values                                                    | Used by                              |
+| ------------------------ | --------------------------------------------------------- | ------------------------------------ |
+| `AnnotationKind`         | `note`, `chat`, `bug_report`                              | `Annotation.kind`                    |
+| `AnnotationResourceType` | `briefing` (only value today)                             | `Annotation.resourceType`            |
+| `OcrStatus`              | `pending`, `processing`, `completed`, `failed`, `skipped` | `AnnotationNoteAttachment.ocrStatus` |
+| `ChatMessageRole`        | `user`, `assistant`, `system`, `tool`                     | `ChatMessage.role`                   |
+| `ArtifactResourceType`   | `agenda_item`                                             | `ArtifactFeedback.artifactType`      |
+| `ArtifactFeedbackKind`   | `positive`, `negative`                                    | `ArtifactFeedback.feedback`          |
+| `ExperimentRunStatus`    | `RUNNING`, `COMPLETED`, `FAILED`                          | `ExperimentRun.status`               |
 
 Note: there is **no** `MeetingSchedule` Prisma model. "The schedule" is a JSON shape (`MeetingSchedule` in `src/generated/agent-job-contracts.ts`) produced by the `meeting_schedule` agent experiment and read on demand from S3 via `MeetingBriefingsService.loadLatestScheduleForOrg()`. The most recent `COMPLETED` schedule run for the org wins.
 
@@ -45,11 +45,11 @@ ElectedOffice created
        ▼
 MeetingBriefingsService.onElectedOfficeCreated()
        │
-       ▼
-ExperimentRunsService.dispatchRun({ type: 'meeting_schedule', ... })
-       │  SQS: agent-dispatch-{env}.fifo
-       ▼
-PMF agent (runbooks) crawls the gov site, returns a MeetingSchedule artifact
+       ├──► ExperimentRunsService.dispatchRun({ type: 'meeting_schedule', ... })
+       └──► ExperimentRunsService.dispatchRun({ type: 'meeting_briefing', ... })
+              │  (both dispatched in parallel — briefing does not wait on schedule)
+              ▼
+PMF agents (runbooks) run independently and emit their artifacts
        │  SQS: agent results queue
        ▼
 QueueConsumerService.handleAgentExperimentResult
@@ -57,15 +57,15 @@ QueueConsumerService.handleAgentExperimentResult
        ▼
 MeetingBriefingsService.onExperimentRunCompleted(run)
        │
-       ├── if experimentType=meeting_schedule → dispatchFirstBriefingForOrg()
-       │      (chains a meeting_briefing dispatch)
-       │
        └── if experimentType=meeting_briefing → upsertBriefingRow()
-              │  Loads schedule artifact, validates briefing_status,
-              │  parses meeting_date, writes/updates MeetingBriefing row
+              │  validates briefing_status, parses meeting_date,
+              │  reads meeting_time + meeting_timezone from the artifact,
+              │  writes/updates the MeetingBriefing row
               ▼
          MeetingBriefing row visible at GET /v1/meetings/:date/briefing
 ```
+
+Schedule and briefing are decoupled. `onExperimentRunCompleted` does nothing on `meeting_schedule` completion — the schedule artifact is read on demand by the list endpoint via `loadLatestScheduleForOrg()` to project upcoming meeting dates from the RRULE. A briefing row is self-sufficient: its `meetingTime` and `meetingTimezone` come from the briefing artifact, not from the schedule.
 
 The daily cron (`dispatchDailyBriefings`, `0 7 * * *` UTC) sweeps every `ElectedOffice`, and dispatches a `meeting_briefing` run for any office whose next future `MeetingBriefing` row is missing.
 
@@ -79,44 +79,44 @@ The daily cron (`dispatchDailyBriefings`, `0 7 * * *` UTC) sweeps every `Elected
 
 ### `src/meetings/controllers/meetingsBriefings.controller.ts` — `/v1/meetings/*`
 
-| Method | Path                            | Notes                                                                                                                       |
-| ------ | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| GET    | `/meetings`                     | Lists upcoming meetings. Merges projected dates from the schedule (RRULE) with existing `MeetingBriefing` rows. Returns `{ scheduleKnown, meetings[] }`. |
-| GET    | `/meetings/:date/briefing`      | Returns the full briefing artifact JSON for that date, or `{ status: 'awaiting_agenda', ... }` if no row yet (200, not 404). Frontend treats `awaiting_agenda` as "the meeting is on the schedule but the agent hasn't filled the briefing yet". |
-| POST   | `/meetings/briefings/dispatch`  | Admin only. Manually kicks a `schedule` or `briefing` dispatch for a specific `electedOfficeId`. 404 if context can't be resolved (missing user clerkId, missing position, etc.). |
+| Method | Path                           | Notes                                                                                                                                                                                                                                            |
+| ------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| GET    | `/meetings`                    | Lists upcoming meetings. Merges projected dates from the schedule (RRULE) with existing `MeetingBriefing` rows. Returns `{ scheduleKnown, meetings[] }`.                                                                                         |
+| GET    | `/meetings/:date/briefing`     | Returns the full briefing artifact JSON for that date, or `{ status: 'awaiting_agenda', ... }` if no row yet (200, not 404). Frontend treats `awaiting_agenda` as "the meeting is on the schedule but the agent hasn't filled the briefing yet". |
+| POST   | `/meetings/briefings/dispatch` | Admin only. Manually kicks a `schedule` or `briefing` dispatch for a specific `electedOfficeId`. 404 if context can't be resolved (missing user clerkId, missing position, etc.).                                                                |
 
 ### `src/annotations/controllers/briefingAnnotations.controller.ts` — `/v1/meetings/:date/briefing/annotations`
 
-| Method | Path  | Notes                                                                                                  |
-| ------ | ----- | ------------------------------------------------------------------------------------------------------ |
-| GET    | `/`   | List the user's annotations (any `kind`) for that briefing. `resourceId` is resolved server-side from the date. |
-| POST   | `/`   | Create a new annotation. Body specifies kind, optional jsonPath + start/end character offsets, and a note body or chat seed. |
+| Method | Path | Notes                                                                                                                        |
+| ------ | ---- | ---------------------------------------------------------------------------------------------------------------------------- |
+| GET    | `/`  | List the user's annotations (any `kind`) for that briefing. `resourceId` is resolved server-side from the date.              |
+| POST   | `/`  | Create a new annotation. Body specifies kind, optional jsonPath + start/end character offsets, and a note body or chat seed. |
 
 ### `src/annotations/controllers/annotations.controller.ts` — `/v1/annotations/:annotationId/*`
 
-| Method | Path                                                       | Notes                                                                |
-| ------ | ---------------------------------------------------------- | -------------------------------------------------------------------- |
-| PUT    | `/:annotationId/note`                                      | Update the typed body of a note annotation. Body may be empty when relying on attachment OCR text. |
-| DELETE | `/:annotationId`                                           | 204. Cascade-deletes note / chat / bug report rows.                  |
-| POST   | `/:annotationId/note/attachments/presign`                  | Returns a presigned PUT URL for direct S3 upload. Creates an `AnnotationNoteAttachment` row in `ocrStatus=pending`. |
-| POST   | `/:annotationId/note/attachments/:attachmentId/complete`   | 204. Caller invokes after the PUT succeeds. Triggers OCR worker.     |
-| DELETE | `/:annotationId/note/attachments/:attachmentId`            | 204.                                                                 |
+| Method | Path                                                     | Notes                                                                                                               |
+| ------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| PUT    | `/:annotationId/note`                                    | Update the typed body of a note annotation. Body may be empty when relying on attachment OCR text.                  |
+| DELETE | `/:annotationId`                                         | 204. Cascade-deletes note / chat / bug report rows.                                                                 |
+| POST   | `/:annotationId/note/attachments/presign`                | Returns a presigned PUT URL for direct S3 upload. Creates an `AnnotationNoteAttachment` row in `ocrStatus=pending`. |
+| POST   | `/:annotationId/note/attachments/:attachmentId/complete` | 204. Caller invokes after the PUT succeeds. Triggers OCR worker.                                                    |
+| DELETE | `/:annotationId/note/attachments/:attachmentId`          | 204.                                                                                                                |
 
 ### `src/artifactFeedback/controllers/briefingItemFeedback.controller.ts` — `/v1/meetings/:date/briefing/items/:itemId/feedback`
 
-| Method | Path | Notes                                                       |
-| ------ | ---- | ----------------------------------------------------------- |
+| Method | Path | Notes                                                                                                      |
+| ------ | ---- | ---------------------------------------------------------------------------------------------------------- |
 | PUT    | `/`  | Set `positive` or `negative` feedback on an agenda item ID. Idempotent per `(user, briefing, item, type)`. |
-| DELETE | `/`  | 204. Clears the user's feedback for the item.               |
+| DELETE | `/`  | 204. Clears the user's feedback for the item.                                                              |
 
 ### `src/chats/briefing-chats/controllers/briefing-chats.controller.ts` — `/v1/briefing-chats/*`
 
-| Method | Path                          | Notes                                                                                                  |
-| ------ | ----------------------------- | ------------------------------------------------------------------------------------------------------ |
-| POST   | `/`                           | Find-or-create the chat conversation for a `(meetingDate, anchor)` pair. Idempotent. Creates an `Annotation` of `kind=chat` linked to a `ChatConversation`. |
-| POST   | `/:annotationId/messages`     | SSE stream. Calls `BriefingChatsService.sendMessage()`. Streams Claude output as `data: {...}\n\n` chunks. 5-minute server timeout. |
-| GET    | `/:annotationId`              | Replay the persisted conversation.                                                                     |
-| DELETE | `/:annotationId`              | 204. Soft-deletes the `ChatConversation` (`deletedAt` set, messages preserved).                        |
+| Method | Path                      | Notes                                                                                                                                                       |
+| ------ | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| POST   | `/`                       | Find-or-create the chat conversation for a `(meetingDate, anchor)` pair. Idempotent. Creates an `Annotation` of `kind=chat` linked to a `ChatConversation`. |
+| POST   | `/:annotationId/messages` | SSE stream. Calls `BriefingChatsService.sendMessage()`. Streams Claude output as `data: {...}\n\n` chunks. 5-minute server timeout.                         |
+| GET    | `/:annotationId`          | Replay the persisted conversation.                                                                                                                          |
+| DELETE | `/:annotationId`          | 204. Soft-deletes the `ChatConversation` (`deletedAt` set, messages preserved).                                                                             |
 
 ## Notes, dictation, and transcription
 
@@ -143,13 +143,13 @@ The frontend uploads asynchronously and polls the attachment until `ocrStatus` i
 
 Built per request in `buildToolsForUser()`. Availability depends on env vars and resolved context:
 
-| Tool                   | Provider                          | Available when                                                                              |
-| ---------------------- | --------------------------------- | ------------------------------------------------------------------------------------------- |
-| `get_artifacts`        | `BriefingArtifactsProvider`       | Always.                                                                                     |
-| `web_search`           | `TavilySearchProvider`            | `TAVILY_API_KEY` is set.                                                                    |
-| `district_insights`    | `DatabricksSqlProvider`           | Databricks env vars are set **and** `DistrictResolverService.resolveByUserId()` returns a district. Locked to the `int__l2_nationwide_uniform_w_haystaq` table with mandatory district filters. |
-| `list_district_topics` | Static                            | Same condition as `district_insights`.                                                      |
-| `get_my_notes`         | `LazyNotesProvider`               | Only when `BriefingNotesService.countNotesForUser()` > 0. The count check is up-front; the actual notes load is deferred to first tool call. |
+| Tool                   | Provider                    | Available when                                                                                                                                                                                  |
+| ---------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get_artifacts`        | `BriefingArtifactsProvider` | Always.                                                                                                                                                                                         |
+| `web_search`           | `TavilySearchProvider`      | `TAVILY_API_KEY` is set.                                                                                                                                                                        |
+| `district_insights`    | `DatabricksSqlProvider`     | Databricks env vars are set **and** `DistrictResolverService.resolveByUserId()` returns a district. Locked to the `int__l2_nationwide_uniform_w_haystaq` table with mandatory district filters. |
+| `list_district_topics` | Static                      | Same condition as `district_insights`.                                                                                                                                                          |
+| `get_my_notes`         | `LazyNotesProvider`         | Only when `BriefingNotesService.countNotesForUser()` > 0. The count check is up-front; the actual notes load is deferred to first tool call.                                                    |
 
 ### Lazy notes provider pattern
 
@@ -178,10 +178,10 @@ The `meetings` feature is a transport-layer caller of the `agentExperiments` mod
 
 ## Cron jobs
 
-| Cron                                  | Service / method                                       | Schedule       |
-| ------------------------------------- | ------------------------------------------------------ | -------------- |
-| Daily briefing dispatch               | `MeetingBriefingsService.dispatchDailyBriefings`       | `0 7 * * *` UTC |
-| Stale experiment-run sweeper          | `ExperimentRunsService.sweepStaleRuns`                 | `*/15 * * * *` |
+| Cron                         | Service / method                                 | Schedule        |
+| ---------------------------- | ------------------------------------------------ | --------------- |
+| Daily briefing dispatch      | `MeetingBriefingsService.dispatchDailyBriefings` | `0 7 * * *` UTC |
+| Stale experiment-run sweeper | `ExperimentRunsService.sweepStaleRuns`           | `*/15 * * * *`  |
 
 In dev/QA, `dispatchDailyBriefings` will fan out one SQS message per `ElectedOffice` if `MEETINGS_AUTOMATION_ENABLED=true`. This is loud — leave the env var unset (or `false`) on non-production environments unless you are deliberately testing the cron.
 
@@ -191,31 +191,31 @@ In dev/QA, `dispatchDailyBriefings` will fan out one SQS message per `ElectedOff
 - **Internal data source names must not leak.** Tables like `int__l2_nationwide_uniform_w_haystaq` and any column starting with `hs_` / `l2_` are internal. The `DISTRICT_INSIGHTS_RULES` block enforces this on the chat path, but the briefing artifact itself can still embed these names — the frontend (and any future export path) must mask at the boundary.
 - **`AnnotationNote.body` is nullable.** Anything reading notes for AI context, surface display, or search must consider the attachment OCR fallback. The current `BriefingNotesService.loadNotesForChat` filters notes with empty body — confirm whether that's intentional for your call site (see "Notes, dictation, and transcription" above). **TODO: verify** that the recent context-unification work actually wires OCR text into this path.
 - **`onExperimentRunCompleted` runs inside the queue consumer.** It uses `optimisticLockingUpdate` on the experiment run. Don't add a second writer to the same row outside that pattern — duplicate SQS deliveries already rely on the lock for idempotency.
-- **`upsertBriefingRow` is unique on `(electedOfficeId, meetingDate)`.** Two briefing runs for the same date overwrite each other (intended). The schedule artifact is resolved at write-time, so a stale schedule can produce a row with a wrong `meetingTime`/`meetingTimezone`.
+- **`upsertBriefingRow` is unique on `(electedOfficeId, meetingDate)`.** Two briefing runs for the same date overwrite each other (intended). `meetingTime` and `meetingTimezone` come from the briefing artifact (`meeting_time`, `meeting_timezone`); the schedule artifact is not consulted here. A malformed `meeting_time` (not `HH:MM`) or missing `meeting_timezone` skips the row write so the next run can retry.
 - **`MeetingBriefing.artifact` is a typed JSONB cache.** Source of truth is the S3 object at `artifactBucket`/`artifactKey`. `GET /:date/briefing` always re-reads from S3; the JSONB copy is only used in list aggregation and is fine to drift in dev.
 - **`awaiting_agenda` is a 200 response, not a 404.** The frontend renders a placeholder for it. If you "fix" this to return 404, you'll break the list view.
 - **`getBriefing` returns raw `JSON.parse` output.** No Zod validation on the response (intentional — the artifact schema is evolving and validating here would cause 500s on legitimate new fields). Treat the response as untrusted-ish in any downstream consumer.
 
 ## Pointer table
 
-| Area                                  | Path                                                                              |
-| ------------------------------------- | --------------------------------------------------------------------------------- |
-| Briefing dispatch + lifecycle         | `src/meetings/services/meetingBriefings.service.ts`                               |
-| Briefing list + read endpoint         | `src/meetings/controllers/meetingsBriefings.controller.ts`                        |
-| Annotations service                   | `src/annotations/services/annotations.service.ts`                                 |
-| Attachment / presign / OCR trigger    | `src/annotations/services/annotationAttachment.service.ts`                        |
-| OCR extractors + Textract             | `src/ocr/`                                                                        |
-| Per-item feedback                     | `src/artifactFeedback/services/artifactFeedback.service.ts`                       |
-| Chat orchestration                    | `src/chats/briefing-chats/services/briefing-chats.service.ts`                     |
-| Chat context loader                   | `src/chats/briefing-chats/services/briefingContext.service.ts`                    |
-| Chat notes loader                     | `src/chats/briefing-chats/services/briefingNotes.service.ts`                      |
-| System prompt builder                 | `src/chats/briefing-chats/services/systemPromptBuilder.ts`                        |
-| AI tools                              | `src/llm/tools/{getArtifacts,getMyNotes,webSearch,districtInsights,districtTopics}.tool.ts` |
-| Experiment dispatch transport         | `src/agentExperiments/services/experimentRuns.service.ts`                         |
-| Queue consumer hook                   | `src/queue/consumer/queueConsumer.service.ts` (`handleAgentExperimentResult`)     |
+| Area                                          | Path                                                                                            |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Briefing dispatch + lifecycle                 | `src/meetings/services/meetingBriefings.service.ts`                                             |
+| Briefing list + read endpoint                 | `src/meetings/controllers/meetingsBriefings.controller.ts`                                      |
+| Annotations service                           | `src/annotations/services/annotations.service.ts`                                               |
+| Attachment / presign / OCR trigger            | `src/annotations/services/annotationAttachment.service.ts`                                      |
+| OCR extractors + Textract                     | `src/ocr/`                                                                                      |
+| Per-item feedback                             | `src/artifactFeedback/services/artifactFeedback.service.ts`                                     |
+| Chat orchestration                            | `src/chats/briefing-chats/services/briefing-chats.service.ts`                                   |
+| Chat context loader                           | `src/chats/briefing-chats/services/briefingContext.service.ts`                                  |
+| Chat notes loader                             | `src/chats/briefing-chats/services/briefingNotes.service.ts`                                    |
+| System prompt builder                         | `src/chats/briefing-chats/services/systemPromptBuilder.ts`                                      |
+| AI tools                                      | `src/llm/tools/{getArtifacts,getMyNotes,webSearch,districtInsights,districtTopics}.tool.ts`     |
+| Experiment dispatch transport                 | `src/agentExperiments/services/experimentRuns.service.ts`                                       |
+| Queue consumer hook                           | `src/queue/consumer/queueConsumer.service.ts` (`handleAgentExperimentResult`)                   |
 | Shared contracts (annotation, feedback, chat) | `contracts/src/annotations/`, `contracts/src/artifactFeedback/`, `contracts/src/briefingChats/` |
-| Frontend route                        | `gp-webapp` → `/elected-official/meetings/*`                                      |
-| Agent runbooks                        | `runbooks/` repo — `meeting_schedule` and `meeting_briefing` experiments          |
-| Module shape ADR                      | `docs/adr/0001-prisma-base-pattern.md`                                            |
-| Single-queue ADR                      | `docs/adr/0003-fifo-sqs-single-queue.md`                                          |
-| Sibling module docs                   | `src/agentExperiments/CLAUDE.md`, `src/queue/CLAUDE.md`, `prisma/CLAUDE.md`       |
+| Frontend route                                | `gp-webapp` → `/elected-official/meetings/*`                                                    |
+| Agent runbooks                                | `runbooks/` repo — `meeting_schedule` and `meeting_briefing` experiments                        |
+| Module shape ADR                              | `docs/adr/0001-prisma-base-pattern.md`                                                          |
+| Single-queue ADR                              | `docs/adr/0003-fifo-sqs-single-queue.md`                                                        |
+| Sibling module docs                           | `src/agentExperiments/CLAUDE.md`, `src/queue/CLAUDE.md`, `prisma/CLAUDE.md`                     |

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -35,7 +35,7 @@ const mockS3 = (responses: Record<string, string | undefined>) => {
   )
 }
 
-describe('POST /v1/elected-office dispatches meeting_schedule', () => {
+describe('POST /v1/elected-office dispatches schedule + briefing in parallel', () => {
   beforeEach(() => {
     vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', 'true')
   })
@@ -62,7 +62,7 @@ describe('POST /v1/elected-office dispatches meeting_schedule', () => {
     expect(dispatchSpy).not.toHaveBeenCalled()
   })
 
-  it('dispatches when org has a position', async () => {
+  it('dispatches both meeting_schedule and meeting_briefing when org has a position', async () => {
     const orgSlug = `eo-create-${Date.now()}`
     await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-123' })
 
@@ -87,6 +87,13 @@ describe('POST /v1/elected-office dispatches meeting_schedule', () => {
     )
 
     expect(res.status).toBe(201)
+    const dispatchedTypes = dispatchSpy.mock.calls.map(
+      ([arg]) => (arg as { type: string }).type,
+    )
+    expect(dispatchedTypes).toEqual(
+      expect.arrayContaining(['meeting_schedule', 'meeting_briefing']),
+    )
+    expect(dispatchSpy).toHaveBeenCalledTimes(2)
     expect(dispatchSpy).toHaveBeenCalledWith({
       type: 'meeting_schedule',
       organizationSlug: expect.stringMatching(/^eo-/) as string,
@@ -95,6 +102,16 @@ describe('POST /v1/elected-office dispatches meeting_schedule', () => {
         elected_office_id: res.data.id as string,
         state: 'MN',
         office: 'City Council',
+      },
+    })
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: 'meeting_briefing',
+      organizationSlug: expect.stringMatching(/^eo-/) as string,
+      clerkUserId: service.user.clerkId!,
+      params: {
+        officialName: `${service.user.firstName} ${service.user.lastName}`,
+        state: 'MN',
+        positionName: 'City Council',
       },
     })
   })
@@ -126,10 +143,9 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
     vi.unstubAllEnvs()
   })
 
-  it('does not dispatch briefing on schedule completion when MEETINGS_AUTOMATION_ENABLED is unset', async () => {
-    vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', '')
-    const orgSlug = `eo-chain-gate-${Date.now()}`
-    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-chain-gate' })
+  it('does not dispatch anything on schedule completion (chaining removed)', async () => {
+    const orgSlug = `eo-chain-removed-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-chain-removed' })
     await service.prisma.electedOffice.create({
       data: { organizationSlug: orgSlug, userId: service.user.id },
     })
@@ -151,74 +167,13 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
     expect(dispatchSpy).not.toHaveBeenCalled()
   })
 
-  it('dispatches meeting_briefing for the org after meeting_schedule completes', async () => {
-    const orgSlug = `eo-chain-${Date.now()}`
-    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-chain' })
-    await service.prisma.electedOffice.create({
-      data: {
-        organizationSlug: orgSlug,
-        userId: service.user.id,
-        campaignId: (
-          await service.prisma.campaign.findFirst({
-            where: { organizationSlug: orgSlug },
-          })
-        )?.id,
-      },
-    })
-    vi.spyOn(
-      service.app.get(ElectionsService),
-      'getPositionById',
-    ).mockResolvedValue({
-      id: 'pos-real-id',
-      brPositionId: 'br-pos-chain',
-      brDatabaseId: 'br-db-chain',
-      state: 'MN',
-      name: 'City Council',
-    })
-    const scheduleRun = await service.prisma.experimentRun.create({
-      data: {
-        organizationSlug: orgSlug,
-        experimentType: 'meeting_schedule',
-        status: ExperimentRunStatus.COMPLETED,
-      },
-    })
-    const dispatchSpy = vi
-      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
-
-    await service.app
-      .get(MeetingBriefingsService)
-      .onExperimentRunCompleted(scheduleRun)
-
-    expect(dispatchSpy).toHaveBeenCalledTimes(1)
-    expect(dispatchSpy).toHaveBeenCalledWith({
-      type: 'meeting_briefing',
-      organizationSlug: orgSlug,
-      clerkUserId: service.user.clerkId!,
-      params: {
-        officialName: `${service.user.firstName} ${service.user.lastName}`,
-        state: 'MN',
-        positionName: 'City Council',
-      },
-    })
-  })
-
-  it('upserts MeetingBriefing row on briefing completion (reads date from artifact)', async () => {
+  it('upserts MeetingBriefing row on briefing completion (time + tz from artifact, no schedule needed)', async () => {
     const orgSlug = `eo-upsert-${Date.now()}`
     await service.prisma.organization.create({
       data: { slug: orgSlug, ownerId: service.user.id },
     })
     const eo = await service.prisma.electedOffice.create({
       data: { organizationSlug: orgSlug, userId: service.user.id },
-    })
-    await service.prisma.experimentRun.create({
-      data: {
-        organizationSlug: orgSlug,
-        experimentType: 'meeting_schedule',
-        status: ExperimentRunStatus.COMPLETED,
-        artifactBucket: 'schedule-bucket',
-        artifactKey: 'schedule.json',
-      },
     })
     const briefingRun = await service.prisma.experimentRun.create({
       data: {
@@ -231,16 +186,11 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
       },
     })
     mockS3({
-      'schedule.json': JSON.stringify({
-        status: 'known',
-        rrule: 'FREQ=WEEKLY;BYDAY=MO',
-        time: '19:00',
-        timezone: 'America/Chicago',
-        duration_minutes: 60,
-      }),
       'briefing.json': JSON.stringify({
         briefing_status: 'briefing_ready',
         meeting_date: '2026-06-08',
+        meeting_time: '19:00',
+        meeting_timezone: 'America/Chicago',
         meeting_name: 'City Council',
         location: 'Council Chambers',
       }),
@@ -259,11 +209,96 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
       },
     })
     expect(row).not.toBeNull()
+    expect(row?.meetingTime).toBe('19:00')
+    expect(row?.meetingTimezone).toBe('America/Chicago')
     expect(row?.artifactBucket).toBe('briefing-bucket')
     expect(row?.artifactKey).toBe('briefing.json')
     expect(row?.experimentRunId).toBe(briefingRun.runId)
     expect(row?.artifact?.meeting_name).toBe('City Council')
     expect(row?.artifact?.location).toBe('Council Chambers')
+  })
+
+  it('does not write a row when meeting_time is missing or malformed', async () => {
+    const orgSlug = `eo-bad-time-${Date.now()}`
+    await service.prisma.organization.create({
+      data: { slug: orgSlug, ownerId: service.user.id },
+    })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing.json',
+        params: { elected_office_id: eo.id },
+      },
+    })
+    mockS3({
+      'briefing.json': JSON.stringify({
+        briefing_status: 'briefing_ready',
+        meeting_date: '2026-06-08',
+        meeting_time: '7pm',
+        meeting_timezone: 'America/Chicago',
+      }),
+    })
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(briefingRun)
+
+    const row = await service.prisma.meetingBriefing.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: eo.id,
+          meetingDate: new Date('2026-06-08'),
+        },
+      },
+    })
+    expect(row).toBeNull()
+  })
+
+  it('does not write a row when meeting_timezone is missing', async () => {
+    const orgSlug = `eo-no-tz-${Date.now()}`
+    await service.prisma.organization.create({
+      data: { slug: orgSlug, ownerId: service.user.id },
+    })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing.json',
+        params: { elected_office_id: eo.id },
+      },
+    })
+    mockS3({
+      'briefing.json': JSON.stringify({
+        briefing_status: 'briefing_ready',
+        meeting_date: '2026-06-08',
+        meeting_time: '19:00',
+      }),
+    })
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(briefingRun)
+
+    const row = await service.prisma.meetingBriefing.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: eo.id,
+          meetingDate: new Date('2026-06-08'),
+        },
+      },
+    })
+    expect(row).toBeNull()
   })
 
   it('does not write a MeetingBriefing row for placeholder briefing_status (awaiting_agenda)', async () => {

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -120,14 +120,14 @@ export class MeetingBriefingsService extends createPrismaBase(
     if (!isAutomationEnabled()) {
       this.logger.info(
         { electedOfficeId: electedOffice.id },
-        'meetings automation disabled; skipping auto schedule dispatch',
+        'meetings automation disabled; skipping auto dispatch',
       )
       return
     }
     const ctx = await this.resolveDispatchContext(electedOffice)
     if (!ctx) return
 
-    await this.dispatchSchedule(ctx)
+    await Promise.all([this.dispatchSchedule(ctx), this.dispatchBriefing(ctx)])
   }
 
   private async dispatchSchedule(ctx: DispatchContext): Promise<void> {
@@ -181,18 +181,6 @@ export class MeetingBriefingsService extends createPrismaBase(
   async onExperimentRunCompleted(run: ExperimentRun): Promise<void> {
     if (run.status !== ExperimentRunStatus.COMPLETED) return
 
-    if (run.experimentType === SCHEDULE_EXPERIMENT_TYPE) {
-      if (!isAutomationEnabled()) {
-        this.logger.info(
-          { runId: run.runId },
-          'meetings automation disabled; skipping briefing dispatch on schedule completion',
-        )
-        return
-      }
-      await this.dispatchFirstBriefingForOrg(run.organizationSlug)
-      return
-    }
-
     if (run.experimentType === BRIEFING_EXPERIMENT_TYPE) {
       await this.upsertBriefingRow(run)
     }
@@ -244,31 +232,6 @@ export class MeetingBriefingsService extends createPrismaBase(
     if (!ctx) return
 
     await this.dispatchBriefing(ctx)
-  }
-
-  private async dispatchFirstBriefingForOrg(
-    organizationSlug: string,
-  ): Promise<void> {
-    const eo = await this.client.electedOffice.findFirst({
-      where: { organizationSlug },
-    })
-    if (!eo) return
-
-    const ctx = await this.resolveDispatchContext(eo)
-    if (!ctx) return
-
-    await this.experimentRuns.dispatchRun({
-      type: BRIEFING_EXPERIMENT_TYPE,
-      organizationSlug: ctx.organizationSlug,
-      clerkUserId: ctx.clerkUserId,
-      params: {
-        officialName: ctx.officialName,
-        state: ctx.state,
-        positionName: ctx.positionName,
-        ...(ctx.l2DistrictType ? { l2DistrictType: ctx.l2DistrictType } : {}),
-        ...(ctx.l2DistrictName ? { l2DistrictName: ctx.l2DistrictName } : {}),
-      },
-    })
   }
 
   private async resolveDispatchContext(
@@ -407,16 +370,27 @@ export class MeetingBriefingsService extends createPrismaBase(
       return
     }
 
-    const schedule = await this.loadLatestScheduleForOrg(run.organizationSlug)
-    if (!schedule || schedule.status === 'not_found') {
+    const meetingTime =
+      typeof artifact.meeting_time === 'string' ? artifact.meeting_time : ''
+    if (!/^([01][0-9]|2[0-3]):[0-5][0-9]$/.test(meetingTime)) {
       this.logger.error(
-        { runId: run.runId, organizationSlug: run.organizationSlug },
-        'meeting_briefing completed but no schedule found for the org',
+        { runId: run.runId, meetingTime },
+        'meeting_briefing artifact has invalid meeting_time',
       )
       return
     }
-    const meetingTime = schedule.time
-    const meetingTimezone = schedule.timezone
+
+    const meetingTimezone =
+      typeof artifact.meeting_timezone === 'string'
+        ? artifact.meeting_timezone
+        : ''
+    if (!meetingTimezone) {
+      this.logger.error(
+        { runId: run.runId },
+        'meeting_briefing artifact missing meeting_timezone',
+      )
+      return
+    }
 
     await this.model.upsert({
       where: {


### PR DESCRIPTION
Updating based on: https://github.com/thegoodparty/runbooks/pull/36

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes experiment orchestration and makes briefing persistence depend on new artifact fields from the paired runbooks change; offices may temporarily lack briefing rows until agents emit valid `meeting_time`/`meeting_timezone`.
> 
> **Overview**
> **Decouples** `meeting_schedule` and `meeting_briefing` so they no longer run in sequence. On elected-office creation (when automation is on), both experiments are dispatched **in parallel**; completing a schedule run **no longer** triggers a briefing dispatch (`dispatchFirstBriefingForOrg` removed).
> 
> **Briefing rows** are populated only from the briefing artifact: `upsertBriefingRow` now requires **`meeting_time`** (24h `HH:MM`) and **`meeting_timezone`** (IANA) on the artifact and **stops** loading time/timezone from the latest schedule S3 artifact. Invalid or missing values skip the DB write so a later run can retry.
> 
> **Contracts/types** are regenerated to match runbooks: briefing artifacts add `meeting_time` / `meeting_timezone`; **`executive_summary`** changes from a string to a structured object (`lead_in` + up to five featured-item entries with `item_id`, `title`, `overview`). Prisma JSON types for `MeetingBriefingArtifact` include the new optional time fields.
> 
> Tests and `src/meetings/CLAUDE.md` document the new flow and validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c621feab2a646b819cfa602ce414d071695e99. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->