### PR TITLE
Agent MCP auth via broker-signed JWT (drop Clerk Frontend-API redemption)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,5 @@
 NODE_ENV="test"
+AGENT_MCP_TOKEN_SECRET=test-agent-mcp-secret-do-not-use-in-prod
 LOG_LEVEL="debug"
 ENABLE_QUERY_LOGGING=false
 LOG_SKIPPED_SCHEDULED_MESSAGES=false

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,3 +1,4 @@
+import { AgentMcpMarkerModule } from '@/authentication/agentMcpMarker'
 import { AgentExperimentsModule } from '@/agentExperiments/agentExperiments.module'
 import { BriefingChatsModule } from '@/chats/briefing-chats/briefing-chats.module'
 import { McpModule } from '@/mcp/mcp.module'
@@ -53,6 +54,7 @@ import { loggerModule } from './observability/logging/logger-module'
 @Module({
   imports: [
     loggerModule,
+    AgentMcpMarkerModule,
     ScheduleModule.forRoot(),
     BraintrustModule,
     GeminiModule,

--- a/src/authentication/agentMcpMarker.ts
+++ b/src/authentication/agentMcpMarker.ts
@@ -1,0 +1,20 @@
+import { Global, Injectable, Module } from '@nestjs/common'
+import { randomBytes } from 'node:crypto'
+
+export const MCP_INTERNAL_MARKER_HEADER = 'x-mcp-internal-marker'
+
+@Injectable()
+export class AgentMcpMarker {
+  // Per-process secret; never leaves the process, so external callers cannot
+  // forge an "internal MCP sub-request". Regenerated each boot.
+  readonly token = randomBytes(32).toString('hex')
+
+  matches(headerValue: string | string[] | undefined): boolean {
+    const v = Array.isArray(headerValue) ? headerValue[0] : headerValue
+    return typeof v === 'string' && v.length > 0 && v === this.token
+  }
+}
+
+@Global()
+@Module({ providers: [AgentMcpMarker], exports: [AgentMcpMarker] })
+export class AgentMcpMarkerModule {}

--- a/src/authentication/authentication.types.ts
+++ b/src/authentication/authentication.types.ts
@@ -7,4 +7,5 @@ export interface IncomingRequest extends Request {
   actorUser?: User
   actorSub?: string
   m2mToken?: VerifiedM2MToken
+  agentToken?: boolean
 }

--- a/src/authentication/guards/Session.guard.test.ts
+++ b/src/authentication/guards/Session.guard.test.ts
@@ -94,6 +94,7 @@ describe('SessionGuard — impersonating flag', () => {
       clerkEnricher as never,
       createMockLogger(),
       new Reflector(),
+      { token: 'test-token', matches: vi.fn().mockReturnValue(false) } as never,
     )
   })
 

--- a/src/authentication/guards/Session.guard.test.ts
+++ b/src/authentication/guards/Session.guard.test.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext } from '@nestjs/common'
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { User, UserRole } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -180,5 +180,72 @@ describe('SessionGuard — impersonating flag', () => {
     expect(req.user?.impersonating).toBe(false)
     expect(req.actorUser).toBeUndefined()
     expect(req.actorSub).toBe('user_nonexistent_789')
+  })
+
+  describe('agent token gating (agentTokenAllowedHere)', () => {
+    const MARKER = 'marker-xyz'
+
+    const buildContextForClass = (
+      req: IncomingRequest,
+      handlerClass: { name: string },
+    ) =>
+      ({
+        switchToHttp: () => ({
+          getRequest: () => req,
+        }),
+        getHandler: () => ({}),
+        getClass: () => handlerClass,
+      }) as unknown as ExecutionContext
+
+    beforeEach(() => {
+      vi.mocked(authProvider.verifySessionToken).mockResolvedValue({
+        externalUserId: baseUser.clerkId!,
+        isAgentToken: true,
+      })
+      usersService.model.findUnique.mockResolvedValue(baseUser)
+
+      guard = new SessionGuard(
+        authProvider,
+        usersService as never,
+        sessions as never,
+        clerkEnricher as never,
+        createMockLogger(),
+        new Reflector(),
+        {
+          token: MARKER,
+          matches: (v: string | string[] | undefined) => v === MARKER,
+        } as never,
+      )
+    })
+
+    it('allows an agent token when the handler is McpController', async () => {
+      class McpController {}
+      const req = buildRequest('agent-tok')
+      const ctx = buildContextForClass(req, McpController)
+
+      await expect(guard.canActivate(ctx)).resolves.toBe(true)
+      expect(req.agentToken).toBe(true)
+    })
+
+    it('allows an agent token on a non-McpController route with a valid marker', async () => {
+      class CampaignsController {}
+      const req = buildRequest('agent-tok')
+      req.headers['x-mcp-internal-marker'] = MARKER
+      const ctx = buildContextForClass(req, CampaignsController)
+
+      await expect(guard.canActivate(ctx)).resolves.toBe(true)
+      expect(req.agentToken).toBe(true)
+    })
+
+    it('rejects an agent token on a non-McpController route without a valid marker', async () => {
+      class CampaignsController {}
+      const req = buildRequest('agent-tok')
+      req.headers['x-mcp-internal-marker'] = 'wrong-marker'
+      const ctx = buildContextForClass(req, CampaignsController)
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        UnauthorizedException,
+      )
+    })
   })
 })

