### PR TITLE
Validate voter file filter on outreach creation

### DIFF
--- a/src/outreach/services/outreach.service.test.ts
+++ b/src/outreach/services/outreach.service.test.ts
@@ -34,6 +34,7 @@ const mockTcrFindFirstOrThrow = vi.fn()
 const mockPeerlyCreateJob = vi.fn()
 const mockResolveP2pJobGeography = vi.fn()
 const mockNotifySuccess = vi.fn()
+const mockFindVoterFileFilter = vi.fn()
 
 vi.mock('../util/campaignGeography.util', () => ({
   resolveP2pJobGeography: (
@@ -55,6 +56,7 @@ describe('OutreachService', () => {
   const mockCampaign = {
     id: 1,
     slug: 'jane-doe',
+    organizationSlug: 'org-test',
     aiContent: {},
     data: { hubspotId: 'hub-1' },
     details: null,
@@ -89,6 +91,7 @@ describe('OutreachService', () => {
     mockResolveP2pJobGeography.mockReset()
     mockNotifySuccess.mockReset()
     mockNotifySuccess.mockResolvedValue(undefined)
+    mockFindVoterFileFilter.mockReset()
 
     const mockPrismaService = {
       outreach: {
@@ -125,7 +128,7 @@ describe('OutreachService', () => {
         {
           provide: VoterFileFilterService,
           useValue: {
-            findByIdAndOrganizationSlug: vi.fn(),
+            findByIdAndOrganizationSlug: mockFindVoterFileFilter,
           },
         },
         OutreachService,
@@ -330,6 +333,53 @@ describe('OutreachService', () => {
       ).rejects.toThrow(/filename and MIME type|Peerly job setup/)
 
       expect(mockTcrFindFirstOrThrow).not.toHaveBeenCalled()
+      expect(mockOutreachCreate).not.toHaveBeenCalled()
+    })
+
+    it('succeeds when voterFileFilterId belongs to the campaign org', async () => {
+      const dto: CreateOutreachSchema = {
+        ...baseCreateDto,
+        voterFileFilterId: 42,
+      }
+      mockFindVoterFileFilter.mockResolvedValue({
+        id: 42,
+        organizationSlug: 'org-test',
+      })
+      const created = {
+        id: 1,
+        ...dto,
+        voterFileFilter: { id: 42 },
+      }
+      mockOutreachCreate.mockResolvedValue(created)
+
+      const result = await service.create(
+        mockUser,
+        mockCampaign,
+        dto,
+        undefined,
+        undefined,
+      )
+
+      expect(mockFindVoterFileFilter).toHaveBeenCalledWith(42, 'org-test')
+      expect(mockOutreachCreate).toHaveBeenCalledTimes(1)
+      expect(result).toEqual(created)
+    })
+
+    it('throws BadRequest when voterFileFilterId does not belong to the campaign org', async () => {
+      const dto: CreateOutreachSchema = {
+        ...baseCreateDto,
+        voterFileFilterId: 99,
+      }
+      mockFindVoterFileFilter.mockResolvedValue(null)
+
+      await expect(
+        service.create(mockUser, mockCampaign, dto, undefined, undefined),
+      ).rejects.toThrow(BadRequestException)
+      await expect(
+        service.create(mockUser, mockCampaign, dto, undefined, undefined),
+      ).rejects.toThrow(/Voter file filter not found/)
+
+      expect(mockFindVoterFileFilter).toHaveBeenCalledWith(99, 'org-test')
       expect(mockOutreachCreate).not.toHaveBeenCalled()
     })
 

--- a/src/outreach/services/outreach.service.test.ts
+++ b/src/outreach/services/outreach.service.test.ts
@@ -384,8 +384,8 @@ describe('OutreachService', () => {
         service.create(mockUser, mockCampaign, dto, undefined, undefined),
       ).rejects.toThrow(/Voter file filter not found/)
 
+      expect(mockFilterAccessCheck).toHaveBeenCalledWith('org-test')
       expect(mockFindVoterFileFilter).toHaveBeenCalledWith(99, 'org-test')
-      expect(mockFilterAccessCheck).not.toHaveBeenCalled()
       expect(mockOutreachCreate).not.toHaveBeenCalled()
     })
 
@@ -394,10 +394,6 @@ describe('OutreachService', () => {
         ...baseCreateDto,
         voterFileFilterId: 42,
       }
-      mockFindVoterFileFilter.mockResolvedValue({
-        id: 42,
-        organizationSlug: 'org-test',
-      })
       mockFilterAccessCheck.mockRejectedValue(
         new BadRequestException('Campaign is not pro'),
       )
@@ -409,6 +405,7 @@ describe('OutreachService', () => {
         service.create(mockUser, mockCampaign, dto, undefined, undefined),
       ).rejects.toThrow(/Campaign is not pro/)
 
+      expect(mockFindVoterFileFilter).not.toHaveBeenCalled()
       expect(mockOutreachCreate).not.toHaveBeenCalled()
     })
 

--- a/src/outreach/services/outreach.service.test.ts
+++ b/src/outreach/services/outreach.service.test.ts
@@ -17,6 +17,7 @@ import { AreaCodeFromZipService } from 'src/ai/util/areaCodeFromZip.util'
 import { CampaignTcrComplianceService } from 'src/campaigns/tcrCompliance/services/campaignTcrCompliance.service'
 import { PrismaService } from 'src/prisma/prisma.service'
 import { GooglePlacesService } from 'src/vendors/google/services/google-places.service'
+import { VoterFileFilterService } from 'src/voters/services/voterFileFilter.service'
 import { PeerlyP2pJobService } from 'src/vendors/peerly/services/peerlyP2pJob.service'
 import type {
   CampaignGeographyInput,
@@ -120,6 +121,12 @@ describe('OutreachService', () => {
         {
           provide: OutreachNotificationService,
           useValue: { notifySuccess: mockNotifySuccess },
+        },
+        {
+          provide: VoterFileFilterService,
+          useValue: {
+            findByIdAndOrganizationSlug: vi.fn(),
+          },
         },
         OutreachService,
       ],

--- a/src/outreach/services/outreach.service.test.ts
+++ b/src/outreach/services/outreach.service.test.ts
@@ -35,6 +35,7 @@ const mockPeerlyCreateJob = vi.fn()
 const mockResolveP2pJobGeography = vi.fn()
 const mockNotifySuccess = vi.fn()
 const mockFindVoterFileFilter = vi.fn()
+const mockFilterAccessCheck = vi.fn()
 
 vi.mock('../util/campaignGeography.util', () => ({
   resolveP2pJobGeography: (
@@ -92,6 +93,8 @@ describe('OutreachService', () => {
     mockNotifySuccess.mockReset()
     mockNotifySuccess.mockResolvedValue(undefined)
     mockFindVoterFileFilter.mockReset()
+    mockFilterAccessCheck.mockReset()
+    mockFilterAccessCheck.mockResolvedValue(undefined)
 
     const mockPrismaService = {
       outreach: {
@@ -129,6 +132,7 @@ describe('OutreachService', () => {
           provide: VoterFileFilterService,
           useValue: {
             findByIdAndOrganizationSlug: mockFindVoterFileFilter,
+            filterAccessCheck: mockFilterAccessCheck,
           },
         },
         OutreachService,
@@ -361,11 +365,12 @@ describe('OutreachService', () => {
       )
 
       expect(mockFindVoterFileFilter).toHaveBeenCalledWith(42, 'org-test')
+      expect(mockFilterAccessCheck).toHaveBeenCalledWith('org-test')
       expect(mockOutreachCreate).toHaveBeenCalledTimes(1)
       expect(result).toEqual(created)
     })
 
-    it('throws BadRequest when voterFileFilterId does not belong to the campaign org', async () => {
+    it('throws NotFoundException when voterFileFilterId does not belong to the campaign org', async () => {
       const dto: CreateOutreachSchema = {
         ...baseCreateDto,
         voterFileFilterId: 99,
@@ -374,12 +379,36 @@ describe('OutreachService', () => {
 
       await expect(
         service.create(mockUser, mockCampaign, dto, undefined, undefined),
-      ).rejects.toThrow(BadRequestException)
+      ).rejects.toThrow(NotFoundException)
       await expect(
         service.create(mockUser, mockCampaign, dto, undefined, undefined),
       ).rejects.toThrow(/Voter file filter not found/)
 
       expect(mockFindVoterFileFilter).toHaveBeenCalledWith(99, 'org-test')
+      expect(mockFilterAccessCheck).not.toHaveBeenCalled()
+      expect(mockOutreachCreate).not.toHaveBeenCalled()
+    })
+
+    it('throws BadRequest when filterAccessCheck rejects a non-pro campaign', async () => {
+      const dto: CreateOutreachSchema = {
+        ...baseCreateDto,
+        voterFileFilterId: 42,
+      }
+      mockFindVoterFileFilter.mockResolvedValue({
+        id: 42,
+        organizationSlug: 'org-test',
+      })
+      mockFilterAccessCheck.mockRejectedValue(
+        new BadRequestException('Campaign is not pro'),
+      )
+
+      await expect(
+        service.create(mockUser, mockCampaign, dto, undefined, undefined),
+      ).rejects.toThrow(BadRequestException)
+      await expect(
+        service.create(mockUser, mockCampaign, dto, undefined, undefined),
+      ).rejects.toThrow(/Campaign is not pro/)
+
       expect(mockOutreachCreate).not.toHaveBeenCalled()
     })
 

--- a/src/outreach/services/outreach.service.ts
+++ b/src/outreach/services/outreach.service.ts
@@ -16,6 +16,7 @@ import { DateFormats, formatDate } from 'src/shared/util/date.util'
 import { GooglePlacesService } from 'src/vendors/google/services/google-places.service'
 import { PeerlyP2pJobService } from 'src/vendors/peerly/services/peerlyP2pJob.service'
 import { Readable } from 'stream'
+import { VoterFileFilterService } from 'src/voters/services/voterFileFilter.service'
 import { CreateOutreachSchema } from '../schemas/createOutreachSchema'
 import {
   resolveP2pJobGeography as resolveP2pJobGeographyUtil,
@@ -42,6 +43,7 @@ export class OutreachService extends createPrismaBase(MODELS.Outreach) {
     private readonly tcrComplianceService: CampaignTcrComplianceService,
     private readonly peerlyP2pJobService: PeerlyP2pJobService,
     private readonly notificationService: OutreachNotificationService,
+    private readonly voterFileFilterService: VoterFileFilterService,
   ) {
     super()
   }
@@ -137,6 +139,17 @@ export class OutreachService extends createPrismaBase(MODELS.Outreach) {
     imageUrl?: string,
     p2pImage?: P2pOutreachImageInput,
   ) {
+    if (createOutreachDto.voterFileFilterId) {
+      const filter =
+        await this.voterFileFilterService.findByIdAndOrganizationSlug(
+          createOutreachDto.voterFileFilterId,
+          campaign.organizationSlug,
+        )
+      if (!filter) {
+        throw new BadRequestException('Voter file filter not found')
+      }
+    }
+
     const isP2p = createOutreachDto.outreachType === OutreachType.p2p
 
     if (isP2p) {

--- a/src/outreach/services/outreach.service.ts
+++ b/src/outreach/services/outreach.service.ts
@@ -140,6 +140,9 @@ export class OutreachService extends createPrismaBase(MODELS.Outreach) {
     p2pImage?: P2pOutreachImageInput,
   ) {
     if (createOutreachDto.voterFileFilterId) {
+      await this.voterFileFilterService.filterAccessCheck(
+        campaign.organizationSlug,
+      )
       const filter =
         await this.voterFileFilterService.findByIdAndOrganizationSlug(
           createOutreachDto.voterFileFilterId,
@@ -148,9 +151,6 @@ export class OutreachService extends createPrismaBase(MODELS.Outreach) {
       if (!filter) {
         throw new NotFoundException('Voter file filter not found')
       }
-      await this.voterFileFilterService.filterAccessCheck(
-        campaign.organizationSlug,
-      )
     }
 
     const isP2p = createOutreachDto.outreachType === OutreachType.p2p

--- a/src/outreach/services/outreach.service.ts
+++ b/src/outreach/services/outreach.service.ts
@@ -146,8 +146,11 @@ export class OutreachService extends createPrismaBase(MODELS.Outreach) {
           campaign.organizationSlug,
         )
       if (!filter) {
-        throw new BadRequestException('Voter file filter not found')
+        throw new NotFoundException('Voter file filter not found')
       }
+      await this.voterFileFilterService.filterAccessCheck(
+        campaign.organizationSlug,
+      )
     }
 
     const isP2p = createOutreachDto.outreachType === OutreachType.p2p


### PR DESCRIPTION
## Summary

Add validation to ensure that when a `voterFileFilterId` is provided during outreach creation, the filter exists and belongs to the campaign's organization.

## Changes

- **OutreachService**: Added validation in `createOutreach()` to check that the voter file filter exists via `VoterFileFilterService.findByIdAndOrganizationSlug()`. Throws `BadRequestException` if the filter is not found.
- **OutreachService**: Injected `VoterFileFilterService` dependency.
- **Test setup**: Added mock for `VoterFileFilterService` in the test module configuration.

## Implementation details

The validation runs early in the `createOutreach()` method, before any P2P-specific logic, ensuring that invalid filter IDs are caught immediately with a clear error message.

https://claude.ai/code/session_01BpNt5WjgBcrwt2cRv1tFwj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard on optional DTO field using an existing org-scoped lookup; no auth or persistence schema changes.
> 
> **Overview**
> When outreach is created with an optional **`voterFileFilterId`**, **`OutreachService.create`** now resolves the filter via **`VoterFileFilterService.findByIdAndOrganizationSlug`** using the campaign’s **`organizationSlug`**, and rejects the request with **`BadRequestException`** (`Voter file filter not found`) if there is no matching row—before P2P or record-creation logic runs.
> 
> **`VoterFileFilterService`** is injected into **`OutreachService`**; unit tests register a mock with **`findByIdAndOrganizationSlug`** so the module still compiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cd7bb06e4e62f9f5cdadbe8d10f68d0245d3c09. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->