### PR TITLE
disable MEETINGS_AUTOMATION_ENABLED in prod

### DIFF
--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -407,7 +407,7 @@ export = async () => {
         preview: '',
         dev: '',
         qa: '',
-        prod: 'true',
+        prod: '',
       }),
       SERVE_ANALYSIS_BUCKET_NAME: `serve-analyze-data-${environment === 'preview' ? 'dev' : environment}`,
       MEETING_PIPELINE_BUCKET: meetingPipelineBucketName,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Stops prod meetings automation at deploy time; behavior change for a production feature flag, though scope is a single env var.
> 
> **Overview**
> **Production** `MEETINGS_AUTOMATION_ENABLED` is no longer set to `'true'` in Pulumi (`deploy/index.ts`); it is now an empty string, matching preview, dev, and qa.
> 
> That turns off meetings automation for the prod ECS service until the flag is set again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a6e7812dd93750d2aa332ea8fd4c10402dfdc7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->