### PR TITLE
Gate daily briefing cron to elected offices created on/after 2026-03-01

### DIFF
--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -571,6 +571,41 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
       }),
     )
   })
+
+  it('skips EOs created before 2026-03-01', async () => {
+    const orgSlug = `eo-cron-old-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-cron-old' })
+    const campaign = await service.prisma.campaign.findFirst({
+      where: { organizationSlug: orgSlug },
+    })
+    await service.prisma.electedOffice.create({
+      data: {
+        organizationSlug: orgSlug,
+        userId: service.user.id,
+        campaignId: campaign?.id,
+        createdAt: new Date('2026-02-28T23:59:59.000Z'),
+      },
+    })
+
+    vi.spyOn(
+      service.app.get(ElectionsService),
+      'getPositionById',
+    ).mockResolvedValue({
+      id: 'pos-real-id',
+      brPositionId: 'br-pos-cron-old',
+      brDatabaseId: 'br-db-cron-old',
+      state: 'MN',
+      name: 'City Council',
+    })
+
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    await service.app.get(MeetingBriefingsService).dispatchDailyBriefings()
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
 })
 
 describe('MeetingBriefingsService.dispatchManual', () => {

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -30,6 +30,10 @@ const parseSchedule = (raw: string): MeetingSchedule =>
 const SCHEDULE_EXPERIMENT_TYPE = 'meeting_schedule'
 const BRIEFING_EXPERIMENT_TYPE = 'meeting_briefing'
 
+const DAILY_BRIEFINGS_ELECTED_OFFICE_CREATED_AT_FLOOR = new Date(
+  '2026-03-01T00:00:00.000Z',
+)
+
 const isAutomationEnabled = () =>
   process.env.MEETINGS_AUTOMATION_ENABLED === 'true'
 
@@ -203,6 +207,9 @@ export class MeetingBriefingsService extends createPrismaBase(
       return
     }
     const offices = await this.client.electedOffice.findMany({
+      where: {
+        createdAt: { gte: DAILY_BRIEFINGS_ELECTED_OFFICE_CREATED_AT_FLOOR },
+      },
       select: { id: true, organizationSlug: true, userId: true },
     })
 


### PR DESCRIPTION
## Summary

The nightly `dispatchDailyBriefings` cron has been fanning out a `meeting_briefing` dispatch for every `ElectedOffice` in the database. Some of those rows predate the current onboarding flow and shouldn't have briefings generated for them — they were never set up with the right context, and the cron is wasting agent runs on them.

This gates the cron to only consider EOs with `createdAt >= 2026-03-01`. Post-create dispatch (`onElectedOfficeCreated`) and admin manual dispatch are unchanged, so a pre-cutoff EO can still be triggered manually if needed.

The floor is a module-level constant rather than env-driven because it's a one-time cutoff tied to the meetings feature rollout, not something we expect to retune.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows an automated cron query only; no auth, API contract, or manual dispatch behavior changes.
> 
> **Overview**
> The **daily `dispatchDailyBriefings` cron** no longer loads every `ElectedOffice`; it only considers rows with **`createdAt` on or after `2026-03-01`**, via a module-level `DAILY_BRIEFINGS_ELECTED_OFFICE_CREATED_AT_FLOOR` constant on `findMany`.
> 
> That limits nightly `meeting_briefing` fan-out to offices created under the current meetings onboarding, while **post-create automation** and **`dispatchManual`** are unchanged (older offices can still be triggered manually).
> 
> A test asserts an EO created just before the cutoff does not get a cron dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99205b9ba421cc66d847a8c66ce5d89b68f5b4fa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->