### PR TITLE
chore(deps): bump typescript to ^5.9 (monorepo prep)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -197,7 +197,7 @@
         "testcontainers": "^11.7.1",
         "ts-morph": "^27.0.2",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.6.3"
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": "22.12.0",

--- a/package.json
+++ b/package.json
@@ -235,6 +235,6 @@
     "testcontainers": "^11.7.1",
     "ts-morph": "^27.0.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.6.3"
+    "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Monorepo prep

Behavior-preserving upstream normalization ahead of the **omni** monorepo migration. Fixing it upstream lets gp-api's own CI validate it in the real deploy environment before it flows into omni.

## What & why

gp-api was on `typescript@^5.6.3`. Align it to `^5.9.3` to match **people-api**, so all packages share a single TypeScript toolchain version in the monorepo (avoids divergent compiler behavior across packages).

- `devDependencies`: `typescript` `^5.6.3` → `^5.9.3` (resolves to 5.9.3).

No source changes were required — the bump is clean.

## Validation

- `npm install` → success (tsc 5.9.3). ✅
- `npm run build` (nest-cli `typeCheck: true`) → **TSC: 0 issues**, build success. ✅
- `npm run lint` → **0 errors** (504 pre-existing warnings, all `sonarjs` style rules unrelated to the bump), Prettier formatting clean. ✅

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency bump with no runtime or source changes; validated as a clean compile/lint upgrade.
> 
> **Overview**
> Bumps the root **gp-api** devDependency **`typescript`** from **`^5.6.3`** to **`^5.9.3`**, with the matching **`package-lock.json`** resolution update. There are **no application or config source edits**—only toolchain alignment ahead of monorepo consolidation with **people-api**.
> 
> **Risk is low** because behavior is intended to stay the same; impact is limited to the compiler version used for build, typecheck, and lint in CI/local dev.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 369c68e9d1ee4cc8de7ee149991937bd53aa90c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->