### PR TITLE
Update domain source handling and contract version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -206,7 +206,7 @@
     },
     "contracts": {
       "name": "@goodparty_org/contracts",
-      "version": "0.9.0",
+      "version": "0.12.0",
       "dependencies": {
         "validator": "^13.12.0",
         "zod": "^3.23.8"

--- a/prisma/schema/domain.prisma
+++ b/prisma/schema/domain.prisma
@@ -6,6 +6,11 @@ enum DomainStatus {
   inactive
 }
 
+enum DomainSource {
+  manual
+  agentic
+}
+
 model Domain {
   id                      Int          @id @default(autoincrement())
   createdAt               DateTime     @default(now()) @map("created_at")
@@ -14,6 +19,7 @@ model Domain {
   websiteId               Int          @unique @map("website_id")
   website                 Website      @relation(fields: [websiteId], references: [id], onDelete: Cascade)
   status                  DomainStatus @default(pending)
+  source                  DomainSource @default(manual)
   operationId             String?      @map("operation_id")
   price                   Decimal?
   paymentId               String?      @map("payment_id")

--- a/prisma/schema/migrations/20260604004729_add_domain_source_discriminator/migration.sql
+++ b/prisma/schema/migrations/20260604004729_add_domain_source_discriminator/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "DomainSource" AS ENUM ('manual', 'agentic');
+
+-- AlterTable
+ALTER TABLE "domain" ADD COLUMN     "source" "DomainSource" NOT NULL DEFAULT 'manual';

--- a/src/websites/controllers/domains.controller.test.ts
+++ b/src/websites/controllers/domains.controller.test.ts
@@ -6,7 +6,8 @@ import {
   ModuleMetadata,
   RequestMethod,
 } from '@nestjs/common'
-import { DomainStatus } from '@prisma/client'
+import { DomainSource, DomainStatus } from '@prisma/client'
+import { IncomingRequest } from '@/authentication/authentication.types'
 import { PinoLogger } from 'nestjs-pino'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DomainsController } from './domains.controller'
@@ -134,15 +135,20 @@ describe('DomainsController.purchaseDomain', () => {
       user: createMockUser({ firstName: 'Jane', lastName: 'Doe' }),
     }
 
-    const result = await controller.purchaseDomain(campaign, {
-      domain: 'voteforjane.run',
-      maxPrice: 50,
-    })
+    const result = await controller.purchaseDomain(
+      campaign,
+      {
+        domain: 'voteforjane.run',
+        maxPrice: 50,
+      },
+      {} as IncomingRequest,
+    )
 
     expect(mockDomains.purchaseDomainForCampaign).toHaveBeenCalledWith(
       campaign,
       'voteforjane.run',
       50,
+      DomainSource.manual,
     )
     expect(result).toEqual({
       domain: {
@@ -168,12 +174,42 @@ describe('DomainsController.purchaseDomain', () => {
     }
 
     await expect(
-      controller.purchaseDomain(campaign, {
-        domain: 'voteforjane.run',
-        maxPrice: 50,
-      }),
+      controller.purchaseDomain(
+        campaign,
+        {
+          domain: 'voteforjane.run',
+          maxPrice: 50,
+        },
+        {} as IncomingRequest,
+      ),
     ).rejects.toBeInstanceOf(ConflictException)
   })
+
+  it.each([
+    { agentToken: true, expected: DomainSource.agentic },
+    { agentToken: false, expected: DomainSource.manual },
+  ])(
+    'derives source from req.agentToken=$agentToken and passes it to the service',
+    async ({ agentToken, expected }) => {
+      const campaign = {
+        ...createMockCampaign({ details: { electionDate: '2026-11-03' } }),
+        user: createMockUser({ firstName: 'Jane', lastName: 'Doe' }),
+      }
+
+      await controller.purchaseDomain(
+        campaign,
+        { domain: 'voteforjane.run', maxPrice: 50 },
+        { agentToken } as IncomingRequest,
+      )
+
+      expect(mockDomains.purchaseDomainForCampaign).toHaveBeenCalledWith(
+        campaign,
+        'voteforjane.run',
+        50,
+        expected,
+      )
+    },
+  )
 
   it('handler is registered for POST /purchase with @UseCampaign() including user, @HttpCode(202), and @McpTool description', () => {
     const reflector = new Reflector()

--- a/src/websites/controllers/domains.controller.ts
+++ b/src/websites/controllers/domains.controller.ts
@@ -9,6 +9,7 @@ import {
   NotFoundException,
   Post,
   Query,
+  Req,
   UsePipes,
 } from '@nestjs/common'
 import { DomainsService } from '../services/domains.service'
@@ -25,7 +26,14 @@ import {
 } from '../schemas/PurchaseDomain.schema'
 import { UseCampaign } from 'src/campaigns/decorators/UseCampaign.decorator'
 import { ReqCampaign } from 'src/campaigns/decorators/ReqCampaign.decorator'
-import { Campaign, DomainStatus, User, UserRole } from '@prisma/client'
+import {
+  Campaign,
+  DomainSource,
+  DomainStatus,
+  User,
+  UserRole,
+} from '@prisma/client'
+import { IncomingRequest } from '@/authentication/authentication.types'
 import { Roles } from 'src/authentication/decorators/Roles.decorator'
 import { WebsitesService } from '../services/websites.service'
 import {
@@ -107,11 +115,14 @@ export class DomainsController {
   async purchaseDomain(
     @ReqCampaign() campaign: Campaign & { user: User },
     @Body() { domain, maxPrice }: PurchaseDomainBodySchema,
+    @Req() req: IncomingRequest,
   ) {
+    const source = req.agentToken ? DomainSource.agentic : DomainSource.manual
     const result = await this.domains.purchaseDomainForCampaign(
       campaign,
       domain,
       maxPrice,
+      source,
     )
     return {
       domain: result.domain,

--- a/src/websites/services/domains.service.test.ts
+++ b/src/websites/services/domains.service.test.ts
@@ -1,5 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { Domain, DomainStatus, WebsiteStatus } from '@prisma/client'
+import {
+  Domain,
+  DomainSource,
+  DomainStatus,
+  WebsiteStatus,
+} from '@prisma/client'
 import { Decimal } from '@prisma/client/runtime/library'
 import { AnalyticsService } from 'src/analytics/analytics.service'
 import { PrismaService } from 'src/prisma/prisma.service'
@@ -37,6 +42,7 @@ const mockDomain: Domain = {
   price: new Decimal(11.25),
   paymentId: 'pi_123',
   status: DomainStatus.pending,
+  source: DomainSource.manual,
   operationId: null,
   emailForwardingDomainId: null,
   registrantVerifiedAt: null,
@@ -601,6 +607,7 @@ describe('DomainsService', () => {
           campaignWithUser,
           domainName,
           maxPrice,
+          DomainSource.manual,
         ),
       ).rejects.toBeInstanceOf(NotFoundException)
 
@@ -614,7 +621,12 @@ describe('DomainsService', () => {
       }
 
       await expect(
-        service.purchaseDomainForCampaign(nonProCampaign, domainName, maxPrice),
+        service.purchaseDomainForCampaign(
+          nonProCampaign,
+          domainName,
+          maxPrice,
+          DomainSource.manual,
+        ),
       ).rejects.toBeInstanceOf(ForbiddenException)
 
       expect(mockPrisma.website.findUnique).not.toHaveBeenCalled()
@@ -638,6 +650,7 @@ describe('DomainsService', () => {
           campaignWithUser,
           mockDomain.name,
           maxPrice,
+          DomainSource.manual,
         )
 
         expect(result.alreadyExisted).toBe(true)
@@ -672,6 +685,7 @@ describe('DomainsService', () => {
             campaignWithUser,
             domainName,
             maxPrice,
+            DomainSource.manual,
           ),
         ).rejects.toBeInstanceOf(ConflictException)
 
@@ -713,6 +727,7 @@ describe('DomainsService', () => {
         campaignWithUser,
         domainName,
         maxPrice,
+        DomainSource.manual,
       )
 
       expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1)
@@ -754,6 +769,7 @@ describe('DomainsService', () => {
         campaignWithUser,
         domainName,
         maxPrice,
+        DomainSource.manual,
       )
 
       const route53Order =
@@ -808,6 +824,7 @@ describe('DomainsService', () => {
         campaignWithUser,
         domainName,
         maxPrice,
+        DomainSource.manual,
       )
 
       expect(mockPrisma.domain.delete).toHaveBeenCalledWith({
@@ -840,6 +857,7 @@ describe('DomainsService', () => {
           campaignWithUser,
           domainName,
           maxPrice,
+          DomainSource.manual,
         ),
       ).rejects.toBeInstanceOf(ConflictException)
 
@@ -857,6 +875,7 @@ describe('DomainsService', () => {
           campaignWithUser,
           domainName,
           maxPrice,
+          DomainSource.manual,
         ),
       ).rejects.toBeInstanceOf(ConflictException)
 
@@ -893,6 +912,7 @@ describe('DomainsService', () => {
         campaignWithUser,
         domainName,
         maxPrice,
+        DomainSource.manual,
       )
 
       expect(result.alreadyExisted).toBe(false)
@@ -908,6 +928,48 @@ describe('DomainsService', () => {
         }),
       })
     })
+
+    it.each([DomainSource.manual, DomainSource.agentic])(
+      'stamps the reserved Domain row with the caller-supplied source=%s',
+      async (source) => {
+        mockPrisma.website.findUnique.mockResolvedValue(baseWebsite)
+        mockPrisma.website.findUniqueOrThrow.mockResolvedValue({
+          content: { contact: {} },
+        })
+        mockRoute53.checkDomainAvailability.mockResolvedValue({
+          Availability: DomainAvailability.AVAILABLE,
+        })
+        mockVercel.checkDomainPrice.mockResolvedValue({ price: 12 })
+        const created = {
+          ...mockDomain,
+          name: domainName,
+          paymentId: null,
+          price: new Decimal(12),
+          source,
+        }
+        mockPrisma.domain.create.mockResolvedValue(created)
+        mockPrisma.domain.findUniqueOrThrow.mockResolvedValue({
+          ...created,
+          status: DomainStatus.submitted,
+        })
+        vi.spyOn(service, 'completeDomainRegistration').mockResolvedValue({
+          vercelResult: null,
+          projectResult: null,
+          message: 'Disabled',
+        })
+
+        await service.purchaseDomainForCampaign(
+          campaignWithUser,
+          domainName,
+          maxPrice,
+          source,
+        )
+
+        expect(mockPrisma.domain.create).toHaveBeenCalledWith({
+          data: expect.objectContaining({ source }),
+        })
+      },
+    )
 
     it('invokes completeDomainRegistration with skipPaymentVerification after reservation', async () => {
       mockPrisma.website.findUnique.mockResolvedValue(baseWebsite)
@@ -941,6 +1003,7 @@ describe('DomainsService', () => {
         campaignWithUser,
         domainName,
         maxPrice,
+        DomainSource.manual,
       )
 
       expect(completeSpy).toHaveBeenCalledTimes(1)
@@ -984,6 +1047,7 @@ describe('DomainsService', () => {
         campaignWithUser,
         domainName,
         maxPrice,
+        DomainSource.manual,
       )
 
       const [, contactArg] = completeSpy.mock.calls[0]
@@ -1012,6 +1076,7 @@ describe('DomainsService', () => {
           campaignWithUser,
           domainName,
           maxPrice,
+          DomainSource.manual,
         ),
       ).rejects.toBeInstanceOf(ConflictException)
 
@@ -1049,6 +1114,7 @@ describe('DomainsService', () => {
           campaignWithUser,
           domainName,
           maxPrice,
+          DomainSource.manual,
         ),
       ).rejects.toBe(registrationError)
 

--- a/src/websites/services/domains.service.ts
+++ b/src/websites/services/domains.service.ts
@@ -9,7 +9,14 @@ import {
   NotFoundException,
 } from '@nestjs/common'
 import { Timeout } from '@nestjs/schedule'
-import { Campaign, Domain, DomainStatus, User, Website } from '@prisma/client'
+import {
+  Campaign,
+  Domain,
+  DomainSource,
+  DomainStatus,
+  User,
+  Website,
+} from '@prisma/client'
 import { AddProjectDomainResponseBody } from '@vercel/sdk/models/addprojectdomainop'
 import { BuySingleDomainResponseBody } from '@vercel/sdk/models/buysingledomainop'
 import { GetDomainResponseBody } from '@vercel/sdk/models/getdomainop'
@@ -521,6 +528,7 @@ export class DomainsService
     campaignId: number,
     domainName: string,
     price: number,
+    source: DomainSource,
   ): Promise<
     | {
         kind: typeof DOMAIN_RESERVATION_KIND.IDEMPOTENT
@@ -589,6 +597,7 @@ export class DomainsService
           price,
           paymentId: null,
           status: DomainStatus.pending,
+          source,
         },
       })
 
@@ -659,6 +668,7 @@ export class DomainsService
     campaign: Campaign & { user: User },
     domainName: string,
     maxPrice: number,
+    source: DomainSource,
   ): Promise<{
     website: Pick<Website, 'id' | 'vanityPath' | 'status' | 'campaignId'>
     domain: Pick<Domain, 'id' | 'name' | 'status'> & { price: number | null }
@@ -716,6 +726,7 @@ export class DomainsService
       campaign.id,
       domainName,
       price,
+      source,
     )
 
     if (locked.kind === DOMAIN_RESERVATION_KIND.IDEMPOTENT) {


### PR DESCRIPTION
- Bump version of @goodparty_org/contracts from 0.9.0 to 0.12.0 in package-lock.json.
- Introduce DomainSource enum with values 'manual' and 'agentic' in the Prisma schema.
- Modify DomainsController and DomainsService to utilize the new DomainSource enum for domain purchases, deriving the source from the request's agentToken.
- Update related tests to ensure correct handling of the new source parameter in domain purchase logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the domain purchase/reservation path and adds a required DB column migration; behavior is additive tagging only, with purchase rules unchanged aside from persisting source.
> 
> **Overview**
> Adds a **`DomainSource`** discriminator (`manual` | `agentic`) on **`domain`** rows (Prisma enum + migration defaulting existing data to **`manual`**), and threads it through **campaign domain purchase**.
> 
> **`POST /domains/purchase`** now reads the request and sets **`agentic`** when **`req.agentToken`** is set (MCP/agent flows), otherwise **`manual`**. That value is passed into **`purchaseDomainForCampaign`** / **`reserveDomainForCampaign`** and stored on the reserved **`Domain`** create. Controller and service tests cover both sources.
> 
> Also bumps **`@goodparty_org/contracts`** in **`package-lock.json`** from **0.9.0** to **0.12.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4e37328f2292380595e3f849fe92f16cb313186. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->