### PR TITLE
feat(meetings): add MeetingResourceLocation and thread location hints

### DIFF
--- a/prisma/schema/electedOffice.prisma
+++ b/prisma/schema/electedOffice.prisma
@@ -14,9 +14,10 @@ model ElectedOffice {
   campaign   Campaign? @relation(fields: [campaignId], references: [id], onDelete: NoAction)
   campaignId Int?      @map("campaign_id")
 
-  polls                  Poll[]
-  pollIndividualMessages PollIndividualMessage[]
-  meetingBriefings       MeetingBriefing[]
+  polls                    Poll[]
+  pollIndividualMessages   PollIndividualMessage[]
+  meetingBriefings         MeetingBriefing[]
+  meetingResourceLocations MeetingResourceLocation[]
 
   @@index([userId])
   @@index([campaignId])

--- a/prisma/schema/experimentRun.prisma
+++ b/prisma/schema/experimentRun.prisma
@@ -31,7 +31,8 @@ model ExperimentRun {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  meetingBriefings MeetingBriefing[]
+  meetingBriefings         MeetingBriefing[]
+  meetingResourceLocations MeetingResourceLocation[]
 
   @@index([organizationSlug, experimentType])
   @@index([status, resumeScheduledFor])

--- a/prisma/schema/meetingResourceLocation.prisma
+++ b/prisma/schema/meetingResourceLocation.prisma
@@ -1,0 +1,23 @@
+enum MeetingResourceLocationType {
+  AGENDA
+  SCHEDULE
+}
+
+model MeetingResourceLocation {
+  id String @id @default(uuid(7))
+
+  electedOfficeId String        @map("elected_office_id")
+  electedOffice   ElectedOffice @relation(fields: [electedOfficeId], references: [id], onDelete: Cascade)
+
+  type        MeetingResourceLocationType
+  description String                      @db.Text
+
+  experimentRunId String?        @map("experiment_run_id")
+  experimentRun   ExperimentRun? @relation(fields: [experimentRunId], references: [runId], onDelete: SetNull)
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([electedOfficeId, type])
+  @@map("meeting_resource_location")
+}

--- a/prisma/schema/migrations/20260603221000_add_meeting_resource_location/migration.sql
+++ b/prisma/schema/migrations/20260603221000_add_meeting_resource_location/migration.sql
@@ -1,0 +1,24 @@
+-- CreateEnum
+CREATE TYPE "MeetingResourceLocationType" AS ENUM ('AGENDA', 'SCHEDULE');
+
+-- CreateTable
+CREATE TABLE "meeting_resource_location" (
+    "id" TEXT NOT NULL,
+    "elected_office_id" TEXT NOT NULL,
+    "type" "MeetingResourceLocationType" NOT NULL,
+    "description" TEXT NOT NULL,
+    "experiment_run_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "meeting_resource_location_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "meeting_resource_location_elected_office_id_type_key" ON "meeting_resource_location"("elected_office_id", "type");
+
+-- AddForeignKey
+ALTER TABLE "meeting_resource_location" ADD CONSTRAINT "meeting_resource_location_elected_office_id_fkey" FOREIGN KEY ("elected_office_id") REFERENCES "elected_office"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "meeting_resource_location" ADD CONSTRAINT "meeting_resource_location_experiment_run_id_fkey" FOREIGN KEY ("experiment_run_id") REFERENCES "experiment_run"("run_id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/generated/agent-job-contracts.ts
+++ b/src/generated/agent-job-contracts.ts
@@ -87,6 +87,10 @@ export interface AgentJobContracts {
   meeting_briefing: {
     Input: {
       /**
+       * Optional hint from a prior run describing where the agenda packet was last found. (Manually added ahead of S3 publish; will be regenerated from the v6 manifest on next sync.)
+       */
+      knownAgendaLocation?: string
+      /**
        * L2 district value to match (e.g. "25"). Required if l2DistrictType is set.
        */
       l2DistrictName?: string
@@ -1549,6 +1553,10 @@ export interface MeetingScheduleInput {
    * Opaque gp-api ElectedOffice.id; passed through to the callback. Not used during research.
    */
   elected_office_id?: string
+  /**
+   * Optional hint from a prior run describing where the meeting schedule was last found. (Manually added ahead of S3 publish; will be regenerated from the v2 manifest on next sync.)
+   */
+  known_schedule_location?: string
   /**
    * Full position/office name as it appears to the candidate (e.g. 'Burnsville City Council Member', 'Mayor of Cheyenne'). Usually contains the jurisdiction verbatim; when generic (e.g. just 'City Council'), the agent must infer the city from the position + state via WebSearch.
    */

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -1,4 +1,7 @@
-import { ExperimentRunStatus } from '@prisma/client'
+import {
+  ExperimentRunStatus,
+  MeetingResourceLocationType,
+} from '@prisma/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { OrganizationsService } from '@/organizations/services/organizations.service'
 import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
@@ -1046,5 +1049,323 @@ describe('MeetingBriefingsService.dispatchManual', () => {
 
     expect(result.dispatched).toBe(false)
     expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('MeetingBriefingsService location hints', () => {
+  beforeEach(() => {
+    mockResolveServeContext(null)
+  })
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('passes known_schedule_location into the schedule dispatch when a row exists', async () => {
+    const orgSlug = `loc-sched-hint-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-sched-hint' })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    await service.prisma.meetingResourceLocation.create({
+      data: {
+        electedOfficeId: eo.id,
+        type: MeetingResourceLocationType.SCHEDULE,
+        description: 'https://example.gov/city-council/meetings',
+      },
+    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .dispatchManual(eo.id, 'schedule')
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'meeting_schedule',
+        params: expect.objectContaining({
+          known_schedule_location: 'https://example.gov/city-council/meetings',
+        }),
+      }),
+    )
+  })
+
+  it('omits known_schedule_location when no row exists', async () => {
+    const orgSlug = `loc-sched-no-hint-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-sched-no-hint' })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .dispatchManual(eo.id, 'schedule')
+
+    const params = dispatchSpy.mock.calls[0]?.[0]?.params as
+      | Record<string, unknown>
+      | undefined
+    expect(params).toBeDefined()
+    expect(params).not.toHaveProperty('known_schedule_location')
+  })
+
+  it('passes knownAgendaLocation and electedOfficeId into the briefing dispatch when a row exists', async () => {
+    const orgSlug = `loc-agenda-hint-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-agenda-hint' })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    await service.prisma.meetingResourceLocation.create({
+      data: {
+        electedOfficeId: eo.id,
+        type: MeetingResourceLocationType.AGENDA,
+        description: 'https://city.granicus.com/ViewPublisher.php?view_id=5',
+      },
+    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    await seedScheduleForOrg(orgSlug)
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .dispatchManual(eo.id, 'briefing')
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'meeting_briefing',
+        params: expect.objectContaining({
+          knownAgendaLocation:
+            'https://city.granicus.com/ViewPublisher.php?view_id=5',
+        }),
+      }),
+    )
+  })
+
+  it('upserts a SCHEDULE location row when the schedule artifact carries discovered_schedule_location', async () => {
+    const orgSlug = `loc-sched-persist-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-sched-persist' })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    const artifactKey = `schedule-loc-${orgSlug}.json`
+    await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_schedule',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'schedule-bucket',
+        artifactKey,
+        params: { elected_office_id: eo.id },
+      },
+    })
+    mockS3({
+      [artifactKey]: JSON.stringify({
+        status: 'found',
+        rrule: 'FREQ=DAILY',
+        time: '19:00',
+        timezone: 'America/Chicago',
+        duration_minutes: 120,
+        meeting_name: 'City Council',
+        location: 'Council Chambers',
+        sources: [],
+        generated_at: new Date().toISOString(),
+        human: 'Daily',
+        discovered_schedule_location:
+          'https://example.gov/government/city-council/',
+      }),
+    })
+    const scheduleRun = await service.prisma.experimentRun.findFirstOrThrow({
+      where: { artifactKey },
+    })
+    vi.spyOn(
+      service.app.get(ExperimentRunsService),
+      'dispatchRun',
+    ).mockResolvedValue(undefined)
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(scheduleRun)
+
+    const row = await service.prisma.meetingResourceLocation.findUnique({
+      where: {
+        electedOfficeId_type: {
+          electedOfficeId: eo.id,
+          type: MeetingResourceLocationType.SCHEDULE,
+        },
+      },
+    })
+    expect(row).not.toBeNull()
+    expect(row?.description).toBe(
+      'https://example.gov/government/city-council/',
+    )
+    expect(row?.experimentRunId).toBe(scheduleRun.runId)
+  })
+
+  it('upserts an AGENDA location row on a placeholder briefing when discovered_agenda_location is set', async () => {
+    const orgSlug = `loc-agenda-placeholder-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, {
+      positionId: 'br-pos-agenda-placeholder',
+    })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing-placeholder.json',
+        params: {},
+      },
+    })
+    mockS3({
+      'briefing-placeholder.json': JSON.stringify({
+        briefing_status: 'awaiting_agenda',
+        meeting_date: '2026-06-10',
+        run_metadata: {
+          agenda_packet_url: null,
+          discovered_agenda_location:
+            'https://city.granicus.com/ViewPublisher.php?view_id=5',
+        },
+      }),
+    })
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(briefingRun)
+
+    // No briefing row written for placeholder status (existing behavior),
+    // but the location hint persists so the next run can use it.
+    const briefingRow = await service.prisma.meetingBriefing.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: eo.id,
+          meetingDate: new Date('2026-06-10'),
+        },
+      },
+    })
+    expect(briefingRow).toBeNull()
+
+    const locationRow = await service.prisma.meetingResourceLocation.findUnique(
+      {
+        where: {
+          electedOfficeId_type: {
+            electedOfficeId: eo.id,
+            type: MeetingResourceLocationType.AGENDA,
+          },
+        },
+      },
+    )
+    expect(locationRow).not.toBeNull()
+    expect(locationRow?.description).toBe(
+      'https://city.granicus.com/ViewPublisher.php?view_id=5',
+    )
+    expect(locationRow?.experimentRunId).toBe(briefingRun.runId)
+  })
+
+  it('overwrites an existing location row on the next run', async () => {
+    const orgSlug = `loc-overwrite-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-overwrite' })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    await service.prisma.meetingResourceLocation.create({
+      data: {
+        electedOfficeId: eo.id,
+        type: MeetingResourceLocationType.AGENDA,
+        description: 'https://old.example.gov/meetings',
+      },
+    })
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing-overwrite.json',
+        params: {},
+      },
+    })
+    mockS3({
+      'briefing-overwrite.json': JSON.stringify({
+        briefing_status: 'briefing_ready',
+        meeting_date: '2026-06-10',
+        meeting_time: '19:00',
+        meeting_timezone: 'America/Chicago',
+        meeting_name: 'City Council',
+        location: 'Council Chambers',
+        run_metadata: {
+          agenda_packet_url:
+            'https://new.example.gov/meetings/2026-06-10/packet.pdf',
+          discovered_agenda_location: 'https://new.example.gov/meetings',
+        },
+      }),
+    })
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(briefingRun)
+
+    const row = await service.prisma.meetingResourceLocation.findUnique({
+      where: {
+        electedOfficeId_type: {
+          electedOfficeId: eo.id,
+          type: MeetingResourceLocationType.AGENDA,
+        },
+      },
+    })
+    expect(row?.description).toBe('https://new.example.gov/meetings')
+    expect(row?.experimentRunId).toBe(briefingRun.runId)
+  })
+
+  it('does not write a location row when discovered_agenda_location is absent', async () => {
+    const orgSlug = `loc-absent-${Date.now()}`
+    await seedOrgAndCampaign(orgSlug, { positionId: 'br-pos-absent' })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing-no-loc.json',
+        params: {},
+      },
+    })
+    mockS3({
+      'briefing-no-loc.json': JSON.stringify({
+        briefing_status: 'briefing_ready',
+        meeting_date: '2026-06-10',
+        meeting_time: '19:00',
+        meeting_timezone: 'America/Chicago',
+        meeting_name: 'City Council',
+        location: 'Council Chambers',
+      }),
+    })
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(briefingRun)
+
+    const row = await service.prisma.meetingResourceLocation.findUnique({
+      where: {
+        electedOfficeId_type: {
+          electedOfficeId: eo.id,
+          type: MeetingResourceLocationType.AGENDA,
+        },
+      },
+    })
+    expect(row).toBeNull()
   })
 })

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -1,28 +1,29 @@
+import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
+import { CronLockService } from '@/cron/services/cronLock.service'
+import { MeetingSchedule } from '@/generated/agent-job-contracts'
+import { LlmService } from '@/llm/services/llm.service'
+import { OrganizationsService } from '@/organizations/services/organizations.service'
+import { parseIsoDateAsUTC } from '@/shared/util/date.util'
+import { getUserFullName } from '@/users/util/users.util'
+import { S3Service } from '@/vendors/aws/services/s3.service'
+import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
+import { SegmentService } from '@/vendors/segment/segment.service'
 import { Injectable } from '@nestjs/common'
 import { Cron } from '@nestjs/schedule'
 import {
   ElectedOffice,
   ExperimentRun,
   ExperimentRunStatus,
+  MeetingResourceLocationType,
   Prisma,
 } from '@prisma/client'
