### PR TITLE
hotfix: disable meetings automation in prod

### DIFF
--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -407,7 +407,7 @@ export = async () => {
         preview: '',
         dev: '',
         qa: '',
-        prod: 'true',
+        prod: '',
       }),
       SERVE_ANALYSIS_BUCKET_NAME: `serve-analyze-data-${environment === 'preview' ? 'dev' : environment}`,
       MEETING_PIPELINE_BUCKET: meetingPipelineBucketName,


### PR DESCRIPTION
Disables the meetings-automation pipeline in production by clearing the `MEETINGS_AUTOMATION_ENABLED` flag for the prod environment.

## Why

The automated meeting-briefing pipeline (daily `dispatchDailyBriefings` cron + the on-elected-office-creation auto-dispatch) is the only consumer gated behind `MEETINGS_AUTOMATION_ENABLED`. Prod was the sole environment with it set to `'true'`. We need an immediate kill switch for the automatic dispatch paths, which have been driving unbounded agent dispatch volume and cost in prod.

This uses the existing, already-tested flag mechanism rather than touching service logic, so the change is one line and trivially reversible — set `prod` back to `'true'` to re-enable. The admin-triggered manual dispatch endpoint (`POST /v1/meetings/briefings/dispatch`) is unaffected, since it is a deliberate human action, not automation.

Requires an infra deploy (`npm run infra deploy prod`) to take effect, since the flag is an ECS task env var.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single env-var change using an existing flag; no application logic changes, easily reversible.
> 
> **Overview**
> Turns off **production** meeting automation by clearing the `MEETINGS_AUTOMATION_ENABLED` ECS env var in `deploy/index.ts` (was `'true'`, now `''` like other environments).
> 
> That flag is the kill switch for automated briefing dispatch (daily cron and on-office-creation flows). **Manual** admin dispatch via `POST /v1/meetings/briefings/dispatch` is unchanged. Effect requires a prod infra deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39673d20ac4b8753981ecc3cf69c845c7af85847. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->