### PR TITLE
feat(domains): implement domain pattern expansion and deduplication

### DIFF
--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -466,6 +466,75 @@ describe('DomainsService', () => {
       expect(mockRoute53.checkDomainAvailability).not.toHaveBeenCalled()
     })
 
+    it('fans bare SLD patterns out across the supported TLDs', async () => {
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 5 })
+
+      const result = await service.searchDomainsForCampaign(
+        campaignWithUser,
+        ['voteforoneill'],
+        10,
+      )
+
+      const tried = mockRoute53.checkDomainAvailability.mock.calls.map(
+        (c) => c[0] as string,
+      )
+      expect(tried.sort()).toEqual(
+        [
+          'voteforoneill.com',
+          'voteforoneill.org',
+          'voteforoneill.vote',
+        ].sort(),
+      )
+      expect(result.candidates.map((c) => c.domain).sort()).toEqual(
+        [
+          'voteforoneill.com',
+          'voteforoneill.org',
+          'voteforoneill.vote',
+        ].sort(),
+      )
+    })
+
+    it('does not fan out patterns that already include a TLD', async () => {
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 5 })
+
+      await service.searchDomainsForCampaign(
+        campaignWithUser,
+        ['vote-{last_name}.run'],
+        10,
+      )
+
+      const tried = mockRoute53.checkDomainAvailability.mock.calls.map(
+        (c) => c[0] as string,
+      )
+      expect(tried).toEqual(['vote-oneill.run'])
+    })
+
+    it('dedupes after fan-out when bare and TLD-bearing patterns overlap', async () => {
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 5 })
+
+      await service.searchDomainsForCampaign(
+        campaignWithUser,
+        ['voteoneill', 'voteoneill.com'],
+        10,
+      )
+
+      const tried = mockRoute53.checkDomainAvailability.mock.calls.map(
+        (c) => c[0] as string,
+      )
+      expect(tried.sort()).toEqual(
+        ['voteoneill.com', 'voteoneill.org', 'voteoneill.vote'].sort(),
+      )
+    })
+
     it('skips candidate when Route53 throws BadRequest (e.g. UnsupportedTLD)', async () => {
       mockRoute53.checkDomainAvailability.mockImplementation(() => {
         throw new BadRequestException('UnsupportedTLD')

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -53,6 +53,8 @@ import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 
 const MAX_PATTERN_CANDIDATES = 50
 
+const SUPPORTED_TLDS = ['com', 'org', 'vote'] as const
+
 const DOMAIN_PURCHASE_ADVISORY_LOCK_KEY = 918_275
 
 const DOMAIN_RESERVATION_KIND = {
@@ -423,9 +425,9 @@ export class DomainsService
       electionDate = new Date()
     }
 
-    let candidates: string[]
+    let expanded: string[]
     try {
-      candidates = expandDomainPatterns(
+      expanded = expandDomainPatterns(
         patterns,
         {
           firstName: campaign.user.firstName ?? '',
@@ -442,6 +444,19 @@ export class DomainsService
       }
       throw error
     }
+
+    // Per the @McpTool description on POST /domains/search, callers may pass
+    // bare SLD patterns (no TLD) and the server fans them out across the
+    // supported TLDs. Patterns that already include a TLD are passed through
+    // unchanged so existing alternation syntax (e.g. `vote-x.(run|bio)`)
+    // keeps working.
+    const candidates = Array.from(
+      new Set(
+        expanded.flatMap((c) =>
+          c.includes('.') ? [c] : SUPPORTED_TLDS.map((tld) => `${c}.${tld}`),
+        ),
+      ),
+    )
 
     const checked = await Promise.allSettled(
       candidates.map((domain) =>


### PR DESCRIPTION
- Added tests to verify the behavior of the `searchDomainsForCampaign` method when handling bare second-level domain (SLD) patterns and their expansion across supported top-level domains (TLDs).
- Ensured that patterns including a TLD are not expanded further and that deduplication occurs when bare and TLD-bearing patterns overlap.
- Introduced a constant for supported TLDs to streamline domain pattern handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which domains are queried for search (more Route53/Vercel calls per bare pattern) but behavior is read-only search with existing caps and tests.
> 
> **Overview**
> **Campaign domain pattern search** now treats expanded strings without a `.` as bare second-level labels and checks **`com`**, **`org`**, and **`vote`** for each. Strings that already include a TLD (e.g. `vote-{last_name}.run` or alternation like `.(run|bio)`) are unchanged.
> 
> Candidates are **deduplicated** after fan-out, so mixing a bare label with the same name plus `.com` does not double Route53/Vercel calls. Tests cover fan-out, no double fan-out, and overlap deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6258afc572ad29bca06bb98552476eea3dfd869b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->