### PR TITLE
fix: resolve meeting dispatch context for override-only orgs

### DIFF
--- a/src/campaigns/services/campaigns.service.test.ts
+++ b/src/campaigns/services/campaigns.service.test.ts
@@ -893,6 +893,7 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
     ).mockResolvedValue({
       district: {
         id: 'd-1',
+        state: 'CA',
         L2DistrictType: 'State_Senate',
         L2DistrictName: 'STATE SENATE 001',
         projectedTurnout: null,
@@ -983,6 +984,7 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
     ).mockResolvedValue({
       district: {
         id: 'd-1',
+        state: 'CA',
         L2DistrictType: 'State_Senate',
         L2DistrictName: 'STATE SENATE 001',
         projectedTurnout: null,
@@ -1083,6 +1085,7 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
       ).mockResolvedValue({
         district: {
           id: 'd-1',
+          state: 'CA',
           L2DistrictType: 'State_Senate',
           L2DistrictName: 'STATE SENATE 001',
           projectedTurnout: null,

--- a/src/elections/services/elections.service.test.ts
+++ b/src/elections/services/elections.service.test.ts
@@ -19,6 +19,7 @@ const makePosition = (
   name: 'State House 005',
   district: {
     id: 'district-1',
+    state: 'TX',
     L2DistrictType: 'State_House',
     L2DistrictName: 'STATE HOUSE 005',
     projectedTurnout:

--- a/src/elections/types/elections.types.ts
+++ b/src/elections/types/elections.types.ts
@@ -138,6 +138,7 @@ export type BuildRaceTargetDetailsInput = (DistrictInfo | DistrictIdInfo) &
 
 export type District = {
   id: string
+  state: string
   L2DistrictType: string
   L2DistrictName: string
   projectedTurnout: SourceProjectedTurnout | null

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -1,6 +1,6 @@
 import { ExperimentRunStatus } from '@prisma/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ElectionsService } from '@/elections/services/elections.service'
+import { OrganizationsService } from '@/organizations/services/organizations.service'
 import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
 import { S3Service } from '@/vendors/aws/services/s3.service'
 import { useTestService } from '@/test-service'
@@ -10,13 +10,19 @@ const service = useTestService()
 
 const seedOrgAndCampaign = async (
   orgSlug: string,
-  options: { positionId?: string } = {},
+  options: {
+    positionId?: string
+    overrideDistrictId?: string
+    customPositionName?: string
+  } = {},
 ) => {
   await service.prisma.organization.create({
     data: {
       slug: orgSlug,
       ownerId: service.user.id,
       positionId: options.positionId ?? null,
+      overrideDistrictId: options.overrideDistrictId ?? null,
+      customPositionName: options.customPositionName ?? null,
     },
   })
   await service.prisma.campaign.create({
@@ -35,9 +41,21 @@ const mockS3 = (responses: Record<string, string | undefined>) => {
   )
 }
 
+const mockResolveServeContext = (
+  result: Awaited<ReturnType<OrganizationsService['resolveServeContext']>>,
+) => {
+  const spy = vi.spyOn(
+    service.app.get(OrganizationsService),
+    'resolveServeContext',
+  )
+  spy.mockResolvedValue(result)
+  return spy
+}
+
 describe('POST /v1/elected-office dispatches schedule + briefing in parallel', () => {
   beforeEach(() => {
     vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', 'true')
+    mockResolveServeContext(null)
   })
   afterEach(() => {
     vi.unstubAllEnvs()
@@ -66,15 +84,9 @@ describe('POST /v1/elected-office dispatches schedule + briefing in parallel', (
     const orgSlug = `eo-create-${Date.now()}`
     await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-123' })
 
-    vi.spyOn(
-      service.app.get(ElectionsService),
-      'getPositionById',
-    ).mockResolvedValue({
-      id: 'pos-real-id',
-      brPositionId: 'br-pos-123',
-      brDatabaseId: 'br-db-123',
+    mockResolveServeContext({
       state: 'MN',
-      name: 'City Council',
+      positionName: 'City Council',
     })
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
@@ -499,6 +511,7 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
 describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
   beforeEach(() => {
     vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', 'true')
+    mockResolveServeContext(null)
   })
   afterEach(() => {
     vi.unstubAllEnvs()
@@ -559,16 +572,7 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
       },
     })
 
-    vi.spyOn(
-      service.app.get(ElectionsService),
-      'getPositionById',
-    ).mockResolvedValue({
-      id: 'pos-real-id',
-      brPositionId: 'br-pos-cron',
-      brDatabaseId: 'br-db-cron',
-      state: 'MN',
-      name: 'City Council',
-    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
 
     const existingBriefingRun = await service.prisma.experimentRun.create({
       data: {
@@ -622,16 +626,7 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
       },
     })
 
-    vi.spyOn(
-      service.app.get(ElectionsService),
-      'getPositionById',
-    ).mockResolvedValue({
-      id: 'pos-real-id',
-      brPositionId: 'br-pos-cron-old',
-      brDatabaseId: 'br-db-cron-old',
-      state: 'MN',
-      name: 'City Council',
-    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
 
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
@@ -649,6 +644,10 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
 })
 
 describe('MeetingBriefingsService.dispatchManual', () => {
+  beforeEach(() => {
+    mockResolveServeContext(null)
+  })
+
   it('dispatches a schedule run regardless of the env gate', async () => {
     vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', '')
     const orgSlug = `eo-manual-schedule-${Date.now()}`
@@ -656,16 +655,7 @@ describe('MeetingBriefingsService.dispatchManual', () => {
     const eo = await service.prisma.electedOffice.create({
       data: { organizationSlug: orgSlug, userId: service.user.id },
     })
-    vi.spyOn(
-      service.app.get(ElectionsService),
-      'getPositionById',
-    ).mockResolvedValue({
-      id: 'pos-real-id',
-      brPositionId: 'br-pos-manual-s',
-      brDatabaseId: 'br-db-manual-s',
-      state: 'MN',
-      name: 'City Council',
-    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
       .mockResolvedValue(undefined)
@@ -687,16 +677,7 @@ describe('MeetingBriefingsService.dispatchManual', () => {
     const eo = await service.prisma.electedOffice.create({
       data: { organizationSlug: orgSlug, userId: service.user.id },
     })
-    vi.spyOn(
-      service.app.get(ElectionsService),
-      'getPositionById',
-    ).mockResolvedValue({
-      id: 'pos-real-id',
-      brPositionId: 'br-pos-manual-b',
-      brDatabaseId: 'br-db-manual-b',
-      state: 'MN',
-      name: 'City Council',
-    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
       .mockResolvedValue(undefined)
@@ -718,6 +699,97 @@ describe('MeetingBriefingsService.dispatchManual', () => {
     const result = await service.app
       .get(MeetingBriefingsService)
       .dispatchManual('not-a-real-id', 'schedule')
+    expect(result.dispatched).toBe(false)
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('dispatches for override-only org (no positionId, overrideDistrictId + customPositionName set)', async () => {
+    const orgSlug = `eo-override-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, {
+      overrideDistrictId: 'district-override-id',
+      customPositionName: 'City Council Member',
+    })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    mockResolveServeContext({
+      state: 'MN',
+      positionName: 'City Council Member',
+      l2DistrictType: 'City',
+      l2DistrictName: 'Minneapolis',
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.app
+      .get(MeetingBriefingsService)
+      .dispatchManual(eo.id, 'briefing')
+
+    expect(result.dispatched).toBe(true)
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: 'meeting_briefing',
+      organizationSlug: orgSlug,
+      clerkUserId: service.user.clerkId!,
+      params: {
+        officialName: `${service.user.firstName} ${service.user.lastName}`,
+        state: 'MN',
+        positionName: 'City Council Member',
+        l2DistrictType: 'City',
+        l2DistrictName: 'Minneapolis',
+      },
+    })
+  })
+
+  it('dispatches for position-based org (existing behavior: state + l2 from position)', async () => {
+    const orgSlug = `eo-position-based-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-based' })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    mockResolveServeContext({
+      state: 'CA',
+      positionName: 'School Board',
+      l2DistrictType: 'SchoolDistrict',
+      l2DistrictName: 'LAUSD',
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.app
+      .get(MeetingBriefingsService)
+      .dispatchManual(eo.id, 'briefing')
+
+    expect(result.dispatched).toBe(true)
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'meeting_briefing',
+        params: expect.objectContaining({
+          state: 'CA',
+          positionName: 'School Board',
+          l2DistrictType: 'SchoolDistrict',
+          l2DistrictName: 'LAUSD',
+        }),
+      }),
+    )
+  })
+
+  it('skips dispatch when resolveServeContext returns null (neither position nor override)', async () => {
+    const orgSlug = `eo-no-ctx-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug)
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    mockResolveServeContext(null)
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.app
+      .get(MeetingBriefingsService)
+      .dispatchManual(eo.id, 'briefing')
+
     expect(result.dispatched).toBe(false)
     expect(dispatchSpy).not.toHaveBeenCalled()
   })

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -9,7 +9,7 @@ import {
 import { rrulestr } from 'rrule'
 import { formatInTimeZone } from 'date-fns-tz'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
-import { ElectionsService } from '@/elections/services/elections.service'
+import { OrganizationsService } from '@/organizations/services/organizations.service'
 import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
 import { S3Service } from '@/vendors/aws/services/s3.service'
 import { SegmentService } from '@/vendors/segment/segment.service'
@@ -62,7 +62,7 @@ export class MeetingBriefingsService extends createPrismaBase(
 ) {
   constructor(
     private readonly s3: S3Service,
-    private readonly elections: ElectionsService,
+    private readonly organizations: OrganizationsService,
     private readonly experimentRuns: ExperimentRunsService,
     private readonly segment: SegmentService,
     private readonly llm: LlmService,
@@ -243,7 +243,6 @@ export class MeetingBriefingsService extends createPrismaBase(
       }),
       this.client.organization.findUnique({
         where: { slug: electedOffice.organizationSlug },
-        select: { positionId: true, customPositionName: true },
       }),
     ])
 
@@ -255,23 +254,18 @@ export class MeetingBriefingsService extends createPrismaBase(
       return null
     }
 
-    const position = organization?.positionId
-      ? await this.elections.getPositionById(organization.positionId, {
-          includeDistrict: true,
-        })
-      : null
-    const state = position?.state ?? ''
-    const positionName =
-      organization?.customPositionName ?? position?.name ?? ''
     const officialName = getUserFullName(user)
+    const serveCtx = organization
+      ? await this.organizations.resolveServeContext(organization)
+      : null
 
-    if (!state || !positionName || !officialName) {
+    if (!serveCtx || !officialName) {
       this.logger.warn(
         {
           electedOfficeId: electedOffice.id,
           missing: {
-            state: !state,
-            positionName: !positionName,
+            state: !serveCtx?.state,
+            positionName: !serveCtx?.positionName,
             officialName: !officialName,
           },
         },
@@ -285,10 +279,10 @@ export class MeetingBriefingsService extends createPrismaBase(
       organizationSlug: electedOffice.organizationSlug,
       clerkUserId: user.clerkId,
       officialName,
-      state,
-      positionName,
-      l2DistrictType: position?.district?.L2DistrictType,
-      l2DistrictName: position?.district?.L2DistrictName,
+      state: serveCtx.state,
+      positionName: serveCtx.positionName,
+      l2DistrictType: serveCtx.l2DistrictType,
+      l2DistrictName: serveCtx.l2DistrictName,
     }
   }
 

--- a/src/organizations/organizations.controller.test.ts
+++ b/src/organizations/organizations.controller.test.ts
@@ -649,6 +649,7 @@ describe('PATCH /v1/organizations/:slug', () => {
       name: 'Mayor',
       district: {
         id: 'district-xyz',
+        state: 'CA',
         L2DistrictType: 'City',
         L2DistrictName: 'San Francisco',
         projectedTurnout: null,
@@ -662,6 +663,7 @@ describe('PATCH /v1/organizations/:slug', () => {
       name: 'Mayor',
       district: {
         id: 'district-xyz',
+        state: 'CA',
         L2DistrictType: 'City',
         L2DistrictName: 'San Francisco',
         projectedTurnout: null,
@@ -669,6 +671,7 @@ describe('PATCH /v1/organizations/:slug', () => {
     })
     vi.spyOn(electionsService, 'getDistrict').mockResolvedValue({
       id: 'different-district',
+      state: 'CA',
       L2DistrictType: 'City',
       L2DistrictName: 'Los Angeles',
       projectedTurnout: null,
@@ -739,6 +742,7 @@ describe('PATCH /v1/organizations/:slug', () => {
     const electionsService = service.app.get(ElectionsService)
     vi.spyOn(electionsService, 'getDistrict').mockResolvedValue({
       id: 'existing-district',
+      state: 'CA',
       L2DistrictType: 'County',
       L2DistrictName: 'Test County',
       projectedTurnout: null,
@@ -780,6 +784,7 @@ describe('PATCH /v1/organizations/:slug', () => {
     const electionsService = service.app.get(ElectionsService)
     vi.spyOn(electionsService, 'getDistrict').mockResolvedValue({
       id: 'keep-this-district',
+      state: 'CA',
       L2DistrictType: 'County',
       L2DistrictName: 'Test County',
       projectedTurnout: null,
@@ -829,6 +834,7 @@ describe('PATCH /v1/organizations/:slug', () => {
         name: 'Mayor',
         district: {
           id: 'dist-inc',
+          state: 'CA',
           L2DistrictType: 'City',
           L2DistrictName: 'Oakland',
           projectedTurnout: null,

--- a/src/organizations/organizations.controller.ts
+++ b/src/organizations/organizations.controller.ts
@@ -54,6 +54,7 @@ const toAPIOrganization = (org: FriendlyOrganization): APIOrganization => {
   result.district = org.district
     ? {
         id: org.district.id,
+        state: org.district.state,
         l2Type: org.district.l2Type,
         l2Name: org.district.l2Name,
       }

--- a/src/organizations/organizations.types.ts
+++ b/src/organizations/organizations.types.ts
@@ -1,1 +1,6 @@
-export type OrgDistrict = { id: string; l2Type: string; l2Name: string }
+export type OrgDistrict = {
+  id: string
+  state: string
+  l2Type: string
+  l2Name: string
+}

--- a/src/organizations/services/organizations.service.ts
+++ b/src/organizations/services/organizations.service.ts
@@ -416,6 +416,34 @@ export class OrganizationsService extends createPrismaBase(
     return this.resolveDistrict(org)
   }
 
+  async resolveServeContext(org: Organization): Promise<{
+    state: string
+    positionName: string
+    l2DistrictType?: string
+    l2DistrictName?: string
+  } | null> {
+    const [position, overrideDistrict] = await Promise.all([
+      org.positionId
+        ? this.electionsService.getPositionById(org.positionId, {
+            includeDistrict: true,
+          })
+        : Promise.resolve(null),
+      org.overrideDistrictId
+        ? this.electionsService.getDistrict(org.overrideDistrictId)
+        : Promise.resolve(null),
+    ])
+    const state = position?.state ?? overrideDistrict?.state ?? ''
+    const positionName = org.customPositionName ?? position?.name ?? ''
+    if (!state || !positionName) return null
+    const district = overrideDistrict ?? position?.district
+    return {
+      state,
+      positionName,
+      l2DistrictType: district?.L2DistrictType,
+      l2DistrictName: district?.L2DistrictName,
+    }
+  }
+
   private async resolveDistrict(
     org: Organization,
   ): Promise<OrgDistrict | null> {
@@ -435,6 +463,7 @@ export class OrganizationsService extends createPrismaBase(
 
     return {
       id: district.id,
+      state: district.state,
       l2Type: district.L2DistrictType,
       l2Name: district.L2DistrictName,
     }
@@ -468,6 +497,7 @@ export class OrganizationsService extends createPrismaBase(
     const district: OrgDistrict | null = rawDistrict
       ? {
           id: rawDistrict.id,
+          state: rawDistrict.state,
           l2Type: rawDistrict.L2DistrictType,
           l2Name: rawDistrict.L2DistrictName,
         }

--- a/src/shared/services/voterFileDownloadAccess.service.test.ts
+++ b/src/shared/services/voterFileDownloadAccess.service.test.ts
@@ -136,6 +136,7 @@ describe('VoterFileDownloadAccessService - canDownload', () => {
       expect(
         service.canDownload(campaign, {
           id: 'dist-1',
+          state: 'CA',
           l2Type: 'US House',
           l2Name: 'CA-12',
         }),
@@ -150,6 +151,7 @@ describe('VoterFileDownloadAccessService - canDownload', () => {
       expect(
         service.canDownload(campaign, {
           id: 'dist-2',
+          state: 'CA',
           l2Type: 'State Senate',
           l2Name: 'CA-15',
         }),
@@ -164,6 +166,7 @@ describe('VoterFileDownloadAccessService - canDownload', () => {
       expect(
         service.canDownload(campaign, {
           id: 'dist-1',
+          state: 'CA',
           l2Type: 'US House',
           l2Name: '',
         }),
@@ -220,6 +223,7 @@ describe('VoterFileDownloadAccessService - canDownload', () => {
       expect(
         service.canDownload(campaign, {
           id: 'dist-1',
+          state: 'CA',
           l2Type: 'US House',
           l2Name: 'CA-12',
         }),
@@ -269,6 +273,7 @@ describe('VoterFileDownloadAccessService - canDownload', () => {
       expect(
         service.canDownload(campaign, {
           id: 'dist-3',
+          state: 'CA',
           l2Type: 'City Council',
           l2Name: 'District 1',
         }),
@@ -291,6 +296,7 @@ describe('VoterFileDownloadAccessService - canDownload', () => {
       expect(
         service.canDownload(campaign, {
           id: 'dist-1',
+          state: 'CA',
           l2Type: 'US House',
           l2Name: 'CA-12',
         }),

--- a/src/vendors/peerly/services/p2pPhoneListUpload.service.test.ts
+++ b/src/vendors/peerly/services/p2pPhoneListUpload.service.test.ts
@@ -44,6 +44,7 @@ const mockCampaign: Campaign = {
 
 const mockDistrict = {
   id: 'dist-1',
+  state: 'OR',
   l2Type: 'City_Portland',
   l2Name: 'PORTLAND',
 }

--- a/src/voters/voterFile/util/voterFile.util.test.ts
+++ b/src/voters/voterFile/util/voterFile.util.test.ts
@@ -19,6 +19,7 @@ const statewideCampaign = (state: string | null | undefined) =>
 
 const statewideDistrict = {
   id: 'dist-1',
+  state: 'CO',
   l2Type: 'State',
   l2Name: 'CO',
 }


### PR DESCRIPTION
~253 serve users have an org where `positionId` is null but `overrideDistrictId` and `customPositionName` are set. `resolveDispatchContext` previously only looked at `positionId`, so it returned null for these orgs — causing every manual and daily-cron meeting dispatch attempt to silently skip without dispatching.

The fix delegates context resolution to `OrganizationsService.resolveServeContext`, a new helper that mirrors the existing `resolveDistrict` logic: it fetches position and override district in parallel and resolves state/positionName/l2 fields from whichever is present, preferring the override district. The meetings module already imported `OrganizationsModule`, so no new wiring is required.

Two type gaps were also closed: `District` (the election-api shape) and `OrgDistrict` (the gp-api-local shape) were both missing the `state` field that election-api has always returned. Adding it required updating fixture objects in several test files but involved no logic changes in those files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the elected-office meeting automation dispatch path and shared org district shapes, but behavior is centralized, mirrors existing resolveDistrict logic, and is covered by new tests.
> 
> **Overview**
> Meeting schedule/briefing dispatch no longer requires a linked `positionId`. **`MeetingBriefingsService`** now builds dispatch params via **`OrganizationsService.resolveServeContext`**, which loads position and override district in parallel and derives state, `positionName`, and L2 fields from whichever source applies (override district wins for geography).
> 
> A new **`resolveServeContext`** helper mirrors existing **`resolveDistrict`** behavior so override-only orgs (`overrideDistrictId` + `customPositionName`, no position) can dispatch instead of silently skipping.
> 
> **`District`** and **`OrgDistrict`** now include **`state`** (aligned with election-api); organization API responses expose district `state`. Tests were updated to mock **`resolveServeContext`** and cover override-only, position-based, and null-context paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6496e85ebe3d9e08d3be03cfa6e478db0ce42386. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->