### PR TITLE
chore: fallback contact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -206,7 +206,7 @@
     },
     "contracts": {
       "name": "@goodparty_org/contracts",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "validator": "^13.12.0",
         "zod": "^3.23.8"

--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -215,28 +215,12 @@ describe('WebsitesController', () => {
     })
   })
 
-  describe('updateWebsite - domain publish precondition', () => {
+  describe('updateWebsite - attached-domain publish gate', () => {
     const publishBody = () => {
       const body = new UpdateWebsiteSchema()
       body.status = WebsiteStatus.published
       return body
     }
-
-    it('rejects publish when no custom domain is attached', async () => {
-      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
-        content: completeContent,
-        hasEverBeenPublished: false,
-        domain: null,
-      })
-
-      await expect(
-        controller.updateWebsite(mockUser, mockCampaign, publishBody()),
-      ).rejects.toMatchObject({
-        status: HttpStatus.BAD_REQUEST,
-        message: expect.stringContaining('no custom domain'),
-      })
-      expect(mockWebsitesService.update).not.toHaveBeenCalled()
-    })
 
     it('rejects publish when attached domain.status is pending', async () => {
       mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
@@ -282,6 +266,18 @@ describe('WebsitesController', () => {
       expect(mockWebsitesService.update).toHaveBeenCalled()
     })
 
+    it('allows publish without an attached domain (non-Pro / GP-hosted candidate site)', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: completeContent,
+        hasEverBeenPublished: false,
+        domain: null,
+      })
+
+      await controller.updateWebsite(mockUser, mockCampaign, publishBody())
+
+      expect(mockWebsitesService.update).toHaveBeenCalled()
+    })
+
     it('does not gate non-published status transitions (no domain required)', async () => {
       mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
         content: {},
@@ -310,34 +306,6 @@ describe('WebsitesController', () => {
       await controller.updateWebsite(mockUser, mockCampaign, body)
 
       expect(mockWebsitesService.update).toHaveBeenCalled()
-    })
-
-    it('allows republish for a legacy site (hasEverBeenPublished=true) without a custom domain', async () => {
-      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
-        content: completeContent,
-        hasEverBeenPublished: true,
-        domain: null,
-      })
-
-      await controller.updateWebsite(mockUser, mockCampaign, publishBody())
-
-      expect(mockWebsitesService.update).toHaveBeenCalled()
-    })
-
-    it('still rejects publish when domain is attached but in a non-publishable status, even on legacy sites', async () => {
-      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
-        content: completeContent,
-        hasEverBeenPublished: true,
-        domain: { status: DomainStatus.pending },
-      })
-
-      await expect(
-        controller.updateWebsite(mockUser, mockCampaign, publishBody()),
-      ).rejects.toMatchObject({
-        status: HttpStatus.BAD_REQUEST,
-        message: expect.stringContaining('pending'),
-      })
-      expect(mockWebsitesService.update).not.toHaveBeenCalled()
     })
   })
 
@@ -383,7 +351,7 @@ describe('WebsitesController', () => {
       await expect(
         controller.updateWebsite(mockUser, mockCampaign, publishBody()),
       ).rejects.toMatchObject({
-        message: expect.stringContaining('contact.phone'),
+        message: expect.stringContaining('contact.email'),
       })
     })
 
