### PR TITLE
Add admin role requirement to top issues endpoints

### DIFF
--- a/src/topIssues/topIssues.controller.test.ts
+++ b/src/topIssues/topIssues.controller.test.ts
@@ -1,0 +1,63 @@
+import { ROLES_KEY } from '@/authentication/decorators/Roles.decorator'
+import { UserRole } from '@prisma/client'
+import { describe, expect, it, vi } from 'vitest'
+import { TopIssuesController } from './topIssues.controller'
+import { TopIssuesService } from './topIssues.service'
+
+function getRoles(
+  methodName: keyof TopIssuesController,
+): UserRole[] | undefined {
+  return Reflect.getMetadata(
+    ROLES_KEY,
+    TopIssuesController.prototype[methodName],
+  )
+}
+
+describe('TopIssuesController', () => {
+  const topIssuesService = {
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getByLocation: vi.fn(),
+  } as unknown as TopIssuesService
+
+  const controller = new TopIssuesController(topIssuesService)
+
+  describe('role guards', () => {
+    it('does not require a role for listTopIssues', () => {
+      expect(getRoles('listTopIssues')).toBeUndefined()
+    })
+
+    it('does not require a role for getByLocation', () => {
+      expect(getRoles('getByLocation')).toBeUndefined()
+    })
+
+    it('requires admin role for createTopIssue', () => {
+      expect(getRoles('createTopIssue')).toEqual(
+        [UserRole.admin],
+      )
+    })
+
+    it('requires admin role for updateTopIssue', () => {
+      expect(getRoles('updateTopIssue')).toEqual(
+        [UserRole.admin],
+      )
+    })
+
+    it('requires admin role for deleteTopIssue', () => {
+      expect(getRoles('deleteTopIssue')).toEqual(
+        [UserRole.admin],
+      )
+    })
+  })
+
+  describe('deleteTopIssue', () => {
+    it('awaits the service and returns undefined', async () => {
+      topIssuesService.delete = vi.fn().mockResolvedValue({})
+      const result = await controller.deleteTopIssue(1)
+      expect(result).toBeUndefined()
+      expect(topIssuesService.delete).toHaveBeenCalledWith(1)
+    })
+  })
+})

--- a/src/topIssues/topIssues.controller.test.ts
+++ b/src/topIssues/topIssues.controller.test.ts
@@ -34,21 +34,15 @@ describe('TopIssuesController', () => {
     })
 
     it('requires admin role for createTopIssue', () => {
-      expect(getRoles('createTopIssue')).toEqual(
-        [UserRole.admin],
-      )
+      expect(getRoles('createTopIssue')).toEqual([UserRole.admin])
     })
 
     it('requires admin role for updateTopIssue', () => {
-      expect(getRoles('updateTopIssue')).toEqual(
-        [UserRole.admin],
-      )
+      expect(getRoles('updateTopIssue')).toEqual([UserRole.admin])
     })
 
     it('requires admin role for deleteTopIssue', () => {
-      expect(getRoles('deleteTopIssue')).toEqual(
-        [UserRole.admin],
-      )
+      expect(getRoles('deleteTopIssue')).toEqual([UserRole.admin])
     })
   })
 

--- a/src/topIssues/topIssues.controller.ts
+++ b/src/topIssues/topIssues.controller.ts
@@ -12,9 +12,11 @@ import {
   Query,
   UsePipes,
 } from '@nestjs/common'
+import { UserRole } from '@prisma/client'
 import { TopIssuesService } from './topIssues.service'
 import { CreateTopIssueDto } from './schemas/topIssues.schema'
 import { ZodValidationPipe } from 'nestjs-zod'
+import { Roles } from '@/authentication/decorators/Roles.decorator'
 
 @Controller('top-issues')
 @UsePipes(ZodValidationPipe)
@@ -27,11 +29,13 @@ export class TopIssuesController {
   }
 
   @Post()
+  @Roles(UserRole.admin)
   async createTopIssue(@Body() body: CreateTopIssueDto) {
     return await this.topIssuesService.create(body)
   }
 
   @Put(':id')
+  @Roles(UserRole.admin)
   async updateTopIssue(
     @Param('id', ParseIntPipe) id: number,
     @Body() body: CreateTopIssueDto,
@@ -40,6 +44,7 @@ export class TopIssuesController {
   }
 
   @Delete(':id')
+  @Roles(UserRole.admin)
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteTopIssue(@Param('id', ParseIntPipe) id: number) {
     await this.topIssuesService.delete(id)


### PR DESCRIPTION
Restrict create, update, and delete operations on top issues to admin users only by applying the `@Roles(UserRole.admin)` decorator to the relevant controller methods.

**Changes:**
- Import `UserRole` from `@prisma/client` and `Roles` decorator from authentication module
- Add `@Roles(UserRole.admin)` to `POST /top-issues` (createTopIssue)
- Add `@Roles(UserRole.admin)` to `PUT /top-issues/:id` (updateTopIssue)
- Add `@Roles(UserRole.admin)` to `DELETE /top-issues/:id` (deleteTopIssue)

The `GET` endpoint remains unrestricted, allowing all users to view top issues.

https://claude.ai/code/session_01DxXpzNuSMnMvSYyYFmcJZ1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization on content-mutating APIs; low blast radius but incorrect guard wiring could block admins or leave writes open if misconfigured.
> 
> **Overview**
> **Top issues** write APIs are now **admin-only**: `POST`, `PUT`, and `DELETE` on `top-issues` use the existing `@Roles(UserRole.admin)` decorator (with `UserRole` and `Roles` imports), matching other admin controllers.
> 
> **Read** paths are unchanged—`GET /top-issues` and `GET /top-issues/by-location` stay open to non-admin callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c9d64c8cccc218169d932af65276705a5663c23. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->