### PR TITLE
Meeting briefing imminence gate

### DIFF
--- a/src/generated/agent-job-contracts.ts
+++ b/src/generated/agent-job-contracts.ts
@@ -95,6 +95,18 @@ export interface AgentJobContracts {
        */
       l2DistrictType?: string
       /**
+       * Target meeting date in YYYY-MM-DD. Required. The caller (gp-api) supplies this from the official's meeting_schedule.
+       */
+      meetingDate: string
+      /**
+       * Start time of the target meeting in 24-hour HH:MM (local time of meetingTimezone). Optional but recommended.
+       */
+      meetingTime?: string
+      /**
+       * IANA timezone name for meetingTime (e.g. "America/New_York"). Optional but recommended.
+       */
+      meetingTimezone?: string
+      /**
        * Full name of the elected official (e.g. "Shekar Krishnan").
        */
       officialName: string

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -52,7 +52,54 @@ const mockResolveServeContext = (
   return spy
 }
 
-describe('POST /v1/elected-office dispatches schedule + briefing in parallel', () => {
+/**
+ * Seed a meeting_schedule ExperimentRun and mock S3 to return its
+ * artifact when the briefing service calls loadLatestScheduleForOrg.
+ *
+ * Defaults: FREQ=DAILY with time 23:59 in America/Chicago — guarantees
+ * the schedule projects a meeting inside any reasonable test window so
+ * the imminence gate passes. Tests that need a meeting OUTSIDE the
+ * window can pass a long-interval RRULE explicitly.
+ */
+const seedScheduleForOrg = async (
+  orgSlug: string,
+  schedule: Partial<{
+    status: 'found' | 'not_found'
+    rrule: string
+    time: string
+    timezone: string
+    duration_minutes: number
+    meeting_name: string
+    location: string
+  }> = {},
+) => {
+  const artifactKey = `schedule-${orgSlug}.json`
+  const body = {
+    status: schedule.status ?? 'found',
+    rrule: schedule.rrule ?? 'FREQ=DAILY',
+    time: schedule.time ?? '23:59',
+    timezone: schedule.timezone ?? 'America/Chicago',
+    duration_minutes: schedule.duration_minutes ?? 120,
+    meeting_name: schedule.meeting_name ?? 'City Council',
+    location: schedule.location ?? 'Council Chambers',
+    sources: [],
+    generated_at: new Date().toISOString(),
+    human: 'Daily test schedule',
+  }
+  await service.prisma.experimentRun.create({
+    data: {
+      organizationSlug: orgSlug,
+      experimentType: 'meeting_schedule',
+      status: ExperimentRunStatus.COMPLETED,
+      artifactBucket: 'schedule-bucket',
+      artifactKey,
+    },
+  })
+  mockS3({ [artifactKey]: JSON.stringify(body) })
+  return artifactKey
+}
+
+describe('POST /v1/elected-office dispatches schedule only (briefing chains via onExperimentRunCompleted)', () => {
   beforeEach(() => {
     vi.stubEnv('MEETINGS_AUTOMATION_ENABLED', 'true')
     mockResolveServeContext(null)
@@ -80,7 +127,7 @@ describe('POST /v1/elected-office dispatches schedule + briefing in parallel', (
     expect(dispatchSpy).not.toHaveBeenCalled()
   })
 
-  it('dispatches both meeting_schedule and meeting_briefing when org has a position', async () => {
+  it('dispatches meeting_schedule only (briefing fires later after the schedule completes)', async () => {
     const orgSlug = `eo-create-${Date.now()}`
     await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-123' })
 
@@ -99,13 +146,10 @@ describe('POST /v1/elected-office dispatches schedule + briefing in parallel', (
     )
 
     expect(res.status).toBe(201)
-    const dispatchedTypes = dispatchSpy.mock.calls.map(
-      ([arg]) => (arg as { type: string }).type,
-    )
-    expect(dispatchedTypes).toEqual(
-      expect.arrayContaining(['meeting_schedule', 'meeting_briefing']),
-    )
-    expect(dispatchSpy).toHaveBeenCalledTimes(2)
+    // Only the schedule fires on creation. The briefing is chained later
+    // in onExperimentRunCompleted once the schedule lands and the
+    // imminence gate confirms a meeting inside the 5-day window.
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
     expect(dispatchSpy).toHaveBeenCalledWith({
       type: 'meeting_schedule',
       organizationSlug: expect.stringMatching(/^eo-/) as string,
@@ -114,16 +158,6 @@ describe('POST /v1/elected-office dispatches schedule + briefing in parallel', (
         elected_office_id: res.data.id as string,
         state: 'MN',
         office: 'City Council',
-      },
-    })
-    expect(dispatchSpy).toHaveBeenCalledWith({
-      type: 'meeting_briefing',
-      organizationSlug: expect.stringMatching(/^eo-/) as string,
-      clerkUserId: service.user.clerkId!,
-      params: {
-        officialName: `${service.user.firstName} ${service.user.lastName}`,
-        state: 'MN',
-        positionName: 'City Council',
       },
     })
   })
@@ -155,17 +189,94 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
     vi.unstubAllEnvs()
   })
 
-  it('does not dispatch anything on schedule completion (chaining removed)', async () => {
-    const orgSlug = `eo-chain-removed-${Date.now()}`
-    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-chain-removed' })
-    await service.prisma.electedOffice.create({
+  it('chains a briefing dispatch when schedule completion shows a meeting inside the 5-day window', async () => {
+    const orgSlug = `eo-chain-imminent-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-chain-imminent' })
+    const eo = await service.prisma.electedOffice.create({
       data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    const artifactKey = await seedScheduleForOrg(orgSlug) // FREQ=DAILY → always inside window
+    const scheduleRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_schedule',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'schedule-bucket',
+        artifactKey,
+        params: { elected_office_id: eo.id },
+      },
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(scheduleRun)
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'meeting_briefing',
+        params: expect.objectContaining({
+          meetingDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/) as string,
+          meetingTime: '23:59',
+          meetingTimezone: 'America/Chicago',
+        }),
+      }),
+    )
+  })
+
+  it('does not chain a briefing when schedule completion shows no meeting inside the 5-day window', async () => {
+    const orgSlug = `eo-chain-far-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-chain-far' })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    // YEARLY with BYMONTH=1 + BYMONTHDAY=1 → next meeting on Jan 1 of next
+    // year, which is virtually always outside a 5-day window.
+    const artifactKey = await seedScheduleForOrg(orgSlug, {
+      rrule: 'FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1',
     })
     const scheduleRun = await service.prisma.experimentRun.create({
       data: {
         organizationSlug: orgSlug,
         experimentType: 'meeting_schedule',
         status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'schedule-bucket',
+        artifactKey,
+        params: { elected_office_id: eo.id },
+      },
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(scheduleRun)
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not chain a briefing when schedule completion has status not_found', async () => {
+    const orgSlug = `eo-chain-not-found-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-chain-not-found' })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    const artifactKey = await seedScheduleForOrg(orgSlug, { status: 'not_found' })
+    const scheduleRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_schedule',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'schedule-bucket',
+        artifactKey,
+        params: { elected_office_id: eo.id },
       },
     })
     const dispatchSpy = vi
@@ -529,7 +640,7 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
     expect(dispatchSpy).not.toHaveBeenCalled()
   })
 
-  it('dispatches only for EOs without a future briefing', async () => {
+  it('dispatches only for EOs without a future briefing (and only when schedule shows imminent meeting)', async () => {
     const orgSlugA = `eo-cron-a-${Date.now()}`
     await seedOrgAndCampaign(orgSlugA, { positionId: 'br-pos-cron-a' })
     const campaignA = await service.prisma.campaign.findFirst({
@@ -577,6 +688,11 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
 
     mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
 
+    // Both orgs have schedules so the imminence gate passes. Org A also has
+    // an existing future briefing → coverage dedupe skips it. Only B fires.
+    await seedScheduleForOrg(orgSlugA)
+    await seedScheduleForOrg(orgSlugB)
+
     const existingBriefingRun = await service.prisma.experimentRun.create({
       data: {
         organizationSlug: orgSlugA,
@@ -609,9 +725,62 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
         organizationSlug: orgSlugB,
         params: expect.objectContaining({
           positionName: 'City Council',
+          meetingDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/) as string,
+          meetingTime: '23:59',
+          meetingTimezone: 'America/Chicago',
         }),
       }),
     )
+  })
+
+  it('skips an EO entirely when no meeting_schedule exists yet', async () => {
+    const orgSlug = `eo-cron-no-schedule-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-cron-no-sched' })
+    const campaign = await service.prisma.campaign.findFirst({
+      where: { organizationSlug: orgSlug },
+    })
+    await service.prisma.electedOffice.create({
+      data: {
+        organizationSlug: orgSlug,
+        userId: service.user.id,
+        campaignId: campaign?.id,
+      },
+    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    await service.app.get(MeetingBriefingsService).dispatchDailyBriefings()
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('skips an EO when the next meeting is outside the 5-day window', async () => {
+    const orgSlug = `eo-cron-far-meeting-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-cron-far' })
+    const campaign = await service.prisma.campaign.findFirst({
+      where: { organizationSlug: orgSlug },
+    })
+    await service.prisma.electedOffice.create({
+      data: {
+        organizationSlug: orgSlug,
+        userId: service.user.id,
+        campaignId: campaign?.id,
+      },
+    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    // YEARLY on Jan 1 → essentially never inside a 5-day window.
+    await seedScheduleForOrg(orgSlug, {
+      rrule: 'FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1',
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    await service.app.get(MeetingBriefingsService).dispatchDailyBriefings()
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
   })
 
   it('runs the dispatch loop once when invoked twice the same day (multi-replica guard)', async () => {
@@ -629,6 +798,7 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
     })
 
     mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    await seedScheduleForOrg(orgSlug)
 
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
@@ -659,6 +829,7 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
     })
 
     mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    await seedScheduleForOrg(orgSlug)
 
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
@@ -703,9 +874,38 @@ describe('MeetingBriefingsService.dispatchManual', () => {
     vi.unstubAllEnvs()
   })
 
-  it('dispatches a briefing run when kind is briefing', async () => {
+  it('dispatches a briefing run when kind is briefing (with meetingDate from schedule)', async () => {
     const orgSlug = `eo-manual-briefing-${Date.now()}`
     await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-manual-b' })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    await seedScheduleForOrg(orgSlug)
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.app
+      .get(MeetingBriefingsService)
+      .dispatchManual(eo.id, 'briefing')
+
+    expect(result.dispatched).toBe(true)
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'meeting_briefing',
+        params: expect.objectContaining({
+          meetingDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/) as string,
+          meetingTime: '23:59',
+          meetingTimezone: 'America/Chicago',
+        }),
+      }),
+    )
+  })
+
+  it('does not dispatch a briefing manually when no schedule exists', async () => {
+    const orgSlug = `eo-manual-no-sched-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-manual-no-sched' })
     const eo = await service.prisma.electedOffice.create({
       data: { organizationSlug: orgSlug, userId: service.user.id },
     })
@@ -718,10 +918,8 @@ describe('MeetingBriefingsService.dispatchManual', () => {
       .get(MeetingBriefingsService)
       .dispatchManual(eo.id, 'briefing')
 
-    expect(result.dispatched).toBe(true)
-    expect(dispatchSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'meeting_briefing' }),
-    )
+    expect(result.dispatched).toBe(false)
+    expect(dispatchSpy).not.toHaveBeenCalled()
   })
 
   it('returns dispatched:false for unknown electedOfficeId', async () => {
@@ -750,6 +948,7 @@ describe('MeetingBriefingsService.dispatchManual', () => {
       l2DistrictType: 'City',
       l2DistrictName: 'Minneapolis',
     })
+    await seedScheduleForOrg(orgSlug)
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
       .mockResolvedValue(undefined)
@@ -767,6 +966,9 @@ describe('MeetingBriefingsService.dispatchManual', () => {
         officialName: `${service.user.firstName} ${service.user.lastName}`,
         state: 'MN',
         positionName: 'City Council Member',
+        meetingDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/) as string,
+        meetingTime: '23:59',
+        meetingTimezone: 'America/Chicago',
         l2DistrictType: 'City',
         l2DistrictName: 'Minneapolis',
       },
@@ -785,6 +987,7 @@ describe('MeetingBriefingsService.dispatchManual', () => {
       l2DistrictType: 'SchoolDistrict',
       l2DistrictName: 'LAUSD',
     })
+    await seedScheduleForOrg(orgSlug)
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
       .mockResolvedValue(undefined)
@@ -802,6 +1005,7 @@ describe('MeetingBriefingsService.dispatchManual', () => {
           positionName: 'School Board',
           l2DistrictType: 'SchoolDistrict',
           l2DistrictName: 'LAUSD',
+          meetingDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/) as string,
         }),
       }),
     )

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -268,7 +268,9 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
       data: { organizationSlug: orgSlug, userId: service.user.id },
     })
     mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
-    const artifactKey = await seedScheduleForOrg(orgSlug, { status: 'not_found' })
+    const artifactKey = await seedScheduleForOrg(orgSlug, {
+      status: 'not_found',
+    })
     const scheduleRun = await service.prisma.experimentRun.create({
       data: {
         organizationSlug: orgSlug,

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -229,36 +229,44 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
   })
 
   it('does not chain a briefing when schedule completion shows no meeting inside the 5-day window', async () => {
-    const orgSlug = `eo-chain-far-${Date.now()}`
-    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-chain-far' })
-    const eo = await service.prisma.electedOffice.create({
-      data: { organizationSlug: orgSlug, userId: service.user.id },
-    })
-    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
-    // YEARLY with BYMONTH=1 + BYMONTHDAY=1 → next meeting on Jan 1 of next
-    // year, which is virtually always outside a 5-day window.
-    const artifactKey = await seedScheduleForOrg(orgSlug, {
-      rrule: 'FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1',
-    })
-    const scheduleRun = await service.prisma.experimentRun.create({
-      data: {
-        organizationSlug: orgSlug,
-        experimentType: 'meeting_schedule',
-        status: ExperimentRunStatus.COMPLETED,
-        artifactBucket: 'schedule-bucket',
-        artifactKey,
-        params: { elected_office_id: eo.id },
-      },
-    })
-    const dispatchSpy = vi
-      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
+    // Pin the clock to mid-year so Jan 1 (the next YEARLY occurrence) is
+    // far outside the 5-day window. Without this, runs between roughly
+    // Dec 27 and Jan 1 would see Jan 1 INSIDE the window and the test
+    // would flake.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date('2026-06-15T12:00:00Z'))
+    try {
+      const orgSlug = `eo-chain-far-${Date.now()}`
+      await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-chain-far' })
+      const eo = await service.prisma.electedOffice.create({
+        data: { organizationSlug: orgSlug, userId: service.user.id },
+      })
+      mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+      const artifactKey = await seedScheduleForOrg(orgSlug, {
+        rrule: 'FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1',
+      })
+      const scheduleRun = await service.prisma.experimentRun.create({
+        data: {
+          organizationSlug: orgSlug,
+          experimentType: 'meeting_schedule',
+          status: ExperimentRunStatus.COMPLETED,
+          artifactBucket: 'schedule-bucket',
+          artifactKey,
+          params: { elected_office_id: eo.id },
+        },
+      })
+      const dispatchSpy = vi
+        .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+        .mockResolvedValue(undefined)
 
-    await service.app
-      .get(MeetingBriefingsService)
-      .onExperimentRunCompleted(scheduleRun)
+      await service.app
+        .get(MeetingBriefingsService)
+        .onExperimentRunCompleted(scheduleRun)
 
-    expect(dispatchSpy).not.toHaveBeenCalled()
+      expect(dispatchSpy).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('does not chain a briefing when schedule completion has status not_found', async () => {
@@ -759,30 +767,38 @@ describe('MeetingBriefingsService.dispatchDailyBriefings', () => {
   })
 
   it('skips an EO when the next meeting is outside the 5-day window', async () => {
-    const orgSlug = `eo-cron-far-meeting-${Date.now()}`
-    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-cron-far' })
-    const campaign = await service.prisma.campaign.findFirst({
-      where: { organizationSlug: orgSlug },
-    })
-    await service.prisma.electedOffice.create({
-      data: {
-        organizationSlug: orgSlug,
-        userId: service.user.id,
-        campaignId: campaign?.id,
-      },
-    })
-    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
-    // YEARLY on Jan 1 → essentially never inside a 5-day window.
-    await seedScheduleForOrg(orgSlug, {
-      rrule: 'FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1',
-    })
-    const dispatchSpy = vi
-      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
+    // Pin clock to mid-year so Jan 1 (the next YEARLY occurrence) is far
+    // outside any 5-day window. Without pinning, runs near new year would
+    // see Jan 1 inside the window and flake.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date('2026-06-15T12:00:00Z'))
+    try {
+      const orgSlug = `eo-cron-far-meeting-${Date.now()}`
+      await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-cron-far' })
+      const campaign = await service.prisma.campaign.findFirst({
+        where: { organizationSlug: orgSlug },
+      })
+      await service.prisma.electedOffice.create({
+        data: {
+          organizationSlug: orgSlug,
+          userId: service.user.id,
+          campaignId: campaign?.id,
+        },
+      })
+      mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+      await seedScheduleForOrg(orgSlug, {
+        rrule: 'FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1',
+      })
+      const dispatchSpy = vi
+        .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+        .mockResolvedValue(undefined)
 
-    await service.app.get(MeetingBriefingsService).dispatchDailyBriefings()
+      await service.app.get(MeetingBriefingsService).dispatchDailyBriefings()
 
-    expect(dispatchSpy).not.toHaveBeenCalled()
+      expect(dispatchSpy).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('runs the dispatch loop once when invoked twice the same day (multi-replica guard)', async () => {

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -42,11 +42,16 @@ const BRIEFING_EXPERIMENT_TYPE = 'meeting_briefing'
  * JSONB column without an unsafe cast. Returns null if the params is
  * not an object, the key is missing, or the value isn't a string.
  */
-const extractElectedOfficeId = (params: Prisma.JsonValue): string | null => {
-  if (typeof params !== 'object' || params === null || Array.isArray(params)) {
+const extractElectedOfficeId = (params: unknown): string | null => {
+  if (
+    typeof params !== 'object' ||
+    params === null ||
+    Array.isArray(params) ||
+    !('elected_office_id' in params)
+  ) {
     return null
   }
-  const value = params['elected_office_id']
+  const value: unknown = params.elected_office_id
   return typeof value === 'string' ? value : null
 }
 

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -37,6 +37,19 @@ const parseSchedule = (raw: string): MeetingSchedule =>
 const SCHEDULE_EXPERIMENT_TYPE = 'meeting_schedule'
 const BRIEFING_EXPERIMENT_TYPE = 'meeting_briefing'
 
+/**
+ * Extract the `elected_office_id` field from an ExperimentRun's params
+ * JSONB column without an unsafe cast. Returns null if the params is
+ * not an object, the key is missing, or the value isn't a string.
+ */
+const extractElectedOfficeId = (params: Prisma.JsonValue): string | null => {
+  if (typeof params !== 'object' || params === null || Array.isArray(params)) {
+    return null
+  }
+  const value = params['elected_office_id']
+  return typeof value === 'string' ? value : null
+}
+
 // Identifies the daily-briefing cron in the cron_run lease table.
 const DAILY_BRIEFINGS_CRON_JOB = 'dispatchDailyBriefings'
 
@@ -304,13 +317,8 @@ export class MeetingBriefingsService extends createPrismaBase(
     if (!isAutomationEnabled()) return
 
     // The schedule run's params include `elected_office_id` (snake_case);
-    // see dispatchSchedule().
-    const params =
-      typeof run.params === 'object' && run.params !== null ? run.params : {}
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const electedOfficeId = (params as Record<string, unknown>)[
-      'elected_office_id'
-    ] as string | undefined
+    // see dispatchSchedule(). Narrow Prisma's JsonValue to a string field.
+    const electedOfficeId = extractElectedOfficeId(run.params)
     if (!electedOfficeId) {
       this.logger.warn(
         { runId: run.runId },

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -67,6 +67,18 @@ const CRON_CONFIG = {
   every: '20m' as const,
 }
 
+// Briefings are dispatched only when the official's next scheduled meeting
+// falls inside this window. Outside the window we skip — the agent's
+// run would either bail to a placeholder (no packet published yet) or
+// repeat work we'll redo when the meeting gets closer.
+const IMMINENCE_WINDOW_DAYS = 5
+
+type TargetMeeting = {
+  meetingDate: string // YYYY-MM-DD
+  meetingTime: string // HH:MM
+  meetingTimezone: string // IANA
+}
+
 @Injectable()
 export class MeetingBriefingsService extends createPrismaBase(
   MODELS.MeetingBriefing,
@@ -142,7 +154,11 @@ export class MeetingBriefingsService extends createPrismaBase(
     const ctx = await this.resolveDispatchContext(electedOffice)
     if (!ctx) return
 
-    await Promise.all([this.dispatchSchedule(ctx), this.dispatchBriefing(ctx)])
+    // Only the schedule fires here. When the schedule run completes,
+    // `onExperimentRunCompleted` checks the imminence gate and dispatches
+    // the briefing if a meeting falls inside the window. This guarantees
+    // we never run a briefing without a fresh schedule.
+    await this.dispatchSchedule(ctx)
   }
 
   private async dispatchSchedule(ctx: DispatchContext): Promise<void> {
@@ -158,7 +174,10 @@ export class MeetingBriefingsService extends createPrismaBase(
     })
   }
 
-  private async dispatchBriefing(ctx: DispatchContext): Promise<void> {
+  private async dispatchBriefing(
+    ctx: DispatchContext,
+    meeting: TargetMeeting,
+  ): Promise<void> {
     await this.experimentRuns.dispatchRun({
       type: BRIEFING_EXPERIMENT_TYPE,
       organizationSlug: ctx.organizationSlug,
@@ -167,10 +186,64 @@ export class MeetingBriefingsService extends createPrismaBase(
         officialName: ctx.officialName,
         state: ctx.state,
         positionName: ctx.positionName,
+        meetingDate: meeting.meetingDate,
+        meetingTime: meeting.meetingTime,
+        meetingTimezone: meeting.meetingTimezone,
         ...(ctx.l2DistrictType ? { l2DistrictType: ctx.l2DistrictType } : {}),
         ...(ctx.l2DistrictName ? { l2DistrictName: ctx.l2DistrictName } : {}),
       },
     })
+  }
+
+  /**
+   * Look up the official's latest meeting_schedule, project the next
+   * meeting from its RRULE, and return the target meeting payload — or
+   * null if no schedule exists, the schedule was not_found, or no
+   * meeting falls inside the window.
+   *
+   * Callers pass `windowDays` to bound how far out to project. The cron
+   * uses IMMINENCE_WINDOW_DAYS; manual dispatches use a wider window
+   * (e.g. 60) so a user clicking "brief now" can override the gate.
+   */
+  private async resolveTargetMeeting(
+    organizationSlug: string,
+    electedOfficeId: string,
+    now: Date,
+    windowDays: number,
+  ): Promise<TargetMeeting | null> {
+    const schedule = await this.loadLatestScheduleForOrg(organizationSlug)
+    if (!schedule) {
+      this.logger.info(
+        { electedOfficeId },
+        'skipping briefing: no meeting_schedule available for org',
+      )
+      return null
+    }
+    if (schedule.status === 'not_found') {
+      this.logger.info(
+        { electedOfficeId },
+        'skipping briefing: meeting_schedule is not_found',
+      )
+      return null
+    }
+    const windowEnd = new Date(now.getTime() + windowDays * 24 * 60 * 60 * 1000)
+    const upcoming = this.projectMeetingDates({
+      schedule,
+      from: now,
+      to: windowEnd,
+    })
+    if (upcoming.length === 0) {
+      this.logger.info(
+        { electedOfficeId, windowDays },
+        'skipping briefing: no projected meeting inside window',
+      )
+      return null
+    }
+    return {
+      meetingDate: upcoming[0],
+      meetingTime: schedule.time,
+      meetingTimezone: schedule.timezone,
+    }
   }
 
   async dispatchManual(
@@ -187,9 +260,21 @@ export class MeetingBriefingsService extends createPrismaBase(
 
     if (kind === 'schedule') {
       await this.dispatchSchedule(ctx)
-    } else {
-      await this.dispatchBriefing(ctx)
+      return { dispatched: true }
     }
+
+    // Manual briefing dispatch bypasses the 5-day imminence gate but still
+    // needs a meetingDate from the schedule. Project up to 60 days out so
+    // an operator can pre-brief a meeting that's still a few weeks away.
+    const target = await this.resolveTargetMeeting(
+      ctx.organizationSlug,
+      ctx.electedOfficeId,
+      new Date(),
+      60,
+    )
+    if (!target) return { dispatched: false }
+
+    await this.dispatchBriefing(ctx, target)
     return { dispatched: true }
   }
 
@@ -198,7 +283,56 @@ export class MeetingBriefingsService extends createPrismaBase(
 
     if (run.experimentType === BRIEFING_EXPERIMENT_TYPE) {
       await this.upsertBriefingRow(run)
+      return
     }
+
+    if (run.experimentType === SCHEDULE_EXPERIMENT_TYPE) {
+      await this.maybeDispatchBriefingAfterSchedule(run)
+    }
+  }
+
+  /**
+   * When a meeting_schedule run completes, check whether that office now
+   * qualifies for a meeting_briefing dispatch (imminence gate + coverage
+   * dedupe). This is the path that fires the first briefing for a newly
+   * created elected office: onElectedOfficeCreated dispatches only the
+   * schedule; this hook dispatches the briefing once the schedule lands.
+   */
+  private async maybeDispatchBriefingAfterSchedule(
+    run: ExperimentRun,
+  ): Promise<void> {
+    if (!isAutomationEnabled()) return
+
+    // The schedule run's params include `elected_office_id` (snake_case);
+    // see dispatchSchedule().
+    const params =
+      typeof run.params === 'object' && run.params !== null ? run.params : {}
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const electedOfficeId = (params as Record<string, unknown>)[
+      'elected_office_id'
+    ] as string | undefined
+    if (!electedOfficeId) {
+      this.logger.warn(
+        { runId: run.runId },
+        'schedule run completed without elected_office_id in params; cannot chain to briefing',
+      )
+      return
+    }
+
+    const eo = await this.client.electedOffice.findUnique({
+      where: { id: electedOfficeId },
+      select: { id: true, organizationSlug: true, userId: true },
+    })
+    if (!eo) return
+
+    await this.dispatchBriefingIfNeeded(eo, new Date()).catch(
+      (err: unknown) => {
+        this.logger.error(
+          { err, electedOfficeId, scheduleRunId: run.runId },
+          'dispatchBriefingIfNeeded failed after schedule completion',
+        )
+      },
+    )
   }
 
   @Cron('0 7 * * *')
@@ -255,11 +389,22 @@ export class MeetingBriefingsService extends createPrismaBase(
     eo: { id: string; organizationSlug: string; userId: number },
     now: Date,
   ): Promise<void> {
+    // Coverage dedupe: skip if a briefing already covers an upcoming meeting.
     const futureBriefing = await this.model.findFirst({
       where: { electedOfficeId: eo.id, meetingDate: { gte: now } },
       select: { id: true },
     })
     if (futureBriefing) return
+
+    // Imminence gate: only dispatch when the schedule shows a meeting
+    // within IMMINENCE_WINDOW_DAYS. No schedule → no briefing.
+    const target = await this.resolveTargetMeeting(
+      eo.organizationSlug,
+      eo.id,
+      now,
+      IMMINENCE_WINDOW_DAYS,
+    )
+    if (!target) return
 
     const electedOffice = await this.client.electedOffice.findUnique({
       where: { id: eo.id },
@@ -269,7 +414,7 @@ export class MeetingBriefingsService extends createPrismaBase(
     const ctx = await this.resolveDispatchContext(electedOffice)
     if (!ctx) return
 
-    await this.dispatchBriefing(ctx)
+    await this.dispatchBriefing(ctx, target)
   }
 
   private async resolveDispatchContext(

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@prisma/client'
 import { rrulestr } from 'rrule'
 import { formatInTimeZone } from 'date-fns-tz'
+import { addDays } from 'date-fns'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { OrganizationsService } from '@/organizations/services/organizations.service'
 import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
@@ -244,7 +245,7 @@ export class MeetingBriefingsService extends createPrismaBase(
       )
       return null
     }
-    const windowEnd = new Date(now.getTime() + windowDays * 24 * 60 * 60 * 1000)
+    const windowEnd = addDays(now, windowDays)
     const upcoming = this.projectMeetingDates({
       schedule,
       from: now,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes elected-office automation timing and experiment chaining; mis-projected RRULEs or missing schedules could delay or skip briefings until manual/cron retry.
> 
> **Overview**
> This PR **gates `meeting_briefing` dispatches on schedule data and meeting timing**, so briefings are not fired in parallel with (or without) a completed `meeting_schedule`.
> 
> **Orchestration:** Creating an elected office now dispatches **only** `meeting_schedule`. When that run completes, `onExperimentRunCompleted` may chain a briefing via `maybeDispatchBriefingAfterSchedule` (imminence + existing coverage dedupe). The daily cron and `dispatchBriefingIfNeeded` also require a projected next meeting within **5 days** (`IMMINENCE_WINDOW_DAYS`); manual `briefing` dispatch uses a **60-day** projection window but still needs a schedule artifact.
> 
> **Agent contract:** `meeting_briefing` input adds required `meetingDate` and optional `meetingTime` / `meetingTimezone`, populated from the latest schedule RRULE via `resolveTargetMeeting`.
> 
> Tests add `seedScheduleForOrg` and cover chain-on-schedule-complete, outside-window skip, `not_found` schedule, cron/manual paths without schedule, and params including meeting fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59a6a72b158b772af4a596a16cc19004728e3ca1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->