--- a/src/authentication/guards/Session.guard.ts
+++ b/src/authentication/guards/Session.guard.ts
@@ -13,6 +13,10 @@ import {
   AuthProvider,
 } from '@/authentication/interfaces/auth-provider.interface'
 import { IncomingRequest } from '@/authentication/authentication.types'
+import {
+  AgentMcpMarker,
+  MCP_INTERNAL_MARKER_HEADER,
+} from '@/authentication/agentMcpMarker'
 import { routeIsPublicAndNoRoles } from '@/authentication/util/routeIsPublicAndNoRoles.util'
 import { TRANSCRIBE_STREAM_PATH } from '@/speech/ws/speechToText.gateway'
 import { UsersService } from '@/users/services/users.service'
@@ -29,6 +33,7 @@ export class SessionGuard implements CanActivate {
     private readonly clerkEnricher: ClerkUserEnricherService,
     private readonly logger: PinoLogger,
     private readonly reflector: Reflector,
+    private readonly agentMcpMarker: AgentMcpMarker,
   ) {
     this.logger.setContext(SessionGuard.name)
   }
@@ -62,8 +67,12 @@ export class SessionGuard implements CanActivate {
     }
 
     try {
-      const { externalUserId, actor } =
+      const { externalUserId, actor, isAgentToken } =
         await this.authProvider.verifySessionToken(token)
+
+      if (isAgentToken) {
+        request.agentToken = true
+      }
 
       if (actor?.sub) {
         request.actorSub = actor.sub
@@ -94,6 +103,11 @@ export class SessionGuard implements CanActivate {
       }
       if (actorUser) {
         request.actorUser = actorUser
+      }
+      if (request.agentToken && !this.agentTokenAllowedHere(context, request)) {
+        throw new UnauthorizedException(
+          'Agent token is only valid on the MCP endpoint',
+        )
       }
       this.sessions.trackSession(user)
     } catch (err) {
@@ -174,5 +188,24 @@ export class SessionGuard implements CanActivate {
       )
       return null
     }
+  }
+
+  private agentTokenAllowedHere(
+    context: ExecutionContext,
+    request: IncomingRequest,
+  ): boolean {
+    // (1) the outer /v1/mcp request — its handler is McpController; or
+    // (2) an internal fastify.inject sub-request stamped by the MCP dispatch.
+    const isMcpRoute = context.getClass()?.name === 'McpController'
+    const headers =
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      request.headers as unknown as Record<
+        string,
+        string | string[] | undefined
+      >
+    const isInternal = this.agentMcpMarker.matches(
+      headers[MCP_INTERNAL_MARKER_HEADER],
+    )
+    return isMcpRoute || isInternal
   }
 }

