### PR TITLE
fix(auth): let the STT WebSocket upgrade bypass SessionGuard

### DIFF
--- a/src/authentication/guards/Session.guard.test.ts
+++ b/src/authentication/guards/Session.guard.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AuthProvider } from '@/authentication/interfaces/auth-provider.interface'
 import { IncomingRequest } from '@/authentication/authentication.types'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { TRANSCRIBE_STREAM_PATH } from '@/speech/ws/speechToText.gateway'
 import { SessionGuard } from './Session.guard'
 
 const baseUser: User = {
@@ -48,8 +49,12 @@ describe('SessionGuard — impersonating flag', () => {
     fetchClerkFields: ReturnType<typeof vi.fn>
   }
 
-  const buildRequest = (token?: string): IncomingRequest =>
+  const buildRequest = (
+    token?: string,
+    url = '/v1/protected',
+  ): IncomingRequest =>
     ({
+      url,
       headers: {
         authorization: token ? `Bearer ${token}` : undefined,
       },
@@ -90,6 +95,17 @@ describe('SessionGuard — impersonating flag', () => {
       createMockLogger(),
       new Reflector(),
     )
+  })
+
+  it('allows the STT WebSocket upgrade without a token (ticket-authed)', async () => {
+    const req = buildRequest(undefined, `${TRANSCRIBE_STREAM_PATH}?ticket=abc`)
+    await expect(guard.canActivate(buildContext(req))).resolves.toBe(true)
+    expect(authProvider.verifySessionToken).not.toHaveBeenCalled()
+  })
+
+  it('still rejects a protected route with no token', async () => {
+    const req = buildRequest(undefined)
+    await expect(guard.canActivate(buildContext(req))).rejects.toThrow()
   })
 
   it('no actor claim: impersonating=false, no actorUser', async () => {

--- a/src/authentication/guards/Session.guard.ts
+++ b/src/authentication/guards/Session.guard.ts
@@ -14,6 +14,7 @@ import {
 } from '@/authentication/interfaces/auth-provider.interface'
 import { IncomingRequest } from '@/authentication/authentication.types'
 import { routeIsPublicAndNoRoles } from '@/authentication/util/routeIsPublicAndNoRoles.util'
+import { TRANSCRIBE_STREAM_PATH } from '@/speech/ws/speechToText.gateway'
 import { UsersService } from '@/users/services/users.service'
 import { SessionsService } from '@/users/services/sessions.service'
 import { ClerkUserEnricherService } from '@/vendors/clerk/services/clerk-user-enricher.service'
@@ -34,6 +35,16 @@ export class SessionGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<IncomingRequest>()
+
+    // The speech-to-text WebSocket upgrade authenticates with a short-lived
+    // ticket verified in SpeechToTextGateway, not the session cookie/JWT.
+    // Browsers can't set an Authorization header on a WS handshake, so this
+    // guard would otherwise reject the upgrade and the ALB returns a 502. It's
+    // a raw Fastify route and can't carry @PublicAccess(), hence the path check.
+    if (request.url.split('?')[0] === TRANSCRIBE_STREAM_PATH) {
+      return true
+    }
+
     const token = request.headers.authorization?.replace('Bearer ', '')
 
     if (!token) {


### PR DESCRIPTION
Dictation in the briefings UI was failing with a 502 the moment a user tried to record. The reason is an auth-vs-transport mismatch, not a problem in the speech code itself.

Dictation opens a browser WebSocket to `/v1/speech/transcribe/stream`, which authenticates with a short-lived ticket that `SpeechToTextGateway` verifies on connect. But the global `SessionGuard` runs first and reads the JWT from the `Authorization` header — and a browser WebSocket handshake cannot set request headers. With no header, the guard threw `UnauthorizedException`. Because that throw happens during the HTTP→WS upgrade, the ALB never sees a completed 101 handshake and surfaces it to the browser as a 502 (not a 401), so the socket never connected and the ticket auth never ran.

The stream route is registered directly on Fastify (it needs the raw socket), so it can't carry `@PublicAccess()` like a normal controller route. This exempts it by path inside the guard and lets the gateway's ticket verification be the sole auth for the endpoint — which was always the design intent. `ClerkM2MAuthGuard` and `RolesGuard` already let it through, so `SessionGuard` was the only blocker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows global auth by path for one endpoint; mis-scoping the path constant could expose the upgrade to unauthenticated handshakes before ticket checks.
> 
> **Overview**
> **`SessionGuard`** now **skips JWT/session checks** when the request path (ignoring query string) matches **`TRANSCRIBE_STREAM_PATH`**, so the browser WebSocket upgrade for speech-to-text can complete without an `Authorization` header. **Ticket verification in `SpeechToTextGateway`** remains the auth for that stream.
> 
> Tests confirm the transcribe URL with only a `ticket` query is allowed without calling **`verifySessionToken`**, and other protected routes still fail with no token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f9579660af468e6d73533d3499ceb8be02f5cf5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->