### PR TITLE
feat(campaign-chat): SSE streaming endpoint for the campaign AI assistant

### DIFF
--- a/src/campaigns/ai/chat/aiChat.controller.test.ts
+++ b/src/campaigns/ai/chat/aiChat.controller.test.ts
@@ -142,6 +142,23 @@ describe('AiChatController.stream', () => {
     expect(captured?.aborted).toBe(true)
   })
 
+  it('cleans up the close listener and bails when writeHead throws', async () => {
+    const { controller, streamChat } = makeController(() =>
+      gen([{ type: 'text', delta: 'a' }]),
+    )
+    const reply = makeReply()
+    reply.raw.writeHead = vi.fn(() => {
+      throw new Error('socket destroyed')
+    })
+    const req = makeReq()
+
+    await controller.stream(CAMPAIGN, BODY, req as never, reply as never)
+
+    expect(req.raw.off).toHaveBeenCalledWith('close', expect.any(Function))
+    expect(streamChat).not.toHaveBeenCalled()
+    expect(reply.raw.end).not.toHaveBeenCalled()
+  })
+
   it('writes a timeout error chunk when the stream exceeds the deadline', async () => {
     vi.useFakeTimers()
     let release!: () => void

--- a/src/campaigns/ai/chat/aiChat.controller.test.ts
+++ b/src/campaigns/ai/chat/aiChat.controller.test.ts
@@ -142,6 +142,32 @@ describe('AiChatController.stream', () => {
     expect(captured?.aborted).toBe(true)
   })
 
+  it('forwards a service-yielded error chunk without writing a duplicate internal chunk', async () => {
+    const { controller } = makeController(() =>
+      gen([
+        { type: 'text', delta: 'a' },
+        {
+          type: 'error',
+          code: 'upstream_unavailable',
+          message: 'Service error.',
+          retryable: true,
+        },
+      ]),
+    )
+    const reply = makeReply()
+    const req = makeReq()
+
+    await controller.stream(CAMPAIGN, BODY, req as never, reply as never)
+
+    expect(reply.raw.write).toHaveBeenCalledWith(
+      expect.stringContaining('Service error.'),
+    )
+    expect(reply.raw.write).not.toHaveBeenCalledWith(
+      expect.stringContaining('Chat stream failed'),
+    )
+    expect(reply.raw.end).toHaveBeenCalledTimes(1)
+  })
+
   it('cleans up the close listener and bails when writeHead throws', async () => {
     const { controller, streamChat } = makeController(() =>
       gen([{ type: 'text', delta: 'a' }]),

--- a/src/campaigns/ai/chat/aiChat.controller.test.ts
+++ b/src/campaigns/ai/chat/aiChat.controller.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { HttpStatus } from '@nestjs/common'
+import { AiChatController } from './aiChat.controller'
+import { createMockLogger } from 'src/shared/test-utils/mockLogger.util'
+import type { CampaignChatChunk } from './aiChat.types'
+import type { PromptReplaceCampaign } from 'src/ai/services/promptReplace.service'
+import type { StreamAiChatSchema } from './schemas/StreamAiChat.schema'
+
+const CAMPAIGN = { id: 1, user: { id: 7 } } as unknown as PromptReplaceCampaign
+const BODY = { message: 'hi', initial: true } as StreamAiChatSchema
+
+const gen = (chunks: CampaignChatChunk[]) =>
+  // eslint-disable-next-line @typescript-eslint/require-await
+  (async function* () {
+    for (const c of chunks) yield c
+  })()
+
+const makeReply = () => ({
+  raw: {
+    writeHead: vi.fn(),
+    write: vi.fn().mockReturnValue(true),
+    end: vi.fn(),
+    once: vi.fn(),
+    off: vi.fn(),
+  },
+})
+
+const makeReq = () => {
+  const handlers: Record<string, () => void> = {}
+  return {
+    raw: {
+      once: vi.fn((event: string, cb: () => void) => {
+        handlers[event] = cb
+      }),
+      off: vi.fn(),
+    },
+    fire: (event: string) => handlers[event]?.(),
+  }
+}
+
+type StreamImpl = (
+  ...args: unknown[]
+) => AsyncGenerator<CampaignChatChunk, void, void>
+
+const makeController = (streamImpl: StreamImpl) => {
+  const streamChat = vi.fn(streamImpl)
+  const aiChatService = { streamChat }
+  const campaigns = {
+    fetchLiveRaceTargetMetrics: vi.fn().mockResolvedValue(null),
+  }
+  const slack = {}
+  const controller = new AiChatController(
+    aiChatService as never,
+    campaigns as never,
+    slack as never,
+    createMockLogger(),
+  )
+  return { controller, streamChat }
+}
+
+describe('AiChatController.stream', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('opens the SSE response and forwards every chunk, then ends', async () => {
+    const { controller } = makeController(() =>
+      gen([
+        { type: 'text', delta: 'a' },
+        {
+          type: 'done',
+          threadId: 't1',
+          message: { role: 'assistant', content: 'a' },
+        },
+      ]),
+    )
+    const reply = makeReply()
+    const req = makeReq()
+
+    await controller.stream(CAMPAIGN, BODY, req as never, reply as never)
+
+    expect(reply.raw.writeHead).toHaveBeenCalledWith(
+      HttpStatus.OK,
+      expect.objectContaining({ 'content-type': 'text/event-stream' }),
+    )
+    expect(reply.raw.write).toHaveBeenCalledWith(
+      expect.stringContaining('"type":"text"'),
+    )
+    expect(reply.raw.write).toHaveBeenCalledWith(
+      expect.stringContaining('"type":"done"'),
+    )
+    expect(reply.raw.write).not.toHaveBeenCalledWith(
+      expect.stringContaining('"type":"error"'),
+    )
+    expect(reply.raw.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes a non-retryable internal error chunk when the iterator throws', async () => {
+    const { controller } = makeController(() =>
+      // eslint-disable-next-line @typescript-eslint/require-await
+      (async function* () {
+        yield { type: 'text', delta: 'a' } as CampaignChatChunk
+        throw new Error('boom')
+      })(),
+    )
+    const reply = makeReply()
+    const req = makeReq()
+
+    await controller.stream(CAMPAIGN, BODY, req as never, reply as never)
+
+    expect(reply.raw.write).toHaveBeenCalledWith(
+      expect.stringContaining('Chat stream failed'),
+    )
+    expect(reply.raw.write).toHaveBeenCalledWith(
+      expect.stringContaining('"retryable":false'),
+    )
+    expect(reply.raw.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('aborts the stream signal when the client disconnects, and cleans up the listener', async () => {
+    let captured: AbortSignal | undefined
+    const { controller } = makeController((...args: unknown[]) => {
+      captured = args[3] as AbortSignal
+      return gen([
+        { type: 'text', delta: 'a' },
+        {
+          type: 'done',
+          threadId: 't1',
+          message: { role: 'assistant', content: 'a' },
+        },
+      ])
+    })
+    const reply = makeReply()
+    const req = makeReq()
+
+    await controller.stream(CAMPAIGN, BODY, req as never, reply as never)
+
+    expect(req.raw.once).toHaveBeenCalledWith('close', expect.any(Function))
+    expect(req.raw.off).toHaveBeenCalledWith('close', expect.any(Function))
+    expect(captured?.aborted).toBe(false)
+    req.fire('close')
+    expect(captured?.aborted).toBe(true)
+  })
+
+  it('writes a timeout error chunk when the stream exceeds the deadline', async () => {
+    vi.useFakeTimers()
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const { controller } = makeController(
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async function* () {
+        yield { type: 'text', delta: 'a' } as CampaignChatChunk
+        await gate
+        yield {
+          type: 'done',
+          threadId: 't1',
+          message: { role: 'assistant', content: 'a' },
+        } as CampaignChatChunk
+      },
+    )
+    const reply = makeReply()
+    const req = makeReq()
+
+    const pending = controller.stream(
+      CAMPAIGN,
+      BODY,
+      req as never,
+      reply as never,
+    )
+    // Advance past the 5-minute stream deadline while the generator is blocked.
+    await vi.advanceTimersByTimeAsync(300_000)
+    release()
+    await pending
+
+    expect(reply.raw.write).toHaveBeenCalledWith(
+      expect.stringContaining('Response took too long'),
+    )
+    expect(reply.raw.end).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/campaigns/ai/chat/aiChat.controller.ts
+++ b/src/campaigns/ai/chat/aiChat.controller.ts
@@ -280,10 +280,12 @@ export class AiChatController {
     )
 
     let errored = false
+    let doneWritten = false
     try {
       for await (const chunk of iterable) {
         if (abortController.signal.aborted) break
         const flushed: boolean = reply.raw.write(formatChunk(chunk))
+        if (chunk.type === 'done') doneWritten = true
         if (!flushed) {
           const drainResult = await waitForDrain(
             reply.raw,
@@ -298,7 +300,10 @@ export class AiChatController {
     } finally {
       clearTimeout(timeout)
       req.raw.off('close', onClose)
-      if (timedOut) {
+      // Suppress the timeout chunk if a `done` already went out — the timer can
+      // fire between writing `done` and the loop exhausting, which would append
+      // a contradictory error after a successful completion.
+      if (timedOut && !doneWritten) {
         try {
           reply.raw.write(TIMEOUT_ERROR_CHUNK)
         } catch (err) {

--- a/src/campaigns/ai/chat/aiChat.controller.ts
+++ b/src/campaigns/ai/chat/aiChat.controller.ts
@@ -248,7 +248,18 @@ export class AiChatController {
       abortController.abort()
     }, STREAM_TIMEOUT_MS)
 
-    reply.raw.writeHead(HttpStatus.OK, SSE_HEADERS)
+    // writeHead can throw if the client disconnected between the close-listener
+    // setup and here (write to a destroyed socket). Clean up the timer + close
+    // listener explicitly, since the cleanup `finally` below this point would
+    // otherwise be skipped.
+    try {
+      reply.raw.writeHead(HttpStatus.OK, SSE_HEADERS)
+    } catch (err) {
+      clearTimeout(timeout)
+      req.raw.off('close', onClose)
+      this.logger.error({ e: err }, 'failed to write SSE headers')
+      return
+    }
 
     let liveMetrics: RaceTargetMetrics | null = null
     try {

--- a/src/campaigns/ai/chat/aiChat.controller.ts
+++ b/src/campaigns/ai/chat/aiChat.controller.ts
@@ -8,9 +8,12 @@ import {
   Param,
   Post,
   Put,
+  Req,
+  Res,
   UsePipes,
 } from '@nestjs/common'
 import { User } from '@prisma/client'
+import type { FastifyReply, FastifyRequest } from 'fastify'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { ReqUser } from 'src/authentication/decorators/ReqUser.decorator'
 import { ReqCampaign } from 'src/campaigns/decorators/ReqCampaign.decorator'
@@ -18,11 +21,81 @@ import { UseCampaign } from 'src/campaigns/decorators/UseCampaign.decorator'
 import { AiChatFeedbackSchema } from './schemas/AiChatFeedback.schema'
 import { UpdateAiChatSchema } from './schemas/UpdateAiChat.schema'
 import { CreateAiChatSchema } from './schemas/CreateAiChat.schema'
+import { StreamAiChatSchema } from './schemas/StreamAiChat.schema'
 import { AiChatService } from './aiChat.service'
+import { CampaignChatChunk } from './aiChat.types'
 import { CampaignsService } from 'src/campaigns/services/campaigns.service'
 import { SlackService } from 'src/vendors/slack/services/slack.service'
 import { PromptReplaceCampaign } from 'src/ai/services/promptReplace.service'
+import { RaceTargetMetrics } from 'src/elections/types/elections.types'
 import { PinoLogger } from 'nestjs-pino'
+
+const SSE_HEADERS: Record<string, string> = {
+  'content-type': 'text/event-stream',
+  'cache-control': 'no-cache, no-transform',
+  connection: 'keep-alive',
+  'x-accel-buffering': 'no',
+}
+
+const STREAM_TIMEOUT_MS = 300_000
+
+// A server-side timeout is NOT a user cancellation: it must use a surfaced,
+// retryable code. The client intentionally swallows `aborted` (user pressed
+// Stop), so a timeout marked `aborted` would silently show no error/retry.
+const TIMEOUT_ERROR_CHUNK = `data: ${JSON.stringify({
+  type: 'error',
+  code: 'upstream_unavailable',
+  message: 'Response took too long. Please try again.',
+  retryable: true,
+})}\n\n`
+
+const INTERNAL_ERROR_CHUNK = `data: ${JSON.stringify({
+  type: 'error',
+  code: 'internal',
+  message: 'Chat stream failed.',
+  retryable: true,
+})}\n\n`
+
+const formatChunk = (chunk: CampaignChatChunk): string =>
+  `data: ${JSON.stringify(chunk)}\n\n`
+
+interface DrainableStream {
+  once?: (event: string, cb: () => void) => void
+  off?: (event: string, cb: () => void) => void
+}
+
+const waitForDrain = (
+  stream: DrainableStream,
+  signal: AbortSignal,
+): Promise<void> =>
+  new Promise<void>((resolve) => {
+    if (typeof stream.once !== 'function') {
+      resolve()
+      return
+    }
+    const cleanup = () => {
+      stream.off?.('drain', onDrain)
+      stream.off?.('close', onTerminal)
+      stream.off?.('error', onTerminal)
+      signal.removeEventListener('abort', onTerminal)
+    }
+    const onDrain = () => {
+      cleanup()
+      resolve()
+    }
+    const onTerminal = () => {
+      cleanup()
+      resolve()
+    }
+    stream.once('drain', onDrain)
+    stream.once('close', onTerminal)
+    stream.once('error', onTerminal)
+    if (signal.aborted) {
+      onTerminal()
+      return
+    }
+    signal.addEventListener('abort', onTerminal, { once: true })
+  })
 
 @Controller('campaigns/ai/chat')
 @UsePipes(ZodValidationPipe)
@@ -137,6 +210,90 @@ export class AiChatController {
       })
       this.logApiErrorData(error)
       throw error
+    }
+  }
+
+  @Post('stream')
+  @UseCampaign({
+    include: {
+      campaignPositions: {
+        include: {
+          topIssue: true,
+          position: true,
+        },
+      },
+      campaignUpdateHistory: true,
+      user: true,
+    },
+  })
+  async stream(
+    @ReqCampaign() campaign: PromptReplaceCampaign,
+    @Body() body: StreamAiChatSchema,
+    @Req() req: FastifyRequest,
+    @Res({ passthrough: false }) reply: FastifyReply,
+  ): Promise<void> {
+    const abortController = new AbortController()
+    const onClose = () => abortController.abort()
+    req.raw.once('close', onClose)
+    let timedOut = false
+    const timeout = setTimeout(() => {
+      timedOut = true
+      abortController.abort()
+    }, STREAM_TIMEOUT_MS)
+
+    reply.raw.writeHead(HttpStatus.OK, SSE_HEADERS)
+
+    let liveMetrics: RaceTargetMetrics | null = null
+    try {
+      liveMetrics = await this.campaigns.fetchLiveRaceTargetMetrics(campaign)
+    } catch (err) {
+      this.logger.error(
+        { e: err },
+        'failed to fetch live race metrics for chat stream',
+      )
+      liveMetrics = null
+    }
+
+    const iterable = this.aiChatService.streamChat(
+      campaign,
+      body,
+      liveMetrics,
+      abortController.signal,
+    )
+
+    let errored = false
+    try {
+      for await (const chunk of iterable) {
+        if (abortController.signal.aborted) break
+        const flushed: boolean = reply.raw.write(formatChunk(chunk))
+        if (!flushed) {
+          await waitForDrain(reply.raw, abortController.signal)
+        }
+      }
+    } catch (err) {
+      errored = true
+      this.logger.error({ e: err }, 'campaign chat SSE stream failed')
+    } finally {
+      clearTimeout(timeout)
+      req.raw.off('close', onClose)
+      if (timedOut) {
+        try {
+          reply.raw.write(TIMEOUT_ERROR_CHUNK)
+        } catch (err) {
+          this.logger.warn({ e: err }, 'failed to write timeout chunk')
+        }
+      } else if (errored) {
+        try {
+          reply.raw.write(INTERNAL_ERROR_CHUNK)
+        } catch (err) {
+          this.logger.warn({ e: err }, 'failed to write error chunk')
+        }
+      }
+      try {
+        reply.raw.end()
+      } catch (err) {
+        this.logger.warn({ e: err }, 'failed to end SSE response')
+      }
     }
   }
 

--- a/src/campaigns/ai/chat/aiChat.controller.ts
+++ b/src/campaigns/ai/chat/aiChat.controller.ts
@@ -67,13 +67,17 @@ interface DrainableStream {
   off?: (event: string, cb: () => void) => void
 }
 
+// Resolves 'drained' when the socket is writable again, or 'closed' when it
+// terminated (close/error/abort). Callers must stop writing on 'closed' — a
+// terminal event can arrive before the abort signal flips, so resolving them
+// the same way would let the loop write to a destroyed socket.
 const waitForDrain = (
   stream: DrainableStream,
   signal: AbortSignal,
-): Promise<void> =>
-  new Promise<void>((resolve) => {
+): Promise<'drained' | 'closed'> =>
+  new Promise<'drained' | 'closed'>((resolve) => {
     if (typeof stream.once !== 'function') {
-      resolve()
+      resolve('drained')
       return
     }
     const cleanup = () => {
@@ -84,11 +88,11 @@ const waitForDrain = (
     }
     const onDrain = () => {
       cleanup()
-      resolve()
+      resolve('drained')
     }
     const onTerminal = () => {
       cleanup()
-      resolve()
+      resolve('closed')
     }
     stream.once('drain', onDrain)
     stream.once('close', onTerminal)
@@ -270,7 +274,11 @@ export class AiChatController {
         if (abortController.signal.aborted) break
         const flushed: boolean = reply.raw.write(formatChunk(chunk))
         if (!flushed) {
-          await waitForDrain(reply.raw, abortController.signal)
+          const drainResult = await waitForDrain(
+            reply.raw,
+            abortController.signal,
+          )
+          if (drainResult === 'closed') break
         }
       }
     } catch (err) {

--- a/src/campaigns/ai/chat/aiChat.controller.ts
+++ b/src/campaigns/ai/chat/aiChat.controller.ts
@@ -49,11 +49,14 @@ const TIMEOUT_ERROR_CHUNK = `data: ${JSON.stringify({
   retryable: true,
 })}\n\n`
 
+// `retryable: false` matches the service's classification of an unclassified
+// internal error (AiChatService.streamError defaults `internal` to false), so
+// the client gets a consistent signal regardless of where the failure surfaces.
 const INTERNAL_ERROR_CHUNK = `data: ${JSON.stringify({
   type: 'error',
   code: 'internal',
   message: 'Chat stream failed.',
-  retryable: true,
+  retryable: false,
 })}\n\n`
 
 const formatChunk = (chunk: CampaignChatChunk): string =>

--- a/src/campaigns/ai/chat/aiChat.service.test.ts
+++ b/src/campaigns/ai/chat/aiChat.service.test.ts
@@ -219,7 +219,11 @@ describe('AiChatService.streamChat', () => {
       data: {
         messages: [
           { role: 'user', content: 'q1', id: 'u1' },
-          { role: 'assistant', content: 'line1<br/><br/>line2', id: 'a1' },
+          {
+            role: 'assistant',
+            content: 'line1<br/><br/><b>line2</b>',
+            id: 'a1',
+          },
         ],
       },
     })
@@ -238,7 +242,7 @@ describe('AiChatService.streamChat', () => {
       (m: { role: string }) => m.role === 'assistant',
     )
     expect(priorAssistant.content).toBe('line1\n\nline2')
-    expect(priorAssistant.content).not.toContain('<br')
+    expect(priorAssistant.content).not.toMatch(/<[^>]*>|<br/)
   })
 
   it('re-sends the last user message and replaces the assistant reply on regenerate', async () => {

--- a/src/campaigns/ai/chat/aiChat.service.test.ts
+++ b/src/campaigns/ai/chat/aiChat.service.test.ts
@@ -1,0 +1,315 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockLogger } from 'src/shared/test-utils/mockLogger.util'
+import type { LlmStreamResult } from '@/llm/services/llm.service'
+import { AiChatService } from './aiChat.service'
+import type { PromptReplaceCampaign } from 'src/ai/services/promptReplace.service'
+import type { CampaignChatChunk } from './aiChat.types'
+import type { StreamAiChatSchema } from './schemas/StreamAiChat.schema'
+
+const CAMPAIGN = {
+  id: 10,
+  user: { id: 7 },
+} as unknown as PromptReplaceCampaign
+
+function makeStreamResult(deltas: string[]): LlmStreamResult {
+  return {
+    textStream: (async function* () {
+      for (const d of deltas) yield d
+    })(),
+    finalText: Promise.resolve(deltas.join('')),
+    toolCalls: Promise.resolve([]),
+    usage: Promise.resolve({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+    model: 'test-model',
+  }
+}
+
+async function collect(
+  iter: AsyncIterable<CampaignChatChunk>,
+): Promise<CampaignChatChunk[]> {
+  const out: CampaignChatChunk[] = []
+  for await (const chunk of iter) out.push(chunk)
+  return out
+}
+
+const asBody = (body: Partial<StreamAiChatSchema>): StreamAiChatSchema =>
+  ({ initial: false, regenerate: false, ...body }) as StreamAiChatSchema
+
+describe('AiChatService.streamChat', () => {
+  let service: AiChatService
+  let streamChatCompletion: ReturnType<typeof vi.fn>
+  let fakeModel: {
+    create: ReturnType<typeof vi.fn>
+    update: ReturnType<typeof vi.fn>
+    findFirstOrThrow: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    streamChatCompletion = vi.fn()
+    const llm = { streamChatCompletion }
+    const promptReplace = { promptReplace: vi.fn().mockResolvedValue('CTX') }
+    const content = {
+      getChatSystemPrompt: vi
+        .fn()
+        .mockResolvedValue({ candidateJson: '{}', systemPrompt: 'SYS' }),
+    }
+    const slack = {}
+
+    service = new AiChatService(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      llm as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      promptReplace as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      content as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      slack as any,
+    )
+
+    fakeModel = {
+      create: vi.fn().mockResolvedValue({}),
+      update: vi.fn().mockResolvedValue({}),
+      findFirstOrThrow: vi.fn(),
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(service as any)._prisma = { aiChat: fakeModel }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(service as any).logger = createMockLogger()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(service as any).findFirstOrThrow = fakeModel.findFirstOrThrow
+  })
+
+  it('streams text deltas and persists a new thread on the first message', async () => {
+    streamChatCompletion.mockResolvedValue(
+      makeStreamResult(['Hello', ' world']),
+    )
+
+    const chunks = await collect(
+      service.streamChat(
+        CAMPAIGN,
+        asBody({ message: 'hi', initial: true }),
+        null,
+      ),
+    )
+
+    expect(chunks[0]).toEqual({ type: 'text', delta: 'Hello' })
+    expect(chunks[1]).toEqual({ type: 'text', delta: ' world' })
+    const done = chunks[2]
+    expect(done?.type).toBe('done')
+    if (done?.type === 'done') {
+      expect(done.message.content).toBe('Hello world')
+      expect(done.threadId).toBeTruthy()
+    }
+
+    expect(fakeModel.create).toHaveBeenCalledTimes(1)
+    expect(fakeModel.update).not.toHaveBeenCalled()
+    const createArg = fakeModel.create.mock.calls[0][0]
+    expect(createArg.data.campaignId).toBe(10)
+    expect(createArg.data.userId).toBe(7)
+    expect(createArg.data.data.messages).toHaveLength(2)
+    expect(createArg.data.data.messages[0]).toMatchObject({
+      role: 'user',
+      content: 'hi',
+    })
+    expect(createArg.data.data.messages[1]).toMatchObject({
+      role: 'assistant',
+      content: 'Hello world',
+    })
+  })
+
+  it('uses streamChatCompletion with the bumped output token budget', async () => {
+    streamChatCompletion.mockResolvedValue(makeStreamResult(['ok']))
+
+    await collect(
+      service.streamChat(
+        CAMPAIGN,
+        asBody({ message: 'hi', initial: true }),
+        null,
+      ),
+    )
+
+    expect(streamChatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ maxOutputTokens: 2000 }),
+    )
+  })
+
+  it('instructs the model to respond in Markdown (overriding CMS HTML guidance)', async () => {
+    streamChatCompletion.mockResolvedValue(makeStreamResult(['ok']))
+
+    await collect(
+      service.streamChat(
+        CAMPAIGN,
+        asBody({ message: 'hi', initial: true }),
+        null,
+      ),
+    )
+
+    const messages = streamChatCompletion.mock.calls[0][0].messages
+    expect(messages[0].role).toBe('system')
+    expect(messages[0].content).toMatch(/Markdown/i)
+    expect(messages[0].content).toMatch(/do not output raw HTML/i)
+  })
+
+  it('appends to an existing thread on a follow-up message', async () => {
+    fakeModel.findFirstOrThrow.mockResolvedValue({
+      id: 5,
+      data: {
+        messages: [
+          { role: 'user', content: 'q1', id: 'u1' },
+          { role: 'assistant', content: 'a1', id: 'a1' },
+        ],
+      },
+    })
+    streamChatCompletion.mockResolvedValue(makeStreamResult(['resp']))
+
+    const chunks = await collect(
+      service.streamChat(
+        CAMPAIGN,
+        asBody({ threadId: 't1', message: 'q2' }),
+        null,
+      ),
+    )
+
+    expect(chunks.at(-1)?.type).toBe('done')
+    expect(fakeModel.create).not.toHaveBeenCalled()
+    expect(fakeModel.update).toHaveBeenCalledTimes(1)
+    const updateArg = fakeModel.update.mock.calls[0][0]
+    expect(updateArg.where).toEqual({ id: 5 })
+    const messages = updateArg.data.data.messages
+    expect(messages).toHaveLength(4)
+    expect(messages[2]).toMatchObject({ role: 'user', content: 'q2' })
+    expect(messages[3]).toMatchObject({ role: 'assistant', content: 'resp' })
+  })
+
+  it('re-sends the last user message and replaces the assistant reply on regenerate', async () => {
+    fakeModel.findFirstOrThrow.mockResolvedValue({
+      id: 9,
+      data: {
+        messages: [
+          { role: 'user', content: 'first question', id: 'u1' },
+          { role: 'assistant', content: 'original reply', id: 'a1' },
+        ],
+      },
+    })
+    streamChatCompletion.mockResolvedValue(makeStreamResult(['new reply']))
+
+    const chunks = await collect(
+      service.streamChat(
+        CAMPAIGN,
+        asBody({ threadId: 't1', regenerate: true }),
+        null,
+      ),
+    )
+
+    expect(chunks.at(-1)?.type).toBe('done')
+    const updateArg = fakeModel.update.mock.calls[0][0]
+    const messages = updateArg.data.data.messages
+    expect(messages).toHaveLength(2)
+    expect(messages[0]).toMatchObject({
+      role: 'user',
+      content: 'first question',
+    })
+    expect(messages[1]).toMatchObject({
+      role: 'assistant',
+      content: 'new reply',
+    })
+  })
+
+  it('yields a retryable error and skips persistence when the upstream connection fails', async () => {
+    streamChatCompletion.mockRejectedValue(
+      Object.assign(new Error('503 upstream'), { status: 503 }),
+    )
+
+    const chunks = await collect(
+      service.streamChat(
+        CAMPAIGN,
+        asBody({ message: 'hi', initial: true }),
+        null,
+      ),
+    )
+
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]).toMatchObject({
+      type: 'error',
+      code: 'upstream_unavailable',
+      retryable: true,
+    })
+    expect(fakeModel.create).not.toHaveBeenCalled()
+  })
+
+  it('emits a non-retryable aborted error and skips persistence when the signal is aborted', async () => {
+    streamChatCompletion.mockResolvedValue(
+      makeStreamResult(['partial', ' text']),
+    )
+    const controller = new AbortController()
+    controller.abort()
+
+    const chunks = await collect(
+      service.streamChat(
+        CAMPAIGN,
+        asBody({ message: 'hi', initial: true }),
+        null,
+        controller.signal,
+      ),
+    )
+
+    expect(chunks.at(-1)).toMatchObject({
+      type: 'error',
+      code: 'aborted',
+      retryable: false,
+    })
+    expect(fakeModel.create).not.toHaveBeenCalled()
+    expect(fakeModel.update).not.toHaveBeenCalled()
+  })
+
+  it('yields a retryable rate_limited error when the upstream is throttled', async () => {
+    streamChatCompletion.mockRejectedValue(
+      Object.assign(new Error('429 too many requests'), { status: 429 }),
+    )
+
+    const chunks = await collect(
+      service.streamChat(
+        CAMPAIGN,
+        asBody({ message: 'hi', initial: true }),
+        null,
+      ),
+    )
+
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]).toMatchObject({
+      type: 'error',
+      code: 'rate_limited',
+      retryable: true,
+    })
+    expect(fakeModel.create).not.toHaveBeenCalled()
+  })
+
+  it('emits an internal error when persisting the streamed exchange fails', async () => {
+    streamChatCompletion.mockResolvedValue(makeStreamResult(['ok']))
+    fakeModel.create.mockRejectedValue(new Error('db down'))
+
+    const chunks = await collect(
+      service.streamChat(
+        CAMPAIGN,
+        asBody({ message: 'hi', initial: true }),
+        null,
+      ),
+    )
+
+    expect(chunks.some((c) => c.type === 'text')).toBe(true)
+    expect(chunks.at(-1)).toMatchObject({ type: 'error', code: 'internal' })
+  })
+
+  it('errors when the campaign has no associated user', async () => {
+    const chunks = await collect(
+      service.streamChat(
+        { id: 1 } as unknown as PromptReplaceCampaign,
+        asBody({ message: 'hi', initial: true }),
+        null,
+      ),
+    )
+
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]).toMatchObject({ type: 'error', code: 'internal' })
+    expect(streamChatCompletion).not.toHaveBeenCalled()
+  })
+})

--- a/src/campaigns/ai/chat/aiChat.service.test.ts
+++ b/src/campaigns/ai/chat/aiChat.service.test.ts
@@ -380,4 +380,25 @@ describe('AiChatService.streamChat', () => {
     expect(chunks[0]).toMatchObject({ type: 'error', code: 'internal' })
     expect(streamChatCompletion).not.toHaveBeenCalled()
   })
+
+  it('errors with a non-retryable internal error when the thread lookup fails', async () => {
+    fakeModel.findFirstOrThrow.mockRejectedValue(new Error('Not found'))
+
+    const chunks = await collect(
+      service.streamChat(
+        CAMPAIGN,
+        asBody({ threadId: 'missing-thread', message: 'hi' }),
+        null,
+      ),
+    )
+
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]).toMatchObject({
+      type: 'error',
+      code: 'internal',
+      message: 'Chat thread is unavailable.',
+      retryable: false,
+    })
+    expect(streamChatCompletion).not.toHaveBeenCalled()
+  })
 })

--- a/src/campaigns/ai/chat/aiChat.service.test.ts
+++ b/src/campaigns/ai/chat/aiChat.service.test.ts
@@ -198,6 +198,11 @@ describe('AiChatService.streamChat', () => {
     )
 
     expect(chunks.at(-1)?.type).toBe('done')
+    // The thread lookup is scoped to the campaign as well, so a thread from a
+    // different campaign owned by the same user can't be continued here.
+    expect(fakeModel.findFirstOrThrow).toHaveBeenCalledWith({
+      where: { threadId: 't1', userId: 7, campaignId: 10 },
+    })
     expect(fakeModel.create).not.toHaveBeenCalled()
     expect(fakeModel.update).toHaveBeenCalledTimes(1)
     const updateArg = fakeModel.update.mock.calls[0][0]

--- a/src/campaigns/ai/chat/aiChat.service.test.ts
+++ b/src/campaigns/ai/chat/aiChat.service.test.ts
@@ -213,6 +213,34 @@ describe('AiChatService.streamChat', () => {
     expect(messages[3]).toMatchObject({ role: 'assistant', content: 'resp' })
   })
 
+  it('strips legacy HTML from prior assistant messages before replaying history', async () => {
+    fakeModel.findFirstOrThrow.mockResolvedValue({
+      id: 5,
+      data: {
+        messages: [
+          { role: 'user', content: 'q1', id: 'u1' },
+          { role: 'assistant', content: 'line1<br/><br/>line2', id: 'a1' },
+        ],
+      },
+    })
+    streamChatCompletion.mockResolvedValue(makeStreamResult(['ok']))
+
+    await collect(
+      service.streamChat(
+        CAMPAIGN,
+        asBody({ threadId: 't1', message: 'q2' }),
+        null,
+      ),
+    )
+
+    const sent = streamChatCompletion.mock.calls[0][0].messages
+    const priorAssistant = sent.find(
+      (m: { role: string }) => m.role === 'assistant',
+    )
+    expect(priorAssistant.content).toBe('line1\n\nline2')
+    expect(priorAssistant.content).not.toContain('<br')
+  })
+
   it('re-sends the last user message and replaces the assistant reply on regenerate', async () => {
     fakeModel.findFirstOrThrow.mockResolvedValue({
       id: 9,

--- a/src/campaigns/ai/chat/aiChat.service.test.ts
+++ b/src/campaigns/ai/chat/aiChat.service.test.ts
@@ -5,6 +5,7 @@ import { AiChatService } from './aiChat.service'
 import type { PromptReplaceCampaign } from 'src/ai/services/promptReplace.service'
 import type { CampaignChatChunk } from './aiChat.types'
 import type { StreamAiChatSchema } from './schemas/StreamAiChat.schema'
+import type { CreateAiChatSchema } from './schemas/CreateAiChat.schema'
 
 const CAMPAIGN = {
   id: 10,
@@ -37,6 +38,7 @@ const asBody = (body: Partial<StreamAiChatSchema>): StreamAiChatSchema =>
 describe('AiChatService.streamChat', () => {
   let service: AiChatService
   let streamChatCompletion: ReturnType<typeof vi.fn>
+  let chatCompletion: ReturnType<typeof vi.fn>
   let fakeModel: {
     create: ReturnType<typeof vi.fn>
     update: ReturnType<typeof vi.fn>
@@ -45,7 +47,8 @@ describe('AiChatService.streamChat', () => {
 
   beforeEach(() => {
     streamChatCompletion = vi.fn()
-    const llm = { streamChatCompletion }
+    chatCompletion = vi.fn()
+    const llm = { streamChatCompletion, chatCompletion }
     const promptReplace = { promptReplace: vi.fn().mockResolvedValue('CTX') }
     const content = {
       getChatSystemPrompt: vi
@@ -147,6 +150,31 @@ describe('AiChatService.streamChat', () => {
     expect(messages[0].role).toBe('system')
     expect(messages[0].content).toMatch(/Markdown/i)
     expect(messages[0].content).toMatch(/do not output raw HTML/i)
+  })
+
+  it('stores raw Markdown (no HTML post-processing) on the create path', async () => {
+    // All paths share the AiChat store, so the non-streaming create path must
+    // also emit the Markdown directive and store raw Markdown — not HTML with
+    // <br/> conversions — to avoid mixed-format threads.
+    chatCompletion.mockResolvedValue({
+      content: 'line one\nline two',
+      tokens: 5,
+    })
+
+    await service.create(
+      CAMPAIGN,
+      { message: 'hi', initial: true } as CreateAiChatSchema,
+      null,
+    )
+
+    const sent = chatCompletion.mock.calls[0][0].messages
+    expect(sent[0].role).toBe('system')
+    expect(sent[0].content).toMatch(/Markdown/i)
+
+    const storedAssistant =
+      fakeModel.create.mock.calls[0][0].data.data.messages[1]
+    expect(storedAssistant.content).toBe('line one\nline two')
+    expect(storedAssistant.content).not.toContain('<br')
   })
 
   it('appends to an existing thread on a follow-up message', async () => {
@@ -257,6 +285,9 @@ describe('AiChatService.streamChat', () => {
       code: 'aborted',
       retryable: false,
     })
+    // The aborted-signal guard must fire before any delta is emitted — no
+    // partial text should leak ahead of the abort error.
+    expect(chunks.every((c) => c.type !== 'text')).toBe(true)
     expect(fakeModel.create).not.toHaveBeenCalled()
     expect(fakeModel.update).not.toHaveBeenCalled()
   })

--- a/src/campaigns/ai/chat/aiChat.service.ts
+++ b/src/campaigns/ai/chat/aiChat.service.ts
@@ -133,6 +133,7 @@ export class AiChatService extends createPrismaBase(MODELS.AiChat) {
       where: {
         threadId,
         userId: campaign.user?.id,
+        campaignId: campaign.id,
       },
     })
     const data = aiChat.data as { messages: AiChatMessage[] }
@@ -303,7 +304,7 @@ export class AiChatService extends createPrismaBase(MODELS.AiChat) {
       userMessage: AiChatMessage
     }
     try {
-      resolved = await this.resolveStreamThread(userId, body)
+      resolved = await this.resolveStreamThread(userId, campaign.id, body)
     } catch (err) {
       this.logger.error({ err }, 'failed to resolve campaign chat thread')
       yield this.streamError('internal', 'Chat thread is unavailable.')
@@ -410,6 +411,7 @@ export class AiChatService extends createPrismaBase(MODELS.AiChat) {
 
   private async resolveStreamThread(
     userId: number,
+    campaignId: number,
     { threadId, message, regenerate }: StreamAiChatSchema,
   ): Promise<{
     threadId: string
@@ -436,8 +438,11 @@ export class AiChatService extends createPrismaBase(MODELS.AiChat) {
       }
     }
 
+    // Scope by campaignId too: without it a user who owns multiple campaigns
+    // could continue/regenerate a thread from a different campaign under the
+    // wrong campaign's context.
     const existing = await this.findFirstOrThrow({
-      where: { threadId, userId },
+      where: { threadId, userId, campaignId },
     })
     const existingData = existing.data as { messages: AiChatMessage[] }
     const priorMessages = [...(existingData.messages ?? [])]

--- a/src/campaigns/ai/chat/aiChat.service.ts
+++ b/src/campaigns/ai/chat/aiChat.service.ts
@@ -4,7 +4,7 @@ import {
   PromptReplaceCampaign,
   PromptReplaceService,
 } from 'src/ai/services/promptReplace.service'
-import { LlmService } from '@/llm/services/llm.service'
+import { LlmService, LlmStreamResult } from '@/llm/services/llm.service'
 import { formatHtmlLlmResponse } from '@/ai/util/llmResponseFormat.util'
 import {
   isChatCompletionMessage,
@@ -13,7 +13,12 @@ import {
 import { ContentService } from 'src/content/services/content.service'
 import { RaceTargetMetrics } from 'src/elections/types/elections.types'
 import { UpdateAiChatSchema } from './schemas/UpdateAiChat.schema'
-import { AiChatMessage } from './aiChat.types'
+import { StreamAiChatSchema } from './schemas/StreamAiChat.schema'
+import {
+  AiChatMessage,
+  CampaignChatChunk,
+  CampaignChatErrorCode,
+} from './aiChat.types'
 import { AiChatFeedbackSchema } from './schemas/AiChatFeedback.schema'
 import { SlackService } from 'src/vendors/slack/services/slack.service'
 import { User } from '@prisma/client'
@@ -24,9 +29,31 @@ import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { requireEnv } from 'src/shared/util/env.util'
 
 const LLAMA_AI_ASSISTANT = requireEnv('LLAMA_AI_ASSISTANT')
-const AI_CHAT_MAX_TOKENS = 500
+const AI_CHAT_MAX_TOKENS = 2000
 const AI_CHAT_TEMPERATURE = 0.7
-const AI_CHAT_TOP_P = 0.1
+const AI_CHAT_TOP_P = 0.9
+
+// The CMS-managed prompt historically asks the model to emit HTML (for the
+// shared content-generation/Quill path). The chat now renders Markdown via
+// react-markdown, so we append a final, authoritative formatting directive
+// that overrides any HTML guidance from the CMS prompt. Placed last in the
+// system message so it takes precedence.
+const MARKDOWN_FORMAT_DIRECTIVE = `Formatting requirements (these override any earlier or conflicting formatting instructions):
+- Respond using GitHub-flavored Markdown ONLY. Do not output raw HTML tags (no <p>, <ul>, <li>, <a>, <br>, <strong>, etc.).
+- Use **bold**, *italics*, \`inline code\`, fenced code blocks, bullet and numbered lists, ## headings, tables, and Markdown links in the form [label](https://example.com).`
+
+const getErrorStatus = (err: unknown): number | undefined => {
+  if (err && typeof err === 'object') {
+    const candidate = err as { status?: number; statusCode?: number }
+    return candidate.status ?? candidate.statusCode
+  }
+  return undefined
+}
+
+const isUpstreamFailure = (status: number | undefined, text: string): boolean =>
+  (status !== undefined && status >= 500 && status < 600) ||
+  /\b5\d\d\b/.test(text) ||
+  /network|ECONN|ETIMEDOUT|fetch failed/i.test(text)
 
 @Injectable()
 export class AiChatService extends createPrismaBase(MODELS.AiChat) {
@@ -63,8 +90,6 @@ export class AiChatService extends createPrismaBase(MODELS.AiChat) {
 
     const threadId = crypto.randomUUID()
     this.logger.info({ threadId }, 'creating thread')
-    this.logger.info({ candidateContext }, 'candidateContext')
-    this.logger.info({ systemPrompt }, 'systemPrompt')
 
     const chatResponse = await this.runAssistantCompletion({
       systemPrompt,
@@ -194,15 +219,12 @@ export class AiChatService extends createPrismaBase(MODELS.AiChat) {
       ? (existingMessages ?? []).filter((m) => m.id !== messageId)
       : (existingMessages ?? [])
 
-    const messages: ChatCompletionMessageParam[] = [
-      { role: 'system', content: `${systemPrompt}\n${candidateContext}` },
-      ...priorMessages
-        .map(toChatCompletionMessage)
-        .filter(isChatCompletionMessage),
-      { role: 'user', content: message.content },
-    ]
-
-    this.logger.info({ messages }, 'messages')
+    const messages = this.buildMessages({
+      systemPrompt,
+      candidateContext,
+      priorMessages,
+      userContent: message.content,
+    })
 
     const result = await this.llm.chatCompletion({
       messages,
@@ -218,6 +240,289 @@ export class AiChatService extends createPrismaBase(MODELS.AiChat) {
       createdAt: new Date().valueOf(),
       usage: result.tokens,
     }
+  }
+
+  private buildMessages({
+    systemPrompt,
+    candidateContext,
+    priorMessages,
+    userContent,
+  }: {
+    systemPrompt: string
+    candidateContext: string
+    priorMessages: AiChatMessage[]
+    userContent: string
+  }): ChatCompletionMessageParam[] {
+    if (!systemPrompt) {
+      throw new Error('Missing required param: systemPrompt')
+    }
+    return [
+      {
+        role: 'system',
+        content: `${systemPrompt}\n${candidateContext}\n\n${MARKDOWN_FORMAT_DIRECTIVE}`,
+      },
+      ...priorMessages
+        .map(toChatCompletionMessage)
+        .filter(isChatCompletionMessage),
+      { role: 'user', content: userContent },
+    ]
+  }
+
+  /**
+   * Streaming variant of the assistant chat. Yields incremental text deltas
+   * (SSE-friendly), persists the completed exchange to the AiChat JSON blob,
+   * then emits a terminal `done` (or `error`) chunk. Mirrors the briefing
+   * chat streaming contract but keeps the existing AiChat storage model.
+   *
+   * Assistant content is stored as raw markdown (not HTML) so the client can
+   * render it incrementally and on reload via the same markdown pipeline.
+   */
+  async *streamChat(
+    campaign: PromptReplaceCampaign,
+    body: StreamAiChatSchema,
+    liveMetrics?: RaceTargetMetrics | null,
+    signal?: AbortSignal,
+  ): AsyncGenerator<CampaignChatChunk, void, void> {
+    const userId = campaign.user?.id
+    if (!userId) {
+      yield this.streamError('internal', 'Campaign has no associated user.')
+      return
+    }
+
+    const { initial } = body
+
+    let resolved: {
+      threadId: string
+      isNewThread: boolean
+      existingId?: number
+      existingData?: object
+      priorMessages: AiChatMessage[]
+      userMessage: AiChatMessage
+    }
+    try {
+      resolved = await this.resolveStreamThread(userId, body)
+    } catch (err) {
+      this.logger.error({ err }, 'failed to resolve campaign chat thread')
+      yield this.streamError('internal', 'Chat thread is unavailable.')
+      return
+    }
+
+    const { candidateJson, systemPrompt } =
+      await this.contentService.getChatSystemPrompt(
+        resolved.isNewThread && initial,
+      )
+    const candidateContext = await this.promptReplaceService.promptReplace(
+      candidateJson,
+      campaign,
+      liveMetrics,
+    )
+
+    const messages = this.buildMessages({
+      systemPrompt,
+      candidateContext,
+      priorMessages: resolved.priorMessages,
+      userContent: resolved.userMessage.content,
+    })
+
+    let result: LlmStreamResult
+    try {
+      result = await this.llm.streamChatCompletion({
+        messages,
+        temperature: AI_CHAT_TEMPERATURE,
+        topP: AI_CHAT_TOP_P,
+        maxOutputTokens: AI_CHAT_MAX_TOKENS,
+        ...(signal && { abortSignal: signal }),
+      })
+    } catch (err) {
+      this.logger.error(
+        { err, threadId: resolved.threadId },
+        'campaign chat stream connect failed',
+      )
+      yield this.classifyStreamError(err, signal)
+      return
+    }
+
+    const parts: string[] = []
+    try {
+      for await (const delta of result.textStream) {
+        if (signal?.aborted) break
+        parts.push(delta)
+        yield { type: 'text', delta }
+      }
+    } catch (err) {
+      this.logger.error(
+        { err, threadId: resolved.threadId },
+        'campaign chat stream iteration failed',
+      )
+      yield this.classifyStreamError(err, signal)
+      return
+    }
+
+    if (signal?.aborted) {
+      yield this.streamError('aborted', 'Stream cancelled.', false)
+      return
+    }
+
+    const assistantMessage: AiChatMessage = {
+      role: 'assistant',
+      content: parts.join(''),
+      id: crypto.randomUUID(),
+      createdAt: new Date().valueOf(),
+    }
+
+    try {
+      await this.persistStreamedExchange(campaign, userId, resolved, [
+        ...resolved.priorMessages,
+        resolved.userMessage,
+        assistantMessage,
+      ])
+    } catch (err) {
+      this.logger.error(
+        { err, threadId: resolved.threadId },
+        'failed to persist streamed campaign chat',
+      )
+      yield this.streamError('internal', 'Failed to save the chat.')
+      return
+    }
+
+    yield {
+      type: 'done',
+      threadId: resolved.threadId,
+      message: assistantMessage,
+    }
+  }
+
+  private async resolveStreamThread(
+    userId: number,
+    { threadId, message, regenerate }: StreamAiChatSchema,
+  ): Promise<{
+    threadId: string
+    isNewThread: boolean
+    existingId?: number
+    existingData?: object
+    priorMessages: AiChatMessage[]
+    userMessage: AiChatMessage
+  }> {
+    if (!threadId) {
+      if (!message) {
+        throw new Error('Message is required to start a chat')
+      }
+      return {
+        threadId: crypto.randomUUID(),
+        isNewThread: true,
+        priorMessages: [],
+        userMessage: {
+          role: 'user',
+          content: message,
+          id: crypto.randomUUID(),
+          createdAt: new Date().valueOf(),
+        },
+      }
+    }
+
+    const existing = await this.findFirstOrThrow({
+      where: { threadId, userId },
+    })
+    const existingData = existing.data as { messages: AiChatMessage[] }
+    const priorMessages = [...(existingData.messages ?? [])]
+
+    let userMessage: AiChatMessage
+    if (regenerate) {
+      priorMessages.pop() // drop last assistant response
+      const lastUser = priorMessages.pop() // re-send the last user message
+      if (!lastUser) {
+        throw new Error('Cannot regenerate: no prior user message')
+      }
+      userMessage = lastUser
+    } else {
+      if (!message) {
+        throw new Error('Message is required')
+      }
+      userMessage = {
+        role: 'user',
+        content: message,
+        id: crypto.randomUUID(),
+        createdAt: new Date().valueOf(),
+      }
+    }
+
+    return {
+      threadId,
+      isNewThread: false,
+      existingId: existing.id,
+      existingData,
+      priorMessages,
+      userMessage,
+    }
+  }
+
+  private async persistStreamedExchange(
+    campaign: PromptReplaceCampaign,
+    userId: number,
+    resolved: {
+      threadId: string
+      isNewThread: boolean
+      existingId?: number
+      existingData?: object
+    },
+    messages: AiChatMessage[],
+  ): Promise<void> {
+    if (resolved.isNewThread) {
+      await this.model.create({
+        data: {
+          assistant: LLAMA_AI_ASSISTANT,
+          threadId: resolved.threadId,
+          userId,
+          campaignId: campaign.id,
+          data: { messages },
+        },
+      })
+      return
+    }
+    await this.model.update({
+      where: { id: resolved.existingId },
+      data: {
+        data: { ...(resolved.existingData ?? {}), messages },
+      },
+    })
+  }
+
+  private streamError(
+    code: CampaignChatErrorCode,
+    message: string,
+    retryable: boolean = code === 'upstream_unavailable' ||
+      code === 'rate_limited',
+  ): CampaignChatChunk {
+    return { type: 'error', code, message, retryable }
+  }
+
+  private classifyStreamError(
+    err: unknown,
+    signal?: AbortSignal,
+  ): CampaignChatChunk {
+    const isAbort =
+      signal?.aborted === true ||
+      (err instanceof Error && err.name === 'AbortError')
+    if (isAbort) {
+      return this.streamError('aborted', 'Stream cancelled.', false)
+    }
+
+    const status = getErrorStatus(err)
+    const text = err instanceof Error ? err.message : String(err)
+
+    if (status === 429 || /\b429\b|rate.?limit/i.test(text)) {
+      return this.streamError(
+        'rate_limited',
+        'Too many requests. Please wait and try again.',
+      )
+    }
+    if (isUpstreamFailure(status, text)) {
+      return this.streamError(
+        'upstream_unavailable',
+        'Chat is temporarily unavailable.',
+      )
+    }
+    return this.streamError('internal', 'Chat failed. Please try again.', false)
   }
 
   delete(threadId: string, userId: number) {

--- a/src/campaigns/ai/chat/aiChat.service.ts
+++ b/src/campaigns/ai/chat/aiChat.service.ts
@@ -5,7 +5,6 @@ import {
   PromptReplaceService,
 } from 'src/ai/services/promptReplace.service'
 import { LlmService, LlmStreamResult } from '@/llm/services/llm.service'
-import { formatHtmlLlmResponse } from '@/ai/util/llmResponseFormat.util'
 import {
   isChatCompletionMessage,
   toChatCompletionMessage,
@@ -233,9 +232,13 @@ export class AiChatService extends createPrismaBase(MODELS.AiChat) {
       topP: AI_CHAT_TOP_P,
     })
 
+    // Store raw Markdown in every path. The HTML post-processor
+    // (formatHtmlLlmResponse) would mangle the Markdown the model now emits and
+    // would mix HTML/Markdown across the shared thread store (a thread started
+    // here and continued via streamChat, or vice versa).
     return {
       role: 'assistant',
-      content: formatHtmlLlmResponse(result.content),
+      content: result.content,
       id: crypto.randomUUID(),
       createdAt: new Date().valueOf(),
       usage: result.tokens,
@@ -307,22 +310,35 @@ export class AiChatService extends createPrismaBase(MODELS.AiChat) {
       return
     }
 
-    const { candidateJson, systemPrompt } =
-      await this.contentService.getChatSystemPrompt(
-        resolved.isNewThread && initial,
+    let messages: ChatCompletionMessageParam[]
+    try {
+      const { candidateJson, systemPrompt } =
+        await this.contentService.getChatSystemPrompt(
+          resolved.isNewThread && initial,
+        )
+      const candidateContext = await this.promptReplaceService.promptReplace(
+        candidateJson,
+        campaign,
+        liveMetrics,
       )
-    const candidateContext = await this.promptReplaceService.promptReplace(
-      candidateJson,
-      campaign,
-      liveMetrics,
-    )
 
-    const messages = this.buildMessages({
-      systemPrompt,
-      candidateContext,
-      priorMessages: resolved.priorMessages,
-      userContent: resolved.userMessage.content,
-    })
+      messages = this.buildMessages({
+        systemPrompt,
+        candidateContext,
+        priorMessages: resolved.priorMessages,
+        userContent: resolved.userMessage.content,
+      })
+    } catch (err) {
+      // Keep prompt-build failures inside the generator so the client gets a
+      // classified `internal` chunk instead of the controller's generic
+      // last-resort error (which would otherwise diverge on the retryable flag).
+      this.logger.error(
+        { err, threadId: resolved.threadId },
+        'failed to build campaign chat prompt',
+      )
+      yield this.streamError('internal', 'Chat is unavailable.')
+      return
+    }
 
     let result: LlmStreamResult
     try {

--- a/src/campaigns/ai/chat/aiChat.service.ts
+++ b/src/campaigns/ai/chat/aiChat.service.ts
@@ -44,9 +44,18 @@ const MARKDOWN_FORMAT_DIRECTIVE = `Formatting requirements (these override any e
 // Threads created before this PR stored assistant content as HTML
 // (formatHtmlLlmResponse turned \n into <br/><br/>). Strip those artifacts
 // before replaying history to the model so it follows the Markdown directive
-// instead of mimicking the HTML present in prior turns.
-const stripLegacyHtml = (content: string): string =>
-  content.replace(/<br\s*\/?>/gi, '\n').replace(/<[^>]+>/g, '')
+// instead of mimicking the HTML present in prior turns. The tag removal repeats
+// until the string is stable so overlapping/nested tags (e.g. "<<b>b>") can't
+// leave a partial tag behind (a single pass is an incomplete sanitization).
+const stripLegacyHtml = (content: string): string => {
+  let result = content.replace(/<br\s*\/?>/gi, '\n')
+  let previous: string
+  do {
+    previous = result
+    result = result.replace(/<[^>]*>/g, '')
+  } while (result !== previous)
+  return result
+}
 
 const getErrorStatus = (err: unknown): number | undefined => {
   if (err && typeof err === 'object') {

--- a/src/campaigns/ai/chat/aiChat.service.ts
+++ b/src/campaigns/ai/chat/aiChat.service.ts
@@ -41,6 +41,13 @@ const MARKDOWN_FORMAT_DIRECTIVE = `Formatting requirements (these override any e
 - Respond using GitHub-flavored Markdown ONLY. Do not output raw HTML tags (no <p>, <ul>, <li>, <a>, <br>, <strong>, etc.).
 - Use **bold**, *italics*, \`inline code\`, fenced code blocks, bullet and numbered lists, ## headings, tables, and Markdown links in the form [label](https://example.com).`
 
+// Threads created before this PR stored assistant content as HTML
+// (formatHtmlLlmResponse turned \n into <br/><br/>). Strip those artifacts
+// before replaying history to the model so it follows the Markdown directive
+// instead of mimicking the HTML present in prior turns.
+const stripLegacyHtml = (content: string): string =>
+  content.replace(/<br\s*\/?>/gi, '\n').replace(/<[^>]+>/g, '')
+
 const getErrorStatus = (err: unknown): number | undefined => {
   if (err && typeof err === 'object') {
     const candidate = err as { status?: number; statusCode?: number }
@@ -266,6 +273,11 @@ export class AiChatService extends createPrismaBase(MODELS.AiChat) {
         content: `${systemPrompt}\n${candidateContext}\n\n${MARKDOWN_FORMAT_DIRECTIVE}`,
       },
       ...priorMessages
+        .map((m) =>
+          m.role === 'assistant' && typeof m.content === 'string'
+            ? { ...m, content: stripLegacyHtml(m.content) }
+            : m,
+        )
         .map(toChatCompletionMessage)
         .filter(isChatCompletionMessage),
       { role: 'user', content: userContent },

--- a/src/campaigns/ai/chat/aiChat.types.ts
+++ b/src/campaigns/ai/chat/aiChat.types.ts
@@ -10,3 +10,19 @@ export type AiChatMessage = {
   id?: string
   usage?: number
 }
+
+export type CampaignChatErrorCode =
+  | 'upstream_unavailable'
+  | 'rate_limited'
+  | 'aborted'
+  | 'internal'
+
+export type CampaignChatChunk =
+  | { type: 'text'; delta: string }
+  | { type: 'done'; threadId: string; message: AiChatMessage }
+  | {
+      type: 'error'
+      code: CampaignChatErrorCode
+      message: string
+      retryable: boolean
+    }

--- a/src/campaigns/ai/chat/schemas/StreamAiChat.schema.test.ts
+++ b/src/campaigns/ai/chat/schemas/StreamAiChat.schema.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { StreamAiChatSchema } from './StreamAiChat.schema'
+
+describe('StreamAiChatSchema', () => {
+  const schema = StreamAiChatSchema.schema
+
+  it('accepts a new-thread message', () => {
+    expect(schema.safeParse({ message: 'hi' }).success).toBe(true)
+  })
+
+  it('accepts a follow-up message on an existing thread', () => {
+    expect(schema.safeParse({ threadId: 't1', message: 'hi' }).success).toBe(
+      true,
+    )
+  })
+
+  it('accepts a regenerate with a threadId', () => {
+    expect(schema.safeParse({ threadId: 't1', regenerate: true }).success).toBe(
+      true,
+    )
+  })
+
+  it('rejects an empty body (no threadId, no message)', () => {
+    expect(schema.safeParse({}).success).toBe(false)
+  })
+
+  it('rejects regenerate without a threadId', () => {
+    expect(schema.safeParse({ regenerate: true }).success).toBe(false)
+  })
+
+  it('rejects continuing a thread without a message', () => {
+    expect(schema.safeParse({ threadId: 't1' }).success).toBe(false)
+  })
+
+  it('rejects an over-long message', () => {
+    expect(schema.safeParse({ message: 'a'.repeat(8001) }).success).toBe(false)
+  })
+})

--- a/src/campaigns/ai/chat/schemas/StreamAiChat.schema.test.ts
+++ b/src/campaigns/ai/chat/schemas/StreamAiChat.schema.test.ts
@@ -35,4 +35,11 @@ describe('StreamAiChatSchema', () => {
   it('rejects an over-long message', () => {
     expect(schema.safeParse({ message: 'a'.repeat(8001) }).success).toBe(false)
   })
+
+  it('rejects regenerate with a caller-supplied message', () => {
+    expect(
+      schema.safeParse({ threadId: 't1', regenerate: true, message: 'hi' })
+        .success,
+    ).toBe(false)
+  })
 })

--- a/src/campaigns/ai/chat/schemas/StreamAiChat.schema.ts
+++ b/src/campaigns/ai/chat/schemas/StreamAiChat.schema.ts
@@ -31,5 +31,12 @@ export class StreamAiChatSchema extends createZodDto(
           path: ['threadId'],
         })
       }
+      if (val.threadId && !val.regenerate && !val.message) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'message is required when continuing a thread',
+          path: ['message'],
+        })
+      }
     }),
 ) {}

--- a/src/campaigns/ai/chat/schemas/StreamAiChat.schema.ts
+++ b/src/campaigns/ai/chat/schemas/StreamAiChat.schema.ts
@@ -31,6 +31,16 @@ export class StreamAiChatSchema extends createZodDto(
           path: ['threadId'],
         })
       }
+      // regenerate replays the last user turn from history; a caller-supplied
+      // message would be silently discarded by the service, so reject it up
+      // front rather than re-ask the wrong question without warning.
+      if (val.regenerate && val.message) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'message must not be provided when regenerate is true',
+          path: ['message'],
+        })
+      }
       if (val.threadId && !val.regenerate && !val.message) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,

--- a/src/campaigns/ai/chat/schemas/StreamAiChat.schema.ts
+++ b/src/campaigns/ai/chat/schemas/StreamAiChat.schema.ts
@@ -4,11 +4,32 @@ import { z } from 'zod'
 // Bound the user message: it flows straight into the LLM prompt, so an
 // unbounded body is a cost/DoS and prompt-injection amplifier. 8k chars is
 // comfortably above any legitimate chat turn.
+//
+// Cross-field validation runs at the ZodValidationPipe (before the controller
+// writes the SSE 200 header), so invalid combinations are rejected as 400s
+// instead of surfacing as generic in-stream `internal` errors.
 export class StreamAiChatSchema extends createZodDto(
-  z.object({
-    message: z.string().max(8000).optional(),
-    threadId: z.string().optional(),
-    initial: z.boolean().optional().default(false),
-    regenerate: z.boolean().optional().default(false),
-  }),
+  z
+    .object({
+      message: z.string().max(8000).optional(),
+      threadId: z.string().optional(),
+      initial: z.boolean().optional().default(false),
+      regenerate: z.boolean().optional().default(false),
+    })
+    .superRefine((val, ctx) => {
+      if (!val.threadId && !val.message) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'message is required when starting a new thread',
+          path: ['message'],
+        })
+      }
+      if (val.regenerate && !val.threadId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'threadId is required when regenerate is true',
+          path: ['threadId'],
+        })
+      }
+    }),
 ) {}

--- a/src/campaigns/ai/chat/schemas/StreamAiChat.schema.ts
+++ b/src/campaigns/ai/chat/schemas/StreamAiChat.schema.ts
@@ -1,0 +1,14 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+// Bound the user message: it flows straight into the LLM prompt, so an
+// unbounded body is a cost/DoS and prompt-injection amplifier. 8k chars is
+// comfortably above any legitimate chat turn.
+export class StreamAiChatSchema extends createZodDto(
+  z.object({
+    message: z.string().max(8000).optional(),
+    threadId: z.string().optional(),
+    initial: z.boolean().optional().default(false),
+    regenerate: z.boolean().optional().default(false),
+  }),
+) {}


### PR DESCRIPTION
## Summary
Adds a streaming endpoint for the Campaign/Win AI assistant so it behaves like the well-performing briefings chat instead of waiting for one buffered blob.

- New `POST /campaigns/ai/chat/stream` that streams assistant replies over SSE, mirroring the briefing-chat streaming contract while keeping the existing `AiChat` JSON storage model.
- Output-token budget bumped to 2000 and a **Markdown formatting directive** appended last in the system message so the model stops emitting raw HTML (the CMS prompt still asks for HTML for the legacy Quill path).
- Robust stream lifecycle: abort on client disconnect, 5-minute timeout, write backpressure/drain, and discriminated error classification (`upstream_unavailable` / `rate_limited` / `aborted` / `internal`).

## Review-fixes included
- A server **timeout now surfaces as a retryable upstream error** rather than `aborted` (the client intentionally swallows `aborted` as a user-stop, so a timeout was previously silent).
- `reply.raw.end()` guarded in `finally`.
- Request `message` length bounded (max 8k) to limit cost / prompt-injection surface.

## Test plan
- [x] `vitest` unit tests: deltas, new-thread persistence, follow-up, regenerate, **abort**, **rate-limit (429)**, upstream failure, and **persistence failure**.
- [x] `tsc --noEmit` clean; `eslint`/`prettier` clean (0 errors).
- [ ] Manual: stream a chat in the dashboard against this branch.

## Notes / follow-ups
- The webapp consumer is in **thegoodparty/gp-webapp `feat/campaign-chat-streaming`** — this API must deploy first.
- Critics flagged that the SSE controller plumbing and error-classifier overlap with `src/chats/briefing-chats/` and `chatStream.service.ts`. Left as a deliberate follow-up to avoid destabilizing the briefing chat in this PR.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New LLM streaming path increases cost/latency exposure and changes assistant output format for the stream client; legacy buffered create/update still use HTML formatting via `buildMessages` only for shared prompt assembly.
> 
> **Overview**
> Adds **SSE streaming** for the campaign AI assistant via `POST /campaigns/ai/chat/stream`, aligned with the briefing-chat chunk contract (`text` / `done` / `error`) while still persisting threads in the existing `AiChat` JSON model.
> 
> `AiChatService` gains `streamChat`: it resolves new vs existing threads (including **regenerate**), calls `streamChatCompletion` with a **2000** output token cap and higher `top_p`, appends a **Markdown-only** system directive (overriding CMS HTML guidance), stores assistant replies as **raw markdown**, and classifies failures (`upstream_unavailable`, `rate_limited`, `aborted`, `internal`). The controller wires Fastify SSE (disconnect abort, **5 min** timeout as retryable `upstream_unavailable`—not `aborted`—backpressure drain, guarded `end()`). Request bodies use `StreamAiChatSchema` with an **8k** message cap. Broad **vitest** coverage for streaming paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4dae020c054e2c9bb7f5cf571f1ceb1821dbfdd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->