### PR TITLE
feat(meetings): rename Agenda Picked Up to Briefing Assistant - Agenda Created

### DIFF
--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -459,20 +459,24 @@ export class MeetingBriefingsService extends createPrismaBase(
     })
 
     try {
-      await this.segment.trackEvent(userId, 'Agenda Picked Up', {
-        agenda_id: dateString,
-        meeting_date: dateString,
-        meeting_time: meetingTime,
-        meeting_timezone: meetingTimezone,
-        meeting_place: artifact.location ?? '',
-        meeting_type: meetingType,
-        exec_summary: execSummary,
-        top_3_agenda_items: topItems.map((it) => it.title),
-      })
+      await this.segment.trackEvent(
+        userId,
+        'Briefing Assistant - Agenda Created',
+        {
+          agendaId: dateString,
+          meetingDate: dateString,
+          meetingTime,
+          meetingTimezone,
+          meetingPlace: artifact.location ?? '',
+          meetingType,
+          execSummary,
+          ...flattenTopAgendaItems(topItems),
+        },
+      )
     } catch (err) {
       this.logger.error(
         { err, userId },
-        '[SEGMENT] Failed to track Agenda Picked Up',
+        '[SEGMENT] Failed to track Briefing Assistant - Agenda Created',
       )
     }
   }
@@ -532,7 +536,7 @@ export class MeetingBriefingsService extends createPrismaBase(
     } catch (err) {
       this.logger.error(
         { err, userId, meetingDate },
-        'Failed to generate Agenda Picked Up hook; falling back to lead_in',
+        'Failed to generate Briefing Assistant - Agenda Created hook; falling back to lead_in',
       )
       return leadInFallback
     }
@@ -549,6 +553,18 @@ const readLeadIn = (artifact: PrismaJson.MeetingBriefingArtifact): string => {
   if (!isRecord(es)) return ''
   const leadIn = es['lead_in']
   return typeof leadIn === 'string' ? leadIn : ''
+}
+
+const flattenTopAgendaItems = (
+  items: { title: string; overview: string }[],
+): Record<string, string> => {
+  const flat: Record<string, string> = {}
+  items.forEach((item, idx) => {
+    const n = idx + 1
+    flat[`agendaItem${n}Name`] = item.title
+    flat[`agendaItem${n}Description`] = item.overview
+  })
+  return flat
 }
 
 const readTopAgendaItems = (


### PR DESCRIPTION
## Why

The user-facing meeting briefings surface is "Briefing Assistant" (renamed from "Meetings" in gp-webapp #1886). Existing Segment dashboards and the new ones being stood up for this feature index on the `Briefing Assistant - *` prefix, so the agenda-pickup event needs to live under that namespace to be discoverable alongside the rest of the surface.

Two adjacent shape changes ride along because they break the same downstream consumers anyway:

- Properties move to camelCase to match the convention the gp-webapp side adopted in the same effort.
- `top_3_agenda_items: string[]` becomes flat `agendaItem{1,2,3}{Name,Description}` properties. The array form forces every downstream — HubSpot drip-segments, Customer.io templates, Looker explores — to either parse JSON or unpack the array client-side. Flat numbered properties drop straight into a templated email or a Segment trait.

Any dashboards / journeys keyed on `Agenda Picked Up`, `top_3_agenda_items`, or the snake_case property names need to be rekeyed when this lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Analytics-only code path, but breaking changes to event name and property schema will break existing Segment dashboards and integrations until they are updated.
> 
> **Overview**
> When a meeting briefing is saved, the Segment event is renamed from **`Agenda Picked Up`** to **`Briefing Assistant - Agenda Created`**, with related log messages updated to match.
> 
> Event properties move from snake_case to **camelCase** (e.g. `agenda_id` → `agendaId`, `exec_summary` → `execSummary`). Top agenda items are no longer sent as `top_3_agenda_items: string[]`; a new **`flattenTopAgendaItems`** helper spreads up to three items into flat fields like `agendaItem1Name` / `agendaItem1Description`.
> 
> **Downstream impact:** Segment dashboards, HubSpot/Customer.io journeys, and Looker that key on the old event name or property shapes need to be rekeyed when this ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c419e9211dfb86fe26da860e411bbcd1d3f81d3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->