### PR TITLE
fix(domains): rename environment variable for domain purchase feature

### DIFF
--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -67,7 +67,7 @@ const DOMAIN_PURCHASE_IN_PROGRESS_MESSAGE =
 
 const GP_CAMPAIGN_DOMAIN_FORWARD_ADDRESS = 'candidate-domains@goodparty.org'
 
-const { ENABLE_DOMAIN_SETUP } = process.env
+const { ENABLE_DOMAIN_PURCHASE } = process.env
 
 @Injectable()
 export class DomainsService
@@ -119,7 +119,7 @@ export class DomainsService
   }
 
   shouldEnableDomainPurchase(): boolean {
-    return ENABLE_DOMAIN_SETUP === 'true'
+    return ENABLE_DOMAIN_PURCHASE === 'true'
   }
 
   private validateDomainSearchResult(searchResult: DomainSearchResult) {


### PR DESCRIPTION
- Updated the environment variable from ENABLE_DOMAIN_SETUP to ENABLE_DOMAIN_PURCHASE to better reflect its purpose.
- Adjusted the shouldEnableDomainPurchase method to use the new variable for enabling domain purchase functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming the env var is a breaking ops change until all deployments update configuration; misconfiguration disables domain purchase and related backfill.
> 
> **Overview**
> Renames the feature flag env var from `ENABLE_DOMAIN_SETUP` to **`ENABLE_DOMAIN_PURCHASE`** in `domains.service.ts`, including the `process.env` binding and **`shouldEnableDomainPurchase()`**, which still gates the same behavior (startup email-forwarding backfill and Vercel purchase paths).
> 
> **Deploy note:** environments must set the new variable name or domain purchase will stay off when the old name is still in use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b12fd11689229e0fd1b7a8026c7a07322dfa5fa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->