### PR TITLE
feat(artifact-feedback): accept + echo optional comment on agenda-ite…

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @goodparty_org/contracts
 
+## 0.9.0
+
+### Minor Changes
+
+- `ArtifactFeedbackSchema` and `SetArtifactFeedbackRequestSchema` now carry
+  an optional `comment` string (max 2000 chars, nullable). Backs the
+  thumbs-down "tell us why" composer on agenda items. Comment is omitted
+  from PUT bodies that don't set it; `null` clears a previously-set
+  comment. The response and the GET-list endpoint echo the stored value
+  so clients can rehydrate the composer with the user's last comment.
+
 ## 0.8.0
 
 ### Minor Changes

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodparty_org/contracts",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Shared Zod schemas and TypeScript types for the GoodParty API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/contracts/src/artifactFeedback/ArtifactFeedback.schema.ts
+++ b/contracts/src/artifactFeedback/ArtifactFeedback.schema.ts
@@ -8,6 +8,13 @@ export const ARTIFACT_FEEDBACK_KIND_VALUES = ['positive', 'negative'] as const
 export const ArtifactFeedbackKindSchema = z.enum(ARTIFACT_FEEDBACK_KIND_VALUES)
 export type ArtifactFeedbackKind = z.infer<typeof ArtifactFeedbackKindSchema>
 