--- a/src/authentication/interfaces/auth-provider.interface.ts
+++ b/src/authentication/interfaces/auth-provider.interface.ts
@@ -1,6 +1,7 @@
 export interface VerifiedSession {
   externalUserId: string
   actor?: { sub: string }
+  isAgentToken?: boolean
 }
 
 export interface VerifiedM2MToken {

--- a/src/mcp/services/mcpServer.service.live.test.ts
+++ b/src/mcp/services/mcpServer.service.live.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import jwt from 'jsonwebtoken'
 import { useTestService } from '@/test-service'
 
 const service = useTestService()
@@ -100,5 +101,117 @@ describe('POST /v1/mcp (JSON-RPC over HTTP)', () => {
       statusCode: 401,
       message: 'Unauthorized',
     })
+  })
+})
+
+describe('agent token (broker-signed)', () => {
+  const signAgentToken = (clerkUserId: string) =>
+    jwt.sign(
+      { act: { sub: 'user_agent_fleet' }, run_id: 'test-run' },
+      process.env.AGENT_MCP_TOKEN_SECRET as string,
+      {
+        issuer: 'gp-broker',
+        audience: 'gp-api',
+        subject: clerkUserId,
+        expiresIn: 120,
+      },
+    )
+
+  it('happy path: agent token accepted on /v1/mcp and tools/call succeeds', async () => {
+    const org = await service.prisma.organization.create({
+      data: { slug: 'agent-test-org', ownerId: service.user.id },
+    })
+    await service.prisma.campaign.create({
+      data: {
+        userId: service.user.id,
+        slug: 'agent-test-campaign',
+        details: {},
+        organizationSlug: org.slug,
+      },
+    })
+
+    const res = await service.client.post(
+      '/v1/mcp',
+      {
+        jsonrpc: '2.0',
+        id: 10,
+        method: 'tools/call',
+        params: { name: 'GET_campaigns_mine', arguments: {} },
+      },
+      {
+        headers: {
+          Accept: MCP_ACCEPT,
+          'x-organization-slug': org.slug,
+          Authorization: `Bearer ${signAgentToken(service.user.clerkId)}`,
+        },
+      },
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.data.result.isError).toBe(false)
+
+    const toolResult = JSON.parse(res.data.result.content[0].text)
+    expect(toolResult).toMatchObject({ slug: 'agent-test-campaign' })
+  })
+
+  it('rejected directly on a non-MCP route', async () => {
+    const org = await service.prisma.organization.create({
+      data: { slug: 'agent-nonmcp-org', ownerId: service.user.id },
+    })
+
+    const res = await service.client.get('/v1/campaigns/mine', {
+      headers: {
+        'x-organization-slug': org.slug,
+        Authorization: `Bearer ${signAgentToken(service.user.clerkId)}`,
+      },
+      validateStatus: () => true,
+    })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('forged x-mcp-internal-marker is rejected on non-MCP route', async () => {
+    const org = await service.prisma.organization.create({
+      data: { slug: 'agent-forged-org', ownerId: service.user.id },
+    })
+
+    const res = await service.client.get('/v1/campaigns/mine', {
+      headers: {
+        'x-organization-slug': org.slug,
+        Authorization: `Bearer ${signAgentToken(service.user.clerkId)}`,
+        'x-mcp-internal-marker': 'guessed',
+      },
+      validateStatus: () => true,
+    })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('bad-signature agent token rejected on /v1/mcp', async () => {
+    const badToken = jwt.sign({}, 'wrong-secret', {
+      issuer: 'gp-broker',
+      audience: 'gp-api',
+      subject: service.user.clerkId,
+      expiresIn: 120,
+    })
+
+    const res = await service.client.post(
+      '/v1/mcp',
+      {
+        jsonrpc: '2.0',
+        id: 11,
+        method: 'tools/list',
+        params: {},
+      },
+      {
+        headers: {
+          Accept: MCP_ACCEPT,
+          Authorization: `Bearer ${badToken}`,
+        },
+        validateStatus: () => true,
+      },
+    )
+
+    expect(res.status).toBe(401)
   })
 })

--- a/src/mcp/services/mcpServer.service.live.test.ts
+++ b/src/mcp/services/mcpServer.service.live.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import jwt from 'jsonwebtoken'
-import { useTestService } from '@/test-service'
+import { TEST_CLERK_ID, useTestService } from '@/test-service'
 
 const service = useTestService()
 
@@ -142,7 +142,7 @@ describe('agent token (broker-signed)', () => {
         headers: {
           Accept: MCP_ACCEPT,
           'x-organization-slug': org.slug,
-          Authorization: `Bearer ${signAgentToken(service.user.clerkId)}`,
+          Authorization: `Bearer ${signAgentToken(TEST_CLERK_ID)}`,
         },
       },
     )
@@ -162,7 +162,7 @@ describe('agent token (broker-signed)', () => {
     const res = await service.client.get('/v1/campaigns/mine', {
       headers: {
         'x-organization-slug': org.slug,
-        Authorization: `Bearer ${signAgentToken(service.user.clerkId)}`,
+        Authorization: `Bearer ${signAgentToken(TEST_CLERK_ID)}`,
       },
       validateStatus: () => true,
     })
@@ -178,7 +178,7 @@ describe('agent token (broker-signed)', () => {
     const res = await service.client.get('/v1/campaigns/mine', {
       headers: {
         'x-organization-slug': org.slug,
-        Authorization: `Bearer ${signAgentToken(service.user.clerkId)}`,
+        Authorization: `Bearer ${signAgentToken(TEST_CLERK_ID)}`,
         'x-mcp-internal-marker': 'guessed',
       },
       validateStatus: () => true,
@@ -191,7 +191,7 @@ describe('agent token (broker-signed)', () => {
     const badToken = jwt.sign({}, 'wrong-secret', {
       issuer: 'gp-broker',
       audience: 'gp-api',
-      subject: service.user.clerkId,
+      subject: TEST_CLERK_ID,
       expiresIn: 120,
     })
 

--- a/src/mcp/services/mcpServer.service.test.ts
+++ b/src/mcp/services/mcpServer.service.test.ts
@@ -18,6 +18,7 @@ import { createZodDto } from 'nestjs-zod'
 import { McpTool } from '../decorators/McpTool.decorator'
 import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { AgentMcpMarker } from '@/authentication/agentMcpMarker'
 import { McpServerService } from './mcpServer.service'
 
 type InjectOpts = {
@@ -43,6 +44,7 @@ const buildAppModule = (controllers: unknown[], inject: InjectFn) => {
     controllers: controllers as never[],
     providers: [
       McpServerService,
+      AgentMcpMarker,
       { provide: HttpAdapterHost, useValue: mockHost },
       { provide: PinoLogger, useValue: createMockLogger() },
     ],

--- a/src/mcp/services/mcpServer.service.ts
+++ b/src/mcp/services/mcpServer.service.ts
@@ -33,6 +33,10 @@ import {
 import { deriveToolName } from '../util/toolName.util'
 import { RegisteredMcpTool } from '../mcp.types'
 import { buildCombinedInputSchema } from '../util/inputSchema.util'
+import {
+  AgentMcpMarker,
+  MCP_INTERNAL_MARKER_HEADER,
+} from '@/authentication/agentMcpMarker'
 
 type FastifyInjectResponse = {
   statusCode: number
@@ -84,6 +88,7 @@ const DROPPED_REQUEST_HEADERS = new Set([
   'expect',
   'te',
   'upgrade',
+  MCP_INTERNAL_MARKER_HEADER,
 ])
 
 @Injectable()
@@ -95,6 +100,7 @@ export class McpServerService {
     private readonly httpAdapterHost: HttpAdapterHost,
     private readonly applicationConfig: ApplicationConfig,
     private readonly logger: PinoLogger,
+    private readonly agentMcpMarker: AgentMcpMarker,
   ) {
     this.logger.setContext(McpServerService.name)
   }
@@ -171,6 +177,10 @@ export class McpServerService {
           if (k.toLowerCase() === 'content-type') delete forwardHeaders[k]
         }
       }
+
+      // Mark this as an internal MCP sub-request so SessionGuard accepts an agent
+      // token here while still rejecting it on any directly-hit route.
+      forwardHeaders[MCP_INTERNAL_MARKER_HEADER] = this.agentMcpMarker.token
 
       const response = await fastify.inject({
         method: tool.method,

--- a/src/test-service.ts
+++ b/src/test-service.ts
@@ -20,7 +20,7 @@ import {
 import './configrc'
 import { PrismaService } from './prisma/prisma.service'
 
-const TEST_CLERK_ID = 'user_test_123'
+export const TEST_CLERK_ID = 'user_test_123'
 
 export type TestServiceContext = {
   /** A client targeting the test service. */

--- a/src/test-service.ts
+++ b/src/test-service.ts
@@ -106,8 +106,22 @@ export const useTestService = (): TestServiceContext => {
     app = await bootstrap({ loggingEnabled: false })
 
     const authProvider = app.get<AuthProvider>(AUTH_PROVIDER_TOKEN)
+    // .bind() returns any — TypeScript cannot infer the bound method signature
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const realVerifySessionToken: AuthProvider['verifySessionToken'] =
+      authProvider.verifySessionToken.bind(authProvider)
     vi.spyOn(authProvider, 'verifySessionToken').mockImplementation(
       async (token: string) => {
+        // Broker-signed agent tokens verify locally with no Clerk dependency,
+        // so delegate to the real method and exercise the production branch.
+        const unverified = jwt.decode(token)
+        if (
+          typeof unverified === 'object' &&
+          unverified !== null &&
+          unverified.iss === 'gp-broker'
+        ) {
+          return realVerifySessionToken(token)
+        }
         const decoded = jwt.verify(token, process.env.AUTH_SECRET!)
         const sub = typeof decoded === 'object' ? decoded.sub : undefined
         if (!sub) {

--- a/src/vendors/clerk/services/clerk-auth.service.ts
+++ b/src/vendors/clerk/services/clerk-auth.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, UnauthorizedException } from '@nestjs/common'
 import { verifyToken, ClerkClient } from '@clerk/backend'
 import { PinoLogger } from 'nestjs-pino'
+import jwt from 'jsonwebtoken'
 import {
   AuthProvider,
   VerifiedM2MToken,
@@ -9,8 +10,12 @@ import {
 import { CLERK_CLIENT_PROVIDER_TOKEN } from '@/vendors/clerk/providers/clerk-client.provider'
 import { M2M_TOKEN_PREFIX } from '@/vendors/clerk/clerk.consts'
 
-const { CLERK_SECRET_KEY, GP_WEBAPP_MACHINE_SECRET, CLERK_AUTHORIZED_PARTIES } =
-  process.env
+const {
+  CLERK_SECRET_KEY,
+  GP_WEBAPP_MACHINE_SECRET,
+  CLERK_AUTHORIZED_PARTIES,
+  AGENT_MCP_TOKEN_SECRET,
+} = process.env
 
 if (!CLERK_SECRET_KEY) {
   throw new Error('CLERK_SECRET_KEY is required for application startup')
@@ -20,6 +25,10 @@ if (!GP_WEBAPP_MACHINE_SECRET) {
   throw new Error(
     'GP_WEBAPP_MACHINE_SECRET must be set in the environment variables',
   )
+}
+
+if (!AGENT_MCP_TOKEN_SECRET && process.env.NODE_ENV !== 'test') {
+  throw new Error('AGENT_MCP_TOKEN_SECRET must be set in the environment')
 }
 
 const authorizedParties = CLERK_AUTHORIZED_PARTIES
@@ -48,6 +57,39 @@ export class ClerkAuthService implements AuthProvider {
   }
 
   async verifySessionToken(token: string): Promise<VerifiedSession> {
+    // Broker-issued agent tokens are HS256 with iss=gp-broker. Detect by the
+    // unverified iss claim, then verify with the shared secret. Clerk tokens
+    // carry iss = the Clerk Frontend API URL and fall through to verifyToken.
+    const unverified = jwt.decode(token)
+    if (
+      typeof unverified === 'object' &&
+      unverified !== null &&
+      unverified.iss === 'gp-broker'
+    ) {
+      let payload: jwt.JwtPayload
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        payload = jwt.verify(token, AGENT_MCP_TOKEN_SECRET as string, {
+          issuer: 'gp-broker',
+          audience: 'gp-api',
+        }) as jwt.JwtPayload
+      } catch {
+        throw new UnauthorizedException('Agent token verification failed')
+      }
+      if (!payload.sub) {
+        throw new UnauthorizedException('Agent token missing sub claim')
+      }
+      return {
+        externalUserId: payload.sub,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        actor: isActorClaim(payload.act as Record<string, unknown> | undefined)
+          ? // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+            (payload.act as { sub: string })
+          : undefined,
+        isAgentToken: true,
+      }
+    }
+
     const payload = await verifyToken(token, {
       secretKey: CLERK_SECRET_KEY,
       authorizedParties,


### PR DESCRIPTION
The agent fleet's MCP calls authenticated *as the user* by redeeming a Clerk actor token through Clerk's Frontend API (`/v1/client/sign_ins`), which is rate-limited to **3 requests / 10s per IP**. Under concurrent agent dispatch this returns `429`s en masse — a recent backfill of ~3,100 runs dead-lettered ~99% on exactly this. There is no backend-only Clerk path to escape it.

This makes gp-api accept a **broker-signed HS256 JWT** (`iss=gp-broker`, `aud=gp-api`, `sub=<clerk user id>`, `act.sub=<agent fleet>`) verified locally in the auth provider — the same shared-secret pattern already used for people-api S2S. No Clerk on the hot path, so dispatch throughput is bounded only by agent capacity.

Agent tokens are **contained to the MCP flow**: `SessionGuard` rejects them on any route that is neither `McpController` nor an internal `fastify.inject` sub-request (identified by a process-local marker the MCP dispatch stamps). So even a leaked secret can only reach the `@McpTool` surface, never arbitrary user routes — strictly better containment than today, where the broker can already mint full Clerk sessions.

Requires `AGENT_MCP_TOKEN_SECRET` in the `GP_API_<ENV>` secret bundle (read at boot — the app won't start without it; the dynamic secrets loop injects it automatically once present).

Pairs with the gp-ai-projects broker PR that issues these tokens. **Deploy order: this (verify) first, then the broker (issue).** Additive — gp-api still accepts Clerk session tokens during the transition.

Design + plan: `docs/superpowers/specs/2026-05-28-agent-mcp-auth-broker-jwt-design.md`, `docs/superpowers/plans/2026-05-28-agent-mcp-broker-jwt-auth.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication and authorization boundaries (new token type, env secret, global guard rules); mistakes could widen agent access beyond MCP tool surfaces.
> 
> **Overview**
> Adds **broker-signed agent JWTs** (`iss=gp-broker`, verified with `AGENT_MCP_TOKEN_SECRET`) so agent MCP traffic no longer depends on Clerk session redemption. `ClerkAuthService` branches on `iss` before Clerk `verifyToken` and returns `isAgentToken: true`; non-test boot requires the secret (`.env.test` supplies one).
> 
> **Scope containment:** `SessionGuard` allows agent tokens only on `McpController` or on internal `fastify.inject` sub-requests stamped with a **per-process** `x-mcp-internal-marker` from `AgentMcpMarker` (forged client headers do not help on direct routes). `McpServerService` sets that marker on tool dispatch and strips it from forwarded hop headers.
> 
> Live and unit tests cover MCP success, rejection on `/v1/campaigns/mine`, forged markers, and bad signatures; the test harness delegates `gp-broker` tokens to real verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c51a5b77d9253c93092d3d7e2106f7cb5e86b15e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->