-import { rrulestr } from 'rrule'
-import { formatInTimeZone } from 'date-fns-tz'
 import { addDays } from 'date-fns'
-import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
-import { OrganizationsService } from '@/organizations/services/organizations.service'
-import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
-import { S3Service } from '@/vendors/aws/services/s3.service'
-import { SegmentService } from '@/vendors/segment/segment.service'
-import { ChatCompletionMessageParam } from 'openai/resources/chat/completions'
-import { LlmService } from '@/llm/services/llm.service'
-import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
-import { parseIsoDateAsUTC } from '@/shared/util/date.util'
-import { MeetingSchedule } from '@/generated/agent-job-contracts'
-import { getUserFullName } from '@/users/util/users.util'
-import { CronLockService } from '@/cron/services/cronLock.service'
+import { formatInTimeZone } from 'date-fns-tz'
 import { chunk } from 'es-toolkit'
 import ms from 'ms'
+import { ChatCompletionMessageParam } from 'openai/resources/chat/completions'
+import { rrulestr } from 'rrule'
+import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 
 const parseBriefingArtifact = (
   raw: string,
@@ -54,6 +55,44 @@ const extractElectedOfficeId = (params: unknown): string | null => {
   }
   const value: unknown = params.elected_office_id
   return typeof value === 'string' ? value : null
+}
+
+// Maximum prose length we persist for a discovered location hint. Mirrors the
+// runbooks manifests so the DB row matches what the schema validator allows.
+const DISCOVERED_LOCATION_MAX = 2000
+
+const readStringField = (obj: unknown, key: string): string | null => {
+  if (
+    typeof obj !== 'object' ||
+    obj === null ||
+    Array.isArray(obj) ||
+    !(key in obj)
+  ) {
+    return null
+  }
+  const value: unknown = Reflect.get(obj, key)
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  return trimmed.slice(0, DISCOVERED_LOCATION_MAX)
+}
+
+const extractDiscoveredScheduleLocation = (schedule: unknown): string | null =>
+  readStringField(schedule, 'discovered_schedule_location')
+
+const extractDiscoveredAgendaLocation = (artifact: unknown): string | null => {
+  if (
+    typeof artifact !== 'object' ||
+    artifact === null ||
+    Array.isArray(artifact) ||
+    !('run_metadata' in artifact)
+  ) {
+    return null
+  }
+  return readStringField(
+    Reflect.get(artifact, 'run_metadata'),
+    'discovered_agenda_location',
+  )
 }
 
 // Identifies the daily-briefing cron in the cron_run lease table.
