### PR TITLE
feat(annotations): accept card-level anchor (json_path only, no offsets)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @goodparty_org/contracts
 
+## 0.7.0
+
+### Minor Changes
+
+- `AnnotationAnchorSchema` now accepts a third valid shape — **card-level**:
+  `json_path` set, `start` and `end` both `null`. The annotation is scoped
+  to a whole node (e.g. an agenda item card) without a passage selection.
+  The previously-valid shapes — fully passage-anchored (all three set) and
+  briefing-wide (all three `null`) — are unchanged. The inverse combination
+  (offsets without a `json_path`) is still rejected. Updated refine message
+  reflects the three valid shapes.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodparty_org/contracts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Shared Zod schemas and TypeScript types for the GoodParty API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/contracts/src/annotations/Annotation.schema.ts
+++ b/contracts/src/annotations/Annotation.schema.ts
@@ -26,8 +26,16 @@ export type AnnotationResourceType = z.infer<
 >
 
 /**
- * Anchor: either all three fields are set (text-anchored) or all three
- * are null (page-level / top-level annotation). Mixed states are rejected.
+ * Anchor: one of three valid shapes
+ *   - Passage-anchored: all three of `json_path`, `start`, `end` are set.
+ *     The annotation maps to a character range inside that node.
+ *   - Card-level:       `json_path` is set, both `start` and `end` are null.
+ *     The annotation is scoped to a whole card / artifact node without a
+ *     passage selection — e.g. a note attached to an entire agenda item.
+ *   - Briefing-wide:    all three are null. Legacy / page-scoped annotation.
+ *
+ * The (json_path null AND start/end set) combination is rejected — you
+ * can't reference an offset without a node to apply it to.
  */
 export const AnnotationAnchorSchema = z
   .object({
@@ -37,11 +45,18 @@ export const AnnotationAnchorSchema = z
   })
   .refine(
     (a) => {
-      const all = a.json_path !== null && a.start !== null && a.end !== null
-      const none = a.json_path === null && a.start === null && a.end === null
-      return all || none
+      const passage =
+        a.json_path !== null && a.start !== null && a.end !== null
+      const cardLevel =
+        a.json_path !== null && a.start === null && a.end === null
+      const briefingWide =
+        a.json_path === null && a.start === null && a.end === null
+      return passage || cardLevel || briefingWide
     },
-    { message: 'anchor must have all of json_path/start/end set or all null' },
+    {
+      message:
+        'anchor must be passage-anchored (all set), card-level (json_path only), or briefing-wide (all null)',
+    },
   )
   .refine((a) => a.start === null || a.end === null || a.start < a.end, {
     message: 'start must be less than end',

--- a/src/annotations/tests/annotations.controller.test.ts
+++ b/src/annotations/tests/annotations.controller.test.ts
@@ -64,6 +64,13 @@ const topLevelNote = {
   payload: { body: 'Top-level note.' },
 }
 
+const cardLevelNote = {
+  kind: 'note' as const,
+  // Card-level: json_path identifies the whole card; start/end are null.
+  anchor: { json_path: '/items/0', start: null, end: null },
+  payload: { body: 'A note about the whole card.' },
+}
+
 const bugReport = {
   kind: 'bug_report' as const,
   anchor: {
@@ -119,6 +126,27 @@ describe('POST /v1/meetings/:date/briefing/annotations', () => {
     })
   })
 
+  it('creates a card-level note when json_path is set but start/end are null', async () => {
+    const orgSlug = 'eo-cardlevel'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, '2026-06-08')
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-06-08/briefing/annotations',
+      cardLevelNote,
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(201)
+    expect(result.data).toMatchObject({
+      kind: 'note',
+      json_path: '/items/0',
+      start: null,
+      end: null,
+      note: { body: 'A note about the whole card.' },
+    })
+  })
+
   it('creates a bug_report', async () => {
     const orgSlug = 'eo-bug'
     const eo = await seedElectedOffice(orgSlug)
@@ -151,7 +179,10 @@ describe('POST /v1/meetings/:date/briefing/annotations', () => {
     expect(result.status).toBe(400)
   })
 
-  it('rejects mixed anchor (some fields null)', async () => {
+  it('rejects an anchor with offsets but no json_path', async () => {
+    // Card-level (json_path only) and briefing-wide (all null) are valid;
+    // only the inverse shape — offsets with no json_path to apply them to
+    // — is rejected.
     const orgSlug = 'eo-mixed-anchor'
     const eo = await seedElectedOffice(orgSlug)
     await seedBriefing(eo.id, orgSlug, '2026-06-08')
@@ -160,8 +191,8 @@ describe('POST /v1/meetings/:date/briefing/annotations', () => {
       '/v1/meetings/2026-06-08/briefing/annotations',
       {
         kind: 'note',
-        anchor: { json_path: '/items/0/title', start: null, end: null },
-        payload: { body: 'mismatch' },
+        anchor: { json_path: null, start: 0, end: 10 },
+        payload: { body: 'orphan offsets' },
       },
       orgHeader(orgSlug),
     )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Contract validation only—expands accepted anchors without changing auth or persistence logic; existing passage and briefing-wide anchors remain valid.
> 
> **Overview**
> **Annotation anchors** now support a third shape: **card-level** notes with `json_path` set and `start`/`end` null (whole card / agenda item), in addition to passage-anchored ranges and briefing-wide (all null).
> 
> The shared `AnnotationAnchorSchema` in contracts was updated so create requests accept that shape; **orphan offsets** (`json_path` null with `start`/`end` set) stay invalid. Controller tests add a **201** case for card-level creation and retarget the negative test to the rejected orphan-offset case (the old “mixed anchor” example with `json_path` only is now valid).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a8a98bf73a10fe00cbab703c00be708a0bb984. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->