@@ -512,6 +480,46 @@ describe('WebsitesController', () => {
       await controller.updateWebsite(mockUser, mockCampaign, publishBody())
 
       expect(mockWebsitesService.update).toHaveBeenCalled()
+    })
+
+    it('fills contact.address and contact.phone from GP_DOMAIN_CONTACT when blank, then publishes', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: {
+          ...completeContent,
+          contact: { email: completeContent.contact!.email },
+        },
+        hasEverBeenPublished: false,
+        domain: { status: DomainStatus.submitted },
+      })
+
+      await controller.updateWebsite(mockUser, mockCampaign, publishBody())
+
+      const updateCall = mockWebsitesService.update.mock.calls[0][0]
+      expect(updateCall.data.content.contact.address).toBe(
+        '916 Silver Spur Rd, Rolling Hills Estates, CA 90274',
+      )
+      expect(updateCall.data.content.contact.phone).toBe('+1.3126851162')
+      expect(updateCall.data.content.contact.email).toBe(
+        completeContent.contact!.email,
+      )
+    })
+
+    it('does not overwrite candidate-provided contact.address or contact.phone', async () => {
+      mockWebsitesService.findUniqueOrThrow.mockResolvedValue({
+        content: completeContent,
+        hasEverBeenPublished: false,
+        domain: { status: DomainStatus.submitted },
+      })
+
+      await controller.updateWebsite(mockUser, mockCampaign, publishBody())
+
+      const updateCall = mockWebsitesService.update.mock.calls[0][0]
+      expect(updateCall.data.content.contact.address).toBe(
+        completeContent.contact!.address,
+      )
+      expect(updateCall.data.content.contact.phone).toBe(
+        completeContent.contact!.phone,
+      )
     })
 
     it('does not gate non-published status transitions', async () => {

--- a/src/websites/controllers/websites.controller.ts
+++ b/src/websites/controllers/websites.controller.ts
@@ -43,6 +43,7 @@ import { PinoLogger } from 'nestjs-pino'
 import { ClerkUserEnricherService } from '@/vendors/clerk/services/clerk-user-enricher.service'
 import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
 import { McpTool } from '@/mcp/decorators/McpTool.decorator'
+import { GP_DOMAIN_CONTACT } from '@/vendors/vercel/vercel.const'
 import { MyWebsiteResponseSchema } from '../schemas/WebsiteResponse.schema'
 import { VerifyLiveResponseSchema } from '../schemas/VerifyLive.schema'
 import { serializeWebsiteWithDomain } from '../util/serializeWebsite.util'
@@ -101,10 +102,25 @@ const REQUIRED_PUBLISH_FIELDS: Array<{
           isIssueReadyToPublish(issue as WebsiteIssueForPublish),
       ),
   },
-  { path: 'contact.address', check: (c) => isNonEmpty(c.contact?.address) },
   { path: 'contact.email', check: (c) => isNonEmpty(c.contact?.email) },
-  { path: 'contact.phone', check: (c) => isNonEmpty(c.contact?.phone) },
 ]
+
+// contact.address and contact.phone are required for TCR/10DLC rendering but
+// fall back to the organization's registered contact when the candidate
+// hasn't filled them in — see applyContactFallbacks at publish time.
+const formatGpFallbackAddress = (): string =>
+  `${GP_DOMAIN_CONTACT.addressLine1}, ${GP_DOMAIN_CONTACT.city}, ` +
+  `${GP_DOMAIN_CONTACT.state} ${GP_DOMAIN_CONTACT.zipCode}`
+
+const applyContactFallbacks = (content: PrismaJson.WebsiteContent) => {
+  content.contact ||= {}
+  if (!isNonEmpty(content.contact.address)) {
+    content.contact.address = formatGpFallbackAddress()
+  }
+  if (!isNonEmpty(content.contact.phone)) {
+    content.contact.phone = GP_DOMAIN_CONTACT.phoneNumber
+  }
+}
 
 const assertReadyToPublish = (content: PrismaJson.WebsiteContent) => {
   const missing = REQUIRED_PUBLISH_FIELDS.filter(
@@ -230,13 +246,16 @@ export class WebsitesController {
       "Update the calling campaign's website content and optionally " +
       'publish it. The body deep-merges into Website.content; pass only ' +
       'fields you want to change. To publish, send `status: "published"` ' +
-      '— this requires (1) the required content sections (main.title, ' +
-      'about.bio, about.issues with title+description, contact.address, ' +
-      'contact.email, contact.phone) to be present, and (2) a custom ' +
-      'domain attached to the website with Domain.status of `submitted`, ' +
-      '`registered`, or `active`. Calling with `status: "published"` ' +
-      'without an attached domain (or with the domain still `pending` / ' +
-      '`inactive`) returns 400. After a successful publish call, poll ' +
+      '— this requires the content sections main.title, about.bio, ' +
+      'about.issues (with title+description), and contact.email to be ' +
+      'present. `contact.address` and `contact.phone` are auto-filled ' +
+      'from the organization fallback if missing. If a custom domain ' +
+      'is attached to the website, its `Domain.status` must be ' +
+      '`submitted`, `registered`, or `active` (publishing while the ' +
+      'attached domain is still `pending` or `inactive` returns 400). ' +
+      'The compliance_setup agent flow calls `POST /v1/domains/purchase` ' +
+      'before this so the attached domain has reached `submitted` by ' +
+      'publish time. After a successful publish call, poll ' +
       '`POST /v1/websites/mine/verify-live` to confirm the live URL ' +
       'serves the rendered site with required TCR sections.',
   })
@@ -273,18 +292,15 @@ export class WebsitesController {
       },
     })
 
