### PR TITLE
Constituent Download Refactor

### DIFF
--- a/deploy/components/service.ts
+++ b/deploy/components/service.ts
@@ -114,7 +114,12 @@ export function createService({
     securityGroups: [albSecurityGroup.id],
     subnets: publicSubnetIds,
     enableCrossZoneLoadBalancing: true,
-    idleTimeout: 120,
+    // 5 minutes — large CSV exports (e.g. constituent contacts proxied from
+    // people-api) can stream for several minutes on slow consumer
+    // connections. The ALB severs any TCP connection idle longer than this,
+    // so we budget room for occasional backpressure stalls without dropping
+    // the download. Bytes ordinarily flow continuously.
+    idleTimeout: 300,
   })
 
   const targetGroup = new aws.lb.TargetGroup('targetGroup', {

--- a/src/contacts/contacts.controller.ts
+++ b/src/contacts/contacts.controller.ts
@@ -31,8 +31,12 @@ export class ContactsController {
     @ReqOrganization() organization: Organization,
     @Res() res: FastifyReply,
   ) {
-    res.header('Content-Type', 'text/csv')
-    res.header('Content-Disposition', 'attachment; filename="contacts.csv"')
+    // Headers (Content-Type, Content-Disposition, Set-Cookie) are written and
+    // flushed inside the service AFTER pre-flight checks pass and the
+    // upstream people-api stream is in hand. That keeps a structured 4xx/5xx
+    // possible if the org isn't pro or the upstream call fails, instead of
+    // committing `attachment; filename="contacts.csv"` to the wire and then
+    // serving a JSON error body the browser would save to disk.
     await this.contactsService.downloadContacts(dto, res, organization)
   }
 

--- a/src/contacts/services/contacts.service.test.ts
+++ b/src/contacts/services/contacts.service.test.ts
@@ -158,13 +158,34 @@ describe('ContactsService', () => {
     })
 
     describe('downloadContacts', () => {
-      it('throws when organization is not pro', async () => {
+      const makeMockStream = () => ({
+        destroyed: false,
+        pipe: vi.fn(),
+        destroy: vi.fn(),
+        on: vi.fn((event: string, cb: (err?: Error) => void) => {
+          if (event === 'end') setImmediate(() => cb())
+        }),
+      })
+
+      const makeMockReply = (headersSent = false) => {
+        const flushHeaders = vi.fn()
+        const setHeader = vi.fn()
+        const on = vi.fn()
+        return {
+          flushHeaders,
+          setHeader,
+          on,
+          res: { raw: { headersSent, flushHeaders, setHeader, on } } as never,
+        }
+      }
+
+      it('throws when organization is not pro and never touches response headers', async () => {
         const org = makeOrganization({
           slug: 'campaign-1',
           overrideDistrictId: OVERRIDE_DISTRICT_ID,
         })
         mockCampaignsService.findFirst.mockResolvedValue({ isPro: false })
-        const res = { raw: {} } as never
+        const { res, flushHeaders, setHeader } = makeMockReply()
 
         await expect(
           service.downloadContacts({ segment: 'all' }, res, org),
@@ -172,6 +193,31 @@ describe('ContactsService', () => {
         await expect(
           service.downloadContacts({ segment: 'all' }, res, org),
         ).rejects.toThrow('Campaign is not pro')
+
+        // Critical: pre-flight failures must NOT leave Content-Disposition,
+        // Set-Cookie, or a flushed 200 on the wire — otherwise the browser
+        // saves the JSON error body as `contacts.csv` and the client cookie
+        // poll falsely flips to "Download started".
+        expect(setHeader).not.toHaveBeenCalled()
+        expect(flushHeaders).not.toHaveBeenCalled()
+      })
+
+      it('throws when the upstream people-api call fails and never touches response headers', async () => {
+        const org = makeOrganization({
+          slug: 'eo-office-1',
+          overrideDistrictId: OVERRIDE_DISTRICT_ID,
+        })
+        mockHttpService.post.mockImplementationOnce(() => {
+          throw new Error('upstream blew up')
+        })
+        const { res, flushHeaders, setHeader } = makeMockReply()
+
+        await expect(
+          service.downloadContacts({ segment: 'all' }, res, org),
+        ).rejects.toThrow('Failed to download contacts from people API')
+
+        expect(setHeader).not.toHaveBeenCalled()
+        expect(flushHeaders).not.toHaveBeenCalled()
       })
 
       it('allows download when campaign is pro (isPro) even with a non-EO org', async () => {
@@ -181,14 +227,8 @@ describe('ContactsService', () => {
         })
         mockCampaignsService.findFirst.mockResolvedValue({ isPro: true })
 
-        const mockStream = {
-          pipe: vi.fn(),
-          on: vi.fn((event: string, cb: () => void) => {
-            if (event === 'end') setImmediate(cb)
-          }),
-        }
-        mockHttpService.post.mockReturnValue(of({ data: mockStream }))
-        const res = { raw: {} } as never
+        mockHttpService.post.mockReturnValue(of({ data: makeMockStream() }))
+        const { res } = makeMockReply()
 
         await expect(
           service.downloadContacts({ segment: 'all' }, res, org),
@@ -200,18 +240,95 @@ describe('ContactsService', () => {
           slug: 'eo-office-1',
           overrideDistrictId: OVERRIDE_DISTRICT_ID,
         })
-        const mockStream = {
-          pipe: vi.fn(),
-          on: vi.fn((event: string, cb: () => void) => {
-            if (event === 'end') setImmediate(cb)
-          }),
-        }
-        mockHttpService.post.mockReturnValue(of({ data: mockStream }))
-        const res = { raw: {} } as never
+        mockHttpService.post.mockReturnValue(of({ data: makeMockStream() }))
+        const { res } = makeMockReply()
 
         await expect(
           service.downloadContacts({ segment: 'all' }, res, org),
         ).resolves.toBeUndefined()
+      })
+
+      it('sets download headers (Content-Type, Content-Disposition, Set-Cookie) and flushes once the upstream stream is ready, then pipes', async () => {
+        const org = makeOrganization({
+          slug: 'eo-office-1',
+          overrideDistrictId: OVERRIDE_DISTRICT_ID,
+        })
+        const mockStream = makeMockStream()
+        mockHttpService.post.mockReturnValue(of({ data: mockStream }))
+        const { res, flushHeaders, setHeader } = makeMockReply()
+
+        await service.downloadContacts({ segment: 'all' }, res, org)
+
+        expect(setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv')
+        expect(setHeader).toHaveBeenCalledWith(
+          'Content-Disposition',
+          'attachment; filename="contacts.csv"',
+        )
+        // Cookie must be present, name=gp_download with a UUID value, and
+        // include Secure (production hygiene) + SameSite=Lax (the cookie
+        // travels on a top-level GET download navigation).
+        const cookieCall = setHeader.mock.calls.find(
+          (call) => call[0] === 'Set-Cookie',
+        )
+        expect(cookieCall).toBeDefined()
+        const cookieValue = cookieCall?.[1] as string
+        expect(cookieValue).toMatch(
+          /^gp_download=[0-9a-f-]{36};.*Path=\/.*Max-Age=30.*SameSite=Lax.*Secure/,
+        )
+
+        expect(flushHeaders).toHaveBeenCalledTimes(1)
+        expect(mockStream.pipe).toHaveBeenCalledTimes(1)
+      })
+
+      it('skips flushHeaders when headers were already sent but still pipes the body', async () => {
+        const org = makeOrganization({
+          slug: 'eo-office-1',
+          overrideDistrictId: OVERRIDE_DISTRICT_ID,
+        })
+        const mockStream = makeMockStream()
+        mockHttpService.post.mockReturnValue(of({ data: mockStream }))
+        const { res, flushHeaders } = makeMockReply(true)
+
+        await service.downloadContacts({ segment: 'all' }, res, org)
+
+        // Negative + positive: an early-return regression that bails on the
+        // whole pipe path can no longer pass this test.
+        expect(flushHeaders).not.toHaveBeenCalled()
+        expect(mockStream.pipe).toHaveBeenCalledTimes(1)
+      })
+
+      it('destroys the upstream stream when the client closes the connection mid-download', async () => {
+        const org = makeOrganization({
+          slug: 'eo-office-1',
+          overrideDistrictId: OVERRIDE_DISTRICT_ID,
+        })
+        const mockStream = makeMockStream()
+        // Override 'end' so the resolver isn't auto-fired; we want the
+        // res.raw 'close' handler to drive resolution.
+        mockStream.on = vi.fn()
+        mockHttpService.post.mockReturnValue(of({ data: mockStream }))
+        const { res, on: rawOn } = makeMockReply()
+
+        const completion = service.downloadContacts(
+          { segment: 'all' },
+          res,
+          org,
+        )
+
+        // `downloadContacts` resolves the segment + district asynchronously
+        // before constructing the streaming Promise, so wait until the
+        // service has wired its `'close'` listener on res.raw.
+        await vi.waitFor(() => {
+          expect(rawOn.mock.calls.some((call) => call[0] === 'close')).toBe(
+            true,
+          )
+        })
+        const closeCall = rawOn.mock.calls.find((call) => call[0] === 'close')
+        const closeHandler = closeCall?.[1] as () => void
+        closeHandler()
+
+        await expect(completion).resolves.toBeUndefined()
+        expect(mockStream.destroy).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -370,13 +487,22 @@ describe('ContactsService', () => {
         })
 
         const mockStream = {
+          destroyed: false,
           pipe: vi.fn(),
-          on: vi.fn((event: string, cb: () => void) => {
-            if (event === 'end') setImmediate(cb)
+          destroy: vi.fn(),
+          on: vi.fn((event: string, cb: (err?: Error) => void) => {
+            if (event === 'end') setImmediate(() => cb())
           }),
         }
         mockHttpService.post.mockReturnValue(of({ data: mockStream }))
-        const res = { raw: {} } as never
+        const res = {
+          raw: {
+            headersSent: false,
+            flushHeaders: vi.fn(),
+            setHeader: vi.fn(),
+            on: vi.fn(),
+          },
+        } as never
 
         await service.downloadContacts({ segment: 'all' }, res, org)
 

--- a/src/contacts/services/contacts.service.test.ts
+++ b/src/contacts/services/contacts.service.test.ts
@@ -297,6 +297,71 @@ describe('ContactsService', () => {
         expect(mockStream.pipe).toHaveBeenCalledTimes(1)
       })
 
+      it('absorbs upstream stream errors after headers are flushed (logs, destroys, does not reject)', async () => {
+        const org = makeOrganization({
+          slug: 'eo-office-1',
+          overrideDistrictId: OVERRIDE_DISTRICT_ID,
+        })
+        // Capture event handlers as they are registered so we can fire
+        // 'error' AFTER pipe + flushHeaders have run.
+        const handlers: Record<string, ((err?: Error) => void) | undefined> = {}
+        const mockStream = {
+          destroyed: false,
+          pipe: vi.fn(),
+          destroy: vi.fn(),
+          on: vi.fn((event: string, cb: (err?: Error) => void) => {
+            handlers[event] = cb
+          }),
+        }
+        mockHttpService.post.mockReturnValue(of({ data: mockStream }))
+
+        // res.raw needs `destroy` + `destroyed` for the post-headers cleanup
+        // path. The service must call `res.raw.destroy(err)` instead of
+        // letting the rejection bubble to the Nest exception filter (which
+        // would call `httpAdapter.reply` on an already-committed response).
+        const flushHeaders = vi.fn()
+        const setHeader = vi.fn()
+        const on = vi.fn()
+        const destroy = vi.fn()
+        const res = {
+          raw: {
+            headersSent: false,
+            destroyed: false,
+            flushHeaders,
+            setHeader,
+            on,
+            destroy,
+          },
+        } as never
+
+        const completion = service.downloadContacts(
+          { segment: 'all' },
+          res,
+          org,
+        )
+
+        // Wait for the service to register the upstream 'error' listener
+        // (segment + district resolution are async).
+        await vi.waitFor(() => {
+          expect(handlers.error).toBeDefined()
+        })
+
+        // Sanity: by the time we're firing 'error', headers MUST already be
+        // committed to the wire — otherwise the bug we are guarding against
+        // (filter writing JSON over committed headers) doesn't apply.
+        expect(flushHeaders).toHaveBeenCalledTimes(1)
+        expect(setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv')
+
+        const upstreamError = new Error('people-api connection reset')
+        handlers.error!(upstreamError)
+
+        await expect(completion).resolves.toBeUndefined()
+        // Both ends torn down, no rejection escapes to Nest's exception filter.
+        expect(mockStream.destroy).toHaveBeenCalledTimes(1)
+        expect(destroy).toHaveBeenCalledTimes(1)
+        expect(destroy).toHaveBeenCalledWith(upstreamError)
+      })
+
       it('destroys the upstream stream when the client closes the connection mid-download', async () => {
         const org = makeOrganization({
           slug: 'eo-office-1',

--- a/src/contacts/services/contacts.service.ts
+++ b/src/contacts/services/contacts.service.ts
@@ -282,7 +282,7 @@ export class ContactsService {
         res.raw.flushHeaders()
       }
 
-      return new Promise<void>((resolve, reject) => {
+      return new Promise<void>((resolve) => {
         let settled = false
         const settle = (fn: () => void) => {
           if (settled) return
@@ -297,10 +297,26 @@ export class ContactsService {
 
         response.data.pipe(res.raw)
         response.data.on('end', () => settle(resolve))
+        // Once `flushHeaders()` above committed our HTTP headers to the wire,
+        // a mid-transfer upstream error must NOT propagate as a rejection.
+        // Nest's global exception filter would call
+        // `httpAdapter.reply(res.raw, jsonBody, 500)` on a response whose
+        // headers are already sent, producing either an
+        // `ERR_HTTP_HEADERS_SENT` warning or a corrupt CSV+JSON blob saved as
+        // `contacts.csv`. Instead: log, tear down both ends, and resolve so
+        // the controller's await falls through cleanly. The browser sees a
+        // truncated download and the operator sees the cause in the logs.
         response.data.on('error', (err: Error) =>
           settle(() => {
+            this.logger.error(
+              { err },
+              'Upstream stream error after download headers committed',
+            )
             destroyUpstream()
-            reject(err)
+            if (!res.raw.destroyed) {
+              res.raw.destroy(err)
+            }
+            resolve()
           }),
         )
         // Browser canceled / network closed mid-download: tear down the

--- a/src/contacts/services/contacts.service.ts
+++ b/src/contacts/services/contacts.service.ts
@@ -11,6 +11,7 @@ import { isAxiosError } from 'axios'
 import { FastifyReply } from 'fastify'
 import jwt from 'jsonwebtoken'
 import { PinoLogger } from 'nestjs-pino'
+import { randomUUID } from 'node:crypto'
 import { Readable } from 'node:stream'
 import { lastValueFrom } from 'rxjs'
 import { CampaignsService } from 'src/campaigns/services/campaigns.service'
@@ -231,8 +232,9 @@ export class ContactsService {
       districtParams: { districtId: string },
       filters: FilterObject,
     ) => {
+      let response: { data: Readable }
       try {
-        const response = await lastValueFrom(
+        response = await lastValueFrom(
           this.httpService.post<Readable>(
             `${PEOPLE_API_URL}/v1/people/download`,
             { ...districtParams, filters },
@@ -244,12 +246,6 @@ export class ContactsService {
             },
           ),
         )
-
-        return new Promise<void>((resolve, reject) => {
-          response.data.pipe(res.raw)
-          response.data.on('end', resolve)
-          response.data.on('error', reject)
-        })
       } catch (error) {
         this.logger.error(
           { error },
@@ -260,6 +256,64 @@ export class ContactsService {
           'Failed to download contacts from people API',
         )
       }
+
+      // Upstream is live. Only now do we commit our own response headers,
+      // because once these are flushed the connection becomes a binary
+      // download that any error response would corrupt (browser would save
+      // the JSON error blob as `contacts.csv`). All earlier failures
+      // (`isProAccess`, district resolution, axios POST) still produce a
+      // structured 4xx/5xx because nothing has been written to the wire yet.
+      res.raw.setHeader('Content-Type', 'text/csv')
+      res.raw.setHeader(
+        'Content-Disposition',
+        'attachment; filename="contacts.csv"',
+      )
+      // Cookie handshake the Download.tsx client polls for. The browser
+      // commits cookies from a download response, so its appearance is the
+      // signal that "the server has actually started streaming" and lets the
+      // client clear its preparing-state spinner ahead of the 15s fallback.
+      // `Secure` is fine for localhost too: Chrome/Firefox/Safari all treat
+      // localhost as a secure context for cookie purposes.
+      res.raw.setHeader(
+        'Set-Cookie',
+        `gp_download=${randomUUID()}; Path=/; Max-Age=30; SameSite=Lax; Secure`,
+      )
+      if (!res.raw.headersSent) {
+        res.raw.flushHeaders()
+      }
+
+      return new Promise<void>((resolve, reject) => {
+        let settled = false
+        const settle = (fn: () => void) => {
+          if (settled) return
+          settled = true
+          fn()
+        }
+        const destroyUpstream = () => {
+          if (!response.data.destroyed) {
+            response.data.destroy()
+          }
+        }
+
+        response.data.pipe(res.raw)
+        response.data.on('end', () => settle(resolve))
+        response.data.on('error', (err: Error) =>
+          settle(() => {
+            destroyUpstream()
+            reject(err)
+          }),
+        )
+        // Browser canceled / network closed mid-download: tear down the
+        // upstream people-api stream so the gp-api → people-api socket and
+        // the underlying pg COPY connection are released promptly instead of
+        // waiting for an idle-timeout.
+        res.raw.on('close', () =>
+          settle(() => {
+            destroyUpstream()
+            resolve()
+          }),
+        )
+      })
     }
 
     const filters = await this.segmentToFilters(segment, organization)

--- a/src/contacts/tests/contacts.e2e.ts
+++ b/src/contacts/tests/contacts.e2e.ts
@@ -233,6 +233,7 @@ test.describe('Contacts and Segments', () => {
     expect(response.status()).toBe(HttpStatus.OK)
     const contentType = response.headers()['content-type']
     const contentDisposition = response.headers()['content-disposition']
+    const setCookie = response.headers()['set-cookie']
     const body = await response.body()
     const csv = body.toString('utf-8')
     const lines = csv
@@ -246,6 +247,13 @@ test.describe('Contacts and Segments', () => {
     if (contentDisposition !== undefined) {
       expect(contentDisposition).toContain('contacts.csv')
     }
+    // The Download.tsx client polls for this cookie to know when the server
+    // has begun streaming. It must be emitted on every successful download
+    // response or the spinner falls back to the 15s timeout. The cookie is
+    // also marked Secure to satisfy production cookie hygiene.
+    expect(setCookie).toBeDefined()
+    expect(setCookie).toContain('gp_download=')
+    expect(setCookie).toContain('Secure')
     expect(body.length).toBeGreaterThan(0)
     expect(lines.length).toBeGreaterThan(1) // header + at least one record
     expect(lines[0]).toContain(',')

--- a/src/polls/polls.test.ts
+++ b/src/polls/polls.test.ts
@@ -161,6 +161,180 @@ describe('POST /polls/initial-poll', () => {
   })
 })
 
+describe('GET /polls/:pollId/download-responses', () => {
+  const eoHeaders = () => ({
+    headers: { 'x-organization-slug': eoOrgSlug },
+    responseType: 'arraybuffer' as const,
+  })
+
+  const seedPoll = async (overrides: Partial<{ name: string }> = {}) => {
+    const electedOffice = await service.prisma.electedOffice.findFirst({
+      where: { organizationSlug: eoOrgSlug },
+    })
+    if (!electedOffice) {
+      throw new Error('test setup: elected office not seeded')
+    }
+
+    return service.prisma.poll.create({
+      data: {
+        name: overrides.name ?? 'My Test Poll',
+        messageContent: 'How do you feel about local issues?',
+        targetAudienceSize: 1000,
+        scheduledDate: new Date('2025-01-01T00:00:00Z'),
+        estimatedCompletionDate: new Date('2025-01-08T00:00:00Z'),
+        electedOfficeId: electedOffice.id,
+      },
+    })
+  }
+
+  const seedIssue = (pollId: string, title: string) =>
+    service.prisma.pollIssue.create({
+      data: {
+        id: uuidv7(),
+        pollId,
+        title,
+        summary: `summary for ${title}`,
+        details: `details for ${title}`,
+        mentionCount: 1,
+        representativeComments: [],
+      },
+    })
+
+  const seedMessage = (
+    pollId: string,
+    overrides: Partial<{
+      content: string
+      sender: 'CONSTITUENT' | 'ELECTED_OFFICIAL'
+      sentAt: Date
+      isOptOut: boolean | null
+      issueIds: string[]
+    }> = {},
+  ) =>
+    service.prisma.pollIndividualMessage.create({
+      data: {
+        id: uuidv7(),
+        personId: uuidv7(),
+        sentAt: overrides.sentAt ?? new Date('2025-01-02T00:00:00Z'),
+        sender: overrides.sender ?? 'CONSTITUENT',
+        content: overrides.content ?? 'Default constituent response',
+        isOptOut: overrides.isOptOut ?? null,
+        pollId,
+        pollIssues: overrides.issueIds
+          ? { connect: overrides.issueIds.map((id) => ({ id })) }
+          : undefined,
+      },
+    })
+
+  it('streams constituent responses as CSV with the BOM + poll name header', async () => {
+    const poll = await seedPoll({ name: 'Town Hall Poll' })
+    const housing = await seedIssue(poll.id, 'Housing')
+    const transit = await seedIssue(poll.id, 'Transit')
+
+    await seedMessage(poll.id, {
+      content: 'We need more affordable housing',
+      sentAt: new Date('2025-01-02T00:00:00Z'),
+      issueIds: [housing.id],
+    })
+    await seedMessage(poll.id, {
+      content: 'Buses need to run later',
+      sentAt: new Date('2025-01-03T00:00:00Z'),
+      issueIds: [transit.id, housing.id],
+    })
+    // Excluded: ELECTED_OFFICIAL sender
+    await seedMessage(poll.id, {
+      content: 'Thanks for your feedback',
+      sender: 'ELECTED_OFFICIAL',
+      sentAt: new Date('2025-01-04T00:00:00Z'),
+    })
+    // Excluded: opt-out
+    await seedMessage(poll.id, {
+      content: 'STOP',
+      isOptOut: true,
+      sentAt: new Date('2025-01-05T00:00:00Z'),
+    })
+
+    const result = await service.client.get(
+      `/v1/polls/${poll.id}/download-responses`,
+      eoHeaders(),
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.headers['content-type']).toContain('text/csv')
+    expect(result.headers['content-disposition']).toContain(
+      'attachment; filename="Town Hall Poll.csv"',
+    )
+
+    const body = Buffer.from(result.data as ArrayBuffer).toString('utf-8')
+    const lines = body.split('\n')
+
+    expect(lines[0]).toBe('\uFEFFTown Hall Poll')
+    expect(lines[1]).toBe('message_content,associated_clusters')
+    // Postgres COPY only quotes fields that contain the delimiter, quote
+    // characters, or newlines. Issues are joined alphabetically with "; ".
+    expect(lines[2]).toBe('We need more affordable housing,Housing')
+    expect(lines[3]).toBe('Buses need to run later,Housing; Transit')
+    // No ELECTED_OFFICIAL row and no opt-out row
+    expect(body).not.toContain('Thanks for your feedback')
+    expect(body).not.toContain('STOP')
+  })
+
+  it('returns 404 for an unknown poll id', async () => {
+    const result = await service.client.get(
+      `/v1/polls/${uuidv7()}/download-responses`,
+      eoHeaders(),
+    )
+    expect(result.status).toBe(404)
+  })
+
+  it('returns 403 when the poll belongs to a different elected office', async () => {
+    const otherEoId = uuidv7()
+    const otherOrgSlug = `eo-${otherEoId}`
+    await service.prisma.organization.create({
+      data: { slug: otherOrgSlug, ownerId: service.user.id },
+    })
+    await service.prisma.electedOffice.create({
+      data: {
+        id: otherEoId,
+        userId: service.user.id,
+        organizationSlug: otherOrgSlug,
+      },
+    })
+    const foreignPoll = await service.prisma.poll.create({
+      data: {
+        name: 'Foreign Poll',
+        messageContent: 'msg',
+        targetAudienceSize: 100,
+        scheduledDate: new Date(),
+        estimatedCompletionDate: new Date(),
+        electedOfficeId: otherEoId,
+      },
+    })
+
+    const result = await service.client.get(
+      `/v1/polls/${foreignPoll.id}/download-responses`,
+      eoHeaders(),
+    )
+    expect(result.status).toBe(403)
+  })
+
+  it('emits only the BOM + name + header when the poll has no constituent responses', async () => {
+    const poll = await seedPoll({ name: 'Empty Poll' })
+    await seedMessage(poll.id, {
+      sender: 'ELECTED_OFFICIAL',
+      content: 'Hello',
+    })
+
+    const result = await service.client.get(
+      `/v1/polls/${poll.id}/download-responses`,
+      eoHeaders(),
+    )
+
+    expect(result.status).toBe(200)
+    const body = Buffer.from(result.data as ArrayBuffer).toString('utf-8')
+    expect(body).toBe('\uFEFFEmpty Poll\nmessage_content,associated_clusters\n')
+  })
+})
+
 describe('POST /polls/analyze-bias', () => {
   let pollBiasAnalysisService: PollBiasAnalysisService
 

--- a/src/polls/services/pollResponsesDownload.service.ts
+++ b/src/polls/services/pollResponsesDownload.service.ts
@@ -8,15 +8,17 @@ import { requireEnv } from 'src/shared/util/env.util'
 
 const UTF8_BOM = '\uFEFF'
 
-const DATABASE_URL = requireEnv('DATABASE_URL')
-
 @Injectable()
 export class PollResponsesDownloadService implements OnModuleDestroy {
   private readonly pool: Pool
 
   constructor(private readonly logger: PinoLogger) {
     this.logger.setContext(PollResponsesDownloadService.name)
-    this.pool = new Pool({ connectionString: DATABASE_URL })
+    // Read DATABASE_URL at construction time (not module-import time) so test
+    // harnesses that swap `process.env.DATABASE_URL` after the file is loaded
+    // — e.g. `useTestService()` pointing at a testcontainers Postgres — see
+    // the correct value.
+    this.pool = new Pool({ connectionString: requireEnv('DATABASE_URL') })
   }
 
   onModuleDestroy() {


### PR DESCRIPTION
These PRs enable a EO to download a 700K district in ~15 seconds


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes live download/streaming behavior and ALB idle timeout for all traffic through the load balancer; incorrect header timing could still affect client download UX, but pre-flight errors are safer than before.
> 
> **Overview**
> This PR hardens **long-running CSV downloads** and fixes cases where the browser saved JSON errors as `.csv`.
> 
> **Infrastructure:** ALB `idleTimeout` increases from **120s to 300s** so large constituent exports proxied from people-api are less likely to be cut off during slow streams or backpressure.
> 
> **Constituent contacts download (`/v1/contacts/download`):** CSV headers (`Content-Type`, `Content-Disposition`) and a **`gp_download` Set-Cookie** are set only **after** pro/district checks pass and the people-api stream is open—so failed requests can still return normal **4xx/5xx JSON**. The controller no longer sets attachment headers up front. Streaming tears down the upstream when the client disconnects mid-download. Unit and e2e tests cover header timing, cookie shape (`Secure`, `SameSite=Lax`), and upstream cleanup.
> 
> **Poll responses download:** `PollResponsesDownloadService` reads **`DATABASE_URL` at pool construction** (not at module load) so test harnesses that swap env after import use the right Postgres. New tests assert CSV shape (BOM + poll name, constituent-only rows, 404/403).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c6b5d60d715c3c5417b541ef74409abb98fd39f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->