### PR TITLE
feat(speech): default TTS voice to Ruth (en-US)

### DIFF
--- a/contracts/src/speech/synthesizeSpeech.schema.ts
+++ b/contracts/src/speech/synthesizeSpeech.schema.ts
@@ -65,13 +65,12 @@ export const SynthesizeSpeechRequestSchema = z.object({
     ),
   options: z
     .object({
-      voiceId: SpeechSynthesisVoiceSchema.default('Amy'),
+      voiceId: SpeechSynthesisVoiceSchema.default('Ruth'),
       engine: SpeechSynthesisEngineSchema.default('generative'),
     })
     .refine(
       ({ voiceId, engine }) =>
-        engine !== 'generative' ||
-        GENERATIVE_VOICE_VALUES.includes(voiceId),
+        engine !== 'generative' || GENERATIVE_VOICE_VALUES.includes(voiceId),
       { message: 'Selected voice does not support the generative engine' },
     )
     .optional(),

--- a/src/speech/services/textToSpeech.service.ts
+++ b/src/speech/services/textToSpeech.service.ts
@@ -57,7 +57,7 @@ export class TextToSpeechService {
       )
     }
 
-    const voiceId: VoiceId = request.options?.voiceId ?? 'Amy'
+    const voiceId: VoiceId = request.options?.voiceId ?? 'Ruth'
     const engine: Engine = request.options?.engine ?? 'generative'
 
     // The contracts schema enforces non-empty + max length on request.text;


### PR DESCRIPTION
## Why

The read-aloud feature on briefings was defaulting to AWS Polly's `Amy` voice. Amy is en-GB — speaking US-focused political briefings in a British accent to a US audience is a mismatch we should fix.

`Ruth` is the closest en-US equivalent: female, supports the `generative` engine, comparable tone. Minimizes perceived change for any existing user while putting us on an American voice.

## Notes

- Callers can still override via `request.options.voiceId` — schema unchanged otherwise.
- S3 audio cache is keyed by `voiceId`, so existing cached MP3s under `Amy` become orphaned; first playback per briefing re-synthesizes under `Ruth`. One-time cost bump, no migration needed.
- Incidental prettier collapse of one line in the contract schema came from the editor formatter hook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-only default change with explicit override still supported; main side effect is cache misses for prior Amy-cached audio, not auth or data integrity.
> 
> **Overview**
> **Default read-aloud voice** switches from **`Amy` (en-GB)** to **`Ruth` (en-US)** for callers who omit `options.voiceId`, while keeping the **`generative`** engine default and the existing generative-voice validation.
> 
> The contract default in `SynthesizeSpeechRequestSchema` and the service fallback in `TextToSpeechService.synthesize` are updated together so API and server behavior stay aligned. **Overrides via `request.options.voiceId` are unchanged.**
> 
> Because segment cache keys include `voiceId`, audio cached under `Amy` will not be reused; first playback after deploy may re-synthesize under `Ruth` (one-time cache miss cost, no migration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77ae24f769f39ffdec5ec7ec023077fee201652. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->