### PR TITLE
Release: qa → master (2026-06-02)

### DIFF
--- a/contracts/.changeset/eng-10280-agent-runs-schemas.md
+++ b/contracts/.changeset/eng-10280-agent-runs-schemas.md
@@ -1,0 +1,14 @@
+---
+'@goodparty_org/contracts': minor
+---
+
+Add agent-runs admin read shapes backing the gp-admin agent-runs dashboard:
+`AgentRunListItemSchema` / `AgentRunListItem` (a list row with a candidate
+summary derived from `compliance_setup` params), `AgentRunsListQuerySchema` /
+`AgentRunsListQuery` (list filters: experimentType, status, organizationSlug,
+createdAfter, createdBefore, plus pagination), `AgentRunSchema` / `AgentRun`
+(the full `experiment_run` row), and `AgentRunDetailSchema` / `AgentRunDetail`
+(`{ run, artifact, conversationLog }`, where `artifact` is an opaque
+`Record<string, unknown>` read from S3 and `conversationLog` is plain text).
+Also export the `ExperimentRunStatus` enum (`ExperimentRunStatusSchema` /
+`EXPERIMENT_RUN_STATUS_VALUES`).

--- a/contracts/src/agentRuns/AgentRun.schema.ts
+++ b/contracts/src/agentRuns/AgentRun.schema.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod'
+import { ExperimentRunStatusSchema } from '../generated/enums'
+import { PaginationOptionsSchema } from '../shared/Pagination.schema'
+
+// Candidate identity surfaced on a run, read from the run's params JSON.
+// Only compliance_setup params carry it; null for every other experiment type.
+export const AgentRunCandidateSummarySchema = z.object({
+  firstName: z.string(),
+  lastName: z.string(),
+  campaignId: z.number().nullable(),
+})
+
+export type AgentRunCandidateSummary = z.infer<
+  typeof AgentRunCandidateSummarySchema
+>
+
+export const AgentRunListItemSchema = z.object({
+  runId: z.string(),
+  experimentType: z.string(),
+  status: ExperimentRunStatusSchema,
+  organizationSlug: z.string(),
+  candidate: AgentRunCandidateSummarySchema.nullable(),
+  durationSeconds: z.number().nullable(),
+  costUsd: z.number().nullable(),
+  createdAt: z.coerce.date(),
+})
+
+export type AgentRunListItem = z.infer<typeof AgentRunListItemSchema>
+
+export const AgentRunsListQuerySchema = PaginationOptionsSchema.extend({
+  experimentType: z.string().optional(),
+  status: ExperimentRunStatusSchema.optional(),
+  organizationSlug: z.string().optional(),
+  createdAfter: z.coerce.date().optional(),
+  createdBefore: z.coerce.date().optional(),
+})
+
+export type AgentRunsListQuery = z.infer<typeof AgentRunsListQuerySchema>
+
+// The full experiment_run row. The artifact + conversation log are read from
+// S3 in the detail endpoint, never persisted as columns.
+export const AgentRunSchema = z.object({
+  runId: z.string(),
+  organizationSlug: z.string(),
+  experimentType: z.string(),
+  status: ExperimentRunStatusSchema,
+  params: z.record(z.string(), z.unknown()),
+  artifactBucket: z.string().nullable(),
+  artifactKey: z.string().nullable(),
+  durationSeconds: z.number().nullable(),
+  costUsd: z.number().nullable(),
+  error: z.string().nullable(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+})
+
+export type AgentRun = z.infer<typeof AgentRunSchema>
+
+// The artifact is opaque to gp-api (ComplianceSetupOutput is `{[k]: unknown}`);
+// gp-admin interprets the known fields. null while the run is still RUNNING.
+export const AgentRunDetailSchema = z.object({
+  run: AgentRunSchema,
+  artifact: z.record(z.string(), z.unknown()).nullable(),
+  conversationLog: z.string().nullable(),
+})
+
+export type AgentRunDetail = z.infer<typeof AgentRunDetailSchema>

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -47,6 +47,9 @@ export {
   type WebsiteStatus,
   WEBSITE_STATUS_VALUES,
   WebsiteStatusSchema,
+  type ExperimentRunStatus,
+  EXPERIMENT_RUN_STATUS_VALUES,
+  ExperimentRunStatusSchema,
 } from './generated/enums'
 
 export { EmailSchema } from './shared/Email.schema'
@@ -330,3 +333,16 @@ export {
   BriefingFeedbackListResponseSchema,
   type BriefingFeedbackListResponse,
 } from './artifactFeedback/ArtifactFeedback.schema'
+
+export {
+  AgentRunCandidateSummarySchema,
+  type AgentRunCandidateSummary,
+  AgentRunListItemSchema,
+  type AgentRunListItem,
+  AgentRunsListQuerySchema,
+  type AgentRunsListQuery,
+  AgentRunSchema,
+  type AgentRun,
+  AgentRunDetailSchema,
+  type AgentRunDetail,
+} from './agentRuns/AgentRun.schema'

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -3,9 +3,12 @@ import { AuthenticationModule } from 'src/authentication/authentication.module'
 import { EmailModule } from 'src/email/email.module'
 import { OrganizationsModule } from 'src/organizations/organizations.module'
 import { SlackModule } from 'src/vendors/slack/slack.module'
+import { AwsModule } from 'src/vendors/aws/aws.module'
 import { AdminCampaignsController } from './campaigns/adminCampaigns.controller'
 import { AdminCampaignsService } from './campaigns/adminCampaigns.service'
 import { AdminUsersController } from './users/adminUsers.controller'
+import { AdminAgentRunsController } from './agentRuns/adminAgentRuns.controller'
+import { AdminAgentRunsService } from './agentRuns/services/adminAgentRuns.service'
 
 @Module({
   imports: [
@@ -13,8 +16,13 @@ import { AdminUsersController } from './users/adminUsers.controller'
     AuthenticationModule,
     OrganizationsModule,
     SlackModule,
+    AwsModule,
   ],
-  controllers: [AdminCampaignsController, AdminUsersController],
-  providers: [AdminCampaignsService],
+  controllers: [
+    AdminCampaignsController,
+    AdminUsersController,
+    AdminAgentRunsController,
+  ],
+  providers: [AdminCampaignsService, AdminAgentRunsService],
 })
 export class AdminModule {}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -4,6 +4,7 @@ import { EmailModule } from 'src/email/email.module'
 import { OrganizationsModule } from 'src/organizations/organizations.module'
 import { SlackModule } from 'src/vendors/slack/slack.module'
 import { AwsModule } from 'src/vendors/aws/aws.module'
+import { AgentExperimentsModule } from 'src/agentExperiments/agentExperiments.module'
 import { AdminCampaignsController } from './campaigns/adminCampaigns.controller'
 import { AdminCampaignsService } from './campaigns/adminCampaigns.service'
 import { AdminUsersController } from './users/adminUsers.controller'
@@ -17,6 +18,7 @@ import { AdminAgentRunsService } from './agentRuns/services/adminAgentRuns.servi
     OrganizationsModule,
     SlackModule,
     AwsModule,
+    AgentExperimentsModule,
   ],
   controllers: [
     AdminCampaignsController,

--- a/src/admin/agentRuns/adminAgentRuns.controller.test.ts
+++ b/src/admin/agentRuns/adminAgentRuns.controller.test.ts
@@ -1,0 +1,65 @@
+import { UserRole } from '@prisma/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ROLES_KEY } from '@/authentication/decorators/Roles.decorator'
+import { MCP_TOOL_KEY } from '@/mcp/decorators/McpTool.decorator'
+import { AdminAgentRunsController } from './adminAgentRuns.controller'
+import { AdminAgentRunsService } from './services/adminAgentRuns.service'
+import { AdminAgentRunsListQueryDto } from './schemas/adminAgentRuns.schema'
+
+const rolesFor = (method: keyof AdminAgentRunsController) =>
+  Reflect.getMetadata(ROLES_KEY, AdminAgentRunsController.prototype[method])
+
+const mcpToolFor = (method: keyof AdminAgentRunsController) =>
+  Reflect.getMetadata(MCP_TOOL_KEY, AdminAgentRunsController.prototype[method])
+
+describe('AdminAgentRunsController', () => {
+  let controller: AdminAgentRunsController
+  let service: AdminAgentRunsService
+
+  beforeEach(() => {
+    const serviceMock: Partial<AdminAgentRunsService> = {
+      list: vi.fn(),
+      detail: vi.fn(),
+    }
+    service = serviceMock as AdminAgentRunsService
+    controller = new AdminAgentRunsController(service)
+  })
+
+  it('restricts both endpoints to admins', () => {
+    expect(rolesFor('list')).toEqual([UserRole.admin])
+    expect(rolesFor('detail')).toEqual([UserRole.admin])
+  })
+
+  it('does not expose either endpoint as an MCP tool', () => {
+    expect(mcpToolFor('list')).toBeUndefined()
+    expect(mcpToolFor('detail')).toBeUndefined()
+  })
+
+  it('delegates list to the service and returns its paginated result', async () => {
+    const paginated = { data: [], meta: { total: 0, offset: 0, limit: 100 } }
+    vi.mocked(service.list).mockResolvedValue(paginated)
+    const query = { offset: 0, limit: 100 } as AdminAgentRunsListQueryDto
+
+    const result = await controller.list(query)
+
+    expect(service.list).toHaveBeenCalledWith(query)
+    expect(result).toBe(paginated)
+  })
+
+  it('delegates detail to the service by runId', async () => {
+    const detail = {
+      run: { runId: 'run-1' },
+      artifact: null,
+      conversationLog: null,
+    }
+    // detail's return type is structural; cast the fixture for the mock
+    vi.mocked(service.detail).mockResolvedValue(
+      detail as Awaited<ReturnType<AdminAgentRunsService['detail']>>,
+    )
+
+    const result = await controller.detail('run-1')
+
+    expect(service.detail).toHaveBeenCalledWith('run-1')
+    expect(result).toBe(detail)
+  })
+})

--- a/src/admin/agentRuns/adminAgentRuns.controller.test.ts
+++ b/src/admin/agentRuns/adminAgentRuns.controller.test.ts
@@ -22,19 +22,22 @@ describe('AdminAgentRunsController', () => {
     const serviceMock: Partial<AdminAgentRunsService> = {
       list: vi.fn(),
       detail: vi.fn(),
+      retry: vi.fn(),
     }
     service = serviceMock as AdminAgentRunsService
     controller = new AdminAgentRunsController(service)
   })
 
-  it('restricts both endpoints to M2M callers (the gp-admin SDK path)', () => {
+  it('restricts every endpoint to M2M callers (the gp-admin SDK path)', () => {
     expect(guardsFor('list')).toContain(M2MOnly)
     expect(guardsFor('detail')).toContain(M2MOnly)
+    expect(guardsFor('retry')).toContain(M2MOnly)
   })
 
-  it('does not expose either endpoint as an MCP tool', () => {
+  it('does not expose any endpoint as an MCP tool', () => {
     expect(mcpToolFor('list')).toBeUndefined()
     expect(mcpToolFor('detail')).toBeUndefined()
+    expect(mcpToolFor('retry')).toBeUndefined()
   })
 
   it('delegates list to the service and returns its paginated result', async () => {
@@ -63,5 +66,17 @@ describe('AdminAgentRunsController', () => {
 
     expect(service.detail).toHaveBeenCalledWith('run-1')
     expect(result).toBe(detail)
+  })
+
+  it('delegates retry to the service and returns the new run', async () => {
+    const newRun = { runId: 'run-2' }
+    vi.mocked(service.retry).mockResolvedValue(
+      newRun as Awaited<ReturnType<AdminAgentRunsService['retry']>>,
+    )
+
+    const result = await controller.retry('run-1')
+
+    expect(service.retry).toHaveBeenCalledWith('run-1')
+    expect(result).toBe(newRun)
   })
 })

--- a/src/admin/agentRuns/adminAgentRuns.controller.test.ts
+++ b/src/admin/agentRuns/adminAgentRuns.controller.test.ts
@@ -1,13 +1,15 @@
-import { UserRole } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ROLES_KEY } from '@/authentication/decorators/Roles.decorator'
+import { M2MOnly } from '@/authentication/guards/M2MOnly.guard'
 import { MCP_TOOL_KEY } from '@/mcp/decorators/McpTool.decorator'
 import { AdminAgentRunsController } from './adminAgentRuns.controller'
 import { AdminAgentRunsService } from './services/adminAgentRuns.service'
 import { AdminAgentRunsListQueryDto } from './schemas/adminAgentRuns.schema'
 
-const rolesFor = (method: keyof AdminAgentRunsController) =>
-  Reflect.getMetadata(ROLES_KEY, AdminAgentRunsController.prototype[method])
+const guardsFor = (method: keyof AdminAgentRunsController) =>
+  Reflect.getMetadata(
+    '__guards__',
+    AdminAgentRunsController.prototype[method],
+  ) ?? []
 
 const mcpToolFor = (method: keyof AdminAgentRunsController) =>
   Reflect.getMetadata(MCP_TOOL_KEY, AdminAgentRunsController.prototype[method])
@@ -25,9 +27,9 @@ describe('AdminAgentRunsController', () => {
     controller = new AdminAgentRunsController(service)
   })
 
-  it('restricts both endpoints to admins', () => {
-    expect(rolesFor('list')).toEqual([UserRole.admin])
-    expect(rolesFor('detail')).toEqual([UserRole.admin])
+  it('restricts both endpoints to M2M callers (the gp-admin SDK path)', () => {
+    expect(guardsFor('list')).toContain(M2MOnly)
+    expect(guardsFor('detail')).toContain(M2MOnly)
   })
 
   it('does not expose either endpoint as an MCP tool', () => {

--- a/src/admin/agentRuns/adminAgentRuns.controller.ts
+++ b/src/admin/agentRuns/adminAgentRuns.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Param, Query, UsePipes } from '@nestjs/common'
+import { UserRole } from '@prisma/client'
+import { ZodValidationPipe } from 'nestjs-zod'
+import { Roles } from '@/authentication/decorators/Roles.decorator'
+import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import { PaginatedResponseSchema } from '@/shared/schemas/PaginatedResponse.schema'
+import { AdminAgentRunsService } from './services/adminAgentRuns.service'
+import {
+  AdminAgentRunsListQueryDto,
+  AgentRunDetailSchema,
+  AgentRunListItemSchema,
+} from './schemas/adminAgentRuns.schema'
+
+@Controller('admin/agent-runs')
+@UsePipes(ZodValidationPipe)
+export class AdminAgentRunsController {
+  constructor(private readonly agentRuns: AdminAgentRunsService) {}
+
+  @Get()
+  @Roles(UserRole.admin)
+  @ResponseSchema(PaginatedResponseSchema(AgentRunListItemSchema))
+  list(@Query() query: AdminAgentRunsListQueryDto) {
+    return this.agentRuns.list(query)
+  }
+
+  @Get(':runId')
+  @Roles(UserRole.admin)
+  @ResponseSchema(AgentRunDetailSchema)
+  detail(@Param('runId') runId: string) {
+    return this.agentRuns.detail(runId)
+  }
+}

--- a/src/admin/agentRuns/adminAgentRuns.controller.ts
+++ b/src/admin/agentRuns/adminAgentRuns.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Param,
+  Post,
   Query,
   UseGuards,
   UsePipes,
@@ -15,6 +16,7 @@ import {
   AdminAgentRunsListQueryDto,
   AgentRunDetailSchema,
   AgentRunListItemSchema,
+  AgentRunSchema,
 } from './schemas/adminAgentRuns.schema'
 
 @Controller('admin/agent-runs')
@@ -34,5 +36,12 @@ export class AdminAgentRunsController {
   @ResponseSchema(AgentRunDetailSchema)
   detail(@Param('runId') runId: string) {
     return this.agentRuns.detail(runId)
+  }
+
+  @Post(':runId/retry')
+  @UseGuards(M2MOnly)
+  @ResponseSchema(AgentRunSchema)
+  retry(@Param('runId') runId: string) {
+    return this.agentRuns.retry(runId)
   }
 }

--- a/src/admin/agentRuns/adminAgentRuns.controller.ts
+++ b/src/admin/agentRuns/adminAgentRuns.controller.ts
@@ -1,7 +1,13 @@
-import { Controller, Get, Param, Query, UsePipes } from '@nestjs/common'
-import { UserRole } from '@prisma/client'
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  UsePipes,
+} from '@nestjs/common'
 import { ZodValidationPipe } from 'nestjs-zod'
-import { Roles } from '@/authentication/decorators/Roles.decorator'
+import { M2MOnly } from '@/authentication/guards/M2MOnly.guard'
 import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
 import { PaginatedResponseSchema } from '@/shared/schemas/PaginatedResponse.schema'
 import { AdminAgentRunsService } from './services/adminAgentRuns.service'
@@ -17,14 +23,14 @@ export class AdminAgentRunsController {
   constructor(private readonly agentRuns: AdminAgentRunsService) {}
 
   @Get()
-  @Roles(UserRole.admin)
+  @UseGuards(M2MOnly)
   @ResponseSchema(PaginatedResponseSchema(AgentRunListItemSchema))
   list(@Query() query: AdminAgentRunsListQueryDto) {
     return this.agentRuns.list(query)
   }
 
   @Get(':runId')
-  @Roles(UserRole.admin)
+  @UseGuards(M2MOnly)
   @ResponseSchema(AgentRunDetailSchema)
   detail(@Param('runId') runId: string) {
     return this.agentRuns.detail(runId)

--- a/src/admin/agentRuns/schemas/adminAgentRuns.schema.ts
+++ b/src/admin/agentRuns/schemas/adminAgentRuns.schema.ts
@@ -8,6 +8,8 @@ export class AdminAgentRunsListQueryDto extends createZodDto(
 export {
   AgentRunListItemSchema,
   type AgentRunListItem,
+  AgentRunSchema,
+  type AgentRun,
   AgentRunDetailSchema,
   type AgentRunDetail,
 } from '@goodparty_org/contracts'

--- a/src/admin/agentRuns/schemas/adminAgentRuns.schema.ts
+++ b/src/admin/agentRuns/schemas/adminAgentRuns.schema.ts
@@ -1,0 +1,13 @@
+import { createZodDto } from 'nestjs-zod'
+import { AgentRunsListQuerySchema } from '@goodparty_org/contracts'
+
+export class AdminAgentRunsListQueryDto extends createZodDto(
+  AgentRunsListQuerySchema,
+) {}
+
+export {
+  AgentRunListItemSchema,
+  type AgentRunListItem,
+  AgentRunDetailSchema,
+  type AgentRunDetail,
+} from '@goodparty_org/contracts'

--- a/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
@@ -16,6 +16,7 @@ const makeRun = (overrides: Partial<ExperimentRun> = {}): ExperimentRun => ({
     candidate_first_name: 'Ada',
     candidate_last_name: 'Lovelace',
     clerk_user_id: 'user_abc',
+    election_date: '2026-11-03',
     trigger: 'initial',
   } as Prisma.JsonValue,
   artifactBucket: 'agent-artifacts',
@@ -261,6 +262,7 @@ describe('AdminAgentRunsService', () => {
           candidate_first_name: 'Ada',
           candidate_last_name: 'Lovelace',
           clerk_user_id: 'user_abc',
+          election_date: '2026-11-03',
           trigger: 'recovery_resume',
         },
       })
@@ -275,6 +277,7 @@ describe('AdminAgentRunsService', () => {
             candidate_first_name: 'Ada',
             candidate_last_name: 'Lovelace',
             clerk_user_id: 'user_abc',
+            election_date: '2026-11-03',
             trigger: 'initial',
             run_id: 'stale-run-id',
           } as Prisma.JsonValue,

--- a/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
@@ -1,7 +1,9 @@
+import { BadGatewayException, BadRequestException } from '@nestjs/common'
 import { ExperimentRun, ExperimentRunStatus, Prisma } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
 import { S3Service } from '@/vendors/aws/services/s3.service'
+import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
 import { AdminAgentRunsService } from './adminAgentRuns.service'
 
 const makeRun = (overrides: Partial<ExperimentRun> = {}): ExperimentRun => ({
@@ -33,6 +35,7 @@ describe('AdminAgentRunsService', () => {
     findUniqueOrThrow: ReturnType<typeof vi.fn>
   }
   const s3 = { getFile: vi.fn() }
+  const experimentRuns = { dispatchRun: vi.fn() }
   const logger = createMockLogger()
 
   beforeEach(() => {
@@ -44,7 +47,10 @@ describe('AdminAgentRunsService', () => {
       findUniqueOrThrow: vi.fn(),
     }
 
-    service = new AdminAgentRunsService(s3 as unknown as S3Service)
+    service = new AdminAgentRunsService(
+      s3 as unknown as S3Service,
+      experimentRuns as unknown as ExperimentRunsService,
+    )
     Object.defineProperty(service, 'model', {
       get: () => mockModel,
       configurable: true,
@@ -224,6 +230,75 @@ describe('AdminAgentRunsService', () => {
 
       await expect(service.detail('missing')).rejects.toThrow()
       expect(s3.getFile).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('retry', () => {
+    it('re-dispatches with the stored type, org, params, and clerk_user_id, and returns the new run', async () => {
+      const run = makeRun()
+      const newRun = makeRun({
+        runId: 'run-2',
+        status: ExperimentRunStatus.RUNNING,
+        artifactBucket: null,
+        artifactKey: null,
+        durationSeconds: null,
+        costUsd: null,
+      })
+      mockModel.findUniqueOrThrow.mockResolvedValue(run)
+      experimentRuns.dispatchRun.mockResolvedValue(newRun)
+
+      const result = await service.retry('run-1')
+
+      expect(experimentRuns.dispatchRun).toHaveBeenCalledWith({
+        type: 'compliance_setup',
+        organizationSlug: 'org-1',
+        clerkUserId: 'user_abc',
+        params: {
+          campaign_id: 42,
+          candidate_first_name: 'Ada',
+          candidate_last_name: 'Lovelace',
+          clerk_user_id: 'user_abc',
+        },
+      })
+      expect(result).toBe(newRun)
+    })
+
+    it('rejects with 400 and never dispatches when params carry no clerk_user_id', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(
+        makeRun({
+          params: {
+            campaign_id: 42,
+            candidate_first_name: 'Ada',
+            candidate_last_name: 'Lovelace',
+          } as Prisma.JsonValue,
+        }),
+      )
+
+      await expect(service.retry('run-1')).rejects.toBeInstanceOf(
+        BadRequestException,
+      )
+      expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
+    })
+
+    it('propagates the not-found error for an unknown runId, never dispatching', async () => {
+      mockModel.findUniqueOrThrow.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('No ExperimentRun found', {
+          code: 'P2025',
+          clientVersion: 'test',
+        }),
+      )
+
+      await expect(service.retry('missing')).rejects.toThrow()
+      expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
+    })
+
+    it('surfaces 502 when dispatch is not configured (dispatchRun returns nothing)', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(makeRun())
+      experimentRuns.dispatchRun.mockResolvedValue(undefined)
+
+      await expect(service.retry('run-1')).rejects.toBeInstanceOf(
+        BadGatewayException,
+      )
     })
   })
 })

--- a/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
@@ -1,0 +1,229 @@
+import { ExperimentRun, ExperimentRunStatus, Prisma } from '@prisma/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { S3Service } from '@/vendors/aws/services/s3.service'
+import { AdminAgentRunsService } from './adminAgentRuns.service'
+
+const makeRun = (overrides: Partial<ExperimentRun> = {}): ExperimentRun => ({
+  runId: 'run-1',
+  organizationSlug: 'org-1',
+  experimentType: 'compliance_setup',
+  status: ExperimentRunStatus.COMPLETED,
+  params: {
+    campaign_id: 42,
+    candidate_first_name: 'Ada',
+    candidate_last_name: 'Lovelace',
+    clerk_user_id: 'user_abc',
+  } as Prisma.JsonValue,
+  artifactBucket: 'agent-artifacts',
+  artifactKey: 'compliance_setup/run-1/artifact.json',
+  durationSeconds: 12.5,
+  costUsd: 0.42,
+  error: null,
+  createdAt: new Date('2026-05-01T00:00:00Z'),
+  updatedAt: new Date('2026-05-01T00:10:00Z'),
+  ...overrides,
+})
+
+describe('AdminAgentRunsService', () => {
+  let service: AdminAgentRunsService
+  let mockModel: {
+    findMany: ReturnType<typeof vi.fn>
+    count: ReturnType<typeof vi.fn>
+    findUniqueOrThrow: ReturnType<typeof vi.fn>
+  }
+  const s3 = { getFile: vi.fn() }
+  const logger = createMockLogger()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockModel = {
+      findMany: vi.fn(),
+      count: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
+    }
+
+    service = new AdminAgentRunsService(s3 as unknown as S3Service)
+    Object.defineProperty(service, 'model', {
+      get: () => mockModel,
+      configurable: true,
+    })
+    Object.defineProperty(service, 'logger', {
+      get: () => logger,
+      configurable: true,
+    })
+  })
+
+  describe('list', () => {
+    it('maps rows with a candidate summary and returns the meta envelope', async () => {
+      mockModel.findMany.mockResolvedValue([makeRun()])
+      mockModel.count.mockResolvedValue(1)
+
+      const result = await service.list({ offset: 0, limit: 20 })
+
+      expect(result).toEqual({
+        data: [
+          {
+            runId: 'run-1',
+            experimentType: 'compliance_setup',
+            status: ExperimentRunStatus.COMPLETED,
+            organizationSlug: 'org-1',
+            candidate: {
+              firstName: 'Ada',
+              lastName: 'Lovelace',
+              campaignId: 42,
+            },
+            durationSeconds: 12.5,
+            costUsd: 0.42,
+            createdAt: new Date('2026-05-01T00:00:00Z'),
+          },
+        ],
+        meta: { total: 1, offset: 0, limit: 20 },
+      })
+    })
+
+    it('returns a null candidate when params carry no candidate fields', async () => {
+      mockModel.findMany.mockResolvedValue([
+        makeRun({
+          experimentType: 'meeting_briefing',
+          params: { officialName: 'Some Mayor' } as Prisma.JsonValue,
+        }),
+      ])
+      mockModel.count.mockResolvedValue(1)
+
+      const { data } = await service.list({})
+
+      expect(data[0].candidate).toBeNull()
+    })
+
+    it('narrows the query by every supplied filter, ordered createdAt desc', async () => {
+      mockModel.findMany.mockResolvedValue([])
+      mockModel.count.mockResolvedValue(0)
+
+      const createdAfter = new Date('2026-05-01T00:00:00Z')
+      const createdBefore = new Date('2026-05-31T00:00:00Z')
+      await service.list({
+        offset: 10,
+        limit: 5,
+        experimentType: 'compliance_setup',
+        status: ExperimentRunStatus.FAILED,
+        organizationSlug: 'org-9',
+        createdAfter,
+        createdBefore,
+      })
+
+      const expectedWhere = {
+        experimentType: 'compliance_setup',
+        status: ExperimentRunStatus.FAILED,
+        organizationSlug: 'org-9',
+        createdAt: { gte: createdAfter, lte: createdBefore },
+      }
+      expect(mockModel.findMany).toHaveBeenCalledWith({
+        where: expectedWhere,
+        orderBy: { createdAt: Prisma.SortOrder.desc },
+        skip: 10,
+        take: 5,
+      })
+      expect(mockModel.count).toHaveBeenCalledWith({ where: expectedWhere })
+    })
+
+    it('builds an empty where clause when no filters are supplied', async () => {
+      mockModel.findMany.mockResolvedValue([])
+      mockModel.count.mockResolvedValue(0)
+
+      await service.list({})
+
+      expect(mockModel.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: {} }),
+      )
+    })
+  })
+
+  describe('detail', () => {
+    it('composes the run, parsed artifact, and conversation log from S3', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(makeRun())
+      s3.getFile.mockImplementation(async (_bucket: string, key: string) =>
+        key.endsWith('artifact.json')
+          ? JSON.stringify({
+              stage: 'tcr_submitted',
+              domain: { name: 'x.org' },
+            })
+          : 'tool: search_domain\ntool: purchase_domain\n',
+      )
+
+      const result = await service.detail('run-1')
+
+      expect(s3.getFile).toHaveBeenCalledWith(
+        'agent-artifacts',
+        'compliance_setup/run-1/artifact.json',
+      )
+      expect(s3.getFile).toHaveBeenCalledWith(
+        'agent-artifacts',
+        'compliance_setup/run-1/logs/workspace/conversation.log',
+      )
+      expect(result.run.runId).toBe('run-1')
+      expect(result.artifact).toEqual({
+        stage: 'tcr_submitted',
+        domain: { name: 'x.org' },
+      })
+      expect(result.conversationLog).toBe(
+        'tool: search_domain\ntool: purchase_domain\n',
+      )
+    })
+
+    it('returns conversationLog null without throwing when the log object is missing', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(makeRun())
+      s3.getFile.mockImplementation(async (_bucket: string, key: string) =>
+        key.endsWith('artifact.json')
+          ? JSON.stringify({ stage: 'done' })
+          : undefined,
+      )
+
+      const result = await service.detail('run-1')
+
+      expect(result.conversationLog).toBeNull()
+      expect(result.artifact).toEqual({ stage: 'done' })
+    })
+
+    it('returns null artifact and conversation log without touching S3 for a RUNNING run', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(
+        makeRun({
+          status: ExperimentRunStatus.RUNNING,
+          artifactBucket: null,
+          artifactKey: null,
+        }),
+      )
+
+      const result = await service.detail('run-1')
+
+      expect(result.artifact).toBeNull()
+      expect(result.conversationLog).toBeNull()
+      expect(s3.getFile).not.toHaveBeenCalled()
+    })
+
+    it('returns null artifact (logged) when the artifact JSON is malformed', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(makeRun())
+      s3.getFile.mockImplementation(async (_bucket: string, key: string) =>
+        key.endsWith('artifact.json') ? '{not json' : undefined,
+      )
+
+      const result = await service.detail('run-1')
+
+      expect(result.artifact).toBeNull()
+      expect(logger.error).toHaveBeenCalled()
+    })
+
+    it('propagates the not-found error for an unknown runId', async () => {
+      mockModel.findUniqueOrThrow.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('No ExperimentRun found', {
+          code: 'P2025',
+          clientVersion: 'test',
+        }),
+      )
+
+      await expect(service.detail('missing')).rejects.toThrow()
+      expect(s3.getFile).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
@@ -1,8 +1,4 @@
-import {
-  BadGatewayException,
-  BadRequestException,
-  ConflictException,
-} from '@nestjs/common'
+import { BadGatewayException, ConflictException } from '@nestjs/common'
 import { ExperimentRun, ExperimentRunStatus, Prisma } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
@@ -271,6 +267,29 @@ describe('AdminAgentRunsService', () => {
       expect(result).toBe(newRun)
     })
 
+    it('drops a stale run_id so the agent uses the fresh dispatch run id', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(
+        makeRun({
+          params: {
+            campaign_id: 42,
+            candidate_first_name: 'Ada',
+            candidate_last_name: 'Lovelace',
+            clerk_user_id: 'user_abc',
+            trigger: 'initial',
+            run_id: 'stale-run-id',
+          } as Prisma.JsonValue,
+        }),
+      )
+      experimentRuns.dispatchRun.mockResolvedValue(makeRun({ runId: 'run-2' }))
+
+      await service.retry('run-1')
+
+      const dispatchedParams =
+        experimentRuns.dispatchRun.mock.calls[0][0].params
+      expect(dispatchedParams.run_id).toBeUndefined()
+      expect(dispatchedParams.trigger).toBe('recovery_resume')
+    })
+
     it('rejects with 409 and never dispatches when the run is still RUNNING', async () => {
       mockModel.findUniqueOrThrow.mockResolvedValue(
         makeRun({ status: ExperimentRunStatus.RUNNING }),
@@ -282,18 +301,28 @@ describe('AdminAgentRunsService', () => {
       expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
     })
 
-    it('rejects with 400 and never dispatches when the experiment type is not retryable', async () => {
+    it('rejects with 400 (wrong-type message) for a realistic non-retryable run, never dispatching', async () => {
+      // A real meeting_briefing run carries no clerk_user_id; the type guard
+      // must fire first so the message names the actual reason. Asserting the
+      // message (not just the 400) keeps the type guard from being shadowed by
+      // the clerk_user_id guard.
       mockModel.findUniqueOrThrow.mockResolvedValue(
-        makeRun({ experimentType: 'meeting_briefing' }),
+        makeRun({
+          experimentType: 'meeting_briefing',
+          params: {
+            officialName: 'Some Mayor',
+            state: 'NY',
+          } as Prisma.JsonValue,
+        }),
       )
 
-      await expect(service.retry('run-1')).rejects.toBeInstanceOf(
-        BadRequestException,
+      await expect(service.retry('run-1')).rejects.toThrow(
+        'cannot be re-dispatched',
       )
       expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
     })
 
-    it('rejects with 400 and never dispatches when params carry no clerk_user_id', async () => {
+    it('rejects with 400 (missing-clerk message) when a retryable run lacks clerk_user_id, never dispatching', async () => {
       mockModel.findUniqueOrThrow.mockResolvedValue(
         makeRun({
           params: {
@@ -304,9 +333,7 @@ describe('AdminAgentRunsService', () => {
         }),
       )
 
-      await expect(service.retry('run-1')).rejects.toBeInstanceOf(
-        BadRequestException,
-      )
+      await expect(service.retry('run-1')).rejects.toThrow('clerk_user_id')
       expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
     })
 

--- a/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
@@ -1,4 +1,8 @@
-import { BadGatewayException, BadRequestException } from '@nestjs/common'
+import {
+  BadGatewayException,
+  BadRequestException,
+  ConflictException,
+} from '@nestjs/common'
 import { ExperimentRun, ExperimentRunStatus, Prisma } from '@prisma/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
@@ -261,6 +265,28 @@ describe('AdminAgentRunsService', () => {
         },
       })
       expect(result).toBe(newRun)
+    })
+
+    it('rejects with 409 and never dispatches when the run is still RUNNING', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(
+        makeRun({ status: ExperimentRunStatus.RUNNING }),
+      )
+
+      await expect(service.retry('run-1')).rejects.toBeInstanceOf(
+        ConflictException,
+      )
+      expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
+    })
+
+    it('rejects with 400 and never dispatches when the experiment type is not retryable', async () => {
+      mockModel.findUniqueOrThrow.mockResolvedValue(
+        makeRun({ experimentType: 'meeting_briefing' }),
+      )
+
+      await expect(service.retry('run-1')).rejects.toBeInstanceOf(
+        BadRequestException,
+      )
+      expect(experimentRuns.dispatchRun).not.toHaveBeenCalled()
     })
 
     it('rejects with 400 and never dispatches when params carry no clerk_user_id', async () => {

--- a/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.test.ts
@@ -20,6 +20,7 @@ const makeRun = (overrides: Partial<ExperimentRun> = {}): ExperimentRun => ({
     candidate_first_name: 'Ada',
     candidate_last_name: 'Lovelace',
     clerk_user_id: 'user_abc',
+    trigger: 'initial',
   } as Prisma.JsonValue,
   artifactBucket: 'agent-artifacts',
   artifactKey: 'compliance_setup/run-1/artifact.json',
@@ -257,11 +258,14 @@ describe('AdminAgentRunsService', () => {
         type: 'compliance_setup',
         organizationSlug: 'org-1',
         clerkUserId: 'user_abc',
+        // trigger flips initial -> recovery_resume so the re-dispatch resumes
+        // from durable state instead of re-running paid side effects.
         params: {
           campaign_id: 42,
           candidate_first_name: 'Ada',
           candidate_last_name: 'Lovelace',
           clerk_user_id: 'user_abc',
+          trigger: 'recovery_resume',
         },
       })
       expect(result).toBe(newRun)

--- a/src/admin/agentRuns/services/adminAgentRuns.service.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.ts
@@ -1,9 +1,10 @@
 import {
   BadGatewayException,
   BadRequestException,
+  ConflictException,
   Injectable,
 } from '@nestjs/common'
-import { ExperimentRun, Prisma } from '@prisma/client'
+import { ExperimentRun, ExperimentRunStatus, Prisma } from '@prisma/client'
 import {
   AgentRunCandidateSummary,
   AgentRunListItem,
@@ -130,6 +131,14 @@ export class AdminAgentRunsService extends createPrismaBase(
   // dispatchRun creates a fresh run row + SQS message; the original is untouched.
   async retry(runId: string): Promise<ExperimentRun> {
     const run = await this.model.findUniqueOrThrow({ where: { runId } })
+
+    // A RUNNING run is still in flight; re-dispatching it would spawn a second
+    // parallel worker on the same params (duplicate domain buy / TCR submit).
+    if (run.status === ExperimentRunStatus.RUNNING) {
+      throw new ConflictException(
+        'run is still RUNNING; only finished runs can be retried',
+      )
+    }
 
     const clerkUserId = clerkUserIdFromParams(run.params)
     if (!clerkUserId) {

--- a/src/admin/agentRuns/services/adminAgentRuns.service.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.ts
@@ -1,4 +1,8 @@
-import { Injectable } from '@nestjs/common'
+import {
+  BadGatewayException,
+  BadRequestException,
+  Injectable,
+} from '@nestjs/common'
 import { ExperimentRun, Prisma } from '@prisma/client'
 import {
   AgentRunCandidateSummary,
@@ -8,6 +12,8 @@ import {
 } from '@goodparty_org/contracts'
 import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
 import { S3Service } from '@/vendors/aws/services/s3.service'
+import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
+import { AgentJobContracts } from '@/generated/agent-job-contracts'
 import {
   DEFAULT_PAGINATION_LIMIT,
   DEFAULT_PAGINATION_OFFSET,
@@ -40,6 +46,28 @@ const deriveCandidate = (params: unknown): AgentRunCandidateSummary | null => {
   }
 }
 
+// Retry re-dispatches as the run's candidate, so only experiments whose params
+// carry a clerk_user_id are retryable. Today that is compliance_setup; the
+// `satisfies` keeps this list honest against the generated contract keys.
+const DISPATCHABLE_EXPERIMENT_TYPES = [
+  'compliance_setup',
+] as const satisfies readonly (keyof AgentJobContracts)[]
+
+type DispatchableExperimentType = (typeof DISPATCHABLE_EXPERIMENT_TYPES)[number]
+
+type DispatchParams = AgentJobContracts[DispatchableExperimentType]['Input']
+
+const isDispatchableExperimentType = (
+  type: string,
+): type is DispatchableExperimentType =>
+  DISPATCHABLE_EXPERIMENT_TYPES.some((known) => known === type)
+
+const clerkUserIdFromParams = (params: unknown): string | null => {
+  if (!isJsonObject(params)) return null
+  const clerkUserId = params['clerk_user_id']
+  return typeof clerkUserId === 'string' ? clerkUserId : null
+}
+
 const toListItem = (run: ExperimentRun): AgentRunListItem => ({
   runId: run.runId,
   experimentType: run.experimentType,
@@ -55,7 +83,10 @@ const toListItem = (run: ExperimentRun): AgentRunListItem => ({
 export class AdminAgentRunsService extends createPrismaBase(
   MODELS.ExperimentRun,
 ) {
-  constructor(private readonly s3: S3Service) {
+  constructor(
+    private readonly s3: S3Service,
+    private readonly experimentRuns: ExperimentRunsService,
+  ) {
     super()
   }
 
@@ -93,6 +124,47 @@ export class AdminAgentRunsService extends createPrismaBase(
     ])
 
     return { data: runs.map(toListItem), meta: { total, offset, limit } }
+  }
+
+  // Re-dispatches a finished run with its stored params as the same candidate.
+  // dispatchRun creates a fresh run row + SQS message; the original is untouched.
+  async retry(runId: string): Promise<ExperimentRun> {
+    const run = await this.model.findUniqueOrThrow({ where: { runId } })
+
+    const clerkUserId = clerkUserIdFromParams(run.params)
+    if (!clerkUserId) {
+      throw new BadRequestException(
+        'run params carry no clerk_user_id; cannot re-dispatch as the candidate',
+      )
+    }
+
+    if (!isDispatchableExperimentType(run.experimentType)) {
+      throw new BadRequestException(
+        `experiment type "${run.experimentType}" cannot be re-dispatched`,
+      )
+    }
+
+    // params were validated against this experiment's Input at the original
+    // dispatch and persisted unchanged, so re-forward them as that Input.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const params = run.params as DispatchParams
+
+    const dispatched = await this.experimentRuns.dispatchRun({
+      type: run.experimentType,
+      organizationSlug: run.organizationSlug,
+      clerkUserId,
+      params,
+    })
+
+    // dispatchRun no-ops (returns undefined) when no queue is configured, e.g.
+    // preview envs. Surface that instead of returning a 200 with no new run.
+    if (!dispatched) {
+      throw new BadGatewayException(
+        'agent dispatch is not configured for this environment',
+      )
+    }
+
+    return dispatched
   }
 
   async detail(runId: string): Promise<{

--- a/src/admin/agentRuns/services/adminAgentRuns.service.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.ts
@@ -140,6 +140,12 @@ export class AdminAgentRunsService extends createPrismaBase(
       )
     }
 
+    if (!isDispatchableExperimentType(run.experimentType)) {
+      throw new BadRequestException(
+        `experiment type "${run.experimentType}" cannot be re-dispatched`,
+      )
+    }
+
     const clerkUserId = clerkUserIdFromParams(run.params)
     if (!clerkUserId) {
       throw new BadRequestException(
@@ -147,22 +153,19 @@ export class AdminAgentRunsService extends createPrismaBase(
       )
     }
 
-    if (!isDispatchableExperimentType(run.experimentType)) {
-      throw new BadRequestException(
-        `experiment type "${run.experimentType}" cannot be re-dispatched`,
-      )
-    }
-
     // params were validated against this experiment's Input at the original
     // dispatch and persisted unchanged, so re-forward them as that Input.
     // Override trigger to recovery_resume so the agent treats this as a
     // re-dispatch (consult durable gp-api state), not a first-time dispatch that
-    // would re-run paid side effects (domain purchase, TCR submission).
+    // would re-run paid side effects (domain purchase, TCR submission). Drop a
+    // stale run_id so the agent falls back to the fresh dispatch's run id rather
+    // than filing the artifact under the original run.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const storedParams = run.params as DispatchParams
     const params: DispatchParams = {
       ...storedParams,
       trigger: 'recovery_resume',
+      run_id: undefined,
     }
 
     const dispatched = await this.experimentRuns.dispatchRun({

--- a/src/admin/agentRuns/services/adminAgentRuns.service.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.ts
@@ -1,0 +1,146 @@
+import { Injectable } from '@nestjs/common'
+import { ExperimentRun, Prisma } from '@prisma/client'
+import {
+  AgentRunCandidateSummary,
+  AgentRunListItem,
+  AgentRunsListQuery,
+  PaginatedList,
+} from '@goodparty_org/contracts'
+import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
+import { S3Service } from '@/vendors/aws/services/s3.service'
+import {
+  DEFAULT_PAGINATION_LIMIT,
+  DEFAULT_PAGINATION_OFFSET,
+} from '@/shared/constants/paginationOptions.consts'
+
+const parseArtifact = (raw: string): Record<string, unknown> =>
+  // JSON.parse returns any; the artifact is opaque at this boundary and is
+  // validated against AgentRunDetailSchema by the response interceptor.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  JSON.parse(raw) as Record<string, unknown>
+
+const isJsonObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+// compliance_setup is the only experiment whose params carry a candidate; for
+// every other experiment type the fields are absent and this returns null.
+// params is an opaque Json column (typed `unknown`), so narrow before reading.
+const deriveCandidate = (params: unknown): AgentRunCandidateSummary | null => {
+  if (!isJsonObject(params)) return null
+  const firstName = params['candidate_first_name']
+  const lastName = params['candidate_last_name']
+  if (typeof firstName !== 'string' || typeof lastName !== 'string') {
+    return null
+  }
+  const campaignId = params['campaign_id']
+  return {
+    firstName,
+    lastName,
+    campaignId: typeof campaignId === 'number' ? campaignId : null,
+  }
+}
+
+const toListItem = (run: ExperimentRun): AgentRunListItem => ({
+  runId: run.runId,
+  experimentType: run.experimentType,
+  status: run.status,
+  organizationSlug: run.organizationSlug,
+  candidate: deriveCandidate(run.params),
+  durationSeconds: run.durationSeconds,
+  costUsd: run.costUsd,
+  createdAt: run.createdAt,
+})
+
+@Injectable()
+export class AdminAgentRunsService extends createPrismaBase(
+  MODELS.ExperimentRun,
+) {
+  constructor(private readonly s3: S3Service) {
+    super()
+  }
+
+  async list({
+    offset = DEFAULT_PAGINATION_OFFSET,
+    limit = DEFAULT_PAGINATION_LIMIT,
+    experimentType,
+    status,
+    organizationSlug,
+    createdAfter,
+    createdBefore,
+  }: AgentRunsListQuery): Promise<PaginatedList<AgentRunListItem>> {
+    const where: Prisma.ExperimentRunWhereInput = {
+      ...(experimentType ? { experimentType } : {}),
+      ...(status ? { status } : {}),
+      ...(organizationSlug ? { organizationSlug } : {}),
+      ...(createdAfter || createdBefore
+        ? {
+            createdAt: {
+              ...(createdAfter ? { gte: createdAfter } : {}),
+              ...(createdBefore ? { lte: createdBefore } : {}),
+            },
+          }
+        : {}),
+    }
+
+    const [runs, total] = await Promise.all([
+      this.model.findMany({
+        where,
+        orderBy: { createdAt: Prisma.SortOrder.desc },
+        skip: offset,
+        take: limit,
+      }),
+      this.model.count({ where }),
+    ])
+
+    return { data: runs.map(toListItem), meta: { total, offset, limit } }
+  }
+
+  async detail(runId: string): Promise<{
+    run: ExperimentRun
+    artifact: Record<string, unknown> | null
+    conversationLog: string | null
+  }> {
+    const run = await this.model.findUniqueOrThrow({ where: { runId } })
+
+    const artifact =
+      run.artifactBucket && run.artifactKey
+        ? await this.loadArtifact(run.artifactBucket, run.artifactKey, runId)
+        : null
+
+    const conversationLog = run.artifactBucket
+      ? await this.loadConversationLog(
+          run.artifactBucket,
+          run.experimentType,
+          runId,
+        )
+      : null
+
+    return { run, artifact, conversationLog }
+  }
+
+  // getFile returns undefined on a missing key (NoSuchKey is swallowed there),
+  // so a still-RUNNING run or an absent artifact maps to null, not a 500.
+  private async loadArtifact(
+    bucket: string,
+    key: string,
+    runId: string,
+  ): Promise<Record<string, unknown> | null> {
+    const raw = await this.s3.getFile(bucket, key)
+    if (!raw) return null
+    try {
+      return parseArtifact(raw)
+    } catch {
+      this.logger.error({ runId }, 'agent-run artifact is not valid JSON')
+      return null
+    }
+  }
+
+  private async loadConversationLog(
+    bucket: string,
+    experimentType: string,
+    runId: string,
+  ): Promise<string | null> {
+    const key = `${experimentType}/${runId}/logs/workspace/conversation.log`
+    return (await this.s3.getFile(bucket, key)) ?? null
+  }
+}

--- a/src/admin/agentRuns/services/adminAgentRuns.service.ts
+++ b/src/admin/agentRuns/services/adminAgentRuns.service.ts
@@ -155,8 +155,15 @@ export class AdminAgentRunsService extends createPrismaBase(
 
     // params were validated against this experiment's Input at the original
     // dispatch and persisted unchanged, so re-forward them as that Input.
+    // Override trigger to recovery_resume so the agent treats this as a
+    // re-dispatch (consult durable gp-api state), not a first-time dispatch that
+    // would re-run paid side effects (domain purchase, TCR submission).
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const params = run.params as DispatchParams
+    const storedParams = run.params as DispatchParams
+    const params: DispatchParams = {
+      ...storedParams,
+      trigger: 'recovery_resume',
+    }
 
     const dispatched = await this.experimentRuns.dispatchRun({
       type: run.experimentType,

--- a/src/admin/users/adminUsers.controller.ts
+++ b/src/admin/users/adminUsers.controller.ts
@@ -30,6 +30,11 @@ import {
   DateRangeFilter,
 } from './schemas/AdminUserList.schema'
 
+const SENSITIVE_USER_FIELDS = {
+  password: true,
+  passwordResetToken: true,
+} as const
+
 @Controller('admin/users')
 @UsePipes(ZodValidationPipe)
 export class AdminUsersController {
@@ -44,8 +49,9 @@ export class AdminUsersController {
   @Get()
   @Roles(UserRole.admin)
   async list(@Query() { dateRange }: AdminUserListSchema) {
+    const omit = SENSITIVE_USER_FIELDS
     if (!dateRange || dateRange === DateRangeFilter.allTime) {
-      return this.usersService.findMany()
+      return this.usersService.findMany({ omit })
     }
     let date = new Date()
     if (dateRange === DateRangeFilter.last12Months) {
@@ -55,11 +61,13 @@ export class AdminUsersController {
     } else if (dateRange === DateRangeFilter.lastWeek) {
       date = subDays(date, 7)
     } else {
-      // input validation should prevent this case
       throw new BadRequestException('Invalid date range')
     }
 
-    return this.usersService.findMany({ where: { createdAt: { gt: date } } })
+    return this.usersService.findMany({
+      where: { createdAt: { gt: date } },
+      omit,
+    })
   }
 
   @Get('search')
@@ -75,13 +83,20 @@ export class AdminUsersController {
   @Get(':id')
   @Roles(UserRole.admin)
   async get(@Param('id', ParseIntPipe) id: number) {
-    return await this.usersService.findUniqueOrThrow({ where: { id } })
+    return this.usersService.findUniqueOrThrow({
+      where: { id },
+      omit: SENSITIVE_USER_FIELDS,
+    })
   }
 
   @Post()
   @Roles(UserRole.admin)
-  create(@Body() body: AdminCreateUserSchema) {
-    return this.usersService.createUser(body)
+  async create(@Body() body: AdminCreateUserSchema) {
+    const { id } = await this.usersService.createUser(body)
+    return this.usersService.findUniqueOrThrow({
+      where: { id },
+      omit: SENSITIVE_USER_FIELDS,
+    })
   }
 
   @Post('impersonate/:id')


### PR DESCRIPTION
## Included PRs (qa → master)

- cb435153 feat(tests): add election_date to ExperimentRun model in unit tests
- e137698c fix(admin): refine error handling and test cases in AdminAgentRunsService
- dc7ca33d feat(admin): update trigger handling in AdminAgentRunsService
- 753bff9a feat(admin): enhance retry logic in AdminAgentRunsService
- c7a013d4 feat(admin): add retry functionality to AdminAgentRunsController and service
- 484e44b4 refactor(admin): update AdminAgentRunsController to use M2MOnly guard
- d3151bd0 feat(admin): add agent runs module and schemas
- 5ab041a6 fix(admin): strip password hash and reset token from admin user responses

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Retry re-dispatches compliance agents (domain/TCR side effects mitigated by recovery_resume but still operational risk), and admin user responses touch credential-related fields.
> 
> **Overview**
> Adds **shared Zod contracts** for gp-admin agent-run reads (list rows with optional candidate summary, filters, full run, detail with S3-backed artifact and conversation log) and exports **`ExperimentRunStatus`**.
> 
> Introduces **M2M-only** `admin/agent-runs` APIs: paginated **list** with filters, **detail** that loads artifact JSON and `conversation.log` from S3 (null while running or missing), and **retry** that re-dispatches finished **`compliance_setup`** runs via `dispatchRun` with `recovery_resume`, cleared stale `run_id`, and guards for RUNNING runs, non-retryable types, missing `clerk_user_id`, and unconfigured dispatch.
> 
> **Admin user** list/get/create responses now **omit** `password` and `passwordResetToken` via Prisma `omit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e794308295370c2f15800bfcb9528d619b867628. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->