### PR TITLE
Add HTTP agent with SSRF protection to website fetches

### DIFF
--- a/src/websites/services/websites.service.ts
+++ b/src/websites/services/websites.service.ts
@@ -8,6 +8,7 @@ import { Prisma, User } from '@prisma/client'
 import axios from 'axios'
 import * as dns from 'node:dns'
 import { promisify } from 'node:util'
+import * as http from 'node:http'
 import * as https from 'node:https'
 import ipaddr from 'ipaddr.js'
 import { CampaignWith } from 'src/campaigns/campaigns.types'
@@ -199,6 +200,7 @@ const fetchLiveHtml = async (url: string): Promise<LiveFetchResult> => {
       validateStatus: () => true,
       maxRedirects: 5,
       transformResponse: [(data: string) => data],
+      httpAgent: new http.Agent({ lookup: ssrfSafeLookup }),
       httpsAgent: new https.Agent({ lookup: ssrfSafeLookup }),
     })
     const body = typeof res.data === 'string' ? res.data : null


### PR DESCRIPTION
## Summary

Extends SSRF (Server-Side Request Forgery) protection to HTTP requests in the `fetchLiveHtml` function by adding an `httpAgent` with the same safe DNS lookup as the existing `httpsAgent`.

## Changes

- Import `http` module from `node:http`
- Configure `httpAgent` with `ssrfSafeLookup` in axios request options, matching the existing `httpsAgent` configuration

## Details

The `fetchLiveHtml` function was already protecting HTTPS requests via a custom `httpsAgent` with `ssrfSafeLookup`. This change ensures HTTP requests receive the same protection, closing a potential security gap where unencrypted website fetches could bypass SSRF safeguards.

https://claude.ai/code/session_01191ghojk26tcMWgPoo6TTe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted security hardening in outbound fetch logic with no API or data-model changes.
> 
> **Overview**
> **SSRF protection for live website fetches** now applies to plain HTTP as well as HTTPS.
> 
> `fetchLiveHtml` already used a custom `httpsAgent` with `ssrfSafeLookup` to block connections to non-public IPs during DNS resolution. This change adds a matching `httpAgent` with the same lookup, so axios cannot bypass those safeguards on unencrypted requests or redirects that use HTTP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b04894fa77307e7b50c558acc3e13b473183e9e7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->