### PR TITLE
fix: store isProUpdatedAt as ISO string instead of unix ms

### DIFF
--- a/contracts/.changeset/fix-is-pro-updated-at-iso.md
+++ b/contracts/.changeset/fix-is-pro-updated-at-iso.md
@@ -1,0 +1,8 @@
+---
+'@goodparty_org/contracts': minor
+---
+
+Widen `CampaignDetails.isProUpdatedAt` from `number` to `string | number`.
+New writes from `gp-api` store an ISO datetime string; legacy unix-ms
+numbers persist in existing rows until backfilled. Readers must handle
+both shapes. The previously-valid `number` shape is unchanged.

--- a/contracts/src/campaigns/types.ts
+++ b/contracts/src/campaigns/types.ts
@@ -137,7 +137,9 @@ export type CampaignDetails = {
   knowRun?: 'yes' | null
   runForOffice?: 'yes' | 'no' | null
   pledged?: boolean
-  isProUpdatedAt?: number
+  // ISO string for new writes; legacy unix-ms numbers persist in existing
+  // rows until backfilled
+  isProUpdatedAt?: string | number
   customIssues?: CustomIssue[]
   runningAgainst?: Opponent[]
   geoLocation?: GeoLocation

--- a/prisma/schema/campaign.jsonTypes.d.ts
+++ b/prisma/schema/campaign.jsonTypes.d.ts
@@ -33,7 +33,9 @@ declare global {
         | 'considering'
         | 'testing'
       pledged?: boolean
-      isProUpdatedAt?: number // TODO: make this an ISO dateTime string
+      // ISO string for new writes; legacy unix-ms numbers persist in
+      // existing rows until backfilled
+      isProUpdatedAt?: string | number
       proUpgradeSlackNotifiedAt?: number
       customIssues?: Record<'title' | 'position', string>[]
       runningAgainst?: Record<'name' | 'party' | 'description', string>[]

--- a/src/campaigns/services/campaigns.service.ts
+++ b/src/campaigns/services/campaigns.service.ts
@@ -12,6 +12,7 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common'
 import { Campaign, Prisma, User } from '@prisma/client'
+import { formatISO } from 'date-fns'
 import { deepmerge as deepMerge } from 'deepmerge-ts'
 import { AnalyticsService } from 'src/analytics/analytics.service'
 import { ElectionsService } from 'src/elections/services/elections.service'
@@ -423,8 +424,8 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
     })
     // Must be in serial so as to not overwrite campaign details w/ concurrent queries
     await this.patchCampaignDetails(campaignId, {
-      isProUpdatedAt: Date.now(),
-    }) // TODO: this should be an ISO dateTime string, not a unix timestamp
+      isProUpdatedAt: formatISO(new Date()),
+    })
 
     if (isBecomingProFirstTime) {
       void this.campaignTasks.notifySlackOnProUpgrade(campaignId)


### PR DESCRIPTION
## Summary
- Switch `isProUpdatedAt` write from `Date.now()` (number) to `formatISO(new Date())` (string) at `src/campaigns/services/campaigns.service.ts`.
- Widen `CampaignDetails.isProUpdatedAt` type to `string | number` in both `prisma/schema/campaign.jsonTypes.d.ts` and `contracts/src/campaigns/types.ts` so existing rows holding legacy unix-ms numbers continue to type-check until backfilled.
- Remove the TODO comment at the write site and on the JSON type.

## Downstream reader audit
- `crmCampaigns.service.ts` destructures `isProUpdatedAt` from `campaignDetails` and passes it through `formatDateForCRM(date: string | number | undefined | null)`. The helper already handles both ISO strings and unix-ms numbers transparently, so no reader-side code change was required — the widened type is backward-compat by design.
- `schemas/updateCampaign.schema.test.ts` only asserts that the field is stripped from user input; the test is value-type-agnostic.

## Motivation
Type drift between the JSON write and downstream readers (TODO at call site).

## Notes
- `contracts/src/campaigns/types.ts` is part of the published `@goodparty_org/contracts` package. The change is additive (`number` -> `string | number`) so existing consumers stay valid, but a manual contracts version + CHANGELOG bump is normally expected for public-surface changes. I did not bump `contracts/package.json` per task constraints; flag if a coordinated release is needed.

## Test plan
- `npm run lint` — exits non-zero only due to 59 pre-existing errors unrelated to touched files (same count before and after the change). Touched files are lint-clean.
- `npx tsc --noEmit` — 19 pre-existing errors unrelated to touched files (same count before and after). Touched files are type-clean.
- `npx vitest run src/campaigns/services/campaigns.service.test.ts src/campaigns/schemas/updateCampaign.schema.test.ts` — 40/40 pass.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible type widening and a single write-path change; CRM formatting already supports both formats.
> 
> **Overview**
> When a campaign’s Pro status is updated via `setIsPro`, **`isProUpdatedAt` in campaign details is now stored as an ISO-8601 string** (`formatISO`) instead of a Unix millisecond number (`Date.now()`).
> 
> **`CampaignDetails.isProUpdatedAt` is typed as `string | number`** in both the published contracts package and Prisma JSON typings, with comments that legacy rows may still hold numeric timestamps until backfilled. Related TODOs about using an ISO datetime were removed at the write site and on the JSON type.
> 
> No CRM reader changes: HubSpot sync already normalizes this field through `formatDateForCRM`, which accepts strings and numbers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87057046e5f0fdd787332c6bbb1aecffe4a9c48a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->