### PR TITLE
fix(meetings): throttle daily briefing dispatch into batches

### DIFF
--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -212,7 +212,7 @@ export class MeetingBriefingsService extends createPrismaBase(
 
     const chunks = chunk(offices, CRON_CONFIG.batchSize)
 
-    for (const batch of chunks) {
+    for (const [i, batch] of chunks.entries()) {
       for (const eo of batch) {
         await this.dispatchBriefingIfNeeded(eo, now).catch((err: unknown) =>
           this.logger.error(
@@ -221,7 +221,11 @@ export class MeetingBriefingsService extends createPrismaBase(
           ),
         )
       }
-      await new Promise((resolve) => setTimeout(resolve, ms(CRON_CONFIG.every)))
+      if (i < chunks.length - 1) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, ms(CRON_CONFIG.every)),
+        )
+      }
     }
   }
 

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -19,6 +19,8 @@ import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
 import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import { MeetingSchedule } from '@/generated/agent-job-contracts'
 import { getUserFullName } from '@/users/util/users.util'
+import { chunk } from 'es-toolkit'
+import ms from 'ms'
 
 const parseBriefingArtifact = (
   raw: string,
@@ -54,6 +56,11 @@ type DispatchContext = {
   positionName: string
   l2DistrictType?: string
   l2DistrictName?: string
+}
+
+const CRON_CONFIG = {
+  batchSize: 100,
+  every: '20m' as const,
 }
 
 @Injectable()
@@ -203,13 +210,18 @@ export class MeetingBriefingsService extends createPrismaBase(
 
     const now = new Date()
 
-    for (const eo of offices) {
-      await this.dispatchBriefingIfNeeded(eo, now).catch((err: unknown) =>
-        this.logger.error(
-          { err, electedOfficeId: eo.id },
-          'dispatchBriefingIfNeeded failed, continuing',
-        ),
-      )
+    const chunks = chunk(offices, CRON_CONFIG.batchSize)
+
+    for (const batch of chunks) {
+      for (const eo of batch) {
+        await this.dispatchBriefingIfNeeded(eo, now).catch((err: unknown) =>
+          this.logger.error(
+            { err, electedOfficeId: eo.id },
+            'dispatchBriefingIfNeeded failed, continuing',
+          ),
+        )
+      }
+      await new Promise((resolve) => setTimeout(resolve, ms(CRON_CONFIG.every)))
     }
   }
 


### PR DESCRIPTION
The daily briefing cron (`dispatchDailyBriefings`) swept every elected office in a single tight loop, dispatching a `meeting_briefing` run for each one back-to-back. Each dispatch mints a Clerk actor token, and because all of prod egresses through a single NAT IP, that loop concentrated mints behind one IP and tripped Clerk's per-IP rate limit (3 req / 10s). That's the same failure mode that dead-lettered the recent backfill — once the cron grows past a few hundred offices it will reproduce the 429 storm on its own.

This spreads the dispatch rate out: offices are chunked into batches of `CRON_CONFIG.batchSize` (100) and the cron pauses `CRON_CONFIG.every` (20m) between batches, keeping the actor-token mint rate well under Clerk's limit while still draining the full set over the day.

Independent of the `createdAt` floor change (#1694) — this PR only touches the dispatch loop, so the two can land in either order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scheduled job timing and throughput for all offices; mis-tuned batch/delay could leave briefings incomplete within the day, but logic per office is unchanged.
> 
> **Overview**
> The daily briefing cron no longer dispatches `meeting_briefing` runs for every elected office in one continuous loop. Offices are split into batches of **100** (`CRON_CONFIG.batchSize`); after each batch finishes, the job **waits 20 minutes** before starting the next, using `chunk` from `es-toolkit` and `ms` for the delay.
> 
> That throttles how fast dispatches hit Clerk (actor tokens minted per egress IP), avoiding the ~3 req / 10s per-IP limit that was causing 429s as office count grows. Per-office error handling inside a batch is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32a1a443c18f1a4d947f19696016568c42c3276a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->