### PR TITLE
fix(deploy): route MEETING_PIPELINE_BUCKET per environment

### DIFF
--- a/deploy/components/meeting-pipeline-bucket.ts
+++ b/deploy/components/meeting-pipeline-bucket.ts
@@ -1,0 +1,57 @@
+import * as aws from '@pulumi/aws'
+
+export interface MeetingPipelineBucketConfig {
+  environment: 'qa' | 'prod'
+}
+
+/**
+ * Bucket for the meeting-pipeline data plane. Shared between:
+ *  - the external `meeting_pipeline` lambdas/ECS tasks that write briefing
+ *    JSON and intermediate artifacts under the `meeting_pipeline/` prefix
+ *  - gp-api `TextToSpeechService`, which caches Polly audio under
+ *    `speech/synth/` and hands the browser presigned GET URLs
+ *
+ * The dev bucket (`meeting-pipeline-dev`) was created out-of-band well
+ * before this file existed; Pulumi does NOT own it. This component creates
+ * the qa/prod buckets so the existing select() in deploy/index.ts has
+ * something real to point at in those environments. When the larger
+ * meeting-pipeline Terraform stack eventually lands in gp-ai-projects,
+ * those buckets can be `terraform import`'d into that module's state and
+ * this component retired.
+ */
+export function createMeetingPipelineBucket({
+  environment,
+}: MeetingPipelineBucketConfig): {
+  bucket: aws.s3.Bucket
+} {
+  const bucketName = `meeting-pipeline-${environment}`
+
+  const bucket = new aws.s3.Bucket('meeting-pipeline-bucket', {
+    bucket: bucketName,
+    forceDestroy: false,
+  })
+
+  new aws.s3.BucketPublicAccessBlock('meeting-pipeline-pab', {
+    bucket: bucket.id,
+    blockPublicAcls: true,
+    blockPublicPolicy: true,
+    ignorePublicAcls: true,
+    restrictPublicBuckets: true,
+  })
+
+  new aws.s3.BucketServerSideEncryptionConfigurationV2(
+    'meeting-pipeline-sse',
+    {
+      bucket: bucket.id,
+      rules: [
+        {
+          applyServerSideEncryptionByDefault: {
+            sseAlgorithm: 'AES256',
+          },
+        },
+      ],
+    },
+  )
+
+  return { bucket }
+}

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -399,7 +399,12 @@ export = async () => {
         prod: 'true',
       }),
       SERVE_ANALYSIS_BUCKET_NAME: `serve-analyze-data-${environment === 'preview' ? 'dev' : environment}`,
-      MEETING_PIPELINE_BUCKET: 'meeting-pipeline-dev',
+      MEETING_PIPELINE_BUCKET: select({
+        preview: 'meeting-pipeline-dev',
+        dev: 'meeting-pipeline-dev',
+        qa: 'meeting-pipeline-qa',
+        prod: 'meeting-pipeline-prod',
+      }),
       TEVYN_POLL_CSVS_BUCKET: tevynPollCsvsBucket.bucket,
       ZIP_TO_AREA_CODE_BUCKET: zipToAreaCodeBucket.bucket,
       ANNOTATION_ATTACHMENTS_BUCKET: annotationAttachmentsBucketName,

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -4,6 +4,7 @@ import { createAnnotationAttachmentsBucket } from './components/annotation-attac
 import { createAssetsBucket } from './components/assets-bucket'
 import { createAssetsRouter } from './components/assets-router'
 import { createGrafanaResources } from './components/grafana'
+import { createMeetingPipelineBucket } from './components/meeting-pipeline-bucket'
 import { createService } from './components/service'
 import { createVpc } from './components/vpc'
 
@@ -128,6 +129,16 @@ export = async () => {
     environment === 'preview'
       ? 'annotation-attachments-dev'
       : createAnnotationAttachmentsBucket({ environment }).bucket.bucket
+
+  // Shared bucket between the external meeting_pipeline (writes briefings)
+  // and gp-api TextToSpeechService (caches Polly audio under speech/synth/,
+  // then hands the browser presigned GETs). Dev bucket exists out-of-band
+  // and is not Pulumi-owned, so preview/dev just reference its name. QA and
+  // prod buckets are created here.
+  const meetingPipelineBucketName =
+    environment === 'preview' || environment === 'dev'
+      ? 'meeting-pipeline-dev'
+      : createMeetingPipelineBucket({ environment }).bucket.bucket
 
   // Assets bucket - used for storing uploaded files, images, etc.
   if (environment !== 'preview') {
@@ -399,12 +410,7 @@ export = async () => {
         prod: 'true',
       }),
       SERVE_ANALYSIS_BUCKET_NAME: `serve-analyze-data-${environment === 'preview' ? 'dev' : environment}`,
-      MEETING_PIPELINE_BUCKET: select({
-        preview: 'meeting-pipeline-dev',
-        dev: 'meeting-pipeline-dev',
-        qa: 'meeting-pipeline-qa',
-        prod: 'meeting-pipeline-prod',
-      }),
+      MEETING_PIPELINE_BUCKET: meetingPipelineBucketName,
       TEVYN_POLL_CSVS_BUCKET: tevynPollCsvsBucket.bucket,
       ZIP_TO_AREA_CODE_BUCKET: zipToAreaCodeBucket.bucket,
       ANNOTATION_ATTACHMENTS_BUCKET: annotationAttachmentsBucketName,


### PR DESCRIPTION
## Summary
1. **Route `MEETING_PIPELINE_BUCKET` per environment** in `deploy/index.ts` instead of hardcoding `meeting-pipeline-dev` for everything. Without this, `TextToSpeechService` (the first user-facing prod consumer of the variable, just promoted to master in #1673) writes to and presigns from `meeting-pipeline-dev` from prod.
2. **Provision the qa + prod buckets in Pulumi.** The reviewer's suggestion assumed the buckets existed, but only `meeting-pipeline-dev` does. The larger Terraform stack that's supposed to own them (`gp-ai-projects` PR #80) has been stale for 3 weeks and only has a dev env config, so this PR provisions them here in the same pattern as `annotation-attachments-bucket` (encryption + public-access block, no CORS / versioning / lifecycle).

Preview and dev continue to reference the existing out-of-band `meeting-pipeline-dev` bucket so this PR doesn't fight whatever currently owns it.

## Resolves
- delegate-reviewer comment on #1673: finding id `0d43dfec-957d-4574-9fa6-f3034eda3a78`.

## Future cleanup
When the `gp-ai-projects` meeting-pipeline Terraform stack is ready to deploy to qa/prod, the buckets created here can be `terraform import`'d into that module's state and `components/meeting-pipeline-bucket.ts` retired (just leaving the per-env routing).

## Test plan
- [ ] Pulumi preview on dev: no diff for `MEETING_PIPELINE_BUCKET` (still `meeting-pipeline-dev`), no new S3 resources.
- [ ] Pulumi preview on qa: env var changes to `meeting-pipeline-qa`, plans to create the bucket + PAB + SSE.
- [ ] Pulumi preview on prod: env var changes to `meeting-pipeline-prod`, plans to create the bucket + PAB + SSE.
- [ ] After qa apply: TTS request succeeds end-to-end (audio written under `speech/synth/`, presigned URL plays).
- [ ] After prod apply: same end-to-end TTS check.