### PR TITLE
disable MEETINGS_AUTOMATION_ENABLED in prod (#1709)

### DIFF
--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -407,7 +407,7 @@ export = async () => {
         preview: '',
         dev: '',
         qa: '',
-        prod: 'true',
+        prod: '',
       }),
       SERVE_ANALYSIS_BUCKET_NAME: `serve-analyze-data-${environment === 'preview' ? 'dev' : environment}`,
       MEETING_PIPELINE_BUCKET: meetingPipelineBucketName,


### PR DESCRIPTION
https://github.com/thegoodparty/gp-api/pull/1709

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stops prod meeting automation at deploy time; behavior change for a production feature flag, though scope is a single env var.
> 
> **Overview**
> Turns off **meetings automation** in production by clearing the `MEETINGS_AUTOMATION_ENABLED` env var for prod in Pulumi (`deploy/index.ts`). It was previously set to `'true'`; preview, dev, and qa stay disabled with empty values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ba5cd253a7d39dc5ee09d03f993fb66e70dfd9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->