+/**
+ * Free-text the submitter optionally attaches to their vote (typically a
+ * 'why this was bad' note on thumbs-down). Mirrors the
+ * `artifact_feedback.comment VARCHAR(2000)` column.
+ */
+const FeedbackCommentSchema = z.string().max(2000).nullable()
+
 export const ArtifactFeedbackSchema = z.object({
   id: z.string(),
   organization_slug: z.string(),
@@ -15,13 +22,17 @@ export const ArtifactFeedbackSchema = z.object({
   artifact_type: ArtifactResourceTypeSchema,
   artifact_id: z.string(),
   feedback: ArtifactFeedbackKindSchema,
+  comment: FeedbackCommentSchema,
   created_at: z.string(),
   updated_at: z.string(),
 })
 export type ArtifactFeedback = z.infer<typeof ArtifactFeedbackSchema>
 
+// Comment is optional on the request — callers can omit it entirely or
+// explicitly pass `null` to clear an existing comment.
 export const SetArtifactFeedbackRequestSchema = z.object({
   feedback: ArtifactFeedbackKindSchema,
+  comment: FeedbackCommentSchema.optional(),
 })
 export type SetArtifactFeedbackRequest = z.infer<
   typeof SetArtifactFeedbackRequestSchema

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,7 +206,7 @@
     },
     "contracts": {
       "name": "@goodparty_org/contracts",
-      "version": "0.7.0",
+      "version": "0.9.0",
       "dependencies": {
         "validator": "^13.12.0",
         "zod": "^3.23.8"

--- a/src/artifactFeedback/controllers/briefingItemFeedback.controller.ts
+++ b/src/artifactFeedback/controllers/briefingItemFeedback.controller.ts
@@ -37,6 +37,7 @@ export class BriefingItemFeedbackController {
       userId: user.id,
       electedOffice,
       feedback: body.feedback,
+      comment: body.comment,
     })
   }
 

--- a/src/artifactFeedback/services/artifactFeedback.service.ts
+++ b/src/artifactFeedback/services/artifactFeedback.service.ts
@@ -17,7 +17,15 @@ type BriefingScope = {
 
 type ItemScope = BriefingScope & { itemId: string }
 
-type SetFeedbackArgs = ItemScope & { feedback: ArtifactFeedbackKind }
+// `comment` is split into three states on the wire:
+//   undefined → caller is not touching the comment (preserve whatever's
+//               already stored on the row, if any).
+//   null      → caller is explicitly clearing the existing comment.
+//   string    → caller is setting / replacing the comment.
+type SetFeedbackArgs = ItemScope & {
+  feedback: ArtifactFeedbackKind
+  comment?: string | null
+}
 
 function toDTO(row: ArtifactFeedbackRow): ArtifactFeedbackDTO {
   return {
@@ -27,6 +35,7 @@ function toDTO(row: ArtifactFeedbackRow): ArtifactFeedbackDTO {
     artifact_type: row.artifactType,
     artifact_id: row.artifactId,
     feedback: row.feedback,
+    comment: row.comment,
     created_at: row.createdAt.toISOString(),
     updated_at: row.updatedAt.toISOString(),
   }
@@ -57,12 +66,20 @@ export class ArtifactFeedbackService extends createPrismaBase(
   }
 
   async setForItem(args: SetFeedbackArgs): Promise<ArtifactFeedbackDTO> {
-    const { meetingDate, itemId, userId, electedOffice, feedback } = args
+    const { meetingDate, itemId, userId, electedOffice, feedback, comment } =
+      args
     const briefingId = await resolveBriefingId(
       this.client,
       meetingDate,
       electedOffice,
     )
+
+    // `undefined` means "don't touch the column"; null / string both mean
+    // "write this value". Build the partial update conditionally so we
+    // don't clobber a previously-saved comment when the user re-votes
+    // without re-typing.
+    const commentPatch: { comment?: string | null } =
+      comment === undefined ? {} : { comment }
 
     const row = await this.client.artifactFeedback.upsert({
       where: {
@@ -80,8 +97,10 @@ export class ArtifactFeedbackService extends createPrismaBase(
         artifactId: itemId,
         artifactType: ArtifactResourceType.agenda_item,
         feedback,
+        // On create, `undefined` falls through to the column default (null).
+        ...commentPatch,
       },
-      update: { feedback },
+      update: { feedback, ...commentPatch },
     })
 
     return toDTO(row)

--- a/src/artifactFeedback/tests/briefingItemFeedback.controller.test.ts
+++ b/src/artifactFeedback/tests/briefingItemFeedback.controller.test.ts
@@ -243,6 +243,102 @@ describe('PUT /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
   })
 })
 
+describe('PUT comment handling', () => {
+  const SAMPLE_COMMENT = 'the summary missed the rezoning vote'
+
+  it('persists a comment supplied on first PUT and echoes it on the response', async () => {
+    const orgSlug = 'eo-fb-comment-create'
+    const eo = await seedElectedOffice(orgSlug)
+    const briefing = await seedBriefing(eo.id, orgSlug, DATE)
+
+    const result = await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'negative', comment: SAMPLE_COMMENT },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data.comment).toBe(SAMPLE_COMMENT)
+
+    const row = await service.prisma.artifactFeedback.findFirst({
+      where: { briefingId: briefing.id, submitterUserId: service.user.id },
+    })
+    expect(row?.comment).toBe(SAMPLE_COMMENT)
+  })
+
+  it('omitting `comment` on a follow-up PUT preserves the previously-stored comment', async () => {
+    const orgSlug = 'eo-fb-comment-preserve'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'negative', comment: 'first take' },
+      orgHeader(orgSlug),
+    )
+    // Re-vote with no `comment` key — the upsert `update` branch must
+    // skip the column so we don't accidentally null out the existing text.
+    const result = await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'negative' },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data.comment).toBe('first take')
+  })
+
+  it('passing `comment: null` clears a previously-set comment', async () => {
+    const orgSlug = 'eo-fb-comment-clear'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'negative', comment: 'original take' },
+      orgHeader(orgSlug),
+    )
+    const result = await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'negative', comment: null },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data.comment).toBeNull()
+  })
+
+  it('rejects a comment longer than 2000 characters with 400', async () => {
+    const orgSlug = 'eo-fb-comment-too-long'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    const tooLong = 'x'.repeat(2001)
+    const result = await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'negative', comment: tooLong },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('echoes `comment: null` for rows that have never had a comment set', async () => {
+    const orgSlug = 'eo-fb-comment-default-null'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, DATE)
+
+    const result = await service.client.put(
+      `/v1/meetings/${DATE}/briefing/items/${ITEM_ID}/feedback`,
+      { feedback: 'positive' },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data.comment).toBeNull()
+  })
+})
+
 describe('DELETE /v1/meetings/:date/briefing/items/:itemId/feedback', () => {
   it('deletes the row and returns 204', async () => {
     const orgSlug = 'eo-fb-delete'
@@ -447,6 +543,40 @@ describe('GET /v1/meetings/:date/briefing/feedback', () => {
     )
     expect(byItem[ITEM_ID]).toBe('positive')
     expect(byItem[OTHER_ITEM_ID]).toBe('negative')
+    // Every row in the listing should carry a `comment` field (null when
+    // unset) so the client can rehydrate the composer without a second call.
+    for (const row of result.data.feedback) {
+      expect(row).toHaveProperty('comment')
+    }
+  })
+
+  it('echoes a stored comment in the GET listing', async () => {
+    const orgSlug = 'eo-fb-list-comment'
+    const eo = await seedElectedOffice(orgSlug)
+    const briefing = await seedBriefing(eo.id, orgSlug, DATE)
+
+    await service.prisma.artifactFeedback.create({
+      data: {
+        organizationSlug: orgSlug,
+        briefingId: briefing.id,
+        submitterUserId: service.user.id,
+        artifactId: ITEM_ID,
+        artifactType: 'agenda_item',
+        feedback: 'negative',
+        comment: 'agenda card 3 missed the rezoning detail',
+      },
+    })
+
+    const result = await service.client.get(
+      `/v1/meetings/${DATE}/briefing/feedback`,
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data.feedback).toHaveLength(1)
+    expect(result.data.feedback[0].comment).toBe(
+      'agenda card 3 missed the rezoning detail',
+    )
   })
 
   it('returns empty list when the user has no feedback', async () => {


### PR DESCRIPTION
…m feedback

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped feedback API and shared schema changes with explicit validation and integration tests; no auth or payment paths touched.
> 
> **Overview**
> Adds optional **free-text comments** (up to 2000 chars) on agenda-item artifact feedback, aligned with `@goodparty_org/contracts` **0.9.0**.
> 
> **Contracts:** `ArtifactFeedbackSchema` responses now include nullable `comment`; `SetArtifactFeedbackRequestSchema` accepts optional `comment` (omit = leave unchanged, `null` = clear).
> 
> **API:** The briefing item feedback `PUT` forwards `comment` into `ArtifactFeedbackService.setForItem`, which upserts with a **partial comment patch** so re-voting without `comment` does not wipe an existing note. DTO mapping and the briefing feedback **GET** list echo `comment` for client rehydration.
> 
> **Tests:** New coverage for create, preserve-on-omit, clear with `null`, max length 400, default null, and list echo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa55c613a420516edab492060eccdc69b528d353. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->