### PR TITLE
fix(deps): declare @smithy/smithy-client (used directly, was phantom)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "@redtea/format-axios-error": "^2.1.1",
         "@segment/analytics-node": "^2.2.1",
         "@slack/web-api": "^7.13.0",
+        "@smithy/smithy-client": "^4.10.9",
         "@ssut/nestjs-sqs": "^3.0.1",
         "@types/ms": "^2.1.0",
         "@types/yargs": "^17.0.35",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@redtea/format-axios-error": "^2.1.1",
     "@segment/analytics-node": "^2.2.1",
     "@slack/web-api": "^7.13.0",
+    "@smithy/smithy-client": "^4.10.9",
     "@ssut/nestjs-sqs": "^3.0.1",
     "@types/ms": "^2.1.0",
     "@types/yargs": "^17.0.35",


### PR DESCRIPTION
## Monorepo prep

Behavior-preserving upstream normalization ahead of the **omni** monorepo migration. Fixing it upstream lets gp-api's own CI validate it in the real deploy environment before it flows into omni.

## What & why

gp-api imports `@smithy/smithy-client` **directly**:

- `src/vendors/aws/services/aws.service.ts` → `import { ServiceException } from '@smithy/smithy-client'`
- `src/vendors/aws/services/s3.service.test.ts` → same

…but it was never declared in `package.json`. Today it resolves only via **npm hoisting** from the AWS SDK packages (which depend on it). Under the omni monorepo layout that hoisting is not guaranteed, surfacing `Cannot find module '@smithy/smithy-client'` typecheck errors.

This PR declares it explicitly at the version already present in the tree:

- `dependencies`: add `"@smithy/smithy-client": "^4.10.9"` (the version `npm ls @smithy/smithy-client` resolves to, deduped across all AWS SDK clients).

No code changes — purely declaring an already-used (phantom) dependency.

## Validation

- `npm install` → success. ✅
- `npm run build` (nest-cli `typeCheck: true`) → **TSC: 0 issues**, build success. ✅

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency declaration only; no runtime or logic changes, aligned with an already-used version in the lockfile.
> 
> **Overview**
> Adds **`@smithy/smithy-client`** (`^4.10.9`) to **`dependencies`** so a package the app already imports directly (`ServiceException` in AWS vendor services) is declared instead of relying on transitive hoisting from AWS SDK packages.
> 
> **No application code changes** — only `package.json` / lockfile updates ahead of monorepo layouts where hoisting may not expose the module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcedfc1b4134883f3e66e088abd5468d0324080c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->