@@ -180,7 +219,22 @@ export class MeetingBriefingsService extends createPrismaBase(
     await this.dispatchSchedule(ctx)
   }
 
+  private async loadLocationHint(
+    electedOfficeId: string,
+    type: MeetingResourceLocationType,
+  ): Promise<string | null> {
+    const row = await this.client.meetingResourceLocation.findUnique({
+      where: { electedOfficeId_type: { electedOfficeId, type } },
+      select: { description: true },
+    })
+    return row?.description ?? null
+  }
+
   private async dispatchSchedule(ctx: DispatchContext): Promise<void> {
+    const hint = await this.loadLocationHint(
+      ctx.electedOfficeId,
+      MeetingResourceLocationType.SCHEDULE,
+    )
     await this.experimentRuns.dispatchRun({
       type: SCHEDULE_EXPERIMENT_TYPE,
       organizationSlug: ctx.organizationSlug,
@@ -189,6 +243,7 @@ export class MeetingBriefingsService extends createPrismaBase(
         elected_office_id: ctx.electedOfficeId,
         state: ctx.state,
         office: ctx.positionName,
+        ...(hint ? { known_schedule_location: hint } : {}),
       },
     })
   }
@@ -197,6 +252,10 @@ export class MeetingBriefingsService extends createPrismaBase(
     ctx: DispatchContext,
     meeting: TargetMeeting,
   ): Promise<void> {
+    const hint = await this.loadLocationHint(
+      ctx.electedOfficeId,
+      MeetingResourceLocationType.AGENDA,
+    )
     await this.experimentRuns.dispatchRun({
       type: BRIEFING_EXPERIMENT_TYPE,
       organizationSlug: ctx.organizationSlug,
@@ -210,6 +269,7 @@ export class MeetingBriefingsService extends createPrismaBase(
         meetingTimezone: meeting.meetingTimezone,
         ...(ctx.l2DistrictType ? { l2DistrictType: ctx.l2DistrictType } : {}),
         ...(ctx.l2DistrictName ? { l2DistrictName: ctx.l2DistrictName } : {}),
+        ...(hint ? { knownAgendaLocation: hint } : {}),
       },
     })
   }
