### PR TITLE
feat(experiment-runs): introduce AWAITING_RESUME status and new field…

### DIFF
--- a/contracts/.changeset/eng-7554-agent-run-resume-fields.md
+++ b/contracts/.changeset/eng-7554-agent-run-resume-fields.md
@@ -1,0 +1,11 @@
+---
+'@goodparty_org/contracts': minor
+---
+
+Add `AWAITING_RESUME` to the `ExperimentRunStatus` enum
+(`ExperimentRunStatusSchema` / `EXPERIMENT_RUN_STATUS_VALUES`) and four fields to
+the agent-run read shapes (`AgentRunListItemSchema` / `AgentRunSchema`):
+`stage`, `dataQuality`, `resumeScheduledFor`, and `resumeAttempts`. These back
+the compliance recovery loop (ENG-7554) — a parked run is now reported as
+`AWAITING_RESUME` rather than `COMPLETED`, with its resume schedule and attempt
+count surfaced for the gp-admin dashboard.


### PR DESCRIPTION
…s for agent-run

Added `AWAITING_RESUME` to the `ExperimentRunStatus` enum and incorporated four new fields (`stage`, `dataQuality`, `resumeScheduledFor`, `resumeAttempts`) into the agent-run read shapes. This enhancement supports the compliance recovery loop, allowing parked runs to be reported as `AWAITING_RESUME` instead of `COMPLETED`, with relevant details displayed on the gp-admin dashboard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive contract fields and enum value with a minor bump; consumers must accept the new status and fields but no auth or runtime logic changes appear in this diff.
> 
> **Overview**
> This PR extends **`@goodparty_org/contracts`** (minor) for the compliance recovery loop (ENG-7554).
> 
> It adds **`AWAITING_RESUME`** to **`ExperimentRunStatus`** so parked runs are distinguishable from **`COMPLETED`**. **`AgentRunListItemSchema`** and **`AgentRunSchema`** gain **`stage`**, **`dataQuality`**, **`resumeScheduledFor`**, and **`resumeAttempts`** so gp-admin can show resume timing and retry count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5068c5eaf86d245138f61eafd08d4eee892a3d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->