### PR TITLE
feat(annotations): raise per-note attachment cap from 1 to 20

### DIFF
--- a/src/annotations/services/annotationAttachment.service.ts
+++ b/src/annotations/services/annotationAttachment.service.ts
@@ -21,7 +21,7 @@ import { OcrService } from '@/ocr/ocr.service'
 import { QueueProducerService } from '@/queue/producer/queueProducer.service'
 import { MessageGroup, QueueType } from '@/queue/queue.types'
 
-const MAX_ATTACHMENTS_PER_NOTE = 1
+const MAX_ATTACHMENTS_PER_NOTE = 20
 const UPLOAD_URL_EXPIRES_IN = 60 * 15 // 15 minutes
 const OCR_TEXT_MAX_BYTES = 200_000
 
@@ -101,8 +101,8 @@ export class AnnotationAttachmentService extends createPrismaBase(
 
   /**
    * Creates a pending attachment row and returns a presigned S3 PUT URL.
-   * Per Phase 2 v1, one attachment per note — caller hitting this twice
-   * gets a 403.
+   * Capped at MAX_ATTACHMENTS_PER_NOTE per note; exceeding callers get a
+   * 403 (`attachment_limit_reached`).
    */
   async createPresign(
     annotationId: string,

--- a/src/annotations/tests/annotationAttachments.controller.test.ts
+++ b/src/annotations/tests/annotationAttachments.controller.test.ts
@@ -113,23 +113,27 @@ describe('POST /v1/annotations/:annotationId/note/attachments/presign', () => {
     expect(s3.upload).toHaveBeenCalledOnce()
   })
 
-  it('rejects a second attachment per note (one-per-note cap)', async () => {
+  it('rejects another attachment once the per-note cap is reached', async () => {
     const { annotation } = await seedBriefingAndNote('eo-cap')
     mockS3()
 
-    const first = await service.client.post(
-      `/v1/annotations/${annotation.id}/note/attachments/presign`,
-      validPresign,
-      orgHeader('eo-cap'),
-    )
-    expect(first.status).toBe(201)
+    // The service caps attachments at 20 per note. Fill it up, then assert
+    // the 21st request is forbidden.
+    for (let i = 0; i < 20; i++) {
+      const accepted = await service.client.post(
+        `/v1/annotations/${annotation.id}/note/attachments/presign`,
+        validPresign,
+        orgHeader('eo-cap'),
+      )
+      expect(accepted.status).toBe(201)
+    }
 
-    const second = await service.client.post(
+    const overflow = await service.client.post(
       `/v1/annotations/${annotation.id}/note/attachments/presign`,
       validPresign,
       orgHeader('eo-cap'),
     )
-    expect(second.status).toBe(403)
+    expect(overflow.status).toBe(403)
   })
 
   it('rejects disallowed mime types', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small constant and test change; existing transactional enforcement and S3/OCR flow are unchanged.
> 
> **Overview**
> Raises the per–briefing-note attachment limit from **1** to **20** on the presign path in `AnnotationAttachmentService`, still enforced inside the existing serializable transaction and returning **403** `attachment_limit_reached` when the cap is exceeded.
> 
> Controller coverage now presigns **20** attachments successfully and asserts the **21st** is rejected, instead of only testing a second upload after one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d71a6c2cf78df37b155445ec4b053ce9d780143. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->