### PR TITLE
chore: lint

### DIFF
--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -482,18 +482,10 @@ describe('DomainsService', () => {
         (c) => c[0] as string,
       )
       expect(tried.sort()).toEqual(
-        [
-          'voteforoneill.com',
-          'voteforoneill.org',
-          'voteforoneill.vote',
-        ].sort(),
+        ['voteforoneill.com', 'voteforoneill.org', 'voteforoneill.vote'].sort(),
       )
       expect(result.candidates.map((c) => c.domain).sort()).toEqual(
-        [
-          'voteforoneill.com',
-          'voteforoneill.org',
-          'voteforoneill.vote',
-        ].sort(),
+        ['voteforoneill.com', 'voteforoneill.org', 'voteforoneill.vote'].sort(),
       )
     })
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only style change with no production or behavioral impact.
> 
> **Overview**
> **Formatting-only** update in `domains.service.test.ts` for the *fans bare SLD patterns out across the supported TLDs* test: two `expect(...).toEqual(...)` assertions now use **single-line** domain arrays instead of multi-line lists. **Expected domains and test behavior are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c9033e07c8c5341d25818f88a746d81a39392c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->