### PR TITLE
feat(domains): update supported TLDs and enhance domain search descri…

### DIFF
--- a/src/websites/controllers/domains.controller.test.ts
+++ b/src/websites/controllers/domains.controller.test.ts
@@ -214,6 +214,22 @@ describe('DomainsController.purchaseDomain', () => {
     })
     expect(overCeilingResult.success).toBe(false)
   })
+
+  it('PurchaseDomainBodySchema rejects domains outside the TLD allowlist', () => {
+    const approved = PurchaseDomainBodySchema.schema.safeParse({
+      domain: 'voteforjane.site',
+      maxPrice: 50,
+    })
+    expect(approved.success).toBe(true)
+
+    for (const domain of ['voteforjane.com', 'voteforjane.org']) {
+      const result = PurchaseDomainBodySchema.schema.safeParse({
+        domain,
+        maxPrice: 50,
+      })
+      expect(result.success).toBe(false)
+    }
+  })
 })
 
 describe('DomainsController.purchaseDomain MCP discoverability', () => {

--- a/src/websites/controllers/domains.controller.ts
+++ b/src/websites/controllers/domains.controller.ts
@@ -11,7 +11,7 @@ import {
   Query,
   UsePipes,
 } from '@nestjs/common'
-import { DomainsService } from '../services/domains.service'
+import { DomainsService, SUPPORTED_TLDS } from '../services/domains.service'
 import { PaymentStatus } from 'src/payments/payments.types'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { SearchDomainSchema } from '../schemas/SearchDomain.schema'
@@ -62,13 +62,16 @@ export class DomainsController {
   @ResponseSchema(SearchDomainsResponseSchema)
   @McpTool({
     description:
-      'Find available .com / .org / .vote domains for the calling ' +
-      'campaign matching one or more name patterns, under a per-domain ' +
-      'price cap. Use during the compliance_setup flow after the ' +
-      "candidate's profile is saved, to pick a domain before purchase. " +
-      'Patterns are literal candidate domain strings without TLD ' +
-      '(e.g. ["janeforsenate", "voteforjane"]); the server checks ' +
-      'availability across supported TLDs and returns { candidates: ' +
+      'Find available campaign domains for the calling campaign ' +
+      'matching one or more name patterns, under a per-domain price ' +
+      'cap. Only GoodParty-approved campaign TLDs are searched: ' +
+      `${SUPPORTED_TLDS.map((tld) => `.${tld}`).join(' / ')} — ` +
+      '.com/.org/.net are never offered. Use during the ' +
+      "compliance_setup flow after the candidate's profile is saved, " +
+      'to pick a domain before purchase. Patterns may be bare SLDs ' +
+      '(e.g. ["janeforsenate", "voteforjane"]), which the server fans ' +
+      'out across all approved TLDs, or include an explicit approved ' +
+      'TLD (e.g. "janeforsenate.run"). Returns { candidates: ' +
       '[{ domain, price }] } for ranking. Returns only available ' +
       'domains; an empty candidates list means nothing matched under ' +
       'the cap. Read-only; safe to retry.',

--- a/src/websites/controllers/domains.controller.ts
+++ b/src/websites/controllers/domains.controller.ts
@@ -11,7 +11,7 @@ import {
   Query,
   UsePipes,
 } from '@nestjs/common'
-import { DomainsService, SUPPORTED_TLDS } from '../services/domains.service'
+import { DomainsService } from '../services/domains.service'
 import { PaymentStatus } from 'src/payments/payments.types'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { SearchDomainSchema } from '../schemas/SearchDomain.schema'
@@ -33,6 +33,7 @@ import {
   DomainOperationType,
   DomainStatusResponse,
   PatternedDomainSearchResult,
+  SUPPORTED_TLDS,
 } from '../domains.types'
 import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
 import { McpTool } from '@/mcp/decorators/McpTool.decorator'

--- a/src/websites/domains.types.ts
+++ b/src/websites/domains.types.ts
@@ -30,6 +30,29 @@ export interface PatternedDomainSearchResult {
   candidates: PatternedDomainCandidate[]
 }
 
+// GoodParty's approved campaign TLD allowlist. Must stay in sync with the
+// compliance_setup agent instruction (runbooks experiments/compliance_setup/
+// instruction.md), which rejects any out-of-allowlist TLD as
+// `unapproved_tld_returned`. .com/.org/.net/.vote are intentionally excluded.
+// Both the search fan-out and the purchase boundary enforce this list, so the
+// `@McpTool` "never offered" promise holds for every code path.
+export const SUPPORTED_TLDS = [
+  'run',
+  'bio',
+  'fyi',
+  'win',
+  'digital',
+  'site',
+] as const
+
+const SUPPORTED_TLD_SET: ReadonlySet<string> = new Set(SUPPORTED_TLDS)
+
+// True when `value`'s TLD (the segment after the last dot) is approved. A bare
+// SLD with no dot returns false — it carries no TLD to approve.
+export const hasSupportedTld = (value: string): boolean =>
+  value.includes('.') &&
+  SUPPORTED_TLD_SET.has(value.slice(value.lastIndexOf('.') + 1))
+
 // Enum for domain operation statuses
 export enum DomainOperationStatus {
   SUBMITTED = 'SUBMITTED',

--- a/src/websites/schemas/PurchaseDomain.schema.ts
+++ b/src/websites/schemas/PurchaseDomain.schema.ts
@@ -2,13 +2,25 @@ import { DomainStatus } from '@prisma/client'
 import { createZodDto } from 'nestjs-zod'
 import { isFQDN } from 'validator'
 import { z } from 'zod'
+import { hasSupportedTld, SUPPORTED_TLDS } from '../domains.types'
 
 export class PurchaseDomainBodySchema extends createZodDto(
   z.object({
-    domain: z.string().refine((v) => isFQDN(v), {
-      message:
-        'Invalid domain format. Must be a Fully Qualified Domain Name (e.g., example.com or foo.example.com)',
-    }),
+    domain: z
+      .string()
+      .refine((v) => isFQDN(v), {
+        message:
+          'Invalid domain format. Must be a Fully Qualified Domain Name (e.g., example.com or foo.example.com)',
+      })
+      // The search fan-out already restricts results to the allowlist, but
+      // purchase takes a caller-supplied domain directly — enforce the same
+      // allowlist here so the irreversible, paid path can't buy an excluded
+      // TLD (matches the searchDomains @McpTool "never offered" contract).
+      .refine((v) => hasSupportedTld(v), {
+        message: `Domain TLD must be one of: ${SUPPORTED_TLDS.map(
+          (tld) => `.${tld}`,
+        ).join(', ')}`,
+      }),
     // Defense-in-depth ceiling: caller-supplied cap can't be larger than this.
     // Standard campaign domains run ~$10–30; premium TLDs occasionally $50–90.
     // $100 leaves headroom while bounding the blast radius of a compromised

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -477,10 +477,24 @@ describe('DomainsService', () => {
         (c) => c[0] as string,
       )
       expect(tried.sort()).toEqual(
-        ['voteforoneill.com', 'voteforoneill.org', 'voteforoneill.vote'].sort(),
+        [
+          'voteforoneill.run',
+          'voteforoneill.bio',
+          'voteforoneill.fyi',
+          'voteforoneill.win',
+          'voteforoneill.digital',
+          'voteforoneill.site',
+        ].sort(),
       )
       expect(result.candidates.map((c) => c.domain).sort()).toEqual(
-        ['voteforoneill.com', 'voteforoneill.org', 'voteforoneill.vote'].sort(),
+        [
+          'voteforoneill.run',
+          'voteforoneill.bio',
+          'voteforoneill.fyi',
+          'voteforoneill.win',
+          'voteforoneill.digital',
+          'voteforoneill.site',
+        ].sort(),
       )
     })
 
@@ -510,7 +524,7 @@ describe('DomainsService', () => {
 
       await service.searchDomainsForCampaign(
         campaignWithUser,
-        ['voteoneill', 'voteoneill.com'],
+        ['voteoneill', 'voteoneill.run'],
         10,
       )
 
@@ -518,7 +532,14 @@ describe('DomainsService', () => {
         (c) => c[0] as string,
       )
       expect(tried.sort()).toEqual(
-        ['voteoneill.com', 'voteoneill.org', 'voteoneill.vote'].sort(),
+        [
+          'voteoneill.run',
+          'voteoneill.bio',
+          'voteoneill.fyi',
+          'voteoneill.win',
+          'voteoneill.digital',
+          'voteoneill.site',
+        ].sort(),
       )
     })
 

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -516,6 +516,25 @@ describe('DomainsService', () => {
       expect(tried).toEqual(['vote-oneill.run'])
     })
 
+    it('drops dot-containing patterns whose TLD is not on the allowlist', async () => {
+      mockRoute53.checkDomainAvailability.mockResolvedValue({
+        Availability: DomainAvailability.AVAILABLE,
+      })
+      mockVercel.checkDomainPrice.mockResolvedValue({ price: 5 })
+
+      const result = await service.searchDomainsForCampaign(
+        campaignWithUser,
+        ['voteoneill.com', 'voteoneill.org', 'voteoneill.run'],
+        10,
+      )
+
+      const tried = mockRoute53.checkDomainAvailability.mock.calls.map(
+        (c) => c[0] as string,
+      )
+      expect(tried).toEqual(['voteoneill.run'])
+      expect(result.candidates.map((c) => c.domain)).toEqual(['voteoneill.run'])
+    })
+
     it('dedupes after fan-out when bare and TLD-bearing patterns overlap', async () => {
       mockRoute53.checkDomainAvailability.mockResolvedValue({
         Availability: DomainAvailability.AVAILABLE,

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -44,8 +44,10 @@ import { EVENTS } from 'src/vendors/segment/segment.types'
 import {
   DomainPurchaseMetadata,
   DomainSearchResult,
+  hasSupportedTld,
   PatternedDomainCandidate,
   PatternedDomainSearchResult,
+  SUPPORTED_TLDS,
 } from '../domains.types'
 import { RegisterDomainSchema } from '../schemas/RegisterDomain.schema'
 import {
@@ -55,19 +57,6 @@ import {
 import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 
 const MAX_PATTERN_CANDIDATES = 50
-
-// GoodParty's approved campaign TLD allowlist. Must stay in sync with the
-// compliance_setup agent instruction (runbooks experiments/compliance_setup/
-// instruction.md), which rejects any out-of-allowlist TLD as
-// `unapproved_tld_returned`. .com/.org/.net/.vote are intentionally excluded.
-export const SUPPORTED_TLDS = [
-  'run',
-  'bio',
-  'fyi',
-  'win',
-  'digital',
-  'site',
-] as const
 
 const DOMAIN_PURCHASE_ADVISORY_LOCK_KEY = 918_275
 
@@ -454,12 +443,16 @@ export class DomainsService
     // bare SLD patterns (no TLD) and the server fans them out across the
     // supported TLDs. Patterns that already include a TLD are passed through
     // unchanged so existing alternation syntax (e.g. `vote-x.(run|bio)`)
-    // keeps working.
+    // keeps working — but only when that TLD is on the allowlist, so an
+    // explicit `candidate.com` can't bypass the "never offered" promise.
     const candidates = Array.from(
       new Set(
-        expanded.flatMap((c) =>
-          c.includes('.') ? [c] : SUPPORTED_TLDS.map((tld) => `${c}.${tld}`),
-        ),
+        expanded.flatMap((c) => {
+          if (!c.includes('.')) {
+            return SUPPORTED_TLDS.map((tld) => `${c}.${tld}`)
+          }
+          return hasSupportedTld(c) ? [c] : []
+        }),
       ),
     )
 

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -56,7 +56,18 @@ import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 
 const MAX_PATTERN_CANDIDATES = 50
 
-const SUPPORTED_TLDS = ['com', 'org', 'vote'] as const
+// GoodParty's approved campaign TLD allowlist. Must stay in sync with the
+// compliance_setup agent instruction (runbooks experiments/compliance_setup/
+// instruction.md), which rejects any out-of-allowlist TLD as
+// `unapproved_tld_returned`. .com/.org/.net/.vote are intentionally excluded.
+export const SUPPORTED_TLDS = [
+  'run',
+  'bio',
+  'fyi',
+  'win',
+  'digital',
+  'site',
+] as const
 
 const DOMAIN_PURCHASE_ADVISORY_LOCK_KEY = 918_275
 


### PR DESCRIPTION
…ption

- Revised the list of supported TLDs to include only GoodParty-approved options: .run, .bio, .fyi, .win, .digital, and .site, excluding .com, .org, and .vote.
- Updated the domain search description in the DomainsController to reflect the new TLDs and clarify the search behavior for campaign domains.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which domains compliance_setup and Pro campaigns can discover and buy; misalignment with the runbook would cause agent validation failures or wrong offerings.
> 
> **Overview**
> Campaign domain search now **fans bare name patterns out only across GoodParty-approved TLDs** (`.run`, `.bio`, `.fyi`, `.win`, `.digital`, `.site`) instead of `.com` / `.org` / `.vote`. The allowlist is **`export`ed** from `domains.service` with a note to keep it aligned with the compliance_setup agent runbook.
> 
> The **POST `/domains/search` MCP tool description** is updated to list those TLDs dynamically, state that `.com` / `.org` / `.net` are never offered, and clarify bare-SLD vs explicit-TLD pattern behavior. **Unit tests** for fan-out and dedupe expectations match the new TLD set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b55d093775faaa88c9033b2e9d3e7f7eb115de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->