### PR TITLE
remove admin gate

### DIFF
--- a/src/meetings/controllers/meetingsBriefings.controller.test.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ExperimentRunStatus, UserRole } from '@prisma/client'
+import { ExperimentRunStatus } from '@prisma/client'
 import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
 import { ElectionsService } from '@/elections/services/elections.service'
 import { addDays, getDay, parseISO } from 'date-fns'
@@ -654,22 +654,7 @@ describe('POST /v1/meetings/briefings/dispatch', () => {
     vi.unstubAllEnvs()
   })
 
-  const makeAdmin = () =>
-    service.prisma.user.update({
-      where: { id: service.user.id },
-      data: { roles: [UserRole.admin] },
-    })
-
-  it('returns 403 when caller is not an admin', async () => {
-    const result = await service.client.post(
-      '/v1/meetings/briefings/dispatch',
-      { electedOfficeId: 'any-id', kind: 'schedule' },
-    )
-    expect(result.status).toBe(403)
-  })
-
   it('returns 400 when body is missing required fields', async () => {
-    await makeAdmin()
     const result = await service.client.post(
       '/v1/meetings/briefings/dispatch',
       {},
@@ -678,7 +663,6 @@ describe('POST /v1/meetings/briefings/dispatch', () => {
   })
 
   it('returns 404 when elected office is not found', async () => {
-    await makeAdmin()
     const result = await service.client.post(
       '/v1/meetings/briefings/dispatch',
       { electedOfficeId: 'nonexistent', kind: 'schedule' },
@@ -687,7 +671,6 @@ describe('POST /v1/meetings/briefings/dispatch', () => {
   })
 
   it('returns 200 and dispatches when admin sends a valid request', async () => {
-    await makeAdmin()
     const orgSlug = `eo-dispatch-${Date.now()}`
     await service.prisma.organization.create({
       data: { slug: orgSlug, ownerId: service.user.id, positionId: 'br-pos-d' },

--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -7,10 +7,9 @@ import {
   Post,
 } from '@nestjs/common'
 import { ZodValidationPipe } from 'nestjs-zod'
-import { ElectedOffice, UserRole } from '@prisma/client'
+import { ElectedOffice } from '@prisma/client'
 import { addMonths, subDays } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
-import { Roles } from '@/authentication/decorators/Roles.decorator'
 import { ReqElectedOffice } from '@/electedOffice/decorators/ReqElectedOffice.decorator'
 import { UseElectedOffice } from '@/electedOffice/decorators/UseElectedOffice.decorator'
 import { S3Service } from '@/vendors/aws/services/s3.service'
@@ -170,7 +169,6 @@ export class MeetingsBriefingsController {
     }
   }
 
-  @Roles(UserRole.admin)
   @Post('briefings/dispatch')
   async dispatchAgent(
     @Body(new ZodValidationPipe(DispatchMeetingAgentSchema))

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -518,11 +518,7 @@ describe('DomainsService', () => {
       }
 
       await expect(
-        service.purchaseDomainForCampaign(
-          nonProCampaign,
-          domainName,
-          maxPrice,
-        ),
+        service.purchaseDomainForCampaign(nonProCampaign, domainName, maxPrice),
       ).rejects.toBeInstanceOf(ForbiddenException)
 
       expect(mockPrisma.website.findUnique).not.toHaveBeenCalled()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Any authenticated user can trigger `meeting_schedule` / `meeting_briefing` experiment dispatches for a supplied `electedOfficeId`, which is a meaningful authorization relaxation on agent automation.
> 
> **Overview**
> Removes the **admin-only** restriction on `POST /v1/meetings/briefings/dispatch` by dropping `@Roles(UserRole.admin)` from `dispatchAgent` in `meetingsBriefings.controller.ts`. The endpoint still requires a normal authenticated session (global guards unchanged) and keeps the same body validation and `dispatchManual` behavior (404 when the elected office or dispatch context cannot be resolved).
> 
> Tests no longer promote the caller to admin: the **403 for non-admin** case and `makeAdmin()` helper are removed, and the remaining dispatch specs run as the default test user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1b9a40b47572f60f1ffd439bc49ae1269399ddb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->