### PR TITLE
feat(admin): add retry functionality to AdminAgentRunsController and …

### DIFF
--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -4,6 +4,7 @@ import { EmailModule } from 'src/email/email.module'
 import { OrganizationsModule } from 'src/organizations/organizations.module'
 import { SlackModule } from 'src/vendors/slack/slack.module'
 import { AwsModule } from 'src/vendors/aws/aws.module'
+import { AgentExperimentsModule } from 'src/agentExperiments/agentExperiments.module'
 import { AdminCampaignsController } from './campaigns/adminCampaigns.controller'
 import { AdminCampaignsService } from './campaigns/adminCampaigns.service'
 import { AdminUsersController } from './users/adminUsers.controller'
@@ -17,6 +18,7 @@ import { AdminAgentRunsService } from './agentRuns/services/adminAgentRuns.servi
     OrganizationsModule,
     SlackModule,
     AwsModule,
+    AgentExperimentsModule,
   ],
   controllers: [
     AdminCampaignsController,

--- a/src/admin/agentRuns/adminAgentRuns.controller.test.ts
+++ b/src/admin/agentRuns/adminAgentRuns.controller.test.ts
@@ -22,19 +22,22 @@ describe('AdminAgentRunsController', () => {
     const serviceMock: Partial<AdminAgentRunsService> = {
       list: vi.fn(),
       detail: vi.fn(),
+      retry: vi.fn(),
     }
     service = serviceMock as AdminAgentRunsService
     controller = new AdminAgentRunsController(service)
   })
 
-  it('restricts both endpoints to M2M callers (the gp-admin SDK path)', () => {
+  it('restricts every endpoint to M2M callers (the gp-admin SDK path)', () => {
     expect(guardsFor('list')).toContain(M2MOnly)
     expect(guardsFor('detail')).toContain(M2MOnly)
+    expect(guardsFor('retry')).toContain(M2MOnly)
   })
 
-  it('does not expose either endpoint as an MCP tool', () => {
+  it('does not expose any endpoint as an MCP tool', () => {
     expect(mcpToolFor('list')).toBeUndefined()
     expect(mcpToolFor('detail')).toBeUndefined()
+    expect(mcpToolFor('retry')).toBeUndefined()
   })
 
   it('delegates list to the service and returns its paginated result', async () => {
@@ -63,5 +66,17 @@ describe('AdminAgentRunsController', () => {
 
     expect(service.detail).toHaveBeenCalledWith('run-1')
     expect(result).toBe(detail)
+  })
+
+  it('delegates retry to the service and returns the new run', async () => {
+    const newRun = { runId: 'run-2' }
+    vi.mocked(service.retry).mockResolvedValue(
+      newRun as Awaited<ReturnType<AdminAgentRunsService['retry']>>,
+    )
+
+    const result = await controller.retry('run-1')
+
+    expect(service.retry).toHaveBeenCalledWith('run-1')
+    expect(result).toBe(newRun)
   })
 })

--- a/src/admin/agentRuns/adminAgentRuns.controller.ts
+++ b/src/admin/agentRuns/adminAgentRuns.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Param,
+  Post,
   Query,
   UseGuards,
   UsePipes,
@@ -15,6 +16,7 @@ import {
   AdminAgentRunsListQueryDto,
   AgentRunDetailSchema,
   AgentRunListItemSchema,
+  AgentRunSchema,
 } from './schemas/adminAgentRuns.schema'
 
 @Controller('admin/agent-runs')
@@ -34,5 +36,12 @@ export class AdminAgentRunsController {
   @ResponseSchema(AgentRunDetailSchema)
   detail(@Param('runId') runId: string) {
     return this.agentRuns.detail(runId)
+  }
+
+  @Post(':runId/retry')
+  @UseGuards(M2MOnly)
+  @ResponseSchema(AgentRunSchema)
+  retry(@Param('runId') runId: string) {
+    return this.agentRuns.retry(runId)
   }
 }

--- a/src/admin/agentRuns/schemas/adminAgentRuns.schema.ts
+++ b/src/admin/agentRuns/schemas/adminAgentRuns.schema.ts
@@ -8,6 +8,8 @@ export class AdminAgentRunsListQueryDto extends createZodDto(
 export {
   AgentRunListItemSchema,
   type AgentRunListItem,
+  AgentRunSchema,
+  type AgentRun,
   AgentRunDetailSchema,
   type AgentRunDetail,
 } from '@goodparty_org/contracts'

--- a/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
@@ -16,6 +16,7 @@ const makeRun = (overrides: Partial<ExperimentRun> = {}): ExperimentRun => ({
     candidate_first_name: 'Ada',
     candidate_last_name: 'Lovelace',
     clerk_user_id: 'user_abc',
+    election_date: '2026-11-03',
     trigger: 'initial',
   } as Prisma.JsonValue,
   artifactBucket: 'agent-artifacts',
@@ -261,6 +262,7 @@ describe('AdminAgentRunsService', () => {
           candidate_first_name: 'Ada',
           candidate_last_name: 'Lovelace',
           clerk_user_id: 'user_abc',
+          election_date: '2026-11-03',
           trigger: 'recovery_resume',
         },
       })
@@ -275,6 +277,7 @@ describe('AdminAgentRunsService', () => {
             candidate_first_name: 'Ada',
             candidate_last_name: 'Lovelace',
             clerk_user_id: 'user_abc',
+            election_date: '2026-11-03',
             trigger: 'initial',
             run_id: 'stale-run-id',
           } as Prisma.JsonValue,

--- a/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
@@ -1,7 +1,9 @@
+import { BadGatewayException, BadRequestException } from '@nestjs/common'
 import { ExperimentRun, ExperimentRunStatus, Prisma } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
 import { S3Service } from '@/vendors/aws/services/s3.service'
+import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
 import { AdminAgentRunsService } from './adminAgentRuns.service'
 
 const makeRun = (overrides: Partial<ExperimentRun> = {}): ExperimentRun => ({
@@ -33,6 +35,7 @@ describe('AdminAgentRunsService', () => {
     findUniqueOrThrow: ReturnType<typeof vi.fn>
   }
   const s3 = { getFile: vi.fn() }
+  const experimentRuns = { dispatchRun: vi.fn() }
   const logger = createMockLogger()
 
   beforeEach(() => {
@@ -44,7 +47,10 @@ describe('AdminAgentRunsService', () => {
       findUniqueOrThrow: vi.fn(),
     }
 
-    service = new AdminAgentRunsService(s3 as unknown as S3Service)
+    service = new AdminAgentRunsService(
+      s3 as unknown as S3Service,
+      experimentRuns as unknown as ExperimentRunsService,
+    )
     Object.defineProperty(service, 'model', {
       get: () => mockModel,
       configurable: true,
@@ -224,6 +230,75 @@ describe('AdminAgentRunsService', () => {
 
       await expect(service.detail('missing')).rejects.toThrow()
       expect(s3.getFile).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('retry', () => {
+    it('re-dispatches with the stored type, org, params, and clerk_user_id, and returns the new run', async () => {
+      const run = makeRun()
+      const newRun = makeRun({
+        runId: 'run-2',
+        status: ExperimentRunStatus.RUNNING,
+        artifactBucket: null,
+        artifactKey: null,
+        durationSeconds: null,
+        costUsd: null,
+      })
+      mockModel.findUniqueOrThrow.mockResolvedValue(run)
+      experimentRuns.dispatchRun.mockResolvedValue(newRun)
+
+      const result = await service.retry('run-1')
+
+      expect(experimentRuns.dispatchRun).toHaveBeenCalledWith({
+        type: 'compliance_setup',
+        organizationSlug: 'org-1',
+        clerkUserId: 'user_abc',
+        params: {
+          campaign_id: 42,
+          candidate_first_name: 'Ada',
+          candidate_last_name: 'Lovelace',
+          clerk_user_id: 'user_abc',
+        },
+      })
+      expect(result).toBe(newRun)
+    })
+
+    it('rejects with 400 and never dispatches when params carry no clerk_user_id', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(
+        makeRun({
+          params: {
+            campaign_id: 42,
+            candidate_first_name: 'Ada',
+            candidate_last_name: 'Lovelace',
+          } as Prisma.JsonValue,
+        }),
+      )
+
+      await expect(service.retry('run-1')).rejects.toBeInstanceOf(
+        BadRequestException,
+      )
+      expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
+    })
+
+    it('propagates the not-found error for an unknown runId, never dispatching', async () => {
+      mockModel.findUniqueOrThrow.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('No ExperimentRun found', {
+          code: 'P2025',
+          clientVersion: 'test',
+        }),
+      )
+
+      await expect(service.retry('missing')).rejects.toThrow()
+      expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
+    })
+
+    it('surfaces 502 when dispatch is not configured (dispatchRun returns nothing)', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(makeRun())
+      experimentRuns.dispatchRun.mockResolvedValue(undefined)
+
+      await expect(service.retry('run-1')).rejects.toBeInstanceOf(
+        BadGatewayException,
+      )
     })
   })
 })

--- a/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
@@ -1,8 +1,4 @@
-import {
-  BadGatewayException,
-  BadRequestException,
-  ConflictException,
-} from '@nestjs/common'
+import { BadGatewayException, ConflictException } from '@nestjs/common'
 import { ExperimentRun, ExperimentRunStatus, Prisma } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
@@ -271,6 +267,29 @@ describe('AdminAgentRunsService', () => {
       expect(result).toBe(newRun)
     })
 
+    it('drops a stale run_id so the agent uses the fresh dispatch run id', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(
+        makeRun({
+          params: {
+            campaign_id: 42,
+            candidate_first_name: 'Ada',
+            candidate_last_name: 'Lovelace',
+            clerk_user_id: 'user_abc',
+            trigger: 'initial',
+            run_id: 'stale-run-id',
+          } as Prisma.JsonValue,
+        }),
+      )
+      experimentRuns.dispatchRun.mockResolvedValue(makeRun({ runId: 'run-2' }))
+
+      await service.retry('run-1')
+
+      const dispatchedParams =
+        experimentRuns.dispatchRun.mock.calls[0][0].params
+      expect(dispatchedParams.run_id).toBeUndefined()
+      expect(dispatchedParams.trigger).toBe('recovery_resume')
+    })
+
     it('rejects with 409 and never dispatches when the run is still RUNNING', async () => {
       mockModel.findUniqueOrThrow.mockResolvedValue(
         makeRun({ status: ExperimentRunStatus.RUNNING }),
@@ -282,18 +301,28 @@ describe('AdminAgentRunsService', () => {
       expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
     })
 
-    it('rejects with 400 and never dispatches when the experiment type is not retryable', async () => {
+    it('rejects with 400 (wrong-type message) for a realistic non-retryable run, never dispatching', async () => {
+      // A real meeting_briefing run carries no clerk_user_id; the type guard
+      // must fire first so the message names the actual reason. Asserting the
+      // message (not just the 400) keeps the type guard from being shadowed by
+      // the clerk_user_id guard.
       mockModel.findUniqueOrThrow.mockResolvedValue(
-        makeRun({ experimentType: 'meeting_briefing' }),
+        makeRun({
+          experimentType: 'meeting_briefing',
+          params: {
+            officialName: 'Some Mayor',
+            state: 'NY',
+          } as Prisma.JsonValue,
+        }),
       )
 
-      await expect(service.retry('run-1')).rejects.toBeInstanceOf(
-        BadRequestException,
+      await expect(service.retry('run-1')).rejects.toThrow(
+        'cannot be re-dispatched',
       )
       expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
     })
 
-    it('rejects with 400 and never dispatches when params carry no clerk_user_id', async () => {
+    it('rejects with 400 (missing-clerk message) when a retryable run lacks clerk_user_id, never dispatching', async () => {
       mockModel.findUniqueOrThrow.mockResolvedValue(
         makeRun({
           params: {
@@ -304,9 +333,7 @@ describe('AdminAgentRunsService', () => {
         }),
       )
 
-      await expect(service.retry('run-1')).rejects.toBeInstanceOf(
-        BadRequestException,
-      )
+      await expect(service.retry('run-1')).rejects.toThrow('clerk_user_id')
       expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
     })
 

--- a/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
@@ -1,4 +1,8 @@
-import { BadGatewayException, BadRequestException } from '@nestjs/common'
+import {
+  BadGatewayException,
+  BadRequestException,
+  ConflictException,
+} from '@nestjs/common'
 import { ExperimentRun, ExperimentRunStatus, Prisma } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
@@ -261,6 +265,28 @@ describe('AdminAgentRunsService', () => {
         },
       })
       expect(result).toBe(newRun)
+    })
+
+    it('rejects with 409 and never dispatches when the run is still RUNNING', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(
+        makeRun({ status: ExperimentRunStatus.RUNNING }),
+      )
+
+      await expect(service.retry('run-1')).rejects.toBeInstanceOf(
+        ConflictException,
+      )
+      expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
+    })
+
+    it('rejects with 400 and never dispatches when the experiment type is not retryable', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(
+        makeRun({ experimentType: 'meeting_briefing' }),
+      )
+
+      await expect(service.retry('run-1')).rejects.toBeInstanceOf(
+        BadRequestException,
+      )
+      expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
     })
 
     it('rejects with 400 and never dispatches when params carry no clerk_user_id', async () => {

--- a/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
@@ -20,6 +20,7 @@ const makeRun = (overrides: Partial<ExperimentRun> = {}): ExperimentRun => ({
     candidate_first_name: 'Ada',
     candidate_last_name: 'Lovelace',
     clerk_user_id: 'user_abc',
+    trigger: 'initial',
   } as Prisma.JsonValue,
   artifactBucket: 'agent-artifacts',
   artifactKey: 'compliance_setup/run-1/artifact.json',
@@ -257,11 +258,14 @@ describe('AdminAgentRunsService', () => {
         type: 'compliance_setup',
         organizationSlug: 'org-1',
         clerkUserId: 'user_abc',
+        // trigger flips initial -> recovery_resume so the re-dispatch resumes
+        // from durable state instead of re-running paid side effects.
         params: {
           campaign_id: 42,
           candidate_first_name: 'Ada',
           candidate_last_name: 'Lovelace',
           clerk_user_id: 'user_abc',
+          trigger: 'recovery_resume',
         },
       })
       expect(result).toBe(newRun)

--- a/src/admin/agentRuns/services/adminAgentRuns.service.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.ts
@@ -1,9 +1,10 @@
 import {
   BadGatewayException,
   BadRequestException,
+  ConflictException,
   Injectable,
 } from '@nestjs/common'
-import { ExperimentRun, Prisma } from '@prisma/client'
+import { ExperimentRun, ExperimentRunStatus, Prisma } from '@prisma/client'
 import {
   AgentRunCandidateSummary,
   AgentRunListItem,
@@ -130,6 +131,14 @@ export class AdminAgentRunsService extends createPrismaBase(
   // dispatchRun creates a fresh run row + SQS message; the original is untouched.
   async retry(runId: string): Promise<ExperimentRun> {
     const run = await this.model.findUniqueOrThrow({ where: { runId } })
+
+    // A RUNNING run is still in flight; re-dispatching it would spawn a second
+    // parallel worker on the same params (duplicate domain buy / TCR submit).
+    if (run.status === ExperimentRunStatus.RUNNING) {
+      throw new ConflictException(
+        'run is still RUNNING; only finished runs can be retried',
+      )
+    }
 
     const clerkUserId = clerkUserIdFromParams(run.params)
     if (!clerkUserId) {

--- a/src/admin/agentRuns/services/adminAgentRuns.service.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.ts
@@ -1,4 +1,8 @@
-import { Injectable } from '@nestjs/common'
+import {
+  BadGatewayException,
+  BadRequestException,
+  Injectable,
+} from '@nestjs/common'
 import { ExperimentRun, Prisma } from '@prisma/client'
 import {
   AgentRunCandidateSummary,
@@ -8,6 +12,8 @@ import {
 } from '@goodparty_org/contracts'
 import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
 import { S3Service } from '@/vendors/aws/services/s3.service'
+import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
+import { AgentJobContracts } from '@/generated/agent-job-contracts'
 import {
   DEFAULT_PAGINATION_LIMIT,
   DEFAULT_PAGINATION_OFFSET,
@@ -40,6 +46,28 @@ const deriveCandidate = (params: unknown): AgentRunCandidateSummary | null => {
   }
 }
 
+// Retry re-dispatches as the run's candidate, so only experiments whose params
+// carry a clerk_user_id are retryable. Today that is compliance_setup; the
+// `satisfies` keeps this list honest against the generated contract keys.
+const DISPATCHABLE_EXPERIMENT_TYPES = [
+  'compliance_setup',
+] as const satisfies readonly (keyof AgentJobContracts)[]
+
+type DispatchableExperimentType = (typeof DISPATCHABLE_EXPERIMENT_TYPES)[number]
+
+type DispatchParams = AgentJobContracts[DispatchableExperimentType]['Input']
+
+const isDispatchableExperimentType = (
+  type: string,
+): type is DispatchableExperimentType =>
+  DISPATCHABLE_EXPERIMENT_TYPES.some((known) => known === type)
+
+const clerkUserIdFromParams = (params: unknown): string | null => {
+  if (!isJsonObject(params)) return null
+  const clerkUserId = params['clerk_user_id']
+  return typeof clerkUserId === 'string' ? clerkUserId : null
+}
+
 const toListItem = (run: ExperimentRun): AgentRunListItem => ({
   runId: run.runId,
   experimentType: run.experimentType,
@@ -55,7 +83,10 @@ const toListItem = (run: ExperimentRun): AgentRunListItem => ({
 export class AdminAgentRunsService extends createPrismaBase(
   MODELS.ExperimentRun,
 ) {
-  constructor(private readonly s3: S3Service) {
+  constructor(
+    private readonly s3: S3Service,
+    private readonly experimentRuns: ExperimentRunsService,
+  ) {
     super()
   }
 
@@ -93,6 +124,47 @@ export class AdminAgentRunsService extends createPrismaBase(
     ])
 
     return { data: runs.map(toListItem), meta: { total, offset, limit } }
+  }
+
+  // Re-dispatches a finished run with its stored params as the same candidate.
+  // dispatchRun creates a fresh run row + SQS message; the original is untouched.
+  async retry(runId: string): Promise<ExperimentRun> {
+    const run = await this.model.findUniqueOrThrow({ where: { runId } })
+
+    const clerkUserId = clerkUserIdFromParams(run.params)
+    if (!clerkUserId) {
+      throw new BadRequestException(
+        'run params carry no clerk_user_id; cannot re-dispatch as the candidate',
+      )
+    }
+
+    if (!isDispatchableExperimentType(run.experimentType)) {
+      throw new BadRequestException(
+        `experiment type "${run.experimentType}" cannot be re-dispatched`,
+      )
+    }
+
+    // params were validated against this experiment's Input at the original
+    // dispatch and persisted unchanged, so re-forward them as that Input.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const params = run.params as DispatchParams
+
+    const dispatched = await this.experimentRuns.dispatchRun({
+      type: run.experimentType,
+      organizationSlug: run.organizationSlug,
+      clerkUserId,
+      params,
+    })
+
+    // dispatchRun no-ops (returns undefined) when no queue is configured, e.g.
+    // preview envs. Surface that instead of returning a 200 with no new run.
+    if (!dispatched) {
+      throw new BadGatewayException(
+        'agent dispatch is not configured for this environment',
+      )
+    }
+
+    return dispatched
   }
 
   async detail(runId: string): Promise<{

--- a/src/admin/agentRuns/services/adminAgentRuns.service.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.ts
@@ -140,6 +140,12 @@ export class AdminAgentRunsService extends createPrismaBase(
       )
     }
 
+    if (!isDispatchableExperimentType(run.experimentType)) {
+      throw new BadRequestException(
+        `experiment type "${run.experimentType}" cannot be re-dispatched`,
+      )
+    }
+
     const clerkUserId = clerkUserIdFromParams(run.params)
     if (!clerkUserId) {
       throw new BadRequestException(
@@ -147,22 +153,19 @@ export class AdminAgentRunsService extends createPrismaBase(
       )
     }
 
-    if (!isDispatchableExperimentType(run.experimentType)) {
-      throw new BadRequestException(
-        `experiment type "${run.experimentType}" cannot be re-dispatched`,
-      )
-    }
-
     // params were validated against this experiment's Input at the original
     // dispatch and persisted unchanged, so re-forward them as that Input.
     // Override trigger to recovery_resume so the agent treats this as a
     // re-dispatch (consult durable gp-api state), not a first-time dispatch that
-    // would re-run paid side effects (domain purchase, TCR submission).
+    // would re-run paid side effects (domain purchase, TCR submission). Drop a
+    // stale run_id so the agent falls back to the fresh dispatch's run id rather
+    // than filing the artifact under the original run.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const storedParams = run.params as DispatchParams
     const params: DispatchParams = {
       ...storedParams,
       trigger: 'recovery_resume',
+      run_id: undefined,
     }
 
     const dispatched = await this.experimentRuns.dispatchRun({

--- a/src/admin/agentRuns/services/adminAgentRuns.service.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.ts
@@ -155,8 +155,15 @@ export class AdminAgentRunsService extends createPrismaBase(
 
     // params were validated against this experiment's Input at the original
     // dispatch and persisted unchanged, so re-forward them as that Input.
+    // Override trigger to recovery_resume so the agent treats this as a
+    // re-dispatch (consult durable gp-api state), not a first-time dispatch that
+    // would re-run paid side effects (domain purchase, TCR submission).
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const params = run.params as DispatchParams
+    const storedParams = run.params as DispatchParams
+    const params: DispatchParams = {
+      ...storedParams,
+      trigger: 'recovery_resume',
+    }
 
     const dispatched = await this.experimentRuns.dispatchRun({
       type: run.experimentType,


### PR DESCRIPTION
…service

- Introduced a new retry endpoint in AdminAgentRunsController to re-dispatch agent runs.
- Updated AdminAgentRunsService to handle the retry logic, including validation for clerk_user_id and dispatching runs.
- Enhanced tests for both the controller and service to cover the new retry functionality and its edge cases.
- Updated Admin module to include necessary imports for the new features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Retry triggers new experiment runs and SQS dispatch from stored params; impact is limited by M2M-only access and narrow experiment-type validation.
> 
> **Overview**
> Adds an **M2M-only** admin API to **retry a past agent run** by creating a **new** run and queue dispatch, leaving the original row unchanged.
> 
> `POST admin/agent-runs/:runId/retry` is wired through `AdminAgentRunsController` with `AgentRunSchema` on the response. `AdminAgentRunsService.retry` loads the stored run, requires `clerk_user_id` in params and a **dispatchable** experiment type (currently only `compliance_setup`), then calls `ExperimentRunsService.dispatchRun` with the saved org, type, and params. Missing `clerk_user_id` or unsupported types return **400**; environments without dispatch configured return **502** when `dispatchRun` does not return a run. `AdminModule` now imports `AgentExperimentsModule` so the service can dispatch. Controller and service tests cover the new endpoint, guards, and retry edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7a013d423fb5feeff67705c243473e98ada373f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->