### PR TITLE
feat(mcp): add NoBodyPostController and update content-type handling

### DIFF
--- a/src/mcp/services/mcpServer.service.test.ts
+++ b/src/mcp/services/mcpServer.service.test.ts
@@ -2,7 +2,15 @@
 // Test fixtures define decorated controller stubs whose method bodies don't matter.
 import { describe, expect, it, vi } from 'vitest'
 import { Test } from '@nestjs/testing'
-import { Body, Controller, Get, Param, Patch, Module } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Module,
+} from '@nestjs/common'
 import { DiscoveryModule, HttpAdapterHost } from '@nestjs/core'
 import { PinoLogger } from 'nestjs-pino'
 import { z } from 'zod'
@@ -247,6 +255,14 @@ class FooController {
   write(@Body() _b: InDto) {}
 }
 
+@Controller('v1')
+class NoBodyPostController {
+  @Post('foo/verify')
+  @ResponseSchema(z.object({ ok: z.boolean() }))
+  @McpTool({ description: 'no-body action' })
+  verify() {}
+}
+
 describe('McpServerService MCP request handlers', () => {
   it('exposes list_tools that returns tool entries with JSON Schema input shapes', async () => {
     const moduleRef = await buildAppModule(
@@ -404,6 +420,78 @@ describe('McpServerService MCP request handlers', () => {
     expect(result.isError).toBe(true)
     expect(result.content[0].text).toMatch(/Invalid arguments/)
     expect(inject).not.toHaveBeenCalled()
+  })
+
+  it('drops content-type from forwarded headers when the tool has no body', async () => {
+    const calls: InjectOpts[] = []
+    const inject = vi.fn(async (opts: InjectOpts) => {
+      calls.push(opts)
+      return { statusCode: 200, body: '{}', headers: {} }
+    })
+    const moduleRef = await buildAppModule(
+      [NoBodyPostController],
+      inject,
+    ).compile()
+    await moduleRef.init()
+
+    const svc = moduleRef.get(McpServerService)
+    const server = svc.createServer() as unknown as {
+      _requestHandlers: Map<
+        string,
+        (req: unknown, extra?: unknown) => Promise<unknown>
+      >
+    }
+    const callHandler = server._requestHandlers.get('tools/call')!
+    await callHandler(
+      {
+        method: 'tools/call',
+        params: { name: 'POST_v1_foo_verify', arguments: {} },
+      },
+      {
+        requestInfo: {
+          headers: {
+            authorization: 'Bearer t',
+            'content-type': 'application/json',
+          },
+        },
+      },
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0].method).toBe('POST')
+    expect(calls[0].payload).toBeUndefined()
+    expect(calls[0].headers?.authorization).toBe('Bearer t')
+    expect(calls[0].headers?.['content-type']).toBeUndefined()
+  })
+
+  it('preserves content-type when the tool call has a body', async () => {
+    const calls: InjectOpts[] = []
+    const inject = vi.fn(async (opts: InjectOpts) => {
+      calls.push(opts)
+      return { statusCode: 200, body: '{}', headers: {} }
+    })
+    const moduleRef = await buildAppModule([FooController], inject).compile()
+    await moduleRef.init()
+
+    const svc = moduleRef.get(McpServerService)
+    const server = svc.createServer() as unknown as {
+      _requestHandlers: Map<
+        string,
+        (req: unknown, extra?: unknown) => Promise<unknown>
+      >
+    }
+    const callHandler = server._requestHandlers.get('tools/call')!
+    await callHandler(
+      {
+        method: 'tools/call',
+        params: { name: 'PATCH_v1_foo', arguments: { body: { slogan: 'x' } } },
+      },
+      {
+        requestInfo: {
+          headers: { 'content-type': 'application/json' },
+        },
+      },
+    )
+    expect(calls[0].headers?.['content-type']).toBe('application/json')
   })
 
   it('returns isError for unknown tool', async () => {

--- a/src/mcp/services/mcpServer.service.ts
+++ b/src/mcp/services/mcpServer.service.ts
@@ -163,6 +163,15 @@ export class McpServerService {
         if (typeof v === 'string') forwardHeaders[name] = v
       }
 
+      // Drop content-type when there's no body to forward — fastify's default
+      // JSON parser 400s on an empty body when content-type is application/json,
+      // which is exactly the shape of every no-body POST MCP tool call.
+      if (args.body == null) {
+        for (const k of Object.keys(forwardHeaders)) {
+          if (k.toLowerCase() === 'content-type') delete forwardHeaders[k]
+        }
+      }
+
       const response = await fastify.inject({
         method: tool.method,
         url,


### PR DESCRIPTION
- Introduced NoBodyPostController with a POST endpoint for 'foo/verify' that does not require a request body.
- Updated McpServerService to drop the 'content-type' header when forwarding requests that do not have a body, addressing issues with Fastify's JSON parser.
- Enhanced tests to verify correct behavior for both body and no-body POST requests, ensuring headers are managed appropriately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change in MCP request forwarding with unit tests; no auth or data-model changes.
> 
> **Overview**
> Fixes **no-body MCP tool calls** (e.g. POST actions without a `@Body` DTO) that were failing when the client forwarded `Content-Type: application/json` with an empty payload.
> 
> `McpServerService` now **strips `content-type` from forwarded headers** when `args.body` is null before `fastify.inject`, so Fastify’s JSON parser no longer 400s on empty bodies. **Other headers** (e.g. `Authorization`) are unchanged; **body-bearing** tool calls still forward `content-type`.
> 
> Tests add a no-body POST fixture and assert both drop and preserve behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d3ce7af32a47e93b6e2de825ddfbaf9b16bc0a8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->