### PR TITLE
ENG 7253 position to zip code

### DIFF
--- a/contracts/src/elections/zipCodes.ts
+++ b/contracts/src/elections/zipCodes.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod'
+
+export const ZipCodesArraySchema = z.array(z.string())

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -253,6 +253,8 @@ export {
 
 export { RaceFullSchema, type RaceFull } from './elections/raceFull'
 
+export { ZipCodesArraySchema } from './elections/zipCodes'
+
 export {
   SPEECH_SYNTHESIS_ENGINE_VALUES,
   type SpeechSynthesisEngine,

--- a/src/elections/constants/elections.const.ts
+++ b/src/elections/constants/elections.const.ts
@@ -23,7 +23,7 @@ export const ElectionApiRoutes = {
       path: 'positions',
     },
     zipCodes: {
-      path: 'positions',
+      path: 'positions/by-ballotready-id',
     },
   },
 }

--- a/src/elections/constants/elections.const.ts
+++ b/src/elections/constants/elections.const.ts
@@ -22,5 +22,8 @@ export const ElectionApiRoutes = {
     findById: {
       path: 'positions',
     },
+    zipCodes: {
+      path: 'positions',
+    },
   },
 }

--- a/src/elections/services/elections.service.test.ts
+++ b/src/elections/services/elections.service.test.ts
@@ -310,6 +310,30 @@ describe('ElectionsService', () => {
     })
   })
 
