### PR TITLE
feat(annotations): GET /attachments/:id/download-url returns presigne…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,3 +125,5 @@ GP_WEBAPP_MACHINE_SECRET=ak_...
 
 # Optional: skip heavy MTFCC seeding for local runs
 SKIP_MTFCC_SEED=false
+
+ANTHROPIC_API_KEY=your-anthropic-key

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @goodparty_org/contracts
 
+## 0.8.0
+
+### Minor Changes
+
+- Add `AttachmentDownloadUrlResponseSchema` /
+  `AttachmentDownloadUrlResponse`. Backs a new
+  `GET /v1/annotations/:annotationId/note/attachments/:attachmentId/download-url`
+  endpoint that returns a short-lived presigned S3 GET URL plus an ISO
+  `expires_at`. Clients render image attachments via `<img src>` and open
+  document attachments in a new tab against this URL; bytes never pass
+  through gp-api.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodparty_org/contracts",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Shared Zod schemas and TypeScript types for the GoodParty API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/contracts/src/annotations/Annotation.schema.ts
+++ b/contracts/src/annotations/Annotation.schema.ts
@@ -209,6 +209,21 @@ export type AttachmentPresignResponse = z.infer<
   typeof AttachmentPresignResponseSchema
 >
 
+/**
+ * Response from the GET-style "download URL" endpoint. The URL is a
+ * pre-signed S3 GET that clients can hit directly (for `<img src>` or
+ * `window.open`) without proxying bytes through gp-api. Short-lived;
+ * `expires_at` is an ISO timestamp the client can use to refetch
+ * before it lapses.
+ */
+export const AttachmentDownloadUrlResponseSchema = z.object({
+  download_url: z.string(),
+  expires_at: z.string(),
+})
+export type AttachmentDownloadUrlResponse = z.infer<
+  typeof AttachmentDownloadUrlResponseSchema
+>
+
 // ---------------------------------------------------------------------------
 // Response schemas
 // ---------------------------------------------------------------------------

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -306,6 +306,8 @@ export {
   type AttachmentPresignRequest,
   AttachmentPresignResponseSchema,
   type AttachmentPresignResponse,
+  AttachmentDownloadUrlResponseSchema,
+  type AttachmentDownloadUrlResponse,
   AnnotationResponseSchema,
   type AnnotationResponse,
   AnnotationsListResponseSchema,

--- a/src/annotations/controllers/annotations.controller.ts
+++ b/src/annotations/controllers/annotations.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  Get,
   HttpCode,
   Param,
   Post,
@@ -11,6 +12,7 @@ import { ZodValidationPipe } from 'nestjs-zod'
 import { ElectedOffice, User } from '@prisma/client'
 import {
   AnnotationResponseSchema,
+  AttachmentDownloadUrlResponseSchema,
   AttachmentPresignRequest,
   AttachmentPresignRequestSchema,
   UpdateNoteRequest,
@@ -90,6 +92,23 @@ export class AnnotationsController {
     @ReqElectedOffice() electedOffice: ElectedOffice,
   ): Promise<void> {
     await this.attachments.completeUpload(
+      annotationId,
+      attachmentId,
+      user.id,
+      electedOffice,
+    )
+  }
+
+  @UseElectedOffice()
+  @Get(':annotationId/note/attachments/:attachmentId/download-url')
+  @ResponseSchema(AttachmentDownloadUrlResponseSchema)
+  async getAttachmentDownloadUrl(
+    @Param('annotationId') annotationId: string,
+    @Param('attachmentId') attachmentId: string,
+    @ReqUser() user: User,
+    @ReqElectedOffice() electedOffice: ElectedOffice,
+  ) {
+    return this.attachments.createDownloadUrl(
       annotationId,
       attachmentId,
       user.id,

--- a/src/annotations/services/annotationAttachment.service.ts
+++ b/src/annotations/services/annotationAttachment.service.ts
@@ -12,6 +12,7 @@ import {
   Prisma,
 } from '@prisma/client'
 import {
+  AttachmentDownloadUrlResponse,
   AttachmentPresignRequest,
   AttachmentPresignResponse,
 } from '@goodparty_org/contracts'
@@ -23,6 +24,7 @@ import { MessageGroup, QueueType } from '@/queue/queue.types'
 
 const MAX_ATTACHMENTS_PER_NOTE = 20
 const UPLOAD_URL_EXPIRES_IN = 60 * 15 // 15 minutes
+const DOWNLOAD_URL_EXPIRES_IN = 60 * 15 // 15 minutes
 const OCR_TEXT_MAX_BYTES = 200_000
 
 /**
@@ -210,6 +212,48 @@ export class AnnotationAttachmentService extends createPrismaBase(
       MessageGroup.default,
       { deduplicationId: `ocr-${attachmentId}` },
     )
+  }
+
+  /**
+   * Returns a short-lived presigned S3 GET URL for this attachment. The
+   * client uses it for `<img src>` thumbnails on image attachments and
+   * `window.open` for non-image attachments. Bytes never pass through
+   * gp-api — the URL points straight at S3.
+   */
+  async createDownloadUrl(
+    annotationId: string,
+    attachmentId: string,
+    userId: number,
+    electedOffice: ElectedOffice,
+  ): Promise<AttachmentDownloadUrlResponse> {
+    const { noteId } = await this.loadOwnedNoteAnnotation(
+      annotationId,
+      userId,
+      electedOffice,
+    )
+    const attachment = await this.client.annotationNoteAttachment.findUnique({
+      where: { id: attachmentId },
+      select: { id: true, noteId: true, storageKey: true },
+    })
+    if (!attachment || attachment.noteId !== noteId) {
+      throw new NotFoundException('attachment_not_found')
+    }
+
+    const downloadUrl = await this.s3.getSignedUrlForViewing(
+      this.bucket,
+      attachment.storageKey,
+      { expiresIn: DOWNLOAD_URL_EXPIRES_IN },
+    )
+    if (!downloadUrl) {
+      throw new NotFoundException('attachment_not_found')
+    }
+
+    return {
+      download_url: downloadUrl,
+      expires_at: new Date(
+        Date.now() + DOWNLOAD_URL_EXPIRES_IN * 1000,
+      ).toISOString(),
+    }
   }
 
   /**

--- a/src/annotations/tests/annotationAttachments.controller.test.ts
+++ b/src/annotations/tests/annotationAttachments.controller.test.ts
@@ -72,6 +72,9 @@ const mockS3 = () => {
     upload: vi
       .spyOn(s3, 'getSignedUrlForUpload')
       .mockResolvedValue('https://s3.example/upload-url'),
+    view: vi
+      .spyOn(s3, 'getSignedUrlForViewing')
+      .mockResolvedValue('https://s3.example/download-url'),
     exists: vi.spyOn(s3, 'objectExists').mockResolvedValue(true),
     get: vi.spyOn(s3, 'getFileBytes').mockResolvedValue(Buffer.from('binary')),
     del: vi.spyOn(s3, 'deleteObject').mockResolvedValue(undefined),
@@ -231,6 +234,69 @@ describe('POST /v1/annotations/:annotationId/note/attachments/:attachmentId/comp
     )
 
     expect(result.status).toBe(400)
+  })
+})
+
+describe('GET /v1/annotations/:annotationId/note/attachments/:attachmentId/download-url', () => {
+  it('returns a presigned S3 GET URL plus an ISO expiry', async () => {
+    const { annotation } = await seedBriefingAndNote('eo-download')
+    const s3 = mockS3()
+
+    const presign = await service.client.post(
+      `/v1/annotations/${annotation.id}/note/attachments/presign`,
+      validPresign,
+      orgHeader('eo-download'),
+    )
+    expect(presign.status).toBe(201)
+    const attachmentId = presign.data.attachment_id
+
+    const result = await service.client.get(
+      `/v1/annotations/${annotation.id}/note/attachments/${attachmentId}/download-url`,
+      orgHeader('eo-download'),
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data).toMatchObject({
+      download_url: 'https://s3.example/download-url',
+    })
+    expect(typeof result.data.expires_at).toBe('string')
+    expect(Number.isNaN(Date.parse(result.data.expires_at))).toBe(false)
+    expect(s3.view).toHaveBeenCalledOnce()
+  })
+
+  it('returns 404 for an unknown attachment id', async () => {
+    const { annotation } = await seedBriefingAndNote('eo-download-missing')
+    mockS3()
+
+    const result = await service.client.get(
+      `/v1/annotations/${annotation.id}/note/attachments/does-not-exist/download-url`,
+      orgHeader('eo-download-missing'),
+    )
+
+    expect(result.status).toBe(404)
+  })
+
+  it('rejects callers who do not own the annotation', async () => {
+    const { annotation } = await seedBriefingAndNote('eo-download-owner')
+    mockS3()
+
+    const presign = await service.client.post(
+      `/v1/annotations/${annotation.id}/note/attachments/presign`,
+      validPresign,
+      orgHeader('eo-download-owner'),
+    )
+    expect(presign.status).toBe(201)
+    const attachmentId = presign.data.attachment_id
+
+    // Seed a second elected office and use its header — that user does
+    // not own the annotation, so the briefing-access check should 403.
+    await seedElectedOffice('eo-download-other')
+    const result = await service.client.get(
+      `/v1/annotations/${annotation.id}/note/attachments/${attachmentId}/download-url`,
+      orgHeader('eo-download-other'),
+    )
+
+    expect(result.status).toBe(403)
   })
 })
 


### PR DESCRIPTION
…d S3 GET URL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated endpoint issues time-limited S3 URLs for briefing attachments; access control mirrors existing attachment routes, but mishandled URLs could expose object bytes until expiry.
> 
> **Overview**
> Adds a **client-facing download path** for annotation note attachments: a new `GET .../download-url` returns a **15-minute presigned S3 GET URL** and `expires_at`, so images and documents load from S3 without streaming through gp-api.
> 
> **@goodparty_org/contracts** is bumped to **0.8.0** with `AttachmentDownloadUrlResponseSchema` / type and exports. **gp-api** wires `AnnotationsController.getAttachmentDownloadUrl` to `AnnotationAttachmentService.createDownloadUrl`, reusing the same note-ownership and briefing access checks as presign/complete/delete, then `S3Service.getSignedUrlForViewing`. Controller tests cover success, missing attachment (404), and non-owner (403).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37467bd4a06716c973ff341a9cc8a0c32089d0b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->