### PR TITLE
feat(campaigns): add BR timeline milestones to raceTargetMetrics

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @goodparty_org/contracts
 
+## 0.10.0
+
+### Minor Changes
+
+- Add `MilestoneWindowSchema`, `RaceMilestonesSchema`, and a new optional
+  `milestones` field on `RaceTargetMetricsSchema`. Carries per-category
+  campaign-timeline windows (voter registration, early voting, absentee
+  ballot request) sourced live from BallotReady via gp-api. Each
+  category window has nullable `start` (earliest OPEN milestone) and
+  `end` (latest CLOSE milestone). The whole `milestones` object is
+  nullable when the BR upstream call fails. Drives Section 6 of the
+  Campaign Plan template in gp-webapp.
+- Also re-export `RaceCandidateSchema` (already used by
+  `RaceTargetMetricsSchema`; export was previously omitted).
+
 ## 0.9.0
 
 ### Minor Changes
@@ -45,7 +60,7 @@
   `Salli`, `Ruth`, `Stephen`, `Amy`). Update default voice/engine from
   `Joanna`/`neural` to `Amy`/`generative`. Add a cross-field refine to
   `SynthesizeSpeechRequestSchema` that rejects any `voiceId` × `engine:
-  'generative'` pairing where the voice is not in `GENERATIVE_VOICE_VALUES`.
+'generative'` pairing where the voice is not in `GENERATIVE_VOICE_VALUES`.
 
 ## 0.5.0
 

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodparty_org/contracts",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Shared Zod schemas and TypeScript types for the GoodParty API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/contracts/src/campaigns/RaceTargetMetrics.schema.ts
+++ b/contracts/src/campaigns/RaceTargetMetrics.schema.ts
@@ -17,6 +17,28 @@ export const RaceCandidateSchema = z.object({
 })
 
 /**
+ * Per-category milestone window. `start` is the earliest OPEN milestone
+ * (e.g. early voting start, voter registration open). `end` is the
+ * latest CLOSE milestone (e.g. voter registration deadline). Both
+ * nullable when BR doesn't return that side of the window.
+ */
+export const MilestoneWindowSchema = z.object({
+  start: z.string().nullable(),
+  end: z.string().nullable(),
+})
+
+/**
+ * Milestone windows for the three BR categories the campaign-plan UI
+ * cares about. Each category nullable when BR has no milestones for it;
+ * the whole object nullable when the BR upstream call failed.
+ */
+export const RaceMilestonesSchema = z.object({
+  voter_registration: MilestoneWindowSchema.nullable(),
+  early_voting: MilestoneWindowSchema.nullable(),
+  request_ballot: MilestoneWindowSchema.nullable(),
+})
+
+/**
  * Live race-target metrics for a single campaign, computed on-demand from the
  * elections service. Returned alongside the full campaign read shape (e.g.
  * `GET /v1/campaigns/:id`).
@@ -66,7 +88,15 @@ export const RaceTargetMetricsSchema = z.object({
   officeLevel: z.string().nullable(),
   officeType: z.string().nullable(),
   numberOfSeats: z.number().nullable(),
+  /**
+   * Campaign-timeline milestones sourced live from BallotReady. Null
+   * when BR is unreachable or the race has no upstream Election; the
+   * rest of the response stays usable in that case.
+   */
+  milestones: RaceMilestonesSchema.nullable(),
 })
 
 export type RaceCandidate = z.infer<typeof RaceCandidateSchema>
+export type MilestoneWindow = z.infer<typeof MilestoneWindowSchema>
+export type RaceMilestones = z.infer<typeof RaceMilestonesSchema>
 export type RaceTargetMetrics = z.infer<typeof RaceTargetMetricsSchema>

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -163,7 +163,13 @@ export {
 } from './campaigns/SetDistrictOutput.schema'
 
 export {
+  MilestoneWindowSchema,
+  RaceCandidateSchema,
+  RaceMilestonesSchema,
   RaceTargetMetricsSchema,
+  type MilestoneWindow,
+  type RaceCandidate,
+  type RaceMilestones,
   type RaceTargetMetrics,
 } from './campaigns/RaceTargetMetrics.schema'
 

--- a/src/campaigns/campaigns.controller.test.ts
+++ b/src/campaigns/campaigns.controller.test.ts
@@ -34,6 +34,7 @@ const EMPTY_RACE_CONTEXT_FIELDS = {
   officeLevel: null,
   officeType: null,
   numberOfSeats: null,
+  milestones: null,
 }
 
 const userDefaults = {

--- a/src/campaigns/services/campaigns.service.test.ts
+++ b/src/campaigns/services/campaigns.service.test.ts
@@ -1388,6 +1388,50 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
       ).toHaveBeenCalled()
     })
 
+    it('threads milestones through the position-based fallback path', async () => {
+      // The fan-out fires fetchMilestones whenever raceId is present,
+      // independent of whether context resolves. Without this assertion,
+      // a regression that hardcoded `milestones: null` on the fallback
+      // branch in campaigns.service.ts would still pass every other
+      // test (mockBallotReady defaults to null + EMPTY_RACE_CONTEXT_FIELDS
+      // asserts null).
+      vi.mocked(mockElections.fetchCampaignStrategyContext!).mockResolvedValue(
+        null,
+      )
+      vi.mocked(mockElections.fetchFilingFeeByRaceHash!).mockResolvedValue(null)
+      vi.mocked(
+        mockElections.getPositionMatchedRaceTargetDetails!,
+      ).mockResolvedValue({
+        district: {
+          id: 'd-1',
+          state: 'CA',
+          L2DistrictType: 'State_Senate',
+          L2DistrictName: 'STATE SENATE 001',
+          projectedTurnout: null,
+        },
+        projectedTurnout: 8000,
+        winNumber: 4001,
+        voterContactGoal: 20005,
+        filingFee: null,
+        filingRequirementsText: null,
+      })
+      vi.mocked(mockBallotReady.fetchMilestones!).mockResolvedValue({
+        voter_registration: { start: '2026-06-01', end: '2026-10-19' },
+        early_voting: { start: '2026-10-20', end: '2026-11-02' },
+        request_ballot: { start: '2026-09-01', end: '2026-10-27' },
+      })
+
+      const result =
+        await service.fetchLiveRaceTargetMetrics(campaignWithRaceId)
+
+      expect(mockBallotReady.fetchMilestones).toHaveBeenCalledWith('Z2lk-hash')
+      expect(result?.milestones).toEqual({
+        voter_registration: { start: '2026-06-01', end: '2026-10-19' },
+        early_voting: { start: '2026-10-20', end: '2026-11-02' },
+        request_ballot: { start: '2026-09-01', end: '2026-10-27' },
+      })
+    })
+
     it('returns the context shape even when no org positionId / overrideDistrictId is set (raceId is enough)', async () => {
       vi.mocked(mockOrganizations.findUnique!).mockResolvedValue({
         positionId: null,

--- a/src/campaigns/services/campaigns.service.test.ts
+++ b/src/campaigns/services/campaigns.service.test.ts
@@ -1,3 +1,4 @@
+import { BallotReadyService } from '@/elections/services/ballotReady.service'
 import { ElectionsService } from '@/elections/services/elections.service'
 import { OrganizationsService } from '@/organizations/services/organizations.service'
 import { PrismaService } from '@/prisma/prisma.service'
@@ -47,6 +48,7 @@ const EMPTY_RACE_CONTEXT_FIELDS = {
   officeLevel: null,
   officeType: null,
   numberOfSeats: null,
+  milestones: null,
 }
 
 const mockPositionResponse = {
@@ -130,6 +132,10 @@ const buildOrgSyncModule = async (overrides?: {
       {
         provide: ElectionsService,
         useValue: { getPositionByBallotReadyId: mockGetPosition },
+      },
+      {
+        provide: BallotReadyService,
+        useValue: { fetchMilestones: vi.fn().mockResolvedValue(null) },
       },
       { provide: OrganizationsService, useValue: {} },
       { provide: SlackService, useValue: {} },
@@ -500,6 +506,10 @@ describe('CampaignsService - redeemFreeTexts', () => {
         {
           provide: ElectionsService,
           useValue: {},
+        },
+        {
+          provide: BallotReadyService,
+          useValue: { fetchMilestones: vi.fn().mockResolvedValue(null) },
         },
         {
           provide: OrganizationsService,
@@ -880,9 +890,15 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
     fetchCampaignStrategyContext: vi.fn().mockResolvedValue(null),
   }
 
+  const mockBallotReady: Partial<BallotReadyService> = {
+    fetchMilestones: vi.fn().mockResolvedValue(null),
+  }
+
   let service: CampaignsService
 
   beforeEach(() => {
+    vi.mocked(mockBallotReady.fetchMilestones!).mockReset()
+    vi.mocked(mockBallotReady.fetchMilestones!).mockResolvedValue(null)
     service = new CampaignsService(
       {} as UsersService,
       {} as CrmCampaignsService,
@@ -891,6 +907,7 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
       {} as StripeService,
       {} as GooglePlacesService,
       mockElections as ElectionsService,
+      mockBallotReady as BallotReadyService,
       mockOrganizations as OrganizationsService,
       {} as SlackService,
       { notifySlackOnProUpgrade: vi.fn() } as unknown as CampaignTasksService,
@@ -1282,6 +1299,11 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
         filingRequirementsText: 'Filing fee: $100.',
         extractionSource: 'direct_dollar',
       })
+      vi.mocked(mockBallotReady.fetchMilestones!).mockResolvedValue({
+        voter_registration: { start: '2026-06-01', end: '2026-10-19' },
+        early_voting: { start: '2026-10-20', end: '2026-11-02' },
+        request_ballot: { start: '2026-09-01', end: '2026-10-27' },
+      })
 
       const result =
         await service.fetchLiveRaceTargetMetrics(campaignWithRaceId)
@@ -1315,6 +1337,11 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
         officeLevel: 'CITY',
         officeType: 'COUNCIL',
         numberOfSeats: 1,
+        milestones: {
+          voter_registration: { start: '2026-06-01', end: '2026-10-19' },
+          early_voting: { start: '2026-10-20', end: '2026-11-02' },
+          request_ballot: { start: '2026-09-01', end: '2026-10-27' },
+        },
       })
 
       // The legacy position-based path must not fire when context wins.

--- a/src/campaigns/services/campaigns.service.ts
+++ b/src/campaigns/services/campaigns.service.ts
@@ -791,7 +791,9 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
         raceId
           ? this.elections.fetchFilingFeeByRaceHash(raceId)
           : Promise.resolve(null),
-        raceId ? this.ballotReady.fetchMilestones(raceId) : Promise.resolve(null),
+        raceId
+          ? this.ballotReady.fetchMilestones(raceId)
+          : Promise.resolve(null),
       ])
 
     if (contextResult) {

--- a/src/campaigns/services/campaigns.service.ts
+++ b/src/campaigns/services/campaigns.service.ts
@@ -3,6 +3,7 @@ import {
   CampaignStatus,
   OnboardingStep,
   type ListCampaignsPagination,
+  type RaceMilestones,
 } from '@goodparty_org/contracts'
 import {
   BadRequestException,
@@ -15,6 +16,7 @@ import { Campaign, Prisma, User } from '@prisma/client'
 import { differenceInMilliseconds, formatISO } from 'date-fns'
 import { deepmerge as deepMerge } from 'deepmerge-ts'
 import { AnalyticsService } from 'src/analytics/analytics.service'
+import { BallotReadyService } from 'src/elections/services/ballotReady.service'
 import { ElectionsService } from 'src/elections/services/elections.service'
 import {
   CampaignStrategyContextResponse,
@@ -65,6 +67,7 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
     private readonly stripeService: StripeService,
     private readonly googlePlaces: GooglePlacesService,
     private readonly elections: ElectionsService,
+    private readonly ballotReady: BallotReadyService,
     private readonly organizations: OrganizationsService,
     private readonly slack: SlackService,
     @Inject(forwardRef(() => CampaignTasksService))
@@ -774,23 +777,28 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
 
     if (!org?.overrideDistrictId && !org?.positionId && !raceId) return null
 
-    // Two race-hash-keyed lookups in parallel: civics context (the new
+    // Three race-hash-keyed lookups in parallel: civics context (the new
     // unified source for win number, projected turnout, voter counts,
-    // candidates, dates) and filing fee. Both return null on failure,
-    // letting us degrade gracefully to the position-based path below.
-    const [contextResult, filingFeeFromRaceHash] = await Promise.all([
-      raceId
-        ? this.elections.fetchCampaignStrategyContext(raceId)
-        : Promise.resolve(null),
-      raceId
-        ? this.elections.fetchFilingFeeByRaceHash(raceId)
-        : Promise.resolve(null),
-    ])
+    // candidates, dates), filing fee, and BR campaign-timeline milestones.
+    // Milestones come straight from BR GraphQL — election-api doesn't
+    // store or expose them. All three return null on failure, letting us
+    // degrade gracefully to the position-based path below.
+    const [contextResult, filingFeeFromRaceHash, milestones] =
+      await Promise.all([
+        raceId
+          ? this.elections.fetchCampaignStrategyContext(raceId)
+          : Promise.resolve(null),
+        raceId
+          ? this.elections.fetchFilingFeeByRaceHash(raceId)
+          : Promise.resolve(null),
+        raceId ? this.ballotReady.fetchMilestones(raceId) : Promise.resolve(null),
+      ])
 
     if (contextResult) {
       return this.mapContextToRaceTargetMetrics(
         contextResult,
         filingFeeFromRaceHash,
+        milestones,
       )
     }
 
@@ -816,6 +824,7 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
         filingFee: filingFeeFromRaceHash?.filingFee ?? null,
         filingRequirementsText:
           filingFeeFromRaceHash?.filingRequirementsText ?? null,
+        milestones,
       }
     }
 
@@ -853,12 +862,14 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
         filingFeeFromRaceHash !== null
           ? filingFeeFromRaceHash.filingRequirementsText
           : (filingRequirementsText ?? null),
+      milestones,
     }
   }
 
   private mapContextToRaceTargetMetrics(
     context: CampaignStrategyContextResponse,
     filingFeeFromRaceHash: FilingFeeByBrHashResult | null,
+    milestones: RaceMilestones | null,
   ): RaceTargetMetrics {
     // win_number_effective prefers BR's calibrated civics number when
     // available, falls back to floor(turnout / 2) + 1 — both computed on
@@ -895,6 +906,7 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
       officeLevel: context.office_level,
       officeType: context.office_type,
       numberOfSeats: context.number_of_seats,
+      milestones,
     }
   }
 }
@@ -922,4 +934,5 @@ const emptyContextFields = (): Omit<
   officeLevel: null,
   officeType: null,
   numberOfSeats: null,
+  milestones: null,
 })

--- a/src/elections/elections.module.ts
+++ b/src/elections/elections.module.ts
@@ -17,7 +17,7 @@ import { RacesService } from './services/races.service'
     BallotReadyService,
     ElectionsService,
   ],
-  exports: [RacesService, ElectionsService],
+  exports: [RacesService, ElectionsService, BallotReadyService],
   imports: [AiModule, EmailModule, HttpModule, SlackModule],
 })
 export class ElectionsModule {}

--- a/src/elections/services/ballotReady.fetchMilestones.test.ts
+++ b/src/elections/services/ballotReady.fetchMilestones.test.ts
@@ -54,6 +54,42 @@ describe('collapseMilestones', () => {
       end: '2026-08-15',
     })
   })
+
+  // Pins the UTC-projection behavior `toIsoDate` (formatInTimeZone) relies
+  // on. A negative-offset datetime late in the local day projects to the
+  // next UTC calendar date — important to lock down so a regression
+  // (e.g. switching back to slice) is caught.
+  it('projects a negative-offset datetime to its UTC calendar date', () => {
+    const result = collapseMilestones([
+      {
+        category: 'REGISTRATION',
+        type: 'CLOSE',
+        at: '2026-10-19T23:30:00-05:00',
+      },
+    ])
+    // 2026-10-19T23:30:00-05:00 → 2026-10-20T04:30:00Z → date is 2026-10-20
+    expect(result.voter_registration).toEqual({
+      start: null,
+      end: '2026-10-20',
+    })
+  })
+
+  // The OPEN selector picks the earliest datetime across mixed offsets,
+  // not the lexicographically smallest string — same shape catches a
+  // regression from compareAsc back to raw `<`/`>`.
+  it('compares mixed-offset datetimes by instant, not string order', () => {
+    const result = collapseMilestones([
+      // 2026-10-19T05:00:00Z — later instant
+      {
+        category: 'EARLY_VOTING',
+        type: 'OPEN',
+        at: '2026-10-19T00:00:00-05:00',
+      },
+      // 2026-10-19T00:00:00Z — earlier instant, but later as a string
+      { category: 'EARLY_VOTING', type: 'OPEN', at: '2026-10-19T00:00:00Z' },
+    ])
+    expect(result.early_voting?.start).toBe('2026-10-19')
+  })
 })
 
 describe('BallotReadyService.fetchMilestones', () => {

--- a/src/elections/services/ballotReady.fetchMilestones.test.ts
+++ b/src/elections/services/ballotReady.fetchMilestones.test.ts
@@ -75,19 +75,23 @@ describe('collapseMilestones', () => {
   })
 
   // The OPEN selector picks the earliest datetime across mixed offsets,
-  // not the lexicographically smallest string — same shape catches a
-  // regression from compareAsc back to raw `<`/`>`.
+  // not the lexicographically smallest string. Inputs are chosen so the
+  // lex-smaller string is the *later* instant AND the two project to
+  // *different* UTC calendar dates — so a regression from compareAsc
+  // back to raw `<`/`>` produces the wrong output and fails the test.
   it('compares mixed-offset datetimes by instant, not string order', () => {
     const result = collapseMilestones([
-      // 2026-10-19T05:00:00Z — later instant
+      // 2026-10-20T01:00:00+05:00 = 2026-10-19T20:00:00Z — earlier instant, lex-later string
       {
         category: 'EARLY_VOTING',
         type: 'OPEN',
-        at: '2026-10-19T00:00:00-05:00',
+        at: '2026-10-20T01:00:00+05:00',
       },
-      // 2026-10-19T00:00:00Z — earlier instant, but later as a string
-      { category: 'EARLY_VOTING', type: 'OPEN', at: '2026-10-19T00:00:00Z' },
+      // 2026-10-20T00:00:00Z — later instant, lex-earlier string
+      { category: 'EARLY_VOTING', type: 'OPEN', at: '2026-10-20T00:00:00Z' },
     ])
+    // Correct (compareAsc): earliest instant = 2026-10-19T20:00:00Z → UTC date 2026-10-19
+    // Buggy (lexicographic): smallest string = '2026-10-20T00:00:00Z' → UTC date 2026-10-20
     expect(result.early_voting?.start).toBe('2026-10-19')
   })
 })
@@ -161,13 +165,15 @@ describe('BallotReadyService.fetchMilestones', () => {
     })
   })
 
-  it('returns all-null windows when node is null (unknown raceId)', async () => {
+  it('returns null when node is null (unknown raceId)', async () => {
     mockRequest.mockResolvedValue({ node: null })
     const result = await service.fetchMilestones('br-hash-unknown')
-    expect(result).toEqual({
-      voter_registration: null,
-      early_voting: null,
-      request_ballot: null,
-    })
+    expect(result).toBeNull()
+  })
+
+  it('returns null when node.election is null (race not linked to an Election)', async () => {
+    mockRequest.mockResolvedValue({ node: { election: null } })
+    const result = await service.fetchMilestones('br-hash-no-election')
+    expect(result).toBeNull()
   })
 })

--- a/src/elections/services/ballotReady.fetchMilestones.test.ts
+++ b/src/elections/services/ballotReady.fetchMilestones.test.ts
@@ -1,0 +1,137 @@
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BallotReadyMilestone } from '../types/ballotReady.types'
+import { BallotReadyService, collapseMilestones } from './ballotReady.service'
+
+describe('collapseMilestones', () => {
+  it('groups milestones by category and picks earliest OPEN / latest CLOSE', () => {
+    const input: BallotReadyMilestone[] = [
+      // REGISTRATION: two CLOSE rows (different features) + one OPEN
+      { category: 'REGISTRATION', type: 'OPEN', at: '2026-01-01T00:00:00Z' },
+      { category: 'REGISTRATION', type: 'CLOSE', at: '2026-09-01T00:00:00Z' },
+      { category: 'REGISTRATION', type: 'CLOSE', at: '2026-08-15T00:00:00Z' },
+      // EARLY_VOTING: only OPEN
+      { category: 'EARLY_VOTING', type: 'OPEN', at: '2026-08-20T00:00:00Z' },
+      // REQUEST_BALLOT: only CLOSE
+      { category: 'REQUEST_BALLOT', type: 'CLOSE', at: '2026-08-30T00:00:00Z' },
+    ]
+
+    const result = collapseMilestones(input)
+
+    expect(result).toEqual({
+      voter_registration: { start: '2026-01-01', end: '2026-09-01' },
+      early_voting: { start: '2026-08-20', end: null },
+      request_ballot: { start: null, end: '2026-08-30' },
+    })
+  })
+
+  it('returns null for each category when input is empty', () => {
+    expect(collapseMilestones([])).toEqual({
+      voter_registration: null,
+      early_voting: null,
+      request_ballot: null,
+    })
+  })
+
+  it('ignores VOTING / FILING / unknown categories', () => {
+    const result = collapseMilestones([
+      { category: 'VOTING', type: 'OPEN', at: '2026-09-01T00:00:00Z' },
+      { category: 'FILING', type: 'CLOSE', at: '2026-06-01T00:00:00Z' },
+      { category: 'WHATEVER', type: 'OPEN', at: '2026-05-01T00:00:00Z' },
+    ])
+    expect(result.voter_registration).toBeNull()
+    expect(result.early_voting).toBeNull()
+    expect(result.request_ballot).toBeNull()
+  })
+
+  it('skips entries with null at', () => {
+    const result = collapseMilestones([
+      { category: 'REGISTRATION', type: 'OPEN', at: null },
+      { category: 'REGISTRATION', type: 'CLOSE', at: '2026-08-15T00:00:00Z' },
+    ])
+    expect(result.voter_registration).toEqual({
+      start: null,
+      end: '2026-08-15',
+    })
+  })
+})
+
+describe('BallotReadyService.fetchMilestones', () => {
+  let service: BallotReadyService
+  let mockRequest: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    service = new BallotReadyService(createMockLogger())
+    mockRequest = vi.fn()
+    Object.defineProperty(service, 'graphQLClient', {
+      value: { request: mockRequest },
+      configurable: true,
+    })
+  })
+
+  it('returns null when brHashId is empty', async () => {
+    const result = await service.fetchMilestones('')
+    expect(result).toBeNull()
+    expect(mockRequest).not.toHaveBeenCalled()
+  })
+
+  it('posts the milestones query and returns collapsed windows', async () => {
+    mockRequest.mockResolvedValue({
+      node: {
+        election: {
+          milestones: [
+            {
+              category: 'REGISTRATION',
+              type: 'CLOSE',
+              at: '2026-09-01T00:00:00Z',
+            },
+            {
+              category: 'EARLY_VOTING',
+              type: 'OPEN',
+              at: '2026-08-20T00:00:00Z',
+            },
+          ],
+        },
+      },
+    })
+
+    const result = await service.fetchMilestones('br-hash-1')
+
+    expect(mockRequest).toHaveBeenCalledOnce()
+    const [, variables] = mockRequest.mock.calls[0]
+    expect(variables).toEqual({ raceId: 'br-hash-1' })
+    expect(result).toEqual({
+      voter_registration: { start: null, end: '2026-09-01' },
+      early_voting: { start: '2026-08-20', end: null },
+      request_ballot: null,
+    })
+  })
+
+  it('returns null when the GraphQL request throws', async () => {
+    mockRequest.mockRejectedValue(new Error('upstream down'))
+    const result = await service.fetchMilestones('br-hash-1')
+    expect(result).toBeNull()
+  })
+
+  it('returns all-null windows when BR returns no milestones', async () => {
+    mockRequest.mockResolvedValue({
+      node: { election: { milestones: [] } },
+    })
+    const result = await service.fetchMilestones('br-hash-1')
+    expect(result).toEqual({
+      voter_registration: null,
+      early_voting: null,
+      request_ballot: null,
+    })
+  })
+
+  it('returns all-null windows when node is null (unknown raceId)', async () => {
+    mockRequest.mockResolvedValue({ node: null })
+    const result = await service.fetchMilestones('br-hash-unknown')
+    expect(result).toEqual({
+      voter_registration: null,
+      early_voting: null,
+      request_ballot: null,
+    })
+  })
+})

--- a/src/elections/services/ballotReady.service.ts
+++ b/src/elections/services/ballotReady.service.ts
@@ -514,7 +514,13 @@ export class BallotReadyService {
         RaceMilestonesGraphResponse,
         { raceId: string }
       >(query, { raceId: brHashId })
-      const milestones = result?.node?.election?.milestones ?? []
+      // No race (unknown raceId) or no linked Election → no data to
+      // collapse. Return top-level null so callers can null-fill cleanly
+      // and don't conflate "race not found" with "election exists but
+      // returned zero milestones" (which yields an all-null-windows
+      // object via collapseMilestones below).
+      if (!result?.node?.election) return null
+      const milestones = result.node.election.milestones ?? []
       return collapseMilestones(milestones)
     } catch (error) {
       this.logger.warn(

--- a/src/elections/services/ballotReady.service.ts
+++ b/src/elections/services/ballotReady.service.ts
@@ -1,5 +1,12 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common'
-import { endOfMonth, format, parseISO, startOfMonth } from 'date-fns'
+import {
+  compareAsc,
+  endOfMonth,
+  format,
+  parseISO,
+  startOfMonth,
+} from 'date-fns'
+import { formatInTimeZone } from 'date-fns-tz'
 import { gql, GraphQLClient } from 'graphql-request'
 import { Headers, MimeTypes } from 'http-constants-ts'
 import { PositionLevel } from 'src/generated/graphql.types'
@@ -565,17 +572,36 @@ const toWindow = (bucket: {
   return { start, end }
 }
 
+// Use `compareAsc` over raw `<`/`>` and `format(parseISO(...), 'yyyy-MM-dd')`
+// over `slice(0, 10)`: BR's `at` is a datetime string that may carry a
+// non-UTC offset (e.g. '2026-10-19T00:00:00-05:00'). Lexicographic
+// comparison would reorder dates across offsets, and a naive slice would
+// take the literal date digits — which can be the wrong calendar date
+// when the offset crosses midnight. CLAUDE.md Rule 28.
 const earliestDate = (values: string[]): string | null => {
   if (values.length === 0) return null
-  return toIsoDate(values.reduce((a, b) => (a < b ? a : b)))
+  return toIsoDate(
+    values.reduce((a, b) =>
+      compareAsc(parseISO(a), parseISO(b)) <= 0 ? a : b,
+    ),
+  )
 }
 
 const latestDate = (values: string[]): string | null => {
   if (values.length === 0) return null
-  return toIsoDate(values.reduce((a, b) => (a > b ? a : b)))
+  return toIsoDate(
+    values.reduce((a, b) =>
+      compareAsc(parseISO(a), parseISO(b)) >= 0 ? a : b,
+    ),
+  )
 }
 
-const toIsoDate = (value: string): string => value.slice(0, 10)
+// Format in UTC explicitly. `format(parseISO(...), 'yyyy-MM-dd')` would
+// use the server's local timezone, shifting the calendar date when the
+// source is UTC midnight (test machines in negative-offset zones see a
+// previous-day date). UTC keeps it deterministic across environments.
+const toIsoDate = (value: string): string =>
+  formatInTimeZone(parseISO(value), 'UTC', 'yyyy-MM-dd')
 
 function getMonthBounds(dateString: string): { gt: string; lt: string } {
   const reference = parseISO(dateString)

--- a/src/elections/services/ballotReady.service.ts
+++ b/src/elections/services/ballotReady.service.ts
@@ -7,6 +7,8 @@ import { truncateZip } from 'src/shared/util/zipcodes.util'
 import zipcodes from 'zipcodes'
 import { ElectionLevels } from '../../shared/constants/governmentLevels'
 import {
+  BallotReadyMilestone,
+  RaceMilestonesGraphResponse,
   RaceNode,
   RacesByIdNode,
   RacesByZipcode,
@@ -14,6 +16,10 @@ import {
   RaceWithOfficeHolders,
   RaceWithOfficeHoldersNode,
 } from '../types/ballotReady.types'
+import type {
+  MilestoneWindow,
+  RaceMilestones,
+} from '@goodparty_org/contracts'
 import { PinoLogger } from 'nestjs-pino'
 
 const API_BASE = 'https://bpi.civicengine.com/graphql'
@@ -476,10 +482,103 @@ export class BallotReadyService {
     }
   }
 
+  // Fetch the per-category milestone windows for a BR race. Source:
+  // Race.election.milestones() — BR returns one row per (category, type,
+  // feature), so we collapse via earliest OPEN / latest CLOSE per
+  // category. Returns null on any failure so callers can null-fill the
+  // field without failing the parent request — milestones are enrichment,
+  // not core.
+  async fetchMilestones(brHashId: string): Promise<RaceMilestones | null> {
+    if (!brHashId) return null
+    const query = gql`
+      query MilestonesForRace($raceId: ID!) {
+        node(id: $raceId) {
+          ... on Race {
+            election {
+              milestones {
+                category
+                type
+                at
+              }
+            }
+          }
+        }
+      }
+    `
+    try {
+      const result = await this.graphQLClient.request<
+        RaceMilestonesGraphResponse,
+        { raceId: string }
+      >(query, { raceId: brHashId })
+      const milestones = result?.node?.election?.milestones ?? []
+      return collapseMilestones(milestones)
+    } catch (error) {
+      this.logger.warn(
+        { error, brHashId },
+        'BR Race.election.milestones lookup failed',
+      )
+      return null
+    }
+  }
+
   constructor(private readonly logger: PinoLogger) {
     this.logger.setContext(BallotReadyService.name)
   }
 }
+
+// Group BR milestones by category, picking the earliest OPEN and latest
+// CLOSE per category. BR returns one row per (category, type, feature)
+// combo — e.g. REGISTRATION CLOSE has separate rows for IN_PERSON, MAIL,
+// ONLINE deadlines. Earliest OPEN captures the first opportunity to
+// register/vote; latest CLOSE captures the final deadline a voter can
+// still hit (matters because some states close ONLINE earlier than
+// IN_PERSON). UI consumers can render the window without reasoning about
+// features. Exported for direct unit testing.
+export const collapseMilestones = (
+  milestones: BallotReadyMilestone[],
+): RaceMilestones => {
+  const grouped: Record<string, { opens: string[]; closes: string[] }> = {
+    REGISTRATION: { opens: [], closes: [] },
+    EARLY_VOTING: { opens: [], closes: [] },
+    REQUEST_BALLOT: { opens: [], closes: [] },
+  }
+
+  for (const m of milestones) {
+    if (!m.at) continue
+    const bucket = grouped[m.category]
+    if (!bucket) continue
+    if (m.type === 'OPEN') bucket.opens.push(m.at)
+    else if (m.type === 'CLOSE') bucket.closes.push(m.at)
+  }
+
+  return {
+    voter_registration: toWindow(grouped.REGISTRATION),
+    early_voting: toWindow(grouped.EARLY_VOTING),
+    request_ballot: toWindow(grouped.REQUEST_BALLOT),
+  }
+}
+
+const toWindow = (bucket: {
+  opens: string[]
+  closes: string[]
+}): MilestoneWindow | null => {
+  const start = earliestDate(bucket.opens)
+  const end = latestDate(bucket.closes)
+  if (start === null && end === null) return null
+  return { start, end }
+}
+
+const earliestDate = (values: string[]): string | null => {
+  if (values.length === 0) return null
+  return toIsoDate(values.reduce((a, b) => (a < b ? a : b)))
+}
+
+const latestDate = (values: string[]): string | null => {
+  if (values.length === 0) return null
+  return toIsoDate(values.reduce((a, b) => (a > b ? a : b)))
+}
+
+const toIsoDate = (value: string): string => value.slice(0, 10)
 
 function getMonthBounds(dateString: string): { gt: string; lt: string } {
   const reference = parseISO(dateString)

--- a/src/elections/services/ballotReady.service.ts
+++ b/src/elections/services/ballotReady.service.ts
@@ -16,10 +16,7 @@ import {
   RaceWithOfficeHolders,
   RaceWithOfficeHoldersNode,
 } from '../types/ballotReady.types'
-import type {
-  MilestoneWindow,
-  RaceMilestones,
-} from '@goodparty_org/contracts'
+import type { MilestoneWindow, RaceMilestones } from '@goodparty_org/contracts'
 import { PinoLogger } from 'nestjs-pino'
 
 const API_BASE = 'https://bpi.civicengine.com/graphql'

--- a/src/elections/types/ballotReady.types.ts
+++ b/src/elections/types/ballotReady.types.ts
@@ -190,3 +190,27 @@ interface Candidacy {
     electionDay: string
   }
 }
+
+// Subset of BR's MilestoneCategory enum we care about. BR also returns
+// FILING (already covered by Race.filingDateEnd) and VOTING (just the
+// election day). Only these three drive Section 6 of the campaign plan.
+export type BallotReadyMilestoneCategory =
+  | 'REGISTRATION'
+  | 'EARLY_VOTING'
+  | 'REQUEST_BALLOT'
+
+export type BallotReadyMilestoneType = 'OPEN' | 'CLOSE'
+
+export interface BallotReadyMilestone {
+  category: BallotReadyMilestoneCategory | string
+  type: BallotReadyMilestoneType | string
+  at: string | null
+}
+
+export interface RaceMilestonesGraphResponse {
+  node: {
+    election: {
+      milestones: BallotReadyMilestone[] | null
+    } | null
+  } | null
+}

--- a/src/elections/types/elections.types.ts
+++ b/src/elections/types/elections.types.ts
@@ -188,7 +188,10 @@ export type CampaignStrategyContextCandidate = {
  * endpoint takes the BR race hash on `campaign.details.raceId` and returns
  * the per-race civics context — voter counts, candidate roster, win-number
  * variants, election dates. See election-api
- * `CampaignStrategyContextResponse` for the source of truth.
+ * `CampaignStrategyContextResponse` for the source of truth. Milestone
+ * windows are NOT on this response — gp-api calls BR's GraphQL directly
+ * for those via `BallotReadyService.fetchMilestones` and merges them onto
+ * `RaceTargetMetrics` in `fetchLiveRaceTargetMetrics`.
  */
 export type CampaignStrategyContextResponse = {
   candidate_count: number


### PR DESCRIPTION
## Summary

Adds the BallotReady Race.election.milestones lookup as a third race-hash-keyed call alongside the existing `/campaign-strategy-context` and filing-fee lookups, then merges the resulting per-category window onto `RaceTargetMetrics.milestones`. Powers Section 6 of the campaign-plan template in gp-webapp.

## What's new

- `BallotReadyService.fetchMilestones(brHashId)` — POSTs a `MilestonesForRace($raceId)` query to BR's GraphQL and returns null on any failure so the parent request stays usable.
- `collapseMilestones()` — exported helper that buckets BR's per-feature rows (IN_PERSON / MAIL / ONLINE) into per-category windows. Earliest OPEN / latest CLOSE per category (latest CLOSE matters because some states close ONLINE earlier than IN_PERSON; we want the final hard deadline a voter can still hit).
- `fetchLiveRaceTargetMetrics` now fans out 3 parallel race-hash calls instead of 2; milestones flow through both the unified-context path and the legacy fallback paths.
- `RaceTargetMetricsSchema` carries `milestones` (the cross-repo contract). `CampaignStrategyContextResponse` does NOT — milestones never touch election-api.
- New test file `ballotReady.fetchMilestones.test.ts` (9 tests covering collapse logic + GraphQL error/empty/unknown-raceId paths).

## Why gp-api and not election-api

Considered putting this in election-api but rolled back when Feliks confirmed in Slack (2026-05-29) that calling BR directly from gp-api was the intended direction. election-api currently has no outbound HTTP calls and no BR client; reusing gp-api's existing `BallotReadyService` (already authenticated with `BALLOT_READY_KEY`) avoids a duplicate integration point.

## Test plan

- [x] `npx vitest run src/elections/services/ballotReady.fetchMilestones.test.ts` — 9/9 pass
- [x] `npx vitest run src/campaigns/services/campaigns.service.test.ts src/campaigns/campaigns.controller.test.ts` — 84/84 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual: hit `/v1/campaigns/:id` on a campaign with `details.raceId` set; confirm `raceTargetMetrics.milestones` carries the 3 category windows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API field and optional BR enrichment with null-on-failure; no changes to auth, payments, or core win-number logic beyond an extra parallel upstream call.
> 
> **Overview**
> Adds **BallotReady election milestones** to live `raceTargetMetrics` so campaign-plan UIs can show voter-registration, early-voting, and ballot-request windows without touching election-api.
> 
> The shared contract gains `MilestoneWindow` / `RaceMilestones` and a nullable **`milestones`** field on `RaceTargetMetrics`. **`BallotReadyService.fetchMilestones`** queries BR GraphQL (`Race.election.milestones`) and **`collapseMilestones`** turns many per-feature OPEN/CLOSE rows into one window per category (earliest open, latest close). **`fetchLiveRaceTargetMetrics`** now runs a third parallel race-hash call alongside strategy context and filing fee; milestones are merged on the unified-context path and on legacy position/district fallbacks. **`BallotReadyService`** is exported from the elections module for injection into **`CampaignsService`**. Failures return `null` for `milestones` only so the rest of the metrics payload still works.
> 
> New unit tests cover collapse logic and GraphQL edge cases; existing campaign tests were updated for the new dependency and field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7e478f52d1fe655815951f4c42e48f5cc7bce76. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->