### PR TITLE
feat(campaign): add primaryResult field to campaign schema and tests

### DIFF
--- a/contracts/.changeset/eng-10256-campaign-primary-result.md
+++ b/contracts/.changeset/eng-10256-campaign-primary-result.md
@@ -1,0 +1,9 @@
+---
+'@goodparty_org/contracts': minor
+---
+
+Add top-level `primaryResult` (`'won' | 'lost'`, nullable) to `CampaignSchema`
+/ `ReadCampaignOutput`. Persists a candidate's primary-election outcome as a
+proper campaign column instead of the `details` JSON blob, so the dashboard's
+Election Results selection survives reloads. Readers can access
+`campaign.primaryResult` directly.

--- a/contracts/src/campaigns/Campaign.schema.ts
+++ b/contracts/src/campaigns/Campaign.schema.ts
@@ -12,6 +12,7 @@ export const CampaignSchema = z.object({
   isPro: z.boolean().nullish(),
   isDemo: z.boolean(),
   didWin: z.boolean().nullish(),
+  primaryResult: z.enum(['won', 'lost']).nullish(),
   dateVerified: z.coerce.date().nullish(),
   tier: CampaignTierSchema.nullish(),
   formattedAddress: z.string().nullish(),

--- a/prisma/schema/campaign.jsonTypes.d.ts
+++ b/prisma/schema/campaign.jsonTypes.d.ts
@@ -24,6 +24,7 @@ declare global {
       ballotLevel?: BallotReadyPositionLevel
       electionDate?: string
       primaryElectionDate?: string
+      primaryResult?: 'won' | 'lost'
       zip?: User['zip']
       knowRun?: 'yes' | null
       runForOffice?: 'yes' | 'no' | null

--- a/prisma/schema/campaign.jsonTypes.d.ts
+++ b/prisma/schema/campaign.jsonTypes.d.ts
@@ -24,7 +24,6 @@ declare global {
       ballotLevel?: BallotReadyPositionLevel
       electionDate?: string
       primaryElectionDate?: string
-      primaryResult?: 'won' | 'lost'
       zip?: User['zip']
       knowRun?: 'yes' | null
       runForOffice?: 'yes' | 'no' | null

--- a/prisma/schema/campaign.prisma
+++ b/prisma/schema/campaign.prisma
@@ -16,6 +16,7 @@ model Campaign {
   isPro                    Boolean?                @default(false) @map("is_pro")
   isDemo                   Boolean                 @default(false) @map("is_demo")
   didWin                   Boolean?                @map("did_win")
+  primaryResult            String?                 @map("primary_result")
   dateVerified             DateTime?               @map("date_verified")
   tier                     CampaignTier?
   formattedAddress         String?                 @map("formatted_address")

--- a/prisma/schema/migrations/20260529185354_add_primary_result_to_campaign/migration.sql
+++ b/prisma/schema/migrations/20260529185354_add_primary_result_to_campaign/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "campaign" ADD COLUMN     "primary_result" TEXT;

--- a/seed/factories/campaign.factory.ts
+++ b/seed/factories/campaign.factory.ts
@@ -21,6 +21,7 @@ export const campaignFactory = generateFactory<Campaign>(() => {
     isPro: faker.datatype.boolean(0.5),
     isDemo: faker.datatype.boolean(0.1),
     didWin: faker.datatype.boolean(0.5),
+    primaryResult: faker.helpers.arrayElement(['won', 'lost', null]),
     dateVerified: null,
     tier: faker.helpers.arrayElement(Object.values(CampaignTier)),
     formattedAddress: null,

--- a/src/campaignStrategy/campaignStrategy.controller.test.ts
+++ b/src/campaignStrategy/campaignStrategy.controller.test.ts
@@ -25,6 +25,7 @@ const sampleCampaign = {
   isPro: false,
   isDemo: false,
   didWin: null,
+  primaryResult: null,
   dateVerified: null,
   tier: null,
   formattedAddress: null,

--- a/src/campaigns/campaigns.controller.test.ts
+++ b/src/campaigns/campaigns.controller.test.ts
@@ -60,6 +60,7 @@ const campaignDefaults = {
   isPro: false,
   isDemo: false,
   didWin: null,
+  primaryResult: null,
   dateVerified: null,
   tier: null,
   formattedAddress: null,

--- a/src/campaigns/campaigns.types.ts
+++ b/src/campaigns/campaigns.types.ts
@@ -34,4 +34,5 @@ export interface UpdateCampaignFieldsInput {
   placeId?: string | null
   canDownloadFederal?: boolean
   overrideDistrictId?: string | null
+  primaryResult?: 'won' | 'lost'
 }

--- a/src/campaigns/campaigns.types.ts
+++ b/src/campaigns/campaigns.types.ts
@@ -34,5 +34,5 @@ export interface UpdateCampaignFieldsInput {
   placeId?: string | null
   canDownloadFederal?: boolean
   overrideDistrictId?: string | null
-  primaryResult?: 'won' | 'lost'
+  primaryResult?: 'won' | 'lost' | null
 }

--- a/src/campaigns/schemas/updateCampaign.schema.test.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.test.ts
@@ -38,6 +38,12 @@ describe('updateCampaignBodySchema', () => {
     },
   )
 
+  it('accepts null primaryResult so a recorded result can be cleared', () => {
+    const result = updateCampaignBodySchema.parse({ primaryResult: null })
+
+    expect(result.primaryResult).toBeNull()
+  })
+
   it('rejects an invalid primaryResult value', () => {
     expect(() =>
       updateCampaignBodySchema.parse({ primaryResult: 'maybe' }),

--- a/src/campaigns/schemas/updateCampaign.schema.test.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.test.ts
@@ -28,4 +28,23 @@ describe('updateCampaignBodySchema', () => {
     expect(result.details).not.toHaveProperty(field)
     expect(result.details).toHaveProperty('state', 'CA')
   })
+
+  it.each(['won', 'lost'])(
+    'preserves primaryResult "%s" so the election result persists',
+    (primaryResult) => {
+      const result = updateCampaignBodySchema.parse({
+        details: { primaryResult },
+      })
+
+      expect(result.details).toHaveProperty('primaryResult', primaryResult)
+    },
+  )
+
+  it('rejects an invalid primaryResult value', () => {
+    expect(() =>
+      updateCampaignBodySchema.parse({
+        details: { primaryResult: 'maybe' },
+      }),
+    ).toThrow()
+  })
 })

--- a/src/campaigns/schemas/updateCampaign.schema.test.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.test.ts
@@ -30,21 +30,25 @@ describe('updateCampaignBodySchema', () => {
   })
 
   it.each(['won', 'lost'])(
-    'preserves primaryResult "%s" so the election result persists',
+    'accepts top-level primaryResult "%s" so the election result persists',
     (primaryResult) => {
-      const result = updateCampaignBodySchema.parse({
-        details: { primaryResult },
-      })
+      const result = updateCampaignBodySchema.parse({ primaryResult })
 
-      expect(result.details).toHaveProperty('primaryResult', primaryResult)
+      expect(result).toHaveProperty('primaryResult', primaryResult)
     },
   )
 
   it('rejects an invalid primaryResult value', () => {
     expect(() =>
-      updateCampaignBodySchema.parse({
-        details: { primaryResult: 'maybe' },
-      }),
+      updateCampaignBodySchema.parse({ primaryResult: 'maybe' }),
     ).toThrow()
+  })
+
+  it('strips primaryResult from details (it is a top-level column)', () => {
+    const result = updateCampaignBodySchema.parse({
+      details: { state: 'CA', primaryResult: 'won' },
+    })
+
+    expect(result.details).not.toHaveProperty('primaryResult')
   })
 })

--- a/src/campaigns/schemas/updateCampaign.schema.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.ts
@@ -72,7 +72,7 @@ export const updateCampaignBodySchema = CampaignSchema.pick({
   .partial()
   .extend({
     details: CampaignDetailsSchema.optional(),
-    primaryResult: z.enum(['won', 'lost']).optional(),
+    primaryResult: z.enum(['won', 'lost']).nullish(),
   })
   .strict()
 

--- a/src/campaigns/schemas/updateCampaign.schema.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.ts
@@ -13,7 +13,6 @@ const CampaignDetailsSchema = z
     ballotLevel: BallotReadyPositionLevelSchema,
     electionDate: z.string(),
     primaryElectionDate: z.string(),
-    primaryResult: z.enum(['won', 'lost']),
     zip: z.string(),
     knowRun: z.enum(['yes']),
     runForOffice: z.enum(['yes', 'no']),
@@ -73,6 +72,7 @@ export const updateCampaignBodySchema = CampaignSchema.pick({
   .partial()
   .extend({
     details: CampaignDetailsSchema.optional(),
+    primaryResult: z.enum(['won', 'lost']).optional(),
   })
   .strict()
 

--- a/src/campaigns/schemas/updateCampaign.schema.ts
+++ b/src/campaigns/schemas/updateCampaign.schema.ts
@@ -13,6 +13,7 @@ const CampaignDetailsSchema = z
     ballotLevel: BallotReadyPositionLevelSchema,
     electionDate: z.string(),
     primaryElectionDate: z.string(),
+    primaryResult: z.enum(['won', 'lost']),
     zip: z.string(),
     knowRun: z.enum(['yes']),
     runForOffice: z.enum(['yes', 'no']),

--- a/src/campaigns/services/campaigns.service.ts
+++ b/src/campaigns/services/campaigns.service.ts
@@ -260,6 +260,7 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
       placeId,
       canDownloadFederal,
       overrideDistrictId,
+      primaryResult,
     } = body
 
     const runUpdate = async (tx: Prisma.TransactionClient) => {
@@ -284,6 +285,9 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
       }
       if (canDownloadFederal !== undefined) {
         campaignUpdateData.canDownloadFederal = canDownloadFederal
+      }
+      if (primaryResult !== undefined) {
+        campaignUpdateData.primaryResult = primaryResult
       }
       if (details) {
         const mergedDetails = deepMerge(

--- a/src/payments/services/purchase.service.test.ts
+++ b/src/payments/services/purchase.service.test.ts
@@ -101,6 +101,7 @@ describe('PurchaseService', () => {
     isPro: true,
     isDemo: false,
     didWin: null,
+    primaryResult: null,
     dateVerified: null,
     tier: null,
     formattedAddress: null,

--- a/src/shared/services/voterFileDownloadAccess.service.test.ts
+++ b/src/shared/services/voterFileDownloadAccess.service.test.ts
@@ -369,6 +369,7 @@ function createMockCampaign(
     isPro: null,
     isDemo: false,
     didWin: null,
+    primaryResult: null,
     dateVerified: null,
     tier: null,
     formattedAddress: null,

--- a/src/shared/test-utils/mockData.util.ts
+++ b/src/shared/test-utils/mockData.util.ts
@@ -35,6 +35,7 @@ export const createMockCampaign = (
   isPro: false,
   isDemo: false,
   didWin: null,
+  primaryResult: null,
   dateVerified: null,
   tier: null,
   data: {},

--- a/src/vendors/peerly/p2p.controller.test.ts
+++ b/src/vendors/peerly/p2p.controller.test.ts
@@ -18,6 +18,7 @@ const mockCampaign: Campaign = {
   isDemo: false,
   isVerified: false,
   didWin: null,
+  primaryResult: null,
   dateVerified: null,
   tier: null,
   formattedAddress: null,

--- a/src/vendors/peerly/services/p2pPhoneListUpload.service.test.ts
+++ b/src/vendors/peerly/services/p2pPhoneListUpload.service.test.ts
@@ -22,6 +22,7 @@ const mockCampaign: Campaign = {
   isDemo: false,
   isVerified: false,
   didWin: null,
+  primaryResult: null,
   dateVerified: null,
   tier: null,
   formattedAddress: null,


### PR DESCRIPTION
- Introduced a new optional field `primaryResult` to the campaign schema, allowing values 'won' or 'lost'.
- Updated the updateCampaign schema tests to ensure `primaryResult` is preserved and correctly validated against invalid values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small schema and validation extension for optional campaign metadata, with no auth or payment logic touched.
> 
> **Overview**
> Adds optional **`primaryResult`** on campaign **`details`**, accepting **`won`** or **`lost`**, so clients can persist primary election outcomes alongside existing dates like **`primaryElectionDate`**.
> 
> The change threads through the Prisma JSON **`CampaignDetails`** typing and the **`updateCampaign`** Zod **`details`** schema, with tests confirming valid values are kept and invalid values (e.g. **`maybe`**) are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a0d6192ece5c1e6d06d0a125442310c7da27cc8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->