### PR TITLE
fix(meetings): run daily briefing cron on a single replica

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,12 @@ jobs:
           name: build-deps
           retention-days: 1
           if-no-files-found: error
+          # upload-artifact@v4 excludes dotfiles by default, which silently
+          # dropped the generated node_modules/.prisma client. Downstream jobs
+          # then fell back to the stale lockfile-keyed node_modules cache, so
+          # any schema change (new model/field) was invisible to typecheck,
+          # lint, and tests until the cache happened to be rebuilt.
+          include-hidden-files: true
           path: |
             node_modules/.prisma
             contracts/dist

--- a/prisma/schema/cronRun.prisma
+++ b/prisma/schema/cronRun.prisma
@@ -1,0 +1,17 @@
+/// A once-per-day claim row used as a durable, multi-instance lock for cron
+/// jobs. With multiple ECS replicas every replica fires its own @Cron, so a
+/// job that must run exactly once per day inserts a row keyed by
+/// (jobName, runDate). The unique constraint lets exactly one replica win the
+/// insert; the others get a unique-violation and skip. Unlike a session
+/// advisory lock this cannot leak across connection-pool churn.
+model CronRun {
+  id String @id @default(uuid(7))
+
+  jobName String   @map("job_name")
+  runDate DateTime @map("run_date") @db.Date
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@unique([jobName, runDate])
+  @@map("cron_run")
+}

