### PR TITLE
feat(crm): add HubSpot configuration check in trackCampaign method

### DIFF
--- a/src/campaigns/services/crmCampaigns.service.test.ts
+++ b/src/campaigns/services/crmCampaigns.service.test.ts
@@ -1,0 +1,46 @@
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { HubspotService } from '@/crm/hubspot.service'
+import { SlackService } from '@/vendors/slack/services/slack.service'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CrmCampaignsService } from './crmCampaigns.service'
+import { CampaignsService } from './campaigns.service'
+
+describe('CrmCampaignsService.trackCampaign', () => {
+  const findUniqueOrThrow = vi.fn()
+  const errorMessage = vi.fn()
+
+  const buildService = (isConfigured: boolean) =>
+    new CrmCampaignsService(
+      { findUniqueOrThrow } as unknown as CampaignsService,
+      {} as never,
+      { isConfigured } as unknown as HubspotService,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      { errorMessage } as unknown as SlackService,
+      {} as never,
+      createMockLogger(),
+    )
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('skips all HubSpot work and alerts when HubSpot is not configured', async () => {
+    const result = await buildService(false).trackCampaign(123)
+
+    expect(result).toBeUndefined()
+    expect(findUniqueOrThrow).not.toHaveBeenCalled()
+    expect(errorMessage).not.toHaveBeenCalled()
+  })
+
+  it('proceeds to load the campaign when HubSpot is configured', async () => {
+    findUniqueOrThrow.mockRejectedValueOnce(new Error('stop here'))
+
+    await expect(buildService(true).trackCampaign(123)).rejects.toThrow(
+      'stop here',
+    )
+    expect(findUniqueOrThrow).toHaveBeenCalledWith({ where: { id: 123 } })
+  })
+})

--- a/src/campaigns/services/crmCampaigns.service.ts
+++ b/src/campaigns/services/crmCampaigns.service.ts
@@ -405,6 +405,13 @@ export class CrmCampaignsService {
   }
 
   async trackCampaign(campaignId: number) {
+    if (!this.hubspot.isConfigured) {
+      this.logger.debug(
+        `HubSpot not configured — skipping trackCampaign for ${campaignId}`,
+      )
+      return
+    }
+
     const campaign = await this.campaigns.findUniqueOrThrow({
       where: { id: campaignId },
     })

--- a/src/crm/hubspot.service.ts
+++ b/src/crm/hubspot.service.ts
@@ -21,6 +21,13 @@ export class HubspotService {
     return !!HUBSPOT_TOKEN
   }
 
+  // False off-prod where HUBSPOT_TOKEN is unset and `client` is a no-op mock,
+  // so callers can skip writes (and their failure alerts) instead of treating
+  // the mock's undefined return as a real HubSpot failure.
+  get isConfigured(): boolean {
+    return this.isTokenAvailable()
+  }
+
   get client(): Client {
     return this.isTokenAvailable()
       ? this._client


### PR DESCRIPTION
- Implemented a check in the trackCampaign method to skip tracking if HubSpot is not configured, enhancing error handling and logging.
- Introduced isConfigured getter in HubspotService to determine if the HubSpot client is available based on the presence of a token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change only when `HUBSPOT_TOKEN` is unset (e.g. non-prod); production with a token is unchanged.
> 
> **Overview**
> **`trackCampaign`** now exits immediately when HubSpot is not configured, logging at debug and avoiding campaign loads and downstream CRM work that would hit the no-op mock client.
> 
> **`HubspotService`** exposes **`isConfigured`** (token present) so callers can distinguish “HubSpot off” from real API failures instead of treating mock **`undefined`** responses as errors.
> 
> Vitest coverage asserts the skip path does not call **`findUniqueOrThrow`** or Slack, and the configured path still loads the campaign.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc95efb9e0af46d611e74ebd0fbb49d9659fd99d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->