### PR TITLE
Enhance ElectedOffice service and tests to return existing offices

### DIFF
--- a/prisma/schema/electedOffice.prisma
+++ b/prisma/schema/electedOffice.prisma
@@ -18,7 +18,7 @@ model ElectedOffice {
   pollIndividualMessages PollIndividualMessage[]
   meetingBriefings       MeetingBriefing[]
 
-  @@index([userId])
+  @@unique([userId])
   @@index([campaignId])
   @@map("elected_office")
 }

--- a/prisma/schema/migrations/20260604172543_elected_office_unique_user_id/migration.sql
+++ b/prisma/schema/migrations/20260604172543_elected_office_unique_user_id/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "elected_office_user_id_idx";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "elected_office_user_id_key" ON "elected_office"("user_id");

--- a/src/electedOffice/electedOffice.controller.test.ts
+++ b/src/electedOffice/electedOffice.controller.test.ts
@@ -241,6 +241,20 @@ describe('ElectedOfficeController', () => {
       })
     })
 
+    it('returns the existing elected office instead of erroring when one already exists', async () => {
+      const first = await createElectedOffice()
+      expect(first.status).toBe(201)
+
+      const second = await createElectedOffice()
+      expect(second.status).toBe(201)
+      expect(second.data.id).toBe(first.data.id)
+
+      const offices = await service.prisma.electedOffice.findMany({
+        where: { userId: service.user.id },
+      })
+      expect(offices).toHaveLength(1)
+    })
+
     it('returns 403 when user has no campaign', async () => {
       await service.prisma.campaign.deleteMany({
         where: { userId: service.user.id },

--- a/src/electedOffice/electedOffice.controller.test.ts
+++ b/src/electedOffice/electedOffice.controller.test.ts
@@ -37,7 +37,7 @@ describe('ElectedOfficeController', () => {
       const created = await createElectedOffice({
         swornInDate: '2024-01-15',
       })
-      expect(created.status).toBe(201)
+      expect(created.status).toBe(200)
 
       const eoOrgSlug = `eo-${created.data.id}`
       const result = await service.client.get('/v1/elected-office/current', {
@@ -63,7 +63,7 @@ describe('ElectedOfficeController', () => {
       const created = await createElectedOffice({
         swornInDate: '2024-01-15',
       })
-      expect(created.status).toBe(201)
+      expect(created.status).toBe(200)
 
       const eoOrgSlug = `eo-${created.data.id}`
       const result = await service.client.get('/v1/elected-office/current', {
@@ -187,7 +187,7 @@ describe('ElectedOfficeController', () => {
         swornInDate: '2024-01-15',
       })
 
-      expect(result.status).toBe(201)
+      expect(result.status).toBe(200)
       expect(result.data).toEqual({
         id: expect.any(String),
         swornInDate: '2024-01-15',
@@ -209,7 +209,7 @@ describe('ElectedOfficeController', () => {
     it('creates elected office with only required fields', async () => {
       const result = await createElectedOffice()
 
-      expect(result.status).toBe(201)
+      expect(result.status).toBe(200)
       expect(result.data).toMatchObject({
         id: expect.any(String),
       })
@@ -235,19 +235,20 @@ describe('ElectedOfficeController', () => {
 
       const result = await createElectedOffice()
 
-      expect(result.status).toBe(201)
+      expect(result.status).toBe(200)
       expect(result.data).toMatchObject({
         id: expect.any(String),
       })
     })
 
-    it('returns the existing elected office instead of erroring when one already exists', async () => {
-      const first = await createElectedOffice()
-      expect(first.status).toBe(201)
+    it('returns the existing elected office, ignoring the new input, when one already exists', async () => {
+      const first = await createElectedOffice({ swornInDate: '2024-01-15' })
+      expect(first.status).toBe(200)
 
-      const second = await createElectedOffice()
-      expect(second.status).toBe(201)
+      const second = await createElectedOffice({ swornInDate: '2025-06-01' })
+      expect(second.status).toBe(200)
       expect(second.data.id).toBe(first.data.id)
+      expect(second.data.swornInDate).toBe('2024-01-15')
 
       const offices = await service.prisma.electedOffice.findMany({
         where: { userId: service.user.id },

--- a/src/electedOffice/electedOffice.controller.ts
+++ b/src/electedOffice/electedOffice.controller.ts
@@ -6,6 +6,8 @@ import {
   Controller,
   ForbiddenException,
   Get,
+  HttpCode,
+  HttpStatus,
   NotFoundException,
   Param,
   Post,
@@ -73,6 +75,7 @@ export class ElectedOfficeController {
   }
 
   @Post('/')
+  @HttpCode(HttpStatus.OK)
   @UseOrganization()
   async create(
     @ReqUser() user: User,

--- a/src/electedOffice/services/electedOffice.service.test.ts
+++ b/src/electedOffice/services/electedOffice.service.test.ts
@@ -16,6 +16,7 @@ describe('ElectedOfficeService', () => {
   let service: ElectedOfficeService
   let mockOrgCreate: ReturnType<typeof vi.fn>
   let mockEoCreate: ReturnType<typeof vi.fn>
+  let mockOnElectedOfficeCreated: ReturnType<typeof vi.fn>
   let mockModel: {
     create: ReturnType<typeof vi.fn>
     update: ReturnType<typeof vi.fn>
@@ -59,8 +60,9 @@ describe('ElectedOfficeService', () => {
       findMany: vi.fn(),
     }
 
+    mockOnElectedOfficeCreated = vi.fn().mockResolvedValue(undefined)
     service = new ElectedOfficeService({
-      onElectedOfficeCreated: vi.fn().mockResolvedValue(undefined),
+      onElectedOfficeCreated: mockOnElectedOfficeCreated,
     } as never)
     Object.defineProperty(service, 'model', {
       get: () => mockModel,
@@ -96,6 +98,9 @@ describe('ElectedOfficeService', () => {
       })
       expect(mockOrgCreate).not.toHaveBeenCalled()
       expect(mockEoCreate).not.toHaveBeenCalled()
+      // The schedule dispatch is the only recovery path for an office whose
+      // earlier create committed but never dispatched, so it must still fire.
+      expect(mockOnElectedOfficeCreated).toHaveBeenCalledWith(existing)
     })
 
     it('returns the concurrently-created office when the insert hits the unique constraint', async () => {
@@ -123,6 +128,7 @@ describe('ElectedOfficeService', () => {
       const result = await service.create(createArgs)
 
       expect(result).toBe(concurrent)
+      expect(mockOnElectedOfficeCreated).toHaveBeenCalledWith(concurrent)
     })
 
     it('creates organization with default org data and elected office in transaction', async () => {

--- a/src/electedOffice/services/electedOffice.service.test.ts
+++ b/src/electedOffice/services/electedOffice.service.test.ts
@@ -1,4 +1,3 @@
-import { ConflictException } from '@nestjs/common'
 import { PrismaClient } from '@prisma/client'
 import {
   beforeEach,
@@ -75,21 +74,23 @@ describe('ElectedOfficeService', () => {
   })
 
   describe('create', () => {
-    it('throws ConflictException when user already has an elected office', async () => {
+    it('returns the existing elected office without creating a new one', async () => {
       const createArgs: CreateElectedOfficeArgs = {
         userId: 1,
         campaignId: 1,
       }
+      const existing = {
+        id: 'existing',
+        userId: 1,
+        campaignId: 1,
+        organizationSlug: 'eo-existing',
+      }
 
-      mockModel.findFirst.mockResolvedValue({ id: 'existing', userId: 1 })
+      mockModel.findFirst.mockResolvedValue(existing)
 
-      await expect(service.create(createArgs)).rejects.toThrow(
-        ConflictException,
-      )
-      await expect(service.create(createArgs)).rejects.toThrow(
-        'User already has an active elected office',
-      )
+      const result = await service.create(createArgs)
 
+      expect(result).toBe(existing)
       expect(mockModel.findFirst).toHaveBeenCalledWith({
         where: { userId: 1 },
       })

--- a/src/electedOffice/services/electedOffice.service.test.ts
+++ b/src/electedOffice/services/electedOffice.service.test.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import { Prisma, PrismaClient } from '@prisma/client'
 import {
   beforeEach,
   describe,
@@ -96,6 +96,33 @@ describe('ElectedOfficeService', () => {
       })
       expect(mockOrgCreate).not.toHaveBeenCalled()
       expect(mockEoCreate).not.toHaveBeenCalled()
+    })
+
+    it('returns the concurrently-created office when the insert hits the unique constraint', async () => {
+      const createArgs: CreateElectedOfficeArgs = {
+        userId: 1,
+        campaignId: 1,
+      }
+      const concurrent = {
+        id: 'concurrent',
+        userId: 1,
+        campaignId: 1,
+        organizationSlug: 'eo-concurrent',
+      }
+
+      mockModel.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(concurrent)
+      mockEoCreate.mockRejectedValueOnce(
+        new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: 'test',
+        }),
+      )
+
+      const result = await service.create(createArgs)
+
+      expect(result).toBe(concurrent)
     })
 
     it('creates organization with default org data and elected office in transaction', async () => {

--- a/src/electedOffice/services/electedOffice.service.ts
+++ b/src/electedOffice/services/electedOffice.service.ts
@@ -1,10 +1,5 @@
 import { OrganizationsService } from '@/organizations/services/organizations.service'
-import {
-  ConflictException,
-  Inject,
-  Injectable,
-  forwardRef,
-} from '@nestjs/common'
+import { Inject, Injectable, forwardRef } from '@nestjs/common'
 import { ElectedOffice, Prisma } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import {
@@ -45,7 +40,7 @@ export class ElectedOfficeService extends createPrismaBase(
       where: { userId: args.userId },
     })
     if (existing) {
-      throw new ConflictException('User already has an active elected office')
+      return existing
     }
 
     const orgData = args.orgData ?? {

--- a/src/electedOffice/services/electedOffice.service.ts
+++ b/src/electedOffice/services/electedOffice.service.ts
@@ -49,27 +49,46 @@ export class ElectedOfficeService extends createPrismaBase(
       overrideDistrictId: null,
     }
 
-    const created = await this.client.$transaction(async (tx) => {
-      const id = uuidv7()
+    let created: ElectedOffice
+    try {
+      created = await this.client.$transaction(async (tx) => {
+        const id = uuidv7()
 
-      await tx.organization.create({
-        data: {
-          slug: OrganizationsService.electedOfficeOrgSlug(id),
-          ownerId: args.userId,
-          ...orgData,
-        },
-      })
+        await tx.organization.create({
+          data: {
+            slug: OrganizationsService.electedOfficeOrgSlug(id),
+            ownerId: args.userId,
+            ...orgData,
+          },
+        })
 
-      return tx.electedOffice.create({
-        data: {
-          id,
-          swornInDate: args.swornInDate,
-          userId: args.userId,
-          campaignId: args.campaignId,
-          organizationSlug: OrganizationsService.electedOfficeOrgSlug(id),
-        },
+        return tx.electedOffice.create({
+          data: {
+            id,
+            swornInDate: args.swornInDate,
+            userId: args.userId,
+            campaignId: args.campaignId,
+            organizationSlug: OrganizationsService.electedOfficeOrgSlug(id),
+          },
+        })
       })
-    })
+    } catch (err) {
+      // A concurrent create that wins the race trips the userId unique
+      // constraint; the transaction rolls back (no orphan org) and we return
+      // the row the other caller committed, keeping the endpoint idempotent.
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2002'
+      ) {
+        const concurrent = await this.model.findFirst({
+          where: { userId: args.userId },
+        })
+        if (concurrent) {
+          return concurrent
+        }
+      }
+      throw err
+    }
 
     await this.meetingBriefings
       .onElectedOfficeCreated(created)

--- a/src/electedOffice/services/electedOffice.service.ts
+++ b/src/electedOffice/services/electedOffice.service.ts
@@ -2,6 +2,7 @@ import { OrganizationsService } from '@/organizations/services/organizations.ser
 import { Inject, Injectable, forwardRef } from '@nestjs/common'
 import { ElectedOffice, Prisma } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
+import { isUniqueConstraintError } from 'src/prisma/util/prismaErrors.util'
 import {
   DEFAULT_PAGINATION_LIMIT,
   DEFAULT_PAGINATION_OFFSET,
@@ -76,10 +77,7 @@ export class ElectedOfficeService extends createPrismaBase(
       // A concurrent create that wins the race trips the userId unique
       // constraint; the transaction rolls back (no orphan org) and we return
       // the row the other caller committed, keeping the endpoint idempotent.
-      if (
-        err instanceof Prisma.PrismaClientKnownRequestError &&
-        err.code === 'P2002'
-      ) {
+      if (isUniqueConstraintError(err)) {
         const concurrent = await this.model.findFirst({
           where: { userId: args.userId },
         })

--- a/src/electedOffice/services/electedOffice.service.ts
+++ b/src/electedOffice/services/electedOffice.service.ts
@@ -41,6 +41,11 @@ export class ElectedOfficeService extends createPrismaBase(
       where: { userId: args.userId },
     })
     if (existing) {
+      // A prior call may have committed the row but crashed before dispatching
+      // the schedule; the schedule dispatch is the only recovery path (the
+      // daily cron dispatches briefings, not the initial schedule), so re-run
+      // it here. onElectedOfficeCreated tolerates re-dispatch.
+      await this.dispatchScheduleAfterCreate(existing)
       return existing
     }
 
@@ -82,22 +87,29 @@ export class ElectedOfficeService extends createPrismaBase(
           where: { userId: args.userId },
         })
         if (concurrent) {
+          await this.dispatchScheduleAfterCreate(concurrent)
           return concurrent
         }
       }
       throw err
     }
 
+    await this.dispatchScheduleAfterCreate(created)
+
+    return created
+  }
+
+  private async dispatchScheduleAfterCreate(
+    electedOffice: ElectedOffice,
+  ): Promise<void> {
     await this.meetingBriefings
-      .onElectedOfficeCreated(created)
+      .onElectedOfficeCreated(electedOffice)
       .catch((err: Error) => {
         this.logger.error(
-          { err, electedOfficeId: created.id },
+          { err, electedOfficeId: electedOffice.id },
           'meeting schedule dispatch failed after EO created',
         )
       })
-
-    return created
   }
 
   async update(args: Prisma.ElectedOfficeUpdateArgs) {

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -123,7 +123,7 @@ describe('POST /v1/elected-office dispatches schedule only (briefing chains via 
       { headers: { 'x-organization-slug': orgSlug } },
     )
 
-    expect(res.status).toBe(201)
+    expect(res.status).toBe(200)
     expect(dispatchSpy).not.toHaveBeenCalled()
   })
 
@@ -145,7 +145,7 @@ describe('POST /v1/elected-office dispatches schedule only (briefing chains via 
       { headers: { 'x-organization-slug': orgSlug } },
     )
 
-    expect(res.status).toBe(201)
+    expect(res.status).toBe(200)
     // Only the schedule fires on creation. The briefing is chained later
     // in onExperimentRunCompleted once the schedule lands and the
     // imminence gate confirms a meeting inside the 5-day window.
@@ -176,7 +176,7 @@ describe('POST /v1/elected-office dispatches schedule only (briefing chains via 
       { headers: { 'x-organization-slug': orgSlug } },
     )
 
-    expect(res.status).toBe(201)
+    expect(res.status).toBe(200)
     expect(dispatchSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -179,6 +179,31 @@ describe('POST /v1/elected-office dispatches schedule only (briefing chains via 
     expect(res.status).toBe(200)
     expect(dispatchSpy).not.toHaveBeenCalled()
   })
+
+  it('skips schedule dispatch when a schedule run already exists for the org', async () => {
+    const suffix = Date.now()
+    const owner = await service.prisma.user.create({
+      data: { email: `dedup-${suffix}@example.com` },
+    })
+    const orgSlug = `eo-dedup-${suffix}`
+    await service.prisma.organization.create({
+      data: { slug: orgSlug, ownerId: owner.id },
+    })
+    const electedOffice = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: owner.id },
+    })
+    await seedScheduleForOrg(orgSlug)
+
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onElectedOfficeCreated(electedOffice)
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
 })
 
 describe('MeetingBriefingsService.onExperimentRunCompleted', () => {

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -204,6 +204,43 @@ describe('POST /v1/elected-office dispatches schedule only (briefing chains via 
 
     expect(dispatchSpy).not.toHaveBeenCalled()
   })
+
+  it('re-dispatches when the only existing schedule run failed', async () => {
+    const suffix = Date.now()
+    const owner = await service.prisma.user.create({
+      data: {
+        email: `failed-run-${suffix}@example.com`,
+        clerkId: `clerk-${suffix}`,
+        firstName: 'Test',
+        lastName: 'Official',
+      },
+    })
+    const orgSlug = `eo-failed-${suffix}`
+    await service.prisma.organization.create({
+      data: { slug: orgSlug, ownerId: owner.id, positionId: 'br-pos-failed' },
+    })
+    const electedOffice = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: owner.id },
+    })
+    await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_schedule',
+        status: ExperimentRunStatus.FAILED,
+      },
+    })
+
+    mockResolveServeContext({ state: 'MN', positionName: 'City Council' })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onElectedOfficeCreated(electedOffice)
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('MeetingBriefingsService.onExperimentRunCompleted', () => {

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -170,6 +170,25 @@ export class MeetingBriefingsService extends createPrismaBase(
       )
       return
     }
+
+    // The elected-office create returns the existing row on retry / concurrent
+    // race and re-invokes this hook. dispatchRun is not idempotent, so only
+    // dispatch the initial schedule when no run has ever been created for this
+    // org — otherwise a retry spawns a duplicate live run and SQS message.
+    const existingScheduleRun = await this.client.experimentRun.findFirst({
+      where: {
+        organizationSlug: electedOffice.organizationSlug,
+        experimentType: SCHEDULE_EXPERIMENT_TYPE,
+      },
+    })
+    if (existingScheduleRun) {
+      this.logger.info(
+        { electedOfficeId: electedOffice.id },
+        'schedule run already exists for org; skipping re-dispatch',
+      )
+      return
+    }
+
     const ctx = await this.resolveDispatchContext(electedOffice)
     if (!ctx) return
 

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -172,13 +172,22 @@ export class MeetingBriefingsService extends createPrismaBase(
     }
 
     // The elected-office create returns the existing row on retry / concurrent
-    // race and re-invokes this hook. dispatchRun is not idempotent, so only
-    // dispatch the initial schedule when no run has ever been created for this
-    // org — otherwise a retry spawns a duplicate live run and SQS message.
+    // race and re-invokes this hook. dispatchRun is not idempotent, so skip
+    // when an active or successful schedule run already exists — otherwise a
+    // retry spawns a duplicate live run and SQS message. A FAILED-only run is
+    // not blocking: the first attempt did not succeed and nothing else
+    // re-dispatches it (sweepStaleRuns only marks stale runs FAILED).
     const existingScheduleRun = await this.client.experimentRun.findFirst({
       where: {
         organizationSlug: electedOffice.organizationSlug,
         experimentType: SCHEDULE_EXPERIMENT_TYPE,
+        status: {
+          in: [
+            ExperimentRunStatus.RUNNING,
+            ExperimentRunStatus.AWAITING_RESUME,
+            ExperimentRunStatus.COMPLETED,
+          ],
+        },
       },
     })
     if (existingScheduleRun) {


### PR DESCRIPTION
- Updated the ElectedOfficeService to return the existing elected office instead of throwing a ConflictException when a user already has one.
- Modified tests in electedOffice.controller.test.ts and electedOffice.service.test.ts to reflect this new behavior, ensuring that the service correctly identifies and returns existing offices without creating duplicates.
- Improved test coverage for scenarios where an elected office already exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public create contract from conflict to success, which can affect clients that relied on 409; behavior is limited to one-office-per-user and skips duplicate provisioning side effects.
> 
> **Overview**
> **POST elected office creation is now idempotent per user.** If `ElectedOfficeService.create` finds an existing row for `userId`, it **returns that record** instead of throwing `ConflictException`—no second org/EO transaction and no duplicate `onElectedOfficeCreated` side effects on repeat calls.
> 
> Controller and unit tests were updated to match: the service test asserts the existing office is returned without calling org/EO create, and a new integration test expects a second `POST /v1/elected-office` to respond with **201** and the **same** `id` while only one DB row exists for the user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b11ce17261dd6d9536eb62a92fd5f3dc2c444200. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->