### PR TITLE
fix(queueConsumer): stop poison-pilling poll analysis on unmapped phones

### DIFF
--- a/src/contacts/services/contacts.service.ts
+++ b/src/contacts/services/contacts.service.ts
@@ -180,6 +180,22 @@ export class ContactsService {
     return this.withOrgDistrictResolution(organization, fetchSample)
   }
 
+  // Lookup a single person in the org's district by phone number.
+  // The People API's list endpoint already accepts phone-shaped strings in
+  // its `search` field and matches against the indexed
+  // `VoterTelephones_CellPhoneFormatted` column. Returns the first match
+  // (a phone may be shared by multiple voters in a household) or null.
+  async findPersonByPhone(
+    phone: string,
+    organization: Organization,
+  ): Promise<PersonOutput | null> {
+    const result = await this.findContacts(
+      { search: phone, segment: 'all', resultsPerPage: 1, page: 1 },
+      organization,
+    )
+    return result.people[0] ?? null
+  }
+
   async findPerson(
     id: string,
     organization: Organization,

--- a/src/queue/consumer/queueConsumer.service.test.ts
+++ b/src/queue/consumer/queueConsumer.service.test.ts
@@ -110,7 +110,10 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
     }
   }
   let campaignsService: { findUnique: ReturnType<typeof vi.fn> }
-  let contactsService: { findContacts: ReturnType<typeof vi.fn> }
+  let contactsService: {
+    findContacts: ReturnType<typeof vi.fn>
+    findPersonByPhone: ReturnType<typeof vi.fn>
+  }
   let pollIssuesService: {
     model: { deleteMany: ReturnType<typeof vi.fn> }
     client: { pollIssue: { createMany: ReturnType<typeof vi.fn> } }
@@ -172,6 +175,7 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
       findContacts: vi
         .fn()
         .mockResolvedValue({ pagination: { totalResults: 100 } }),
+      findPersonByPhone: vi.fn().mockResolvedValue(null),
     }
     pollIssuesService = {
       model: { deleteMany: vi.fn().mockResolvedValue(undefined) },
@@ -267,8 +271,9 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
     )
   })
 
