### PR TITLE
Prod <- QA

### DIFF
--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -212,7 +212,7 @@ export class MeetingBriefingsService extends createPrismaBase(
 
     const chunks = chunk(offices, CRON_CONFIG.batchSize)
 
-    for (const batch of chunks) {
+    for (const [i, batch] of chunks.entries()) {
       for (const eo of batch) {
         await this.dispatchBriefingIfNeeded(eo, now).catch((err: unknown) =>
           this.logger.error(
@@ -221,7 +221,11 @@ export class MeetingBriefingsService extends createPrismaBase(
           ),
         )
       }
-      await new Promise((resolve) => setTimeout(resolve, ms(CRON_CONFIG.every)))
+      if (i < chunks.length - 1) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, ms(CRON_CONFIG.every)),
+        )
+      }
     }
   }
 

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -19,6 +19,8 @@ import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
 import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import { MeetingSchedule } from '@/generated/agent-job-contracts'
 import { getUserFullName } from '@/users/util/users.util'
+import { chunk } from 'es-toolkit'
+import ms from 'ms'
 
 const parseBriefingArtifact = (
   raw: string,
@@ -54,6 +56,11 @@ type DispatchContext = {
   positionName: string
   l2DistrictType?: string
   l2DistrictName?: string
+}
+
+const CRON_CONFIG = {
+  batchSize: 100,
+  every: '20m' as const,
 }
 
 @Injectable()
@@ -203,13 +210,18 @@ export class MeetingBriefingsService extends createPrismaBase(
 
     const now = new Date()
 
-    for (const eo of offices) {
-      await this.dispatchBriefingIfNeeded(eo, now).catch((err: unknown) =>
-        this.logger.error(
-          { err, electedOfficeId: eo.id },
-          'dispatchBriefingIfNeeded failed, continuing',
-        ),
-      )
+    const chunks = chunk(offices, CRON_CONFIG.batchSize)
+
+    for (const batch of chunks) {
+      for (const eo of batch) {
+        await this.dispatchBriefingIfNeeded(eo, now).catch((err: unknown) =>
+          this.logger.error(
+            { err, electedOfficeId: eo.id },
+            'dispatchBriefingIfNeeded failed, continuing',
+          ),
+        )
+      }
+      await new Promise((resolve) => setTimeout(resolve, ms(CRON_CONFIG.every)))
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Operational change to a production cron that fans out SQS-backed briefing runs; offices beyond the first batch are processed up to ~20 minutes later per batch, which can delay catch-up dispatches on large tenant counts.
> 
> **Overview**
> The **daily meeting briefing cron** (`dispatchDailyBriefings`) no longer processes every elected office in one tight loop. Offices are split into **batches of 100** (`es-toolkit` `chunk`), and after each batch except the last the job **waits 20 minutes** (`ms('20m')`) before continuing.
> 
> Per-office behavior is unchanged: each office still runs `dispatchBriefingIfNeeded` with the same error handling. The change only **paces** how many briefing experiment dispatches hit the queue when many offices lack a future briefing row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0185740f408c2a7d6473a096ac05834e731284c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->