### PR TITLE
feat(artifact-feedback): add optional comment column (VARCHAR(2000))

### DIFF
--- a/prisma/schema/artifactFeedback.prisma
+++ b/prisma/schema/artifactFeedback.prisma
@@ -24,6 +24,11 @@ model ArtifactFeedback {
 
   feedback ArtifactFeedbackKind
 
+  /// Optional free-text the submitter attaches to their thumbs-up / thumbs-down
+  /// — e.g. why the briefing's agenda-item summary was bad. Capped at 2000
+  /// chars at the DB layer to keep pathological inputs out of the table.
+  comment String? @db.VarChar(2000)
+
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 

--- a/prisma/schema/migrations/20260528000000_add_artifact_feedback_comment/migration.sql
+++ b/prisma/schema/migrations/20260528000000_add_artifact_feedback_comment/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "artifact_feedback" ADD COLUMN     "comment" VARCHAR(2000);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Schema-only additive nullable column with a straightforward migration; no auth or business-logic changes in this PR.
> 
> **Overview**
> Adds an optional **`comment`** field on **`ArtifactFeedback`** so submitters can attach free-text when they thumbs-up or thumbs-down an artifact (e.g. why an agenda-item summary was wrong).
> 
> The column is nullable **`VARCHAR(2000)`** in Prisma and applied via migration **`20260528000000_add_artifact_feedback_comment`** on **`artifact_feedback`**. No API or service changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5db344dd3f93e467f769a8814f7be975262222ae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->