### PR TITLE
Omit sensitive user fields from admin user endpoints

### DIFF
--- a/src/admin/users/adminUsers.controller.ts
+++ b/src/admin/users/adminUsers.controller.ts
@@ -30,6 +30,11 @@ import {
   DateRangeFilter,
 } from './schemas/AdminUserList.schema'
 
+const SENSITIVE_USER_FIELDS = {
+  password: true,
+  passwordResetToken: true,
+} as const
+
 @Controller('admin/users')
 @UsePipes(ZodValidationPipe)
 export class AdminUsersController {
@@ -44,8 +49,9 @@ export class AdminUsersController {
   @Get()
   @Roles(UserRole.admin)
   async list(@Query() { dateRange }: AdminUserListSchema) {
+    const omit = SENSITIVE_USER_FIELDS
     if (!dateRange || dateRange === DateRangeFilter.allTime) {
-      return this.usersService.findMany()
+      return this.usersService.findMany({ omit })
     }
     let date = new Date()
     if (dateRange === DateRangeFilter.last12Months) {
@@ -55,11 +61,13 @@ export class AdminUsersController {
     } else if (dateRange === DateRangeFilter.lastWeek) {
       date = subDays(date, 7)
     } else {
-      // input validation should prevent this case
       throw new BadRequestException('Invalid date range')
     }
 
-    return this.usersService.findMany({ where: { createdAt: { gt: date } } })
+    return this.usersService.findMany({
+      where: { createdAt: { gt: date } },
+      omit,
+    })
   }
 
   @Get('search')
@@ -75,13 +83,20 @@ export class AdminUsersController {
   @Get(':id')
   @Roles(UserRole.admin)
   async get(@Param('id', ParseIntPipe) id: number) {
-    return await this.usersService.findUniqueOrThrow({ where: { id } })
+    return this.usersService.findUniqueOrThrow({
+      where: { id },
+      omit: SENSITIVE_USER_FIELDS,
+    })
   }
 
   @Post()
   @Roles(UserRole.admin)
-  create(@Body() body: AdminCreateUserSchema) {
-    return this.usersService.createUser(body)
+  async create(@Body() body: AdminCreateUserSchema) {
+    const { id } = await this.usersService.createUser(body)
+    return this.usersService.findUniqueOrThrow({
+      where: { id },
+      omit: SENSITIVE_USER_FIELDS,
+    })
   }
 
   @Post('impersonate/:id')


### PR DESCRIPTION
Prevents password and password reset tokens from being exposed in admin user list, detail, and create endpoints by omitting these fields from all service responses.

**Changes:**
- Added `SENSITIVE_USER_FIELDS` constant to define fields that should never be returned to clients (password, passwordResetToken)
- Updated `list()` endpoint to omit sensitive fields for both all-time and date-filtered queries
- Updated `get()` endpoint to omit sensitive fields when fetching a single user by ID
- Updated `create()` endpoint to fetch and return the created user with sensitive fields omitted, rather than returning the raw creation response

**Implementation details:**
- Uses the `omit` parameter supported by the underlying `usersService` methods (Prisma-based)
- Consistent application across all three user retrieval endpoints
- Removed unnecessary comment about input validation in the date range logic

https://claude.ai/code/session_019G9pofLB8rjDYtUCPx71wR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows API exposure of credentials-related columns on admin-only routes; behavior change is intentional hardening with no new auth paths.
> 
> **Overview**
> Admin user **list**, **get**, and **create** responses no longer include `password` or `passwordResetToken`. A shared `SENSITIVE_USER_FIELDS` constant is passed as Prisma `omit` on `findMany` / `findUniqueOrThrow` for those routes.
> 
> **Create** now re-fetches the new user by id with `omit` instead of returning the raw `createUser` payload. A minor cleanup removes an obsolete comment on invalid date-range handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab041a6d65c029270a4aed9e473fc959069fe36. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->