### PR TITLE
Fix develop: provide AgentMcpMarker to MCP discoverability test modules

### DIFF
--- a/src/websites/controllers/domains.controller.test.ts
+++ b/src/websites/controllers/domains.controller.test.ts
@@ -16,6 +16,7 @@ import { UseCampaignGuard } from 'src/campaigns/guards/UseCampaign.guard'
 import { REQUIRE_CAMPAIGN_META_KEY } from 'src/campaigns/decorators/UseCampaign.decorator'
 import { MCP_TOOL_KEY } from '@/mcp/decorators/McpTool.decorator'
 import { McpServerService } from '@/mcp/services/mcpServer.service'
+import { AgentMcpMarker } from '@/authentication/agentMcpMarker'
 import {
   PurchaseDomainBodySchema,
   PurchaseDomainResponseSchema,
@@ -221,6 +222,7 @@ describe('DomainsController.purchaseDomain MCP discoverability', () => {
     controllers: [DomainsController],
     providers: [
       McpServerService,
+      AgentMcpMarker,
       { provide: DomainsService, useValue: {} },
       { provide: WebsitesService, useValue: {} },
       {

--- a/src/websites/controllers/websites.controller.test.ts
+++ b/src/websites/controllers/websites.controller.test.ts
@@ -32,6 +32,7 @@ import { UseCampaignGuard } from 'src/campaigns/guards/UseCampaign.guard'
 import { REQUIRE_CAMPAIGN_META_KEY } from 'src/campaigns/decorators/UseCampaign.decorator'
 import { MCP_TOOL_KEY } from '@/mcp/decorators/McpTool.decorator'
 import { McpServerService } from '@/mcp/services/mcpServer.service'
+import { AgentMcpMarker } from '@/authentication/agentMcpMarker'
 import { MyWebsiteResponseSchema } from '../schemas/WebsiteResponse.schema'
 import { VerifyLiveResponseSchema } from '../schemas/VerifyLive.schema'
 
@@ -813,6 +814,7 @@ describe('WebsitesController MCP discoverability', () => {
     controllers: [WebsitesController],
     providers: [
       McpServerService,
+      AgentMcpMarker,
       { provide: PrismaService, useValue: {} },
       { provide: WebsitesService, useValue: {} },
       { provide: WebsiteContactsService, useValue: {} },


### PR DESCRIPTION
PR #1695 added an `AgentMcpMarker` constructor dependency to `McpServerService`, and updated `mcpServer.service.test.ts` to provide it — but two other test modules that construct `McpServerService` to call `gatherTools()` were missed, so they fail DI resolution on develop (`Nest can't resolve dependencies of the McpServerService ... argument AgentMcpMarker at index [6]`). #1695 merged while its Test check was still running, so develop went red.

Adds `AgentMcpMarker` to the provider arrays in `websites.controller.test.ts` and `domains.controller.test.ts` (the only other test modules that instantiate `McpServerService`). These were the only two failing files in develop CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only DI fixes with no runtime code paths touched.
> 
> **Overview**
> Repairs **develop CI** by registering **`AgentMcpMarker`** in the Nest test modules used for MCP discoverability on **`domains.controller.test.ts`** and **`websites.controller.test.ts`**.
> 
> After **`McpServerService`** started requiring **`AgentMcpMarker`**, those suites still built **`McpServerService`** via **`gatherTools()`** / **`getTools()`** without the new provider, so Nest failed dependency resolution. The change mirrors **`mcpServer.service.test.ts`**: import the marker and add it to each **`buildModule()`** provider list. No production or MCP behavior changes—test wiring only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d04cc1d5980c53368a3ea5373ab84ebb033f4ea0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->