### PR TITLE
Remove daily-briefing createdAt floor (sweep all elected offices)

### DIFF
--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -607,7 +607,7 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
     )
   })
 
-  it('skips EOs created before 2026-03-01', async () => {
+  it('dispatches for EOs regardless of when they were created', async () => {
     const orgSlug = `eo-cron-old-${Date.now()}`
     await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-cron-old' })
     const campaign = await service.prisma.campaign.findFirst({
@@ -639,7 +639,12 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
 
     await service.app.get(MeetingBriefingsService).dispatchDailyBriefings()
 
-    expect(dispatchSpy).not.toHaveBeenCalled()
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'meeting_briefing',
+        organizationSlug: orgSlug,
+      }),
+    )
   })
 })
 

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -34,10 +34,6 @@ const parseSchedule = (raw: string): MeetingSchedule =>
 const SCHEDULE_EXPERIMENT_TYPE = 'meeting_schedule'
 const BRIEFING_EXPERIMENT_TYPE = 'meeting_briefing'
 
-const DAILY_BRIEFINGS_ELECTED_OFFICE_CREATED_AT_FLOOR = new Date(
-  '2026-03-01T00:00:00.000Z',
-)
-
 const isAutomationEnabled = () =>
   process.env.MEETINGS_AUTOMATION_ENABLED === 'true'
 
@@ -202,9 +198,6 @@ export class MeetingBriefingsService extends createPrismaBase(
       return
     }
     const offices = await this.client.electedOffice.findMany({
-      where: {
-        createdAt: { gte: DAILY_BRIEFINGS_ELECTED_OFFICE_CREATED_AT_FLOOR },
-      },
       select: { id: true, organizationSlug: true, userId: true },
     })
 


### PR DESCRIPTION
The `2026-03-01` `createdAt` floor on `dispatchDailyBriefings` was a temporary rollout guard that limited the nightly briefing cron to recently-created elected offices. Removing it lets the cron generate briefings for every sitting elected official, which is the intended steady state.

Ordering note: this broadens the nightly fan-out, so it should only be live in prod *after* the agent-dispatch auth rework lands (broker-signed JWTs replacing the Clerk actor-token → Frontend API `sign_ins` redemption). Until then, a broadened cron would hit Clerk's 3-req/10s-per-IP sign-in limit. `MEETINGS_AUTOMATION_ENABLED` is unset outside prod, so merging to develop has no dev/qa effect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> In production with MEETINGS_AUTOMATION_ENABLED, nightly briefing fan-out grows to all elected offices, increasing agent dispatch volume and auth/sign-in pressure until the planned broker-JWT rework ships.
> 
> **Overview**
> Removes the temporary **`2026-03-01`** `createdAt` cutoff on the daily **`dispatchDailyBriefings`** cron so it considers **all** elected offices, not only those created on or after that date. The rollout guard constant and Prisma `where` filter are deleted; per-office behavior is unchanged (**`dispatchBriefingIfNeeded`** still skips offices that already have a future briefing).
> 
> Tests are updated so an elected office with **`createdAt`** before the old floor **does** get a **`meeting_briefing`** dispatch when automation is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3a7cdfb19950b0fe0d25f069a31a03c96e5c46. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->