### PR TITLE
test: add unit tests for payments + purchase controllers

### DIFF
--- a/src/payments/payments.controller.test.ts
+++ b/src/payments/payments.controller.test.ts
@@ -1,0 +1,131 @@
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { BadRequestException, HttpException, HttpStatus } from '@nestjs/common'
+import { UserRole } from '@prisma/client'
+import Stripe from 'stripe'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { IS_PUBLIC_KEY } from '../authentication/decorators/PublicAccess.decorator'
+import { ROLES_KEY } from '../authentication/decorators/Roles.decorator'
+import { CampaignsService } from '../campaigns/services/campaigns.service'
+import { StripeService } from '../vendors/stripe/services/stripe.service'
+import { PaymentsController } from './payments.controller'
+import { PaymentEventsService } from './services/paymentEventsService'
+import { PaymentsService } from './services/payments.service'
+
+type WebhookReq = Parameters<PaymentsController['handleStripeEvent']>[0]
+
+const buildRequest = (rawBody: Buffer | null): WebhookReq =>
+  ({ rawBody }) as unknown as WebhookReq
+
+describe('PaymentsController', () => {
+  let controller: PaymentsController
+  let stripeService: { parseWebhookEvent: ReturnType<typeof vi.fn> }
+  let stripeEvents: { handleEvent: ReturnType<typeof vi.fn> }
+  let paymentsService: { fixMissingCustomerIds: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    stripeService = { parseWebhookEvent: vi.fn() }
+    stripeEvents = { handleEvent: vi.fn() }
+    paymentsService = { fixMissingCustomerIds: vi.fn() }
+
+    controller = new PaymentsController(
+      stripeService as unknown as StripeService,
+      stripeEvents as unknown as PaymentEventsService,
+      {} as CampaignsService,
+      paymentsService as unknown as PaymentsService,
+      createMockLogger(),
+    )
+  })
+
+  describe('decorators', () => {
+    it('marks handleStripeEvent as @PublicAccess', () => {
+      const isPublic = Reflect.getMetadata(
+        IS_PUBLIC_KEY,
+        PaymentsController.prototype.handleStripeEvent,
+      )
+      expect(isPublic).toBe(true)
+    })
+
+    it('restricts fixMissingCustomerIds to admin via @Roles', () => {
+      const roles = Reflect.getMetadata(
+        ROLES_KEY,
+        PaymentsController.prototype.fixMissingCustomerIds,
+      )
+      expect(roles).toEqual([UserRole.admin])
+    })
+  })
+
+  describe('handleStripeEvent', () => {
+    const headers = { 'stripe-signature': 'sig_test' }
+    const rawBody = Buffer.from('{"id":"evt_test"}')
+    const stripeEvent = {
+      id: 'evt_test',
+      type: 'checkout.session.completed',
+    } as unknown as Stripe.Event
+
+    it('parses the event and dispatches to PaymentEventsService', async () => {
+      stripeService.parseWebhookEvent.mockResolvedValue(stripeEvent)
+      stripeEvents.handleEvent.mockResolvedValue(undefined)
+
+      await controller.handleStripeEvent(buildRequest(rawBody), headers)
+
+      expect(stripeService.parseWebhookEvent).toHaveBeenCalledWith(
+        rawBody,
+        headers['stripe-signature'],
+      )
+      expect(stripeEvents.handleEvent).toHaveBeenCalledWith(stripeEvent)
+    })
+
+    it('throws BadRequestException when the signature header is missing', async () => {
+      await expect(
+        controller.handleStripeEvent(buildRequest(rawBody), {}),
+      ).rejects.toThrow(BadRequestException)
+      expect(stripeService.parseWebhookEvent).not.toHaveBeenCalled()
+    })
+
+    it('throws BadRequestException when signature verification fails', async () => {
+      stripeService.parseWebhookEvent.mockRejectedValue(
+        new Error('Invalid signature'),
+      )
+
+      await expect(
+        controller.handleStripeEvent(buildRequest(rawBody), headers),
+      ).rejects.toThrow(BadRequestException)
+      expect(stripeEvents.handleEvent).not.toHaveBeenCalled()
+    })
+
+    it('rethrows HttpException from PaymentEventsService unchanged', async () => {
+      const original = new HttpException('boom', HttpStatus.BAD_GATEWAY)
+      stripeService.parseWebhookEvent.mockResolvedValue(stripeEvent)
+      stripeEvents.handleEvent.mockRejectedValue(original)
+
+      await expect(
+        controller.handleStripeEvent(buildRequest(rawBody), headers),
+      ).rejects.toBe(original)
+    })
+
+    it('wraps unknown handler errors in BadRequestException', async () => {
+      stripeService.parseWebhookEvent.mockResolvedValue(stripeEvent)
+      stripeEvents.handleEvent.mockRejectedValue(new Error('db down'))
+
+      await expect(
+        controller.handleStripeEvent(buildRequest(rawBody), headers),
+      ).rejects.toThrow(BadRequestException)
+    })
+  })
+
+  describe('fixMissingCustomerIds', () => {
+    it('delegates to PaymentsService.fixMissingCustomerIds', async () => {
+      const result = {
+        message: 'Processed 0 users',
+        success: 0,
+        failed: 0,
+        skipped: 0,
+        details: { success: [], failed: [], skipped: [] },
+      }
+      paymentsService.fixMissingCustomerIds.mockResolvedValue(result)
+
+      await expect(controller.fixMissingCustomerIds()).resolves.toBe(result)
+      expect(paymentsService.fixMissingCustomerIds).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/src/payments/purchase.controller.test.ts
+++ b/src/payments/purchase.controller.test.ts
@@ -1,0 +1,219 @@
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { BadRequestException } from '@nestjs/common'
+import { Campaign, Organization, User, UserRole } from '@prisma/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UsersService } from '../users/services/users.service'
+import { StripeService } from '../vendors/stripe/services/stripe.service'
+import { PurchaseController } from './purchase.controller'
+import {
+  CompleteCheckoutSessionDto,
+  CompleteFreePurchaseDto,
+  CreateCheckoutSessionDto,
+  PurchaseType,
+} from './purchase.types'
+import { PurchaseService } from './services/purchase.service'
+
+const userId = 7
+
+const mockUser: User = {
+  id: userId,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+  firstName: 'Test',
+  lastName: 'User',
+  name: 'Test User',
+  avatar: null,
+  password: null,
+  hasPassword: false,
+  email: 'buyer@example.com',
+  phone: '5555555555',
+  zip: '12345',
+  roles: [UserRole.candidate],
+  metaData: null,
+  passwordResetToken: null,
+  clerkId: null,
+}
+
+const mockCampaign = { id: 111, slug: 'cmp' } as unknown as Campaign
+const mockOrganization = { slug: 'org-slug' } as unknown as Organization
+
+describe('PurchaseController', () => {
+  let controller: PurchaseController
+  let stripeService: {
+    createCheckoutSession: ReturnType<typeof vi.fn>
+    createPortalSession: ReturnType<typeof vi.fn>
+  }
+  let usersService: { patchUserMetaData: ReturnType<typeof vi.fn> }
+  let purchaseService: {
+    createCheckoutSession: ReturnType<typeof vi.fn>
+    completeCheckoutSession: ReturnType<typeof vi.fn>
+    completeFreePurchase: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    stripeService = {
+      createCheckoutSession: vi.fn(),
+      createPortalSession: vi.fn(),
+    }
+    usersService = { patchUserMetaData: vi.fn() }
+    purchaseService = {
+      createCheckoutSession: vi.fn(),
+      completeCheckoutSession: vi.fn(),
+      completeFreePurchase: vi.fn(),
+    }
+
+    controller = new PurchaseController(
+      stripeService as unknown as StripeService,
+      usersService as unknown as UsersService,
+      purchaseService as unknown as PurchaseService,
+      createMockLogger(),
+    )
+  })
+
+  describe('createProCheckoutSession', () => {
+    it('creates the session and persists checkoutSessionId on the user', async () => {
+      stripeService.createCheckoutSession.mockResolvedValue({
+        redirectUrl: 'https://stripe.test/checkout',
+        checkoutSessionId: 'cs_test_123',
+      })
+
+      const result = await controller.createProCheckoutSession(mockUser)
+
+      expect(stripeService.createCheckoutSession).toHaveBeenCalledWith(
+        userId,
+        mockUser.email,
+      )
+      expect(usersService.patchUserMetaData).toHaveBeenCalledWith(userId, {
+        checkoutSessionId: 'cs_test_123',
+      })
+      expect(result).toEqual({ redirectUrl: 'https://stripe.test/checkout' })
+    })
+  })
+
+  describe('createPortalSession', () => {
+    it('throws BadRequestException when the user has no customerId', async () => {
+      await expect(controller.createPortalSession(mockUser)).rejects.toThrow(
+        BadRequestException,
+      )
+      expect(stripeService.createPortalSession).not.toHaveBeenCalled()
+    })
+
+    it('returns the portal redirect URL when a customerId exists', async () => {
+      const userWithCustomer: User = {
+        ...mockUser,
+        metaData: { customerId: 'cus_123' },
+      }
+      stripeService.createPortalSession.mockResolvedValue({
+        url: 'https://stripe.test/portal',
+      })
+
+      const result = await controller.createPortalSession(userWithCustomer)
+
+      expect(stripeService.createPortalSession).toHaveBeenCalledWith('cus_123')
+      expect(result).toEqual({ redirectUrl: 'https://stripe.test/portal' })
+    })
+  })
+
+  describe('createCheckoutSession', () => {
+    const dto: CreateCheckoutSessionDto<unknown> = {
+      type: PurchaseType.TEXT,
+      metadata: { contactCount: 100 },
+    }
+
+    it('throws BadRequestException when neither campaign nor organization is supplied', async () => {
+      await expect(
+        controller.createCheckoutSession(mockUser, dto, undefined, undefined),
+      ).rejects.toThrow(BadRequestException)
+      expect(purchaseService.createCheckoutSession).not.toHaveBeenCalled()
+    })
+
+    it('forwards campaignId and organizationSlug to the purchase service', async () => {
+      const expected = {
+        id: 'cs_x',
+        clientSecret: 'cs_secret',
+        amount: 50,
+      }
+      purchaseService.createCheckoutSession.mockResolvedValue(expected)
+
+      const result = await controller.createCheckoutSession(
+        mockUser,
+        dto,
+        mockCampaign,
+        mockOrganization,
+      )
+
+      expect(purchaseService.createCheckoutSession).toHaveBeenCalledWith({
+        user: mockUser,
+        dto,
+        metadata: {
+          campaignId: mockCampaign.id,
+          organizationSlug: mockOrganization.slug,
+        },
+      })
+      expect(result).toBe(expected)
+    })
+
+    it('logs and rethrows errors from the purchase service', async () => {
+      const error = new Error('boom')
+      purchaseService.createCheckoutSession.mockRejectedValue(error)
+
+      await expect(
+        controller.createCheckoutSession(
+          mockUser,
+          dto,
+          mockCampaign,
+          undefined,
+        ),
+      ).rejects.toBe(error)
+    })
+  })
+
+  describe('completeCheckoutSession', () => {
+    it('delegates to PurchaseService.completeCheckoutSession', async () => {
+      const dto: CompleteCheckoutSessionDto = {
+        checkoutSessionId: 'cs_complete',
+      }
+      const response = { alreadyProcessed: false, result: { ok: true } }
+      purchaseService.completeCheckoutSession.mockResolvedValue(response)
+
+      await expect(controller.completeCheckoutSession(dto)).resolves.toBe(
+        response,
+      )
+      expect(purchaseService.completeCheckoutSession).toHaveBeenCalledWith(dto)
+    })
+  })
+
+  describe('completeFreePurchase', () => {
+    const dto: CompleteFreePurchaseDto = {
+      purchaseType: PurchaseType.TEXT,
+      metadata: { campaignId: 111 },
+    }
+
+    it('forwards user, dto, and campaign to the purchase service', async () => {
+      const response = { result: { ok: true } }
+      purchaseService.completeFreePurchase.mockResolvedValue(response)
+
+      const result = await controller.completeFreePurchase(
+        mockUser,
+        dto,
+        mockCampaign,
+      )
+
+      expect(purchaseService.completeFreePurchase).toHaveBeenCalledWith({
+        dto,
+        campaign: mockCampaign,
+        user: mockUser,
+      })
+      expect(result).toBe(response)
+    })
+
+    it('logs and rethrows errors from the purchase service', async () => {
+      const error = new Error('boom')
+      purchaseService.completeFreePurchase.mockRejectedValue(error)
+
+      await expect(
+        controller.completeFreePurchase(mockUser, dto, mockCampaign),
+      ).rejects.toBe(error)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `payments.controller.test.ts` — covers Stripe webhook signature + happy path + N error cases.
- Add `purchase.controller.test.ts` — covers checkout/fulfillment endpoints with mocked services.

## Motivation
Most sensitive money path in the system had zero unit test coverage.

## Test plan
- New tests pass: `npx vitest run src/payments/payments.controller.test.ts src/payments/purchase.controller.test.ts`
- `npm run lint` passes
- `npx tsc --noEmit` passes

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no runtime or payment logic changes.
> 
> **Overview**
> Adds **Vitest unit tests** for the payments HTTP layer—previously untested on this path.
> 
> **`payments.controller.test.ts`** exercises `PaymentsController`: metadata checks that the Stripe webhook is `@PublicAccess` and `fixMissingCustomerIds` is admin-only; webhook flow (signature parse → `PaymentEventsService`); missing/invalid signature and handler error mapping; admin repair endpoint delegation.
> 
> **`purchase.controller.test.ts`** exercises `PurchaseController` with mocked Stripe/users/purchase services: Pro checkout + persisting `checkoutSessionId`; billing portal when `customerId` is missing vs present; campaign/org checkout validation and service forwarding; complete checkout and free-purchase paths including error rethrow behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d1657ddeac53e1d1b411eb52ec33babb374d18e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->