-    if (body.status === WebsiteStatus.published) {
-      if (!domain && !hasEverBeenPublished) {
-        throw new BadRequestException(
-          'Cannot publish: no custom domain is attached to this website.',
-        )
-      }
-      if (domain && !PUBLISHABLE_DOMAIN_STATUSES.includes(domain.status)) {
-        throw new BadRequestException(
-          `Cannot publish: attached domain is in status "${domain.status}". ` +
-            'Domain must reach status `submitted` or later before publish.',
-        )
-      }
+    if (
+      body.status === WebsiteStatus.published &&
+      domain &&
+      !PUBLISHABLE_DOMAIN_STATUSES.includes(domain.status)
+    ) {
+      throw new BadRequestException(
+        `Cannot publish: attached domain is in status "${domain.status}". ` +
+          'Domain must reach status `submitted` or later before publish.',
+      )
     }
 
     const updatedContent: PrismaJson.WebsiteContent = merge(
@@ -298,6 +314,7 @@ export class WebsitesController {
     }
 
     if (body.status === WebsiteStatus.published) {
+      applyContactFallbacks(updatedContent)
       assertReadyToPublish(updatedContent)
     }
 

--- a/src/websites/tests/website-contacts.e2e.ts
+++ b/src/websites/tests/website-contacts.e2e.ts
@@ -23,15 +23,9 @@ test.describe('Websites - Contacts', () => {
     }
   })
 
-  // ENG-10258: PUT /websites/mine with status=published now requires an
-  // attached domain in status submitted/registered/active. This test creates
-  // a fresh candidate with no domain, so the publish step 4xx's and the
-  // contact form has nothing to write against. Rewrite under the new
-  // compliance_setup flow (domain purchase first) before re-enabling.
   test('should submit contact form on published website', async ({
     request,
   }) => {
-    test.skip()
     const email = generateRandomEmail()
     const firstName = generateRandomName()
     const lastName = generateRandomName()
@@ -149,11 +143,7 @@ test.describe('Websites - Contacts', () => {
     expect(response.status()).toBe(403)
   })
 
-  // ENG-10258: depends on the "should submit contact form on published
-  // website" test above. Same root cause — publish requires an attached
-  // domain in the new compliance flow.
   test('should get website contacts', async ({ request }) => {
-    test.skip()
     const email = generateRandomEmail()
     const firstName = generateRandomName()
     const lastName = generateRandomName()

--- a/src/websites/tests/website-crud.e2e.ts
+++ b/src/websites/tests/website-crud.e2e.ts
@@ -96,15 +96,7 @@ test.describe('Websites - CRUD Operations', () => {
     expect(website).toHaveProperty('content')
   })
 
-  // ENG-10258: PUT /websites/mine with status=published now requires an
-  // attached domain in status submitted/registered/active. This test
-  // publishes from a fresh candidate with no domain; the publish 4xx's.
-  // Content-update behavior IS still covered by the
-  // "should update website and merge with existing content" test below
-  // (which uses status=unpublished). Rewrite under the new flow before
-  // re-enabling.
   test('should update website with text fields', async ({ request }) => {
-    test.skip()
     const email = generateRandomEmail()
     const firstName = generateRandomName()
     const lastName = generateRandomName()

--- a/src/websites/tests/website-vanity-path.e2e.ts
+++ b/src/websites/tests/website-vanity-path.e2e.ts
@@ -146,13 +146,7 @@ test.describe('Websites - Vanity Path', () => {
     )
   })
 
-  // ENG-10258: publishing now requires an attached domain in
-  // submitted/registered/active. Fresh candidates in this test have no
-  // domain, so publish 4xx's and the subsequent GET returns 403 (or 404).
-  // Rewrite under the new compliance_setup flow (domain purchase first)
-  // before re-enabling.
   test('should view published website by vanity path', async ({ request }) => {
-    test.skip()
     const email = generateRandomEmail()
     const firstName = generateRandomName()
     const lastName = generateRandomName()

--- a/src/websites/tests/website-views.e2e.ts
+++ b/src/websites/tests/website-views.e2e.ts
@@ -23,13 +23,7 @@ test.describe('Websites - Views', () => {
     }
   })
 
-  // ENG-10258: publishing now requires an attached domain in
-  // submitted/registered/active. Fresh candidates here have no domain, so
-  // the publish step 4xx's and the public track-view endpoint can't find
-  // the published vanity path. Rewrite under the new compliance_setup flow
-  // before re-enabling.
   test('should track website view', async ({ request }) => {
-    test.skip()
     const email = generateRandomEmail()
     const firstName = generateRandomName()
     const lastName = generateRandomName()
@@ -88,12 +82,9 @@ test.describe('Websites - Views', () => {
     expect(view.websiteId).toBeDefined()
   })
 
-  // ENG-10258: same root cause as "should track website view" above —
-  // publish requires an attached domain in the new flow.
   test('should track multiple views from different visitors', async ({
     request,
   }) => {
-    test.skip()
     const email = generateRandomEmail()
     const firstName = generateRandomName()
     const lastName = generateRandomName()

--- a/src/websites/tests/websites.e2e.ts
+++ b/src/websites/tests/websites.e2e.ts
@@ -95,13 +95,7 @@ test.describe('Candidate Website', () => {
     expect(result).toHaveProperty('available')
   })
 
-  // ENG-10258: publishing now requires an attached domain in
-  // submitted/registered/active. Without a domain, the PUT below 4xx's,
-  // the website stays unpublished, and the public GET returns 403 (not
-  // 200 / 404). Rewrite under the new compliance_setup flow before
-  // re-enabling.
   test('should get website by vanity path', async ({ request }) => {
-    test.skip()
     const createResponse = await request.post('/v1/websites', {
       headers: authHeaders(authToken, orgSlug),
     })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes who can publish and what contact data is persisted on live sites (compliance/TCR-related), though behavior is covered by updated unit and e2e tests.
> 
> **Overview**
> **Website publish** rules are relaxed so candidates can go live on GP-hosted vanity sites **without** a custom domain; domain status (`submitted` / `registered` / `active`) is enforced **only when** a domain is attached.
> 
> On publish, **`contact.address`** and **`contact.phone`** are no longer required in content validation—blank values are filled from **`GP_DOMAIN_CONTACT`** before save, while candidate-provided values are left unchanged. Required content for publish is now **`contact.email`** plus the existing main/about fields.
> 
> **Unit tests** reflect the new gates and fallback behavior; **Playwright e2e** tests that were skipped for ENG-10258 are run again. MCP **`PUT /websites/mine`** docs describe the updated publish contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f29b957899ea9cc5f669d1e16e518309d87c48db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->