-  it('throws when person with cell phone is not found in poll', async () => {
+  it('skips response and completes poll when phone is in neither outreach nor People DB (no poison pill)', async () => {
     pollIndividualMessage.findMany.mockResolvedValue([])
+    contactsService.findPersonByPhone.mockResolvedValue(null)
     const json = createPollAnalysisJson([
       {
         phoneNumber: '+15559999999',
@@ -280,12 +285,112 @@ describe('QueueConsumerService - handlePollAnalysisComplete', () => {
     s3Service.getFile.mockResolvedValue(json)
     const message = createPollAnalysisCompleteMessage({ pollId })
 
-    await expect(service.processMessage(message)).rejects.toThrow(
-      InternalServerErrorException,
+    const result = await service.processMessage(message)
+
+    expect(result).toBe(true)
+    expect(contactsService.findPersonByPhone).toHaveBeenCalledWith(
+      '5559999999',
+      expect.anything(),
     )
-    await expect(service.processMessage(message)).rejects.toThrow(
-      /not found in poll/,
+    expect(pollIndividualMessage.client.$transaction).toHaveBeenCalled()
+    const txCb = pollIndividualMessage.client.$transaction.mock.calls[0][0]
+    const mockTx = {
+      pollIndividualMessage: { deleteMany: vi.fn(), createMany: vi.fn() },
+      $executeRaw: vi.fn(),
+    }
+    await txCb(mockTx)
+    expect(mockTx.pollIndividualMessage.createMany).toHaveBeenCalledWith({
+      data: [],
+    })
+    expect(pollsService.markPollComplete).toHaveBeenCalled()
+  })
+
+  it('falls back to People DB when phone is missing from outreach and persists with the matched personId', async () => {
+    pollIndividualMessage.findMany.mockResolvedValue([])
+    contactsService.findPersonByPhone.mockResolvedValue({
+      id: 'people-db-person-1',
+    })
+    const json = createPollAnalysisJson([
+      {
+        phoneNumber: '+15559999999',
+        receivedAt: '2024-01-15T10:00:00Z',
+        originalMessage: 'Forwarded reply',
+        clusterId: 1,
+      },
+    ])
+    s3Service.getFile.mockResolvedValue(json)
+    const message = createPollAnalysisCompleteMessage({ pollId })
+
+    const result = await service.processMessage(message)
+
+    expect(result).toBe(true)
+    expect(contactsService.findPersonByPhone).toHaveBeenCalledWith(
+      '5559999999',
+      expect.anything(),
     )
+    const txCb = pollIndividualMessage.client.$transaction.mock.calls[0][0]
+    const mockTx = {
+      pollIndividualMessage: { deleteMany: vi.fn(), createMany: vi.fn() },
+      $executeRaw: vi.fn(),
+    }
+    await txCb(mockTx)
+    expect(mockTx.pollIndividualMessage.createMany).toHaveBeenCalledWith({
+      data: expect.arrayContaining([
+        expect.objectContaining({
+          personId: 'people-db-person-1',
+          content: 'Forwarded reply',
+        }),
+      ]),
+    })
+  })
+
+  it('does not call People DB fallback when every response phone maps to outreach', async () => {
+    const json = createPollAnalysisJson([
+      {
+        phoneNumber,
+        receivedAt: '2024-01-15T10:00:00Z',
+        originalMessage: 'Hi',
+        clusterId: 1,
+      },
+    ])
+    s3Service.getFile.mockResolvedValue(json)
+    const message = createPollAnalysisCompleteMessage({ pollId })
+
+    await service.processMessage(message)
+
+    expect(contactsService.findPersonByPhone).not.toHaveBeenCalled()
+  })
+
+  it('skips response when People DB lookup throws (e.g. district unresolved) — still no poison pill', async () => {
+    pollIndividualMessage.findMany.mockResolvedValue([])
+    contactsService.findPersonByPhone.mockRejectedValue(
+      new Error(
+        'Organization does not have sufficient data to resolve district',
+      ),
+    )
+    const json = createPollAnalysisJson([
+      {
+        phoneNumber: '+15559999999',
+        receivedAt: '2024-01-15T10:00:00Z',
+        originalMessage: 'Hello',
+        clusterId: 1,
+      },
+    ])
+    s3Service.getFile.mockResolvedValue(json)
+    const message = createPollAnalysisCompleteMessage({ pollId })
+
+    const result = await service.processMessage(message)
+
+    expect(result).toBe(true)
+    const txCb = pollIndividualMessage.client.$transaction.mock.calls[0][0]
+    const mockTx = {
+      pollIndividualMessage: { deleteMany: vi.fn(), createMany: vi.fn() },
+      $executeRaw: vi.fn(),
+    }
+    await txCb(mockTx)
+    expect(mockTx.pollIndividualMessage.createMany).toHaveBeenCalledWith({
+      data: [],
+    })
   })
 
   it('creates poll issues, coalesces JSON rows by phone+receivedAt, creates messages and links by clusterId', async () => {

--- a/src/queue/consumer/queueConsumer.service.ts
+++ b/src/queue/consumer/queueConsumer.service.ts
@@ -657,6 +657,44 @@ export class QueueConsumerService {
       phoneNumbers,
     })
 
+    // Some response phones won't appear in this poll's outreach map — most
+    // often because the original recipient forwarded the SMS and somebody
+    // else replied. Try to resolve those phones in the org's district via
+    // the People DB so we can still attribute the response to a real
+    // constituent. Anything still unresolved after this is skipped (logged)
+    // rather than thrown, to avoid poison-pilling the entire poll's
+    // analysis on a single unattributable reply.
+    const unmappedPhones = phoneNumbers.filter(
+      (p) => !phoneToPersonIdMap.has(p),
+    )
+    if (unmappedPhones.length > 0) {
+      this.logger.info(
+        { pollId, unmappedPhoneCount: unmappedPhones.length },
+        "Some response phones weren't in this poll's outreach; trying People DB fallback",
+      )
+      const lookups = await Promise.all(
+        unmappedPhones.map(async (normalized) => {
+          const digitsOnly = normalized.replace(/^\+1/, '')
+          try {
+            const person = await this.contactsService.findPersonByPhone(
+              digitsOnly,
+              organization,
+            )
+            return { phone: normalized, personId: person?.id ?? null }
+          } catch (err) {
+            this.logger.warn(
+              { err: serializeError(err), phone: normalized, pollId },
+              'People DB lookup failed for unmapped poll phone',
+            )
+            return { phone: normalized, personId: null }
+          }
+        }),
+      )
+      for (const { phone, personId } of lookups) {
+        if (personId) phoneToPersonIdMap.set(phone, personId)
+      }
+    }
+
     const scalarData: Prisma.PollIndividualMessageCreateManyInput[] = []
     const joinValues: Prisma.Sql[] = []
 
@@ -674,9 +712,16 @@ export class QueueConsumerService {
       const normalizedPhone = normalizePhoneNumber(phoneNumber)
       const personId = phoneToPersonIdMap.get(normalizedPhone)
       if (!personId) {
-        throw new InternalServerErrorException(
-          `Person with cell phone ${phoneNumber} not found in poll ${pollId}`,
+        // Throwing here would bubble back to SQS and cause infinite
+        // redelivery (see queue/CLAUDE.md), blocking *all* other valid
+        // responses for this poll from being persisted. A single
+        // unattributable reply is the lesser evil — drop the row, keep a
+        // record in the logs, and let the rest of the analysis through.
+        this.logger.warn(
+          { pollId, phoneNumber: normalizedPhone, isOptOut },
+          'Skipping poll response: phone not in outreach and not found in People DB',
         )
+        continue
       }
 
       const uuid = uuidv5(


### PR DESCRIPTION
## Summary

`handlePollAnalysisComplete` previously threw `InternalServerErrorException` when a response phone wasn't in this poll's outreach map (a constituent replied from a number we never sent to — usually a forwarded SMS). Per `gp-api/src/queue/CLAUDE.md`:

> `throw` from inside a handler triggers infinite redelivery, not DLQ. An unhandled exception bubbles up to SQS, which treats it as transient and requeues the message.

So a single unattributable reply was poison-pilling the entire poll's analysis: `markPollComplete` never ran, every other valid response in the same message was never persisted, the poll stayed stuck in `IN_PROGRESS`, and analytics never fired — all until the SQS redrive policy gave up. Triggered in production today on poll `019e02ff-ebbe-7dda-acaf-1555994d4c77` (phone `18322481704`).

This PR makes two changes:

1. **People DB fallback.** Before giving up on an unmapped phone, look it up in the org's district via the People API. Its `search` field already accepts phone-shaped strings and matches on the indexed `VoterTelephones_CellPhoneFormatted` column, so a forwarded reply from a real constituent in the district can still be attributed. New thin helper `ContactsService.findPersonByPhone`; lookups in `Promise.all` to keep latency flat.
2. **Warn-and-skip instead of throw.** If the People DB also doesn't know the number (e.g. forwarded SMS to someone outside the district), log a warning with `pollId`/phone and `continue`. We lose one already-unattributable row instead of poison-pilling the whole poll.

## Trade-offs

- A `CONSTITUENT` row created via the fallback path won't have a paired `ELECTED_OFFICIAL` row in this poll. Verified the only direct downstream consumer (`pollResponsesDownload.service.ts`) queries `CONSTITUENT` rows alone, so the CSV download is unaffected.
- The fallback is district-scoped via `withOrgDistrictResolution`, so a forwarded reply from someone outside the constituency still drops (correctly — they're not a constituent of this elected official).
- One extra People API call per unmapped phone. In practice 0–5 per poll; calls run in parallel.

## Test plan

- [x] `src/queue/consumer/queueConsumer.service.test.ts` — 29 tests pass, including 4 new ones:
  - poll-only happy path doesn't hit People DB fallback
  - People DB fallback persists row with matched `personId`
  - phone unknown to both → row skipped, poll still completes (no throw)
  - People DB lookup error → treated as a miss (still no throw)
- [x] `src/contacts/services/contacts.service.test.ts` — 20 existing tests still pass
- [x] `npm run lint` clean on touched files
- [x] `npx tsc --noEmit` clean on touched files (pre-existing unrelated errors only)
- [ ] Re-drive original SQS message after merge to unblock poll `019e02ff-ebbe-7dda-acaf-1555994d4c77`

## Follow-ups (not in this PR)

- Wrap the `POLL_ANALYSIS_COMPLETE` case in `withLegacyErrorSwallowing` (or equivalent) so any *future* unrecoverable error in this handler ages out to DLQ instead of looping — broader CLAUDE.md hardening guidance.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes poll response persistence and SQS failure behavior for `POLL_ANALYSIS_COMPLETE`; wrong attribution or over-skipping could drop legitimate replies, but scope is limited to unmapped phones with logging and parallel People API calls.
> 
> **Overview**
> Poll analysis completion no longer fails the whole SQS message when a reply phone isn’t in the poll’s outreach map. **`handlePollAnalysisComplete`** now tries a **district-scoped People API lookup** via new **`ContactsService.findPersonByPhone`** (parallel per unmapped phone), then **logs and skips** any row still without a `personId` instead of throwing—so one unattributable SMS (e.g. forwarded thread) doesn’t block **`markPollComplete`** and infinite SQS redelivery for the rest of the poll.
> 
> Tests replace the old “throws when person not found” case with coverage for skip-on-miss, People DB attribution, no fallback when outreach already maps phones, and lookup errors treated as misses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb32e838e1c05f8f09f54aaf99de19ddc6d7bb3b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->