### PR TITLE
fix: migrate IS_PROD to OTEL_SERVICE_ENVIRONMENT (ENG-10165)

### DIFF
--- a/src/campaigns/util/buildMapFilters.ts
+++ b/src/campaigns/util/buildMapFilters.ts
@@ -1,6 +1,6 @@
 import { Prisma } from '@prisma/client'
 import { capitalizeFirstLetter } from 'src/shared/util/strings.util'
-import { IS_PROD } from 'src/shared/util/appEnvironment.util'
+import { IS_PROD_DEPLOY } from 'src/shared/util/appEnvironment.util'
 
 const WINNERS_ELECTION_YEAR = process.env.WINNERS_ELECTION_YEAR
 
@@ -90,8 +90,7 @@ export function buildMapFilters(
     },
   })
 
-  // TODO(ENG-10165): IS_PROD is true in every deploy (so this filter applies on dev/qa/preview too). Should be `process.env.OTEL_SERVICE_ENVIRONMENT === 'prod'`. See appEnvironment.util.ts.
-  if (IS_PROD) {
+  if (IS_PROD_DEPLOY) {
     const isProdCondition = createJsonOrConditionString('Yes', [
       'hubSpotUpdates',
       'verified_candidates',

--- a/src/observability/blockedState/blockedState.interceptor.ts
+++ b/src/observability/blockedState/blockedState.interceptor.ts
@@ -9,6 +9,7 @@ import { User } from '@prisma/client'
 import { FastifyRequest } from 'fastify'
 import { Observable, catchError, throwError } from 'rxjs'
 import { recordBlockedStateEvent } from '@/observability/grafana/otel.client'
+import { OTEL_SERVICE_ENVIRONMENT } from '@/shared/util/appEnvironment.util'
 import { deriveRootCause, shouldRecordBlockedState } from './blockedState.rules'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -124,8 +125,7 @@ export class BlockedStateInterceptor implements NestInterceptor {
 
         const blockedStateAttributes = {
           service: 'gp-api' as const,
-          // TODO(ENG-10165): NODE_ENV is 'production' in every deploy; for accurate observability env tagging use `process.env.OTEL_SERVICE_ENVIRONMENT`. See appEnvironment.util.ts.
-          environment: process.env.NODE_ENV,
+          environment: OTEL_SERVICE_ENVIRONMENT,
           userId,
           endpoint,
           method,

--- a/src/payments/services/paymentEventsService.ts
+++ b/src/payments/services/paymentEventsService.ts
@@ -17,7 +17,7 @@ import { DateFormats, formatDate } from '../../shared/util/date.util'
 import { getUserFullName } from '../../users/util/users.util'
 import { EmailService } from '../../email/email.service'
 import { SlackChannel } from '../../vendors/slack/slackService.types'
-import { IS_PROD } from 'src/shared/util/appEnvironment.util'
+import { IS_PROD_DEPLOY } from 'src/shared/util/appEnvironment.util'
 import { CrmCampaignsService } from '../../campaigns/services/crmCampaigns.service'
 import { OrganizationsService } from '../../organizations/services/organizations.service'
 import { VoterFileDownloadAccessService } from '../../shared/services/voterFileDownloadAccess.service'
@@ -443,8 +443,7 @@ export class PaymentEventsService {
           slug
         }\` ended their pro subscription!`,
       },
-      // TODO(ENG-10165): IS_PROD is true in every deploy; should be `process.env.OTEL_SERVICE_ENVIRONMENT === 'prod'`. See appEnvironment.util.ts.
-      IS_PROD ? SlackChannel.botPolitics : SlackChannel.botDev,
+      IS_PROD_DEPLOY ? SlackChannel.botPolitics : SlackChannel.botDev,
     )
   }
 
@@ -453,8 +452,7 @@ export class PaymentEventsService {
       {
         text: `PRO PLAN RESUMED: \`${getUserFullName(user)}\` w/ email ${user.email} and campaign slug \`${campaign.slug}\` RESUMED their pro subscription!`,
       },
-      // TODO(ENG-10165): IS_PROD is true in every deploy; should be `process.env.OTEL_SERVICE_ENVIRONMENT === 'prod'`. See appEnvironment.util.ts.
-      IS_PROD ? SlackChannel.botPolitics : SlackChannel.botDev,
+      IS_PROD_DEPLOY ? SlackChannel.botPolitics : SlackChannel.botDev,
     )
   }
 
@@ -481,8 +479,7 @@ export class PaymentEventsService {
             : 'No CRM company found'
         }`,
       },
-      // TODO(ENG-10165): IS_PROD is true in every deploy; should be `process.env.OTEL_SERVICE_ENVIRONMENT === 'prod'`. See appEnvironment.util.ts.
-      IS_PROD ? SlackChannel.botPolitics : SlackChannel.botDev,
+      IS_PROD_DEPLOY ? SlackChannel.botPolitics : SlackChannel.botDev,
     )
   }
 }

--- a/src/shared/services/voterFileDownloadAccess.service.ts
+++ b/src/shared/services/voterFileDownloadAccess.service.ts
@@ -1,5 +1,5 @@
 import { OrgDistrict } from '@/organizations/organizations.types'
-import { IS_PROD } from '@/shared/util/appEnvironment.util'
+import { IS_PROD_DEPLOY } from '@/shared/util/appEnvironment.util'
 import { SlackService } from '@/vendors/slack/services/slack.service'
 import { SlackChannel } from '@/vendors/slack/slackService.types'
 import { Inject, OnModuleInit } from '@nestjs/common'
@@ -55,8 +55,7 @@ export class VoterFileDownloadAccessService implements OnModuleInit {
         {
           text: `Campaign ${campaign.slug} has been upgraded to Pro but the voter file is not available. Email: ${user.email}\nvisit https://goodparty.org/admin/pro-no-voter-file to see all users without L2 data\n${alertSlackMessage}`,
         },
-        // TODO(ENG-10165): IS_PROD is true in every deploy; should be `process.env.OTEL_SERVICE_ENVIRONMENT === 'prod'`. See appEnvironment.util.ts.
-        IS_PROD ? SlackChannel.botPolitics : SlackChannel.botDev,
+        IS_PROD_DEPLOY ? SlackChannel.botPolitics : SlackChannel.botDev,
       )
     }
   }