@@ -301,13 +361,80 @@ export class MeetingBriefingsService extends createPrismaBase(
     if (run.status !== ExperimentRunStatus.COMPLETED) return
 
     if (run.experimentType === BRIEFING_EXPERIMENT_TYPE) {
-      await this.upsertBriefingRow(run)
+      await this.handleBriefingCompletion(run)
       return
     }
 
     if (run.experimentType === SCHEDULE_EXPERIMENT_TYPE) {
+      await this.persistScheduleLocationFromRun(run)
       await this.maybeDispatchBriefingAfterSchedule(run)
     }
+  }
+
+  private async handleBriefingCompletion(run: ExperimentRun): Promise<void> {
+    const loaded = await this.loadBriefingArtifact(run)
+    if (!loaded) return
+    // Location persists regardless of briefing_status — placeholder runs
+    // still produce a hint when the parent page was reachable.
+    await this.persistAgendaLocationFromArtifact(
+      run,
+      loaded.electedOffice.id,
+      loaded.artifact,
+    )
+    await this.writeBriefingRowFromArtifact(
+      run,
+      loaded.electedOffice,
+      loaded.artifact,
+    )
+  }
+
+  private async upsertResourceLocation(args: {
+    electedOfficeId: string
+    type: MeetingResourceLocationType
+    description: string
+    experimentRunId: string
+  }): Promise<void> {
+    const { electedOfficeId, type, description, experimentRunId } = args
+    await this.client.meetingResourceLocation.upsert({
+      where: { electedOfficeId_type: { electedOfficeId, type } },
+      create: { electedOfficeId, type, description, experimentRunId },
+      update: { description, experimentRunId },
+    })
+  }
+
+  private async persistScheduleLocationFromRun(
+    run: ExperimentRun,
+  ): Promise<void> {
+    if (!run.artifactBucket || !run.artifactKey) return
+
+    const raw = await this.s3.getFile(run.artifactBucket, run.artifactKey)
+    if (!raw) return
+
+    let schedule: unknown
+    try {
+      schedule = JSON.parse(raw)
+    } catch {
+      return
+    }
+
+    const description = extractDiscoveredScheduleLocation(schedule)
+    if (!description) return
+
+    const electedOfficeId = extractElectedOfficeId(run.params)
+    if (!electedOfficeId) {
+      this.logger.warn(
+        { runId: run.runId },
+        'schedule run completed without elected_office_id in params; cannot persist location hint',
+      )
+      return
+    }
+
+    await this.upsertResourceLocation({
+      electedOfficeId,
+      type: MeetingResourceLocationType.SCHEDULE,
+      description,
+      experimentRunId: run.runId,
+    })
   }
 
   /**
@@ -483,13 +610,16 @@ export class MeetingBriefingsService extends createPrismaBase(
     }
   }
 
-  private async upsertBriefingRow(run: ExperimentRun): Promise<void> {
+  private async loadBriefingArtifact(run: ExperimentRun): Promise<{
+    artifact: PrismaJson.MeetingBriefingArtifact
+    electedOffice: { id: string; userId: number }
+  } | null> {
     if (!run.artifactBucket || !run.artifactKey) {
       this.logger.error(
         { runId: run.runId },
         'meeting_briefing completed without artifact pointers',
       )
-      return
+      return null
     }
 
     const electedOffice = await this.client.electedOffice.findUnique({
@@ -501,9 +631,8 @@ export class MeetingBriefingsService extends createPrismaBase(
         { runId: run.runId, organizationSlug: run.organizationSlug },
         'meeting_briefing completed but no ElectedOffice for the org',
       )
-      return
+      return null
     }
-    const electedOfficeId = electedOffice.id
 
     const raw = await this.s3.getFile(run.artifactBucket, run.artifactKey)
     if (!raw) {
@@ -511,19 +640,41 @@ export class MeetingBriefingsService extends createPrismaBase(
         { runId: run.runId },
         'meeting_briefing artifact missing from S3',
       )
-      return
+      return null
     }
 
-    let artifact: PrismaJson.MeetingBriefingArtifact
     try {
-      artifact = parseBriefingArtifact(raw)
+      return { artifact: parseBriefingArtifact(raw), electedOffice }
     } catch {
       this.logger.error(
         { runId: run.runId },
         'meeting_briefing artifact is not valid JSON',
       )
-      return
+      return null
     }
+  }
+
+  private async persistAgendaLocationFromArtifact(
+    run: ExperimentRun,
+    electedOfficeId: string,
+    artifact: PrismaJson.MeetingBriefingArtifact,
+  ): Promise<void> {
+    const description = extractDiscoveredAgendaLocation(artifact)
+    if (!description) return
+    await this.upsertResourceLocation({
+      electedOfficeId,
+      type: MeetingResourceLocationType.AGENDA,
+      description,
+      experimentRunId: run.runId,
+    })
+  }
+
+  private async writeBriefingRowFromArtifact(
+    run: ExperimentRun,
+    electedOffice: { id: string; userId: number },
+    artifact: PrismaJson.MeetingBriefingArtifact,
+  ): Promise<void> {
+    if (!run.artifactBucket || !run.artifactKey) return
 
     const briefingStatus = artifact.briefing_status
     if (briefingStatus === undefined) {
@@ -583,6 +734,7 @@ export class MeetingBriefingsService extends createPrismaBase(
       return
     }
 
+    const electedOfficeId = electedOffice.id
     await this.model.upsert({
       where: {
         electedOfficeId_meetingDate: {

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -366,24 +366,31 @@ export class MeetingBriefingsService extends createPrismaBase(
     }
 
     if (run.experimentType === SCHEDULE_EXPERIMENT_TYPE) {
-      await this.persistScheduleLocationFromRun(run)
+      // Critical work first (cron chain). Hint persistence is a best-effort
+      // optimization and must not gate the briefing dispatch — the queue
+      // consumer swallows throws from this handler without retry.
       await this.maybeDispatchBriefingAfterSchedule(run)
+      await this.persistScheduleLocationFromRun(run)
     }
   }
 
   private async handleBriefingCompletion(run: ExperimentRun): Promise<void> {
     const loaded = await this.loadBriefingArtifact(run)
     if (!loaded) return
-    // Location persists regardless of briefing_status — placeholder runs
-    // still produce a hint when the parent page was reachable.
-    await this.persistAgendaLocationFromArtifact(
-      run,
-      loaded.electedOffice.id,
-      loaded.artifact,
-    )
+    // Critical work first (the briefing row). Location persistence comes
+    // after so a hint-upsert failure can't block the row write — the queue
+    // consumer swallows throws from this handler without retry. Location
+    // persists regardless of briefing_status (writeBriefingRowFromArtifact
+    // early-returns on placeholder statuses), so placeholder runs still
+    // capture the hint.
     await this.writeBriefingRowFromArtifact(
       run,
       loaded.electedOffice,
+      loaded.artifact,
+    )
+    await this.persistAgendaLocationFromArtifact(
+      run,
+      loaded.electedOffice.id,
       loaded.artifact,
     )
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes meeting experiment dispatch params and completion hooks for elected offices; additive schema and hints, but incorrect hints could mislead agent research until the next successful run.
> 
> **Overview**
> Adds **`MeetingResourceLocation`** storage (per elected office, **AGENDA** vs **SCHEDULE**) so meeting automation can remember where agents last found schedule and agenda pages.
> 
> **`MeetingBriefingsService`** now **reads** those rows when dispatching `meeting_schedule` (`known_schedule_location`) and `meeting_briefing` (`knownAgendaLocation`), and **upserts** them when runs complete from artifact fields `discovered_schedule_location` and `run_metadata.discovered_agenda_location` (including placeholder briefings, without changing when briefing rows are written). Agent job contracts gain the matching optional input fields; tests cover dispatch hints and persistence/overwrite behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b2b4c84f6d833a9cfdee1eeb55666e06a8f8557. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->