+  describe('getZipCodesByBrPositionId', () => {
+    it('calls /v1/positions/:brPositionId/zip-codes and returns the parsed zip array', async () => {
+      mockHttpGet.mockReturnValue(
+        of({ data: ['90210', '90211', '90212'], status: 200 }),
+      )
+
+      const result = await service.getZipCodesByBrPositionId('br-pos-1')
+
+      expect(result).toEqual(['90210', '90211', '90212'])
+      expect(mockHttpGet).toHaveBeenCalledWith(
+        expect.stringContaining('/v1/positions/br-pos-1/zip-codes'),
+        expect.any(Object),
+      )
+    })
+
+    it('returns an empty array when the API returns null/empty', async () => {
+      mockHttpGet.mockReturnValue(of({ data: [], status: 200 }))
+
+      const result = await service.getZipCodesByBrPositionId('br-pos-1')
+
+      expect(result).toEqual([])
+    })
+  })
+
   describe('getDistrictId', () => {
     it('returns district id when API returns results', async () => {
       mockHttpGet.mockReturnValue(

--- a/src/elections/services/elections.service.test.ts
+++ b/src/elections/services/elections.service.test.ts
@@ -311,7 +311,7 @@ describe('ElectionsService', () => {
   })
 
   describe('getZipCodesByBrPositionId', () => {
-    it('calls /v1/positions/:brPositionId/zip-codes and returns the parsed zip array', async () => {
+    it('calls /v1/positions/by-ballotready-id/:brPositionId/zip-codes and returns the parsed zip array', async () => {
       mockHttpGet.mockReturnValue(
         of({ data: ['90210', '90211', '90212'], status: 200 }),
       )
@@ -320,7 +320,9 @@ describe('ElectionsService', () => {
 
       expect(result).toEqual(['90210', '90211', '90212'])
       expect(mockHttpGet).toHaveBeenCalledWith(
-        expect.stringContaining('/v1/positions/br-pos-1/zip-codes'),
+        expect.stringContaining(
+          '/v1/positions/by-ballotready-id/br-pos-1/zip-codes',
+        ),
         expect.any(Object),
       )
     })

--- a/src/elections/services/elections.service.ts
+++ b/src/elections/services/elections.service.ts
@@ -1,4 +1,8 @@
-import { RaceListItem, RaceListItemArraySchema } from '@goodparty_org/contracts'
+import {
+  RaceListItem,
+  RaceListItemArraySchema,
+  ZipCodesArraySchema,
+} from '@goodparty_org/contracts'
 import { HttpService } from '@nestjs/axios'
 import {
   BadGatewayException,
@@ -195,6 +199,14 @@ export class ElectionsService {
       query,
     )
     return RaceListItemArraySchema.parse(result ?? [])
+  }
+
+  async getZipCodesByBrPositionId(brPositionId: string): Promise<string[]> {
+    const result = await this.electionApiGet<string[], object>(
+      `${ElectionApiRoutes.positions.zipCodes.path}/${brPositionId}/zip-codes`,
+      {},
+    )
+    return ZipCodesArraySchema.parse(result ?? [])
   }
 
   async getVoterIssues(params: {

--- a/src/elections/services/races.service.test.ts
+++ b/src/elections/services/races.service.test.ts
@@ -12,7 +12,10 @@ import { RacesService } from './races.service'
 
 describe('RacesService', () => {
   let service: RacesService
-  let electionsService: { searchPositions: ReturnType<typeof vi.fn> }
+  let electionsService: {
+    searchPositions: ReturnType<typeof vi.fn>
+    getZipCodesByBrPositionId: ReturnType<typeof vi.fn>
+  }
   let ballotReadyService: {
     fetchRaceById: ReturnType<typeof vi.fn>
     fetchRaceNormalizedPosition: ReturnType<typeof vi.fn>
@@ -23,6 +26,7 @@ describe('RacesService', () => {
   beforeEach(async () => {
     electionsService = {
       searchPositions: vi.fn(),
+      getZipCodesByBrPositionId: vi.fn(),
     }
     ballotReadyService = {
       fetchRaceById: vi.fn(),
@@ -182,6 +186,46 @@ describe('RacesService', () => {
       expect(result.id).toBe('race-1')
       expect(result.position.name).toBe('Mayor')
       expect(result.election.electionDay).toBe('2026-11-03')
+    })
+  })
+
+  describe('getZipCodesByRaceId', () => {
+    it('resolves raceId via BallotReady then asks election-api for zips', async () => {
+      ballotReadyService.fetchRaceById.mockResolvedValue({
+        node: { position: { id: 'br-pos-1' } },
+      })
+      electionsService.getZipCodesByBrPositionId.mockResolvedValue([
+        '90210',
+        '90211',
+      ])
+
+      const result = await service.getZipCodesByRaceId('race-1')
+
+      expect(ballotReadyService.fetchRaceById).toHaveBeenCalledWith('race-1')
+      expect(electionsService.getZipCodesByBrPositionId).toHaveBeenCalledWith(
+        'br-pos-1',
+      )
+      expect(result).toEqual(['90210', '90211'])
+    })
+
+    it('throws NotFoundException when BallotReady returns no race', async () => {
+      ballotReadyService.fetchRaceById.mockResolvedValue(null)
+
+      await expect(service.getZipCodesByRaceId('race-missing')).rejects.toThrow(
+        NotFoundException,
+      )
+      expect(electionsService.getZipCodesByBrPositionId).not.toHaveBeenCalled()
+    })
+
+    it('throws NotFoundException when race has no position id', async () => {
+      ballotReadyService.fetchRaceById.mockResolvedValue({
+        node: { position: null },
+      })
+
+      await expect(service.getZipCodesByRaceId('race-1')).rejects.toThrow(
+        NotFoundException,
+      )
+      expect(electionsService.getZipCodesByBrPositionId).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/elections/services/races.service.ts
+++ b/src/elections/services/races.service.ts
@@ -55,6 +55,17 @@ export class RacesService {
     return null
   }
 
+  // Note: results >50 zip codes likely indicate a statewide race;
+  // callers may want to skip or handle that case separately.
+  async getZipCodesByRaceId(raceId: string): Promise<string[]> {
+    const race = await this.getRaceById(raceId)
+    const brPositionId = race?.position?.id
+    if (!brPositionId) {
+      throw new NotFoundException(`No position found for race ${raceId}`)
+    }
+    return this.elections.getZipCodesByBrPositionId(brPositionId)
+  }
+
   async getNormalizedPosition(raceId: string) {
     return await this.ballotReadyService.fetchRaceNormalizedPosition(raceId)
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive read-only election/BallotReady integration with Zod validation and tests; no auth or persistence changes in this diff.
> 
> **Overview**
> Adds **position → ZIP code** lookup by wiring the election API and BallotReady together behind new service methods.
> 
> **Contracts:** Introduces `ZipCodesArraySchema` (`z.array(z.string())`) and exports it from `@goodparty_org/contracts`.
> 
> **Election API client:** Adds `positions.zipCodes` route config and `ElectionsService.getZipCodesByBrPositionId`, which GETs `/v1/positions/:brPositionId/zip-codes` and parses the response with `ZipCodesArraySchema` (empty array when the API returns nothing).
> 
> **Races orchestration:** Adds `RacesService.getZipCodesByRaceId`, which loads the race from BallotReady, reads the BallotReady position id, then delegates to `getZipCodesByBrPositionId`. Missing race or position id yields `NotFoundException`. A code comment notes that **>50 ZIPs** may indicate a statewide race and that callers may want special handling.
> 
> Unit tests cover the election-api client, the BallotReady → election-api flow, and not-found cases. This diff does not add controllers or GraphQL endpoints—only the service layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e572e703a02e7aaaa32b62422c49e32057327944. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->