--- a/src/shared/util/appEnvironment.util.ts
+++ b/src/shared/util/appEnvironment.util.ts
@@ -17,18 +17,15 @@ export const WEBAPP_API_PATH = '/api/v1/'
 // CAUTION: IS_PROD is true in EVERY Docker-built deploy (preview/dev/qa/prod)
 // because deploy/Dockerfile pins NODE_ENV=production for runtime performance.
 // IS_PROD therefore only reliably distinguishes LOCAL vs DEPLOYED — not
-// prod-deploy vs non-prod-deploy.
-//
-// For routing that needs to differ between actual deploys (Slack channels,
-// telemetry env tags, prod-only data filters), use:
-//
-//   process.env.OTEL_SERVICE_ENVIRONMENT === 'prod'
-//
-// OTEL_SERVICE_ENVIRONMENT is set per-deploy in deploy/index.ts as one of
-// 'preview' | 'dev' | 'qa' | 'prod'. Existing IS_PROD usages tagged with
-// `TODO(ENG-10165)` should migrate.
+// prod-deploy vs non-prod-deploy. For routing that needs to differ between
+// actual deploys (Slack channels, telemetry env tags, prod-only data filters),
+// use IS_PROD_DEPLOY or OTEL_SERVICE_ENVIRONMENT below.
 export const IS_PROD = isEnvironment(AppEnv.PROD)
 export const IS_DEV = isEnvironment(AppEnv.DEV)
+
+// Set per-deploy in deploy/index.ts as one of 'preview' | 'dev' | 'qa' | 'prod'.
+export const OTEL_SERVICE_ENVIRONMENT = process.env.OTEL_SERVICE_ENVIRONMENT
+export const IS_PROD_DEPLOY = OTEL_SERVICE_ENVIRONMENT === 'prod'
 
 function isEnvironment(env: AppEnv) {
   return CURRENT_ENV === env

--- a/src/vendors/braintrust/braintrust.service.ts
+++ b/src/vendors/braintrust/braintrust.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import * as braintrust from 'braintrust'
-import { CURRENT_ENVIRONMENT } from 'src/shared/util/appEnvironment.util'
+import { OTEL_SERVICE_ENVIRONMENT } from 'src/shared/util/appEnvironment.util'
 import { PinoLogger } from 'nestjs-pino'
 
 export const VALID_CHAT_ROLES = ['system', 'user', 'assistant'] as const
@@ -180,8 +180,10 @@ export class BraintrustService {
       span.log({
         input: options?.input,
         output,
-        // TODO(ENG-10165): CURRENT_ENVIRONMENT is 'production' in every deploy; for accurate Braintrust env tagging use `process.env.OTEL_SERVICE_ENVIRONMENT`. See appEnvironment.util.ts.
-        metadata: { environment: CURRENT_ENVIRONMENT, ...options?.metadata },
+        metadata: {
+          environment: OTEL_SERVICE_ENVIRONMENT,
+          ...options?.metadata,
+        },
       })
     } catch (err) {
       this.logger.warn(

--- a/src/voters/voterFile/voterFile.service.ts
+++ b/src/voters/voterFile/voterFile.service.ts
@@ -3,7 +3,7 @@ import { Campaign, OutreachType, User } from '@prisma/client'
 import { CampaignTaskType } from 'src/campaigns/tasks/campaignTasks.types'
 import { OrgDistrict } from 'src/organizations/organizations.types'
 import { SlackService } from 'src/vendors/slack/services/slack.service'
-import { IS_PROD } from 'src/shared/util/appEnvironment.util'
+import { IS_PROD_DEPLOY } from 'src/shared/util/appEnvironment.util'
 import { WrapperType } from 'src/shared/types/utility.types'
 import { CrmCampaignsService } from '../../campaigns/services/crmCampaigns.service'
 import { SlackChannel } from '../../vendors/slack/slackService.types'
@@ -195,8 +195,7 @@ export class VoterFileService {
 
     await this.slack.message(
       slackBlocks,
-      // TODO(ENG-10165): IS_PROD is true in every deploy; should be `process.env.OTEL_SERVICE_ENVIRONMENT === 'prod'`. See appEnvironment.util.ts.
-      IS_PROD ? SlackChannel.botPolitics : SlackChannel.botDev,
+      IS_PROD_DEPLOY ? SlackChannel.botPolitics : SlackChannel.botDev,
     )
 
     return true


### PR DESCRIPTION
## Summary
- Migrates 7 sites tagged `TODO(ENG-10165)` from `IS_PROD` / `CURRENT_ENVIRONMENT` / `process.env.NODE_ENV` to `OTEL_SERVICE_ENVIRONMENT === 'prod'` (or the raw `OTEL_SERVICE_ENVIRONMENT` value where the env tag is the actual payload).
- Centralizes the prod-deploy check in `src/shared/util/appEnvironment.util.ts` with two new exports: `IS_PROD_DEPLOY` (boolean) and `OTEL_SERVICE_ENVIRONMENT` (the raw deploy env string). No ad-hoc inline `process.env.OTEL_SERVICE_ENVIRONMENT` checks added.

## Motivation
`IS_PROD` (and `CURRENT_ENVIRONMENT`) returned true for every Docker deploy because `deploy/Dockerfile` pins `NODE_ENV=production` for runtime performance. As a result:

- Slack alerts (`voterFile.service`, `voterFileDownloadAccess.service`, `paymentEventsService` × 3) were routing pro-signup / pro-cancel / pro-resume / voter-file-help / no-voter-file messages to `#bot-politics` from preview/dev/qa deploys, not just prod.
- Braintrust spans (`braintrust.service`) were tagged `environment: 'production'` regardless of deploy.
- The blocked-state observability interceptor was tagging events with `NODE_ENV` instead of the deploy env.
- The map-filter (`buildMapFilters`) was applying the `verified_candidates` / `isVerified` filter on every deploy.

`OTEL_SERVICE_ENVIRONMENT` is set per-deploy in `deploy/index.ts` to one of `'preview' | 'dev' | 'qa' | 'prod'` and is the reliable signal.

## Files changed
- `src/shared/util/appEnvironment.util.ts` — add `IS_PROD_DEPLOY` and `OTEL_SERVICE_ENVIRONMENT` exports; refresh CAUTION comment
- `src/voters/voterFile/voterFile.service.ts`
- `src/vendors/braintrust/braintrust.service.ts`
- `src/shared/services/voterFileDownloadAccess.service.ts`
- `src/payments/services/paymentEventsService.ts` (3 sites)
- `src/observability/blockedState/blockedState.interceptor.ts`
- `src/campaigns/util/buildMapFilters.ts`

## Test plan
- `npm run lint` — files I touched have no errors (only pre-existing repo-wide warnings)
- `npx tsc --noEmit` — no errors introduced in any touched file (pre-existing failures in unrelated modules: `CampaignStrategy` Prisma types, generated `route-types`, `@goodparty_org/contracts`, `@google/genai`)
- Manual review of each migrated site to confirm intent preserved (boolean vs raw env string)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior on non-prod deploys (Slack channels, map data filtering, observability tags); fixes misrouting but should be verified in preview/qa that alerts and filters match expectations.
> 
> **Overview**
> **Docker deploys were all treated as “production”** because `NODE_ENV` is pinned to `production` in every image. This PR switches prod-only behavior to **`OTEL_SERVICE_ENVIRONMENT`** (set per deploy in `deploy/index.ts`).
> 
> `appEnvironment.util.ts` now exports **`IS_PROD_DEPLOY`** (`OTEL_SERVICE_ENVIRONMENT === 'prod'`) and **`OTEL_SERVICE_ENVIRONMENT`**, with an updated caution on when to use them vs `IS_PROD`.
> 
> Call sites updated: **Slack routing** (pro signup/cancel/resume, voter-file help, missing L2 alerts) uses `IS_PROD_DEPLOY` so preview/dev/qa go to dev channels; **map filters** apply verified-candidate constraints only on prod deploy; **blocked-state** and **Braintrust** telemetry tag the real deploy env instead of `NODE_ENV` / `CURRENT_ENVIRONMENT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1987f94258a8f0f505a6da6f283a48a541ce68ef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->