### PR TITLE
fix: remove debug log and use date-fns in ballotReady.getMonthBounds

### DIFF
--- a/src/elections/services/ballotReady.service.ts
+++ b/src/elections/services/ballotReady.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common'
+import { endOfMonth, format, parseISO, startOfMonth } from 'date-fns'
 import { gql, GraphQLClient } from 'graphql-request'
 import { Headers, MimeTypes } from 'http-constants-ts'
 import { PositionLevel } from 'src/generated/graphql.types'
@@ -481,16 +482,9 @@ export class BallotReadyService {
 }
 
 function getMonthBounds(dateString: string): { gt: string; lt: string } {
-  console.log('dateString', dateString)
-  // Parse the date parts directly from the string to avoid timezone issues
-  const [year, month] = dateString.split('-').map(Number)
-
-  const gt = new Date(year, month - 1, 1) // month - 1 because months are 0-based
-    .toISOString()
-    .split('T')[0]
-  const lt = new Date(year, month, 0) // Last day of the month
-    .toISOString()
-    .split('T')[0]
-
-  return { gt, lt }
+  const reference = parseISO(dateString)
+  return {
+    gt: format(startOfMonth(reference), 'yyyy-MM-dd'),
+    lt: format(endOfMonth(reference), 'yyyy-MM-dd'),
+  }
 }


### PR DESCRIPTION
## Summary
- Remove stray `console.log('dateString', ...)` in `getMonthBounds`.
- Replace raw `Date` math with `date-fns` `startOfMonth` / `endOfMonth`.

## Motivation
Debug leak in production path; raw `Date` math violates `rules.mdc` Rule 28.

## Test plan
- `npm run lint` passes
- `npx tsc --noEmit` passes
- Existing test (if any) for `ballotReady.service` still passes

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small helper refactor with no auth or data-model changes; behavior should match prior month filtering for zipcode race queries.
> 
> **Overview**
> **`getMonthBounds`** in `ballotReady.service.ts` no longer logs the input date and now derives the first/last day of the month with **`date-fns`** (`parseISO`, `startOfMonth`, `endOfMonth`, `format`) instead of manual `Date` construction and `toISOString().split('T')[0]`.
> 
> That helper still feeds the **`electionDay` `gte`/`lte`** window when **`fetchRacesByZipcode`** is called with an **`electionDate`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 283a60fac37346dc1779ac89ffa92616ea41557b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->