### PR TITLE
QA <- Dev

### DIFF
--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -212,7 +212,7 @@ export class MeetingBriefingsService extends createPrismaBase(
 
     const chunks = chunk(offices, CRON_CONFIG.batchSize)
 
-    for (const batch of chunks) {
+    for (const [i, batch] of chunks.entries()) {
       for (const eo of batch) {
         await this.dispatchBriefingIfNeeded(eo, now).catch((err: unknown) =>
           this.logger.error(
@@ -221,7 +221,11 @@ export class MeetingBriefingsService extends createPrismaBase(
           ),
         )
       }
-      await new Promise((resolve) => setTimeout(resolve, ms(CRON_CONFIG.every)))
+      if (i < chunks.length - 1) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, ms(CRON_CONFIG.every)),
+        )
+      }
     }
   }
 

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -19,6 +19,8 @@ import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
 import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import { MeetingSchedule } from '@/generated/agent-job-contracts'
 import { getUserFullName } from '@/users/util/users.util'
+import { chunk } from 'es-toolkit'
+import ms from 'ms'
 
 const parseBriefingArtifact = (
   raw: string,
@@ -54,6 +56,11 @@ type DispatchContext = {
   positionName: string
   l2DistrictType?: string
   l2DistrictName?: string
+}
+
+const CRON_CONFIG = {
+  batchSize: 100,
+  every: '20m' as const,
 }
 
 @Injectable()
@@ -203,13 +210,18 @@ export class MeetingBriefingsService extends createPrismaBase(
 
     const now = new Date()
 
-    for (const eo of offices) {
-      await this.dispatchBriefingIfNeeded(eo, now).catch((err: unknown) =>
-        this.logger.error(
-          { err, electedOfficeId: eo.id },
-          'dispatchBriefingIfNeeded failed, continuing',
-        ),
-      )
+    const chunks = chunk(offices, CRON_CONFIG.batchSize)
+
+    for (const batch of chunks) {
+      for (const eo of batch) {
+        await this.dispatchBriefingIfNeeded(eo, now).catch((err: unknown) =>
+          this.logger.error(
+            { err, electedOfficeId: eo.id },
+            'dispatchBriefingIfNeeded failed, continuing',
+          ),
+        )
+      }
+      await new Promise((resolve) => setTimeout(resolve, ms(CRON_CONFIG.every)))
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Extends the daily cron runtime when office count exceeds 100 and delays some briefing dispatches by hours, which could affect timely briefings for large tenant counts.
> 
> **Overview**
> The **daily meeting briefing cron** (`dispatchDailyBriefings`) no longer processes every `ElectedOffice` in one tight loop. Offices are split into batches of **100**; after each batch finishes, the job **waits 20 minutes** before starting the next batch (via `es-toolkit` `chunk` and `ms`).
> 
> Per-office behavior is unchanged: each office still runs `dispatchBriefingIfNeeded` with the same error handling. The change only **paces** how many briefing experiment dispatches can fire in a short window, which should reduce burst load on queues/agents when many offices exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767fe5dc66c0fe3897ee9ec9170070b0237c7e7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->