--- a/prisma/schema/cronRun.prisma
+++ b/prisma/schema/cronRun.prisma
@@ -10,6 +10,12 @@ model CronRun {
   jobName String   @map("job_name")
   runDate DateTime @map("run_date") @db.Date
 
+  // When the winning replica finished the job. A row that stays null past the
+  // staleness window means the claimer crashed mid-run, so another replica may
+  // take the claim over and retry.
+  completedAt DateTime? @map("completed_at")
+
+  // Doubles as the claim timestamp: refreshed when a stale claim is taken over.
   createdAt DateTime @default(now()) @map("created_at")
 
   @@unique([jobName, runDate])

--- a/prisma/schema/migrations/20260529154418_add_cron_run/migration.sql
+++ b/prisma/schema/migrations/20260529154418_add_cron_run/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "cron_run" (
+    "id" TEXT NOT NULL,
+    "job_name" TEXT NOT NULL,
+    "run_date" DATE NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "cron_run_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "cron_run_job_name_run_date_key" ON "cron_run"("job_name", "run_date");

--- a/prisma/schema/migrations/20260529161114_add_cron_run_completed_at/migration.sql
+++ b/prisma/schema/migrations/20260529161114_add_cron_run_completed_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "cron_run" ADD COLUMN     "completed_at" TIMESTAMP(3);

--- a/src/cron/cron.module.ts
+++ b/src/cron/cron.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { CronLockService } from './services/cronLock.service'
+
+@Module({
+  providers: [CronLockService],
+  exports: [CronLockService],
+})
+export class CronModule {}

--- a/src/cron/services/cronLock.service.test.ts
+++ b/src/cron/services/cronLock.service.test.ts
@@ -4,6 +4,8 @@ import { CronLockService } from './cronLock.service'
 
 const service = useTestService()
 
+const JOB = 'jobX'
+
 describe('CronLockService.tryClaimDailyRun', () => {
   beforeEach(async () => {
     await service.prisma.cronRun.deleteMany({})
@@ -13,18 +15,20 @@ describe('CronLockService.tryClaimDailyRun', () => {
     const lock = service.app.get(CronLockService)
     const now = new Date('2026-05-29T07:00:00.000Z')
 
-    expect(await lock.tryClaimDailyRun('jobX', now)).toBe(true)
-    expect(await lock.tryClaimDailyRun('jobX', now)).toBe(false)
+    expect(await lock.tryClaimDailyRun(JOB, now)).toBe(true)
+    expect(await lock.tryClaimDailyRun(JOB, now)).toBe(false)
   })
 
   it('treats different times on the same UTC date as the same claim', async () => {
     const lock = service.app.get(CronLockService)
 
+    // Two times on the same UTC date, within the staleness window so the active
+    // claim is not eligible for takeover.
     expect(
-      await lock.tryClaimDailyRun('jobX', new Date('2026-05-29T00:00:01.000Z')),
+      await lock.tryClaimDailyRun(JOB, new Date('2026-05-29T00:00:01.000Z')),
     ).toBe(true)
     expect(
-      await lock.tryClaimDailyRun('jobX', new Date('2026-05-29T23:59:59.000Z')),
+      await lock.tryClaimDailyRun(JOB, new Date('2026-05-29T04:00:00.000Z')),
     ).toBe(false)
   })
 
@@ -32,10 +36,10 @@ describe('CronLockService.tryClaimDailyRun', () => {
     const lock = service.app.get(CronLockService)
 
     expect(
-      await lock.tryClaimDailyRun('jobX', new Date('2026-05-29T12:00:00.000Z')),
+      await lock.tryClaimDailyRun(JOB, new Date('2026-05-29T12:00:00.000Z')),
     ).toBe(true)
     expect(
-      await lock.tryClaimDailyRun('jobX', new Date('2026-05-30T12:00:00.000Z')),
+      await lock.tryClaimDailyRun(JOB, new Date('2026-05-30T12:00:00.000Z')),
     ).toBe(true)
   })
 
@@ -45,5 +49,42 @@ describe('CronLockService.tryClaimDailyRun', () => {
 
     expect(await lock.tryClaimDailyRun('jobA', now)).toBe(true)
     expect(await lock.tryClaimDailyRun('jobB', now)).toBe(true)
+  })
+
+  it('does not take over an in-progress (not yet stale) claim', async () => {
+    const lock = service.app.get(CronLockService)
+
+    expect(
+      await lock.tryClaimDailyRun(JOB, new Date('2026-05-29T07:00:00.000Z')),
+    ).toBe(true)
+    // 2 hours later, same day: prior claim is still within the staleness window.
+    expect(
+      await lock.tryClaimDailyRun(JOB, new Date('2026-05-29T09:00:00.000Z')),
+    ).toBe(false)
+  })
+
+  it('takes over a stale claim that never completed (crashed run)', async () => {
+    const lock = service.app.get(CronLockService)
+
+    expect(
+      await lock.tryClaimDailyRun(JOB, new Date('2026-05-29T07:00:00.000Z')),
+    ).toBe(true)
+    // 7 hours later (> STALE_CLAIM_MS) with no markCompleted: assume a crash.
+    expect(
+      await lock.tryClaimDailyRun(JOB, new Date('2026-05-29T14:00:00.000Z')),
+    ).toBe(true)
+  })
+
+  it('never takes over a completed claim, even when stale', async () => {
+    const lock = service.app.get(CronLockService)
+    const now = new Date('2026-05-29T07:00:00.000Z')
+
+    expect(await lock.tryClaimDailyRun(JOB, now)).toBe(true)
+    await lock.markCompleted(JOB, now)
+
+    // Long after completion, same day: a completed run must not be retried.
+    expect(
+      await lock.tryClaimDailyRun(JOB, new Date('2026-05-29T20:00:00.000Z')),
+    ).toBe(false)
   })
 })

--- a/src/cron/services/cronLock.service.test.ts
+++ b/src/cron/services/cronLock.service.test.ts
@@ -75,6 +75,24 @@ describe('CronLockService.tryClaimDailyRun', () => {
     ).toBe(true)
   })
 
+  it('lets only one of two concurrent takeovers win', async () => {
+    const lock = service.app.get(CronLockService)
+
+    expect(
+      await lock.tryClaimDailyRun(JOB, new Date('2026-05-29T07:00:00.000Z')),
+    ).toBe(true)
+
+    // Two replicas race to take over the same stale claim; the conditional
+    // update must let exactly one succeed.
+    const later = new Date('2026-05-29T14:00:00.000Z')
+    const results = await Promise.all([
+      lock.tryClaimDailyRun(JOB, later),
+      lock.tryClaimDailyRun(JOB, later),
+    ])
+
+    expect(results.filter(Boolean)).toHaveLength(1)
+  })
+
   it('never takes over a completed claim, even when stale', async () => {
     const lock = service.app.get(CronLockService)
     const now = new Date('2026-05-29T07:00:00.000Z')

--- a/src/cron/services/cronLock.service.test.ts
+++ b/src/cron/services/cronLock.service.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useTestService } from '@/test-service'
+import { CronLockService } from './cronLock.service'
+
+const service = useTestService()
+
+describe('CronLockService.tryClaimDailyRun', () => {
+  beforeEach(async () => {
+    await service.prisma.cronRun.deleteMany({})
+  })
+
+  it('grants the first caller and denies a second caller for the same UTC day', async () => {
+    const lock = service.app.get(CronLockService)
+    const now = new Date('2026-05-29T07:00:00.000Z')
+
+    expect(await lock.tryClaimDailyRun('jobX', now)).toBe(true)
+    expect(await lock.tryClaimDailyRun('jobX', now)).toBe(false)
+  })
+
+  it('treats different times on the same UTC date as the same claim', async () => {
+    const lock = service.app.get(CronLockService)
+
+    expect(
+      await lock.tryClaimDailyRun('jobX', new Date('2026-05-29T00:00:01.000Z')),
+    ).toBe(true)
+    expect(
+      await lock.tryClaimDailyRun('jobX', new Date('2026-05-29T23:59:59.000Z')),
+    ).toBe(false)
+  })
+
+  it('grants the claim again on a different UTC day', async () => {
+    const lock = service.app.get(CronLockService)
+
+    expect(
+      await lock.tryClaimDailyRun('jobX', new Date('2026-05-29T12:00:00.000Z')),
+    ).toBe(true)
+    expect(
+      await lock.tryClaimDailyRun('jobX', new Date('2026-05-30T12:00:00.000Z')),
+    ).toBe(true)
+  })
+
+  it('isolates claims per jobName', async () => {
+    const lock = service.app.get(CronLockService)
+    const now = new Date('2026-05-29T07:00:00.000Z')
+
+    expect(await lock.tryClaimDailyRun('jobA', now)).toBe(true)
+    expect(await lock.tryClaimDailyRun('jobB', now)).toBe(true)
+  })
+})

--- a/src/cron/services/cronLock.service.test.ts
+++ b/src/cron/services/cronLock.service.test.ts
@@ -32,6 +32,20 @@ describe('CronLockService.tryClaimDailyRun', () => {
     ).toBe(false)
   })
 
+  it('denies a second instance firing ~1s later the same day (two-replica race)', async () => {
+    const lock = service.app.get(CronLockService)
+
+    // The two ECS replicas fire their @Cron a fraction of a second apart. The
+    // lock keys on the date only, so both resolve to the same runDate and only
+    // the first wins — sub-second clock differences must not let both through.
+    expect(
+      await lock.tryClaimDailyRun(JOB, new Date('2026-05-29T07:00:00.123Z')),
+    ).toBe(true)
+    expect(
+      await lock.tryClaimDailyRun(JOB, new Date('2026-05-29T07:00:01.456Z')),
+    ).toBe(false)
+  })
+
   it('grants the claim again on a different UTC day', async () => {
     const lock = service.app.get(CronLockService)
 

--- a/src/cron/services/cronLock.service.ts
+++ b/src/cron/services/cronLock.service.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@nestjs/common'
-import { formatInTimeZone } from 'date-fns-tz'
 import ms from 'ms'
 import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
 import { isUniqueConstraintError } from '@/prisma/util/prismaErrors.util'
-import { parseIsoDateAsUTC } from '@/shared/util/date.util'
+import { getMidnightForDate } from '@/shared/util/date.util'
 
 // A claim that is still incomplete after this long is assumed to belong to a
 // crashed run and may be taken over. Must comfortably exceed the longest a
@@ -13,10 +12,6 @@ const STALE_CLAIM_MS = ms('6h')
 
 @Injectable()
 export class CronLockService extends createPrismaBase(MODELS.CronRun) {
-  private runDateFor(now: Date): Date {
-    return parseIsoDateAsUTC(formatInTimeZone(now, 'UTC', 'yyyy-MM-dd'))
-  }
-
   /**
    * Claims the once-per-day run slot for `jobName`. Returns `true` if this
    * process won the claim and should run the job, `false` if another process
@@ -39,7 +34,7 @@ export class CronLockService extends createPrismaBase(MODELS.CronRun) {
     jobName: string,
     now: Date = new Date(),
   ): Promise<boolean> {
-    const runDate = this.runDateFor(now)
+    const runDate = getMidnightForDate(now)
 
     try {
       // createdAt doubles as the claim timestamp for staleness checks, so set it
@@ -87,7 +82,7 @@ export class CronLockService extends createPrismaBase(MODELS.CronRun) {
    * @param now Defaults to the current time; injectable for tests.
    */
   async markCompleted(jobName: string, now: Date = new Date()): Promise<void> {
-    const runDate = this.runDateFor(now)
+    const runDate = getMidnightForDate(now)
     await this.model.updateMany({
       where: { jobName, runDate },
       data: { completedAt: now },

--- a/src/cron/services/cronLock.service.ts
+++ b/src/cron/services/cronLock.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common'
+import { subMilliseconds } from 'date-fns'
 import ms from 'ms'
 import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
 import { isUniqueConstraintError } from '@/prisma/util/prismaErrors.util'
@@ -48,7 +49,7 @@ export class CronLockService extends createPrismaBase(MODELS.CronRun) {
       // A row already exists. Take it over only if it never completed and its
       // claim is stale — refreshing createdAt so concurrent takeovers can't
       // both win (the conditional update matches at most one row).
-      const cutoff = new Date(now.getTime() - STALE_CLAIM_MS)
+      const cutoff = subMilliseconds(now, STALE_CLAIM_MS)
       const { count } = await this.model.updateMany({
         where: {
           jobName,

--- a/src/cron/services/cronLock.service.ts
+++ b/src/cron/services/cronLock.service.ts
@@ -1,23 +1,37 @@
 import { Injectable } from '@nestjs/common'
-import { Prisma } from '@prisma/client'
 import { formatInTimeZone } from 'date-fns-tz'
+import ms from 'ms'
 import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
+import { isUniqueConstraintError } from '@/prisma/util/prismaErrors.util'
 import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 
-const PRISMA_UNIQUE_VIOLATION = 'P2002'
+// A claim that is still incomplete after this long is assumed to belong to a
+// crashed run and may be taken over. Must comfortably exceed the longest a
+// guarded job can legitimately run (the daily briefings loop batches with
+// 20-minute sleeps and can take a few hours).
+const STALE_CLAIM_MS = ms('6h')
 
 @Injectable()
 export class CronLockService extends createPrismaBase(MODELS.CronRun) {
+  private runDateFor(now: Date): Date {
+    return parseIsoDateAsUTC(formatInTimeZone(now, 'UTC', 'yyyy-MM-dd'))
+  }
+
   /**
    * Claims the once-per-day run slot for `jobName`. Returns `true` if this
    * process won the claim and should run the job, `false` if another process
-   * (e.g. a second ECS replica firing the same @Cron) already claimed it for
-   * the same UTC calendar date.
+   * (e.g. a second ECS replica firing the same @Cron) already holds an active
+   * or completed claim for the same UTC calendar date.
    *
    * The `(jobName, runDate)` unique constraint is the lock: the first insert
    * wins, concurrent inserts get a unique violation. This is durable and
    * pooling-safe — unlike a session advisory lock it cannot leak and block a
    * future day's run.
+   *
+   * If a prior claim is still incomplete past {@link STALE_CLAIM_MS} the
+   * claimer is assumed to have crashed, and the claim is atomically taken over
+   * so the job can be retried instead of silently lost for the day. Callers
+   * must invoke {@link markCompleted} once the job finishes.
    *
    * @param now Defaults to the current time; injectable for tests.
    */
@@ -25,26 +39,58 @@ export class CronLockService extends createPrismaBase(MODELS.CronRun) {
     jobName: string,
     now: Date = new Date(),
   ): Promise<boolean> {
-    const runDate = parseIsoDateAsUTC(
-      formatInTimeZone(now, 'UTC', 'yyyy-MM-dd'),
-    )
+    const runDate = this.runDateFor(now)
 
     try {
-      await this.model.create({ data: { jobName, runDate } })
+      // createdAt doubles as the claim timestamp for staleness checks, so set it
+      // explicitly rather than relying on the DB default.
+      await this.model.create({ data: { jobName, runDate, createdAt: now } })
       this.logger.info({ jobName, runDate }, 'claimed daily cron run')
       return true
     } catch (err) {
-      if (
-        err instanceof Prisma.PrismaClientKnownRequestError &&
-        err.code === PRISMA_UNIQUE_VIOLATION
-      ) {
-        this.logger.info(
+      if (!isUniqueConstraintError(err)) throw err
+
+      // A row already exists. Take it over only if it never completed and its
+      // claim is stale — refreshing createdAt so concurrent takeovers can't
+      // both win (the conditional update matches at most one row).
+      const cutoff = new Date(now.getTime() - STALE_CLAIM_MS)
+      const { count } = await this.model.updateMany({
+        where: {
+          jobName,
+          runDate,
+          completedAt: null,
+          createdAt: { lt: cutoff },
+        },
+        data: { createdAt: now },
+      })
+
+      if (count > 0) {
+        this.logger.warn(
           { jobName, runDate },
-          'daily cron run already claimed by another instance; skipping',
+          'took over stale daily cron run claim (previous run never completed)',
         )
-        return false
+        return true
       }
-      throw err
+
+      this.logger.info(
+        { jobName, runDate },
+        'daily cron run already claimed by another instance; skipping',
+      )
+      return false
     }
+  }
+
+  /**
+   * Marks the current UTC day's claim for `jobName` as completed, so a later
+   * invocation will not treat it as a crashed run and take it over.
+   *
+   * @param now Defaults to the current time; injectable for tests.
+   */
+  async markCompleted(jobName: string, now: Date = new Date()): Promise<void> {
+    const runDate = this.runDateFor(now)
+    await this.model.updateMany({
+      where: { jobName, runDate },
+      data: { completedAt: now },
+    })
   }
 }

--- a/src/cron/services/cronLock.service.ts
+++ b/src/cron/services/cronLock.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common'
+import { Prisma } from '@prisma/client'
+import { formatInTimeZone } from 'date-fns-tz'
+import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
+import { parseIsoDateAsUTC } from '@/shared/util/date.util'
+
+const PRISMA_UNIQUE_VIOLATION = 'P2002'
+
+@Injectable()
+export class CronLockService extends createPrismaBase(MODELS.CronRun) {
+  /**
+   * Claims the once-per-day run slot for `jobName`. Returns `true` if this
+   * process won the claim and should run the job, `false` if another process
+   * (e.g. a second ECS replica firing the same @Cron) already claimed it for
+   * the same UTC calendar date.
+   *
+   * The `(jobName, runDate)` unique constraint is the lock: the first insert
+   * wins, concurrent inserts get a unique violation. This is durable and
+   * pooling-safe — unlike a session advisory lock it cannot leak and block a
+   * future day's run.
+   *
+   * @param now Defaults to the current time; injectable for tests.
+   */
+  async tryClaimDailyRun(
+    jobName: string,
+    now: Date = new Date(),
+  ): Promise<boolean> {
+    const runDate = parseIsoDateAsUTC(
+      formatInTimeZone(now, 'UTC', 'yyyy-MM-dd'),
+    )
+
+    try {
+      await this.model.create({ data: { jobName, runDate } })
+      this.logger.info({ jobName, runDate }, 'claimed daily cron run')
+      return true
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === PRISMA_UNIQUE_VIOLATION
+      ) {
+        this.logger.info(
+          { jobName, runDate },
+          'daily cron run already claimed by another instance; skipping',
+        )
+        return false
+      }
+      throw err
+    }
+  }
+}

--- a/src/cron/services/cronLock.service.ts
+++ b/src/cron/services/cronLock.service.ts
@@ -35,6 +35,11 @@ export class CronLockService extends createPrismaBase(MODELS.CronRun) {
     jobName: string,
     now: Date = new Date(),
   ): Promise<boolean> {
+    // The lock key is the UTC calendar date only: getMidnightForDate zeroes the
+    // time and run_date is a @db.Date column, so two replicas whose `now` differ
+    // by a fraction of a second still collapse to the same runDate and collide
+    // on the unique (jobName, runDate) constraint. `now` keeps its time because
+    // createdAt (below) uses it as the claim timestamp for staleness/takeover.
     const runDate = getMidnightForDate(now)
 
     try {

--- a/src/meetings/meetings.module.ts
+++ b/src/meetings/meetings.module.ts
@@ -6,6 +6,7 @@ import { OrganizationsModule } from '@/organizations/organizations.module'
 import { AwsModule } from '@/vendors/aws/aws.module'
 import { SegmentModule } from '@/vendors/segment/segment.module'
 import { LlmModule } from '@/llm/llm.module'
+import { CronModule } from '@/cron/cron.module'
 import { BriefingsPdfController } from './controllers/briefingsPdf.controller'
 import { BriefingsPdfRateLimitGuard } from './controllers/briefingsPdfRateLimit.guard'
 import { MeetingsBriefingsController } from './controllers/meetingsBriefings.controller'
@@ -21,6 +22,7 @@ import { MeetingBriefingsService } from './services/meetingBriefings.service'
     AwsModule,
     SegmentModule,
     LlmModule,
+    CronModule,
   ],
   controllers: [MeetingsBriefingsController, BriefingsPdfController],
   providers: [

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -509,9 +509,12 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
 })
 
 describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', 'true')
     mockResolveServeContext(null)
+    // The cron claims a once-per-day lease; clear it so each test's first
+    // invocation wins the claim (all tests run on the same UTC date).
+    await service.prisma.cronRun.deleteMany({})
   })
   afterEach(() => {
     vi.unstubAllEnvs()
@@ -609,6 +612,35 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
         }),
       }),
     )
+  })
+
+  it('runs the dispatch loop once when invoked twice the same day (multi-replica guard)', async () => {
+    const orgSlug = `eo-cron-guard-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-cron-guard' })
+    const campaign = await service.prisma.campaign.findFirst({
+      where: { organizationSlug: orgSlug },
+    })
+    await service.prisma.electedOffice.create({
+      data: {
+        organizationSlug: orgSlug,
+        userId: service.user.id,
+        campaignId: campaign?.id,
+      },
+    })
+
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const svc = service.app.get(MeetingBriefingsService)
+    // Simulate both ECS replicas firing the cron on the same day. The second
+    // invocation must lose the lease and skip the loop entirely.
+    await svc.dispatchDailyBriefings()
+    await svc.dispatchDailyBriefings()
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
   })
 
   it('dispatches for EOs regardless of when they were created', async () => {

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -241,6 +241,10 @@ export class MeetingBriefingsService extends createPrismaBase(
         )
       }
     }
+
+    // Mark the claim complete so a crashed-run takeover (see CronLockService)
+    // is only triggered when the loop did not finish.
+    await this.cronLock.markCompleted(DAILY_BRIEFINGS_CRON_JOB)
   }
 
   private async dispatchBriefingIfNeeded(

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -210,19 +210,23 @@ export class MeetingBriefingsService extends createPrismaBase(
       return
     }
 
+    // Pin a single timestamp for the whole run so the lease claim and its
+    // completion resolve to the same UTC run-date even if the long loop below
+    // crosses midnight.
+    const now = new Date()
+
     // Every ECS replica fires this @Cron, so without a guard each office would
     // be enqueued once per replica (2x in prod). Claim a once-per-day lease so
     // only the winning replica runs the long batched dispatch loop below.
     const claimed = await this.cronLock.tryClaimDailyRun(
       DAILY_BRIEFINGS_CRON_JOB,
+      now,
     )
     if (!claimed) return
 
     const offices = await this.client.electedOffice.findMany({
       select: { id: true, organizationSlug: true, userId: true },
     })
-
-    const now = new Date()
 
     const chunks = chunk(offices, CRON_CONFIG.batchSize)
 
@@ -244,7 +248,7 @@ export class MeetingBriefingsService extends createPrismaBase(
 
     // Mark the claim complete so a crashed-run takeover (see CronLockService)
     // is only triggered when the loop did not finish.
-    await this.cronLock.markCompleted(DAILY_BRIEFINGS_CRON_JOB)
+    await this.cronLock.markCompleted(DAILY_BRIEFINGS_CRON_JOB, now)
   }
 
   private async dispatchBriefingIfNeeded(

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -19,6 +19,7 @@ import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
 import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import { MeetingSchedule } from '@/generated/agent-job-contracts'
 import { getUserFullName } from '@/users/util/users.util'
+import { CronLockService } from '@/cron/services/cronLock.service'
 import { chunk } from 'es-toolkit'
 import ms from 'ms'
 
@@ -35,6 +36,9 @@ const parseSchedule = (raw: string): MeetingSchedule =>
 
 const SCHEDULE_EXPERIMENT_TYPE = 'meeting_schedule'
 const BRIEFING_EXPERIMENT_TYPE = 'meeting_briefing'
+
+// Identifies the daily-briefing cron in the cron_run lease table.
+const DAILY_BRIEFINGS_CRON_JOB = 'dispatchDailyBriefings'
 
 const isAutomationEnabled = () =>
   process.env.MEETINGS_AUTOMATION_ENABLED === 'true'
@@ -74,6 +78,7 @@ export class MeetingBriefingsService extends createPrismaBase(
     private readonly segment: SegmentService,
     private readonly llm: LlmService,
     private readonly braintrust: BraintrustService,
+    private readonly cronLock: CronLockService,
   ) {
     super()
   }
@@ -204,6 +209,15 @@ export class MeetingBriefingsService extends createPrismaBase(
       )
       return
     }
+
+    // Every ECS replica fires this @Cron, so without a guard each office would
+    // be enqueued once per replica (2x in prod). Claim a once-per-day lease so
+    // only the winning replica runs the long batched dispatch loop below.
+    const claimed = await this.cronLock.tryClaimDailyRun(
+      DAILY_BRIEFINGS_CRON_JOB,
+    )
+    if (!claimed) return
+
     const offices = await this.client.electedOffice.findMany({
       select: { id: true, organizationSlug: true, userId: true },
     })


### PR DESCRIPTION
## Problem

In prod, gp-api runs **2 ECS Fargate tasks**. The daily briefing dispatch uses `@nestjs/schedule`'s `@Cron('0 7 * * *')`, which fires **inside every replica's process**. So both tasks independently ran `dispatchDailyBriefings()` — the long batched loop (100 offices/batch, 20-min sleeps) — and **double-enqueued every elected office's `meeting_briefing` run** to the agent queue.

The existing per-EO guard (`dispatchBriefingIfNeeded`) doesn't help, because at cron time no future `MeetingBriefing` row exists yet and `dispatchRun` uses a random SQS dedup id.

## Fix

Add a durable, multi-instance **cron lock** so only one replica runs the loop:

- New `cron_run` table with a unique `(job_name, run_date)` constraint (Prisma model + migration).
- New reusable `CronLockService.tryClaimDailyRun(jobName)` — the first replica to insert the row for today's UTC date wins; concurrent inserts hit the unique violation and return `false`.
- `dispatchDailyBriefings()` now claims the lease first and returns early if it didn't win. The winning replica runs the batched loop exactly once.

### Why a lease table (not an advisory lock)?

The cron loop runs for potentially hours (batches with 20-min sleeps), so it can't live inside an SQS handler (visibility timeout) or a transaction-scoped `pg_advisory_xact_lock`. A session advisory lock (`pg_try_advisory_lock`) can leak across Prisma's connection-pool churn and block the next day's run. The unique-constraint lease is durable, pooling-safe, and reusable by other crons.

## Test plan

- [x] `CronLockService` unit/integration tests: first caller wins, second is denied same UTC day, different day re-grants, claims isolated per `jobName`.
- [x] New `dispatchDailyBriefings` test: invoking twice on the same day runs the dispatch loop only once (multi-replica guard).
- [x] Existing meeting-briefing tests pass (clear `cron_run` in `beforeEach`).
- [x] `npm run types`, eslint, prettier clean on changed files.
- [x] 25 tests pass locally (Testcontainers Postgres applies the new migration).

## Notes

- This fixes future runs only. Yesterday's already-double-enqueued runs are a separate cleanup — happy to follow up.
- Migration `20260529154418_add_cron_run` is additive (new table only).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daily automation enqueue behavior and adds a migration; mis-claim logic could skip or duplicate dispatches, though scope is limited to the cron path and additive schema.
> 
> **Overview**
> Adds a **once-per-day cron lease** so only one ECS replica runs the daily meeting-briefing dispatch when multiple tasks each fire `@Cron('0 7 * * *')`.
> 
> A new **`cron_run`** table and **`CronLockService.tryClaimDailyRun(jobName)`** use a unique `(job_name, run_date)` insert as the lock (UTC calendar day); the first insert wins, others get a unique violation and skip. **`dispatchDailyBriefings`** claims `dispatchDailyBriefings` before the batched loop and returns early if it did not win. **`CronModule`** is wired into **`MeetingsModule`**.
> 
> Tests cover the lock service and a double-invocation case where **`dispatchRun`** runs only once per day; existing cron tests clear **`cron_run`** in **`beforeEach`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918b4d4de14354edc0269a83b9ad7a89da911973. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


# Long Term Issue:
## The real smell: a multi-hour loop inside a cron
The deepest issue is the shape itself — an hours-long for loop with 20-minute setTimeout sleeps pinned to one Node process, holding "today's run" in memory. No checkpointing, no progress visibility, killed on every deploy. The lease is partly a band-aid over the fact that this loop is fragile. The natural architecture is fan-out: the cron (fired once, deduped) enqueues per-office messages; SQS consumers process them in parallel with built-in retries, visibility timeouts, and a DLQ; each per-office dispatch is idempotent via the claim. That removes the long loop and the need for the lease, and reuses infra you already have.

## So: is it good?
As a stop-gap to stop bleeding money today: yes, acceptable. It's simple, durable, pooling-safe, low-risk, and it does stop the 2× enqueue. Ship-able.
As "the solution": no. It's a per-job patch for a systemic problem ("every @Cron runs on every replica" — note this PR fixes exactly one of your N crons; the rest still double-fire), it doesn't establish the real invariant (idempotent per-office dispatch), and the recovery half is non-functional while having removed prior redundancy.
What I'd actually recommend (in priority order)
Make dispatch idempotent at the source — deterministic claim or unique key on (electedOfficeId, runDate) before dispatchRun, mirroring campaignTcrCompliance. This kills duplicates from all triggers and makes the lease optional. This is the single highest-value change.
Add an alarm on incomplete runs — if the briefing batch doesn't markCompleted, someone should know. Right now nobody watches it.
Decide honestly about recovery: either (a) drop completedAt/takeover as dead weight, or (b) make it real by running the cron more frequently (e.g., hourly) so a stale claim can actually be taken over same-day. Don't keep non-functional recovery code.
Solve the class, not the instance — a leader-election / single-instance scheduler service (desiredCount: 1), or an external trigger (EventBridge Scheduler → one-shot task/Lambda), eliminates double-firing for every cron and removes per-job lease boilerplate.
Longer term, convert the multi-hour loop to SQS fan-out.
A pragmatic split: keep this PR as the immediate mitigation (maybe trimming the illusory takeover), and file a follow-up for #1 + #2, which are the durable fixes.

One thing worth verifying that I couldn't confirm read-only: @Cron('0 7 * * *') runs in the container's local timezone unless you pass { timeZone: 'UTC' }, but the lease buckets strictly by UTC date (getMidnightForDate). If the container TZ isn't UTC, the "day" the cron means and the day the lease keys could diverge near midnight. Worth checking the scheduler config.