### PR TITLE
fix(tests): adapt cross-office 403 tests to one-elected-office-per-user

### DIFF
--- a/src/annotations/tests/annotationAttachments.controller.test.ts
+++ b/src/annotations/tests/annotationAttachments.controller.test.ts
@@ -23,6 +23,7 @@ const seedElectedOffice = async (orgSlug: string, userId?: number) => {
 const seedBriefingAndNote = async (
   orgSlug: string,
   userId: number = service.user.id,
+  authorUserId: number = userId,
 ) => {
   const eo = await seedElectedOffice(orgSlug, userId)
   const briefingRun = await service.prisma.experimentRun.create({
@@ -45,7 +46,7 @@ const seedBriefingAndNote = async (
   })
   const annotation = await service.prisma.annotation.create({
     data: {
-      author: { connect: { id: userId } },
+      author: { connect: { id: authorUserId } },
       kind: 'note',
       resourceType: 'briefing',
       resourceId: briefing.id,
@@ -276,24 +277,40 @@ describe('GET /v1/annotations/:annotationId/note/attachments/:attachmentId/downl
     expect(result.status).toBe(404)
   })
 
-  it('rejects callers who do not own the annotation', async () => {
-    const { annotation } = await seedBriefingAndNote('eo-download-owner')
+  it('rejects access through an elected office that does not own the briefing', async () => {
+    // The briefing lives under another user's elected office, but the
+    // calling (default) user authored the annotation. Since a user owns at
+    // most one elected office, the caller reaches the annotation through
+    // their own office header and the briefing-access check must 403.
+    const otherUser = await service.prisma.user.create({
+      data: {
+        clerkId: 'other_download',
+        email: 'other-download@goodparty.org',
+        firstName: 'A',
+        lastName: 'B',
+      },
+    })
+    const { annotation, noteId } = await seedBriefingAndNote(
+      'eo-download-foreign',
+      otherUser.id,
+      service.user.id,
+    )
+    const attachment = await service.prisma.annotationNoteAttachment.create({
+      data: {
+        noteId,
+        fileName: 'photo.jpg',
+        mimeType: 'image/jpeg',
+        sizeBytes: 1_500_000,
+        storageKey: `annotations/${annotation.id}/seed`,
+        ocrStatus: OcrStatus.pending,
+      },
+    })
     mockS3()
 
-    const presign = await service.client.post(
-      `/v1/annotations/${annotation.id}/note/attachments/presign`,
-      validPresign,
-      orgHeader('eo-download-owner'),
-    )
-    expect(presign.status).toBe(201)
-    const attachmentId = presign.data.attachment_id
-
-    // Seed a second elected office and use its header — that user does
-    // not own the annotation, so the briefing-access check should 403.
-    await seedElectedOffice('eo-download-other')
+    await seedElectedOffice('eo-download-mine')
     const result = await service.client.get(
-      `/v1/annotations/${annotation.id}/note/attachments/${attachmentId}/download-url`,
-      orgHeader('eo-download-other'),
+      `/v1/annotations/${annotation.id}/note/attachments/${attachment.id}/download-url`,
+      orgHeader('eo-download-mine'),
     )
 
     expect(result.status).toBe(403)

--- a/src/annotations/tests/annotationAttachments.controller.test.ts
+++ b/src/annotations/tests/annotationAttachments.controller.test.ts
@@ -315,6 +315,43 @@ describe('GET /v1/annotations/:annotationId/note/attachments/:attachmentId/downl
 
     expect(result.status).toBe(403)
   })
+
+  it('rejects callers who did not author the annotation', async () => {
+    // Annotation is authored by another user; the caller owns their own
+    // elected office but is not the author, so the author check 403s
+    // before the briefing-access check is reached.
+    const otherUser = await service.prisma.user.create({
+      data: {
+        clerkId: 'other_download_author',
+        email: 'other-download-author@goodparty.org',
+        firstName: 'A',
+        lastName: 'B',
+      },
+    })
+    const { annotation, noteId } = await seedBriefingAndNote(
+      'eo-download-foreign-author',
+      otherUser.id,
+    )
+    const attachment = await service.prisma.annotationNoteAttachment.create({
+      data: {
+        noteId,
+        fileName: 'photo.jpg',
+        mimeType: 'image/jpeg',
+        sizeBytes: 1_500_000,
+        storageKey: `annotations/${annotation.id}/seed`,
+        ocrStatus: OcrStatus.pending,
+      },
+    })
+    mockS3()
+
+    await seedElectedOffice('eo-download-mine-author')
+    const result = await service.client.get(
+      `/v1/annotations/${annotation.id}/note/attachments/${attachment.id}/download-url`,
+      orgHeader('eo-download-mine-author'),
+    )
+
+    expect(result.status).toBe(403)
+  })
 })
 
 describe('DELETE /v1/annotations/:annotationId/note/attachments/:attachmentId', () => {

--- a/src/annotations/tests/annotationAttachments.controller.test.ts
+++ b/src/annotations/tests/annotationAttachments.controller.test.ts
@@ -317,9 +317,10 @@ describe('GET /v1/annotations/:annotationId/note/attachments/:attachmentId/downl
   })
 
   it('rejects callers who did not author the annotation', async () => {
-    // Annotation is authored by another user; the caller owns their own
-    // elected office but is not the author, so the author check 403s
-    // before the briefing-access check is reached.
+    // Annotation is authored by another user, but the briefing lives under
+    // the requesting user's own elected office. Only the author check should
+    // fire; if it were removed the briefing-access check would pass and the
+    // request would succeed, making this a true regression guard.
     const otherUser = await service.prisma.user.create({
       data: {
         clerkId: 'other_download_author',
@@ -329,7 +330,8 @@ describe('GET /v1/annotations/:annotationId/note/attachments/:attachmentId/downl
       },
     })
     const { annotation, noteId } = await seedBriefingAndNote(
-      'eo-download-foreign-author',
+      'eo-download-mine-author',
+      service.user.id,
       otherUser.id,
     )
     const attachment = await service.prisma.annotationNoteAttachment.create({
@@ -344,7 +346,6 @@ describe('GET /v1/annotations/:annotationId/note/attachments/:attachmentId/downl
     })
     mockS3()
 
-    await seedElectedOffice('eo-download-mine-author')
     const result = await service.client.get(
       `/v1/annotations/${annotation.id}/note/attachments/${attachment.id}/download-url`,
       orgHeader('eo-download-mine-author'),

--- a/src/polls/polls.test.ts
+++ b/src/polls/polls.test.ts
@@ -287,15 +287,21 @@ describe('GET /polls/:pollId/download-responses', () => {
   })
 
   it('returns 403 when the poll belongs to a different elected office', async () => {
+    // A user owns at most one elected office, so the "other" office must
+    // belong to a different user. The caller still reaches the endpoint
+    // through their own office header and is rejected on poll ownership.
+    const otherUser = await service.prisma.user.create({
+      data: { email: `other-office-${uuidv7()}@example.com` },
+    })
     const otherEoId = uuidv7()
     const otherOrgSlug = `eo-${otherEoId}`
     await service.prisma.organization.create({
-      data: { slug: otherOrgSlug, ownerId: service.user.id },
+      data: { slug: otherOrgSlug, ownerId: otherUser.id },
     })
     await service.prisma.electedOffice.create({
       data: {
         id: otherEoId,
-        userId: service.user.id,
+        userId: otherUser.id,
         organizationSlug: otherOrgSlug,
       },
     })


### PR DESCRIPTION
## Summary
- PR #1742 added a `UNIQUE` constraint on `elected_office.user_id` (one elected office per user), which broke develop CI: two tests still seeded **two** elected offices for the **same** user within a single test to simulate a "foreign" office, now tripping `Unique constraint failed on the fields: (user_id)`.
- Fixed `polls.test.ts` ("returns 403 when the poll belongs to a different elected office") and `annotationAttachments.controller.test.ts` (the briefing-access 403 case) by placing the "other" elected office on a **separate user**. The caller still reaches the endpoint through their own single office header and is correctly rejected by the resource-ownership check.
- Mirrors the existing, passing pattern in `annotations.controller.test.ts` ("rejects updating an annotation tied to a different elected office").

No production code changed — these are test-only fixes for the constraint introduced in #1742.

## Test plan
- [x] `npx vitest run src/polls/polls.test.ts src/annotations/tests/annotationAttachments.controller.test.ts` — all pass
- [x] `npx vitest run src/meetings/services/meetingBriefings.service.test.ts src/meetings/controllers/meetingsBriefings.controller.test.ts` — all pass
- [ ] CI green on develop

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test seeding and assertions changed; no runtime API or authorization logic was modified.
> 
> **Overview**
> Updates integration tests that simulated a **foreign** elected office by creating two offices for the same user. After the **one elected office per user** constraint (#1742), those setups hit a unique `user_id` violation on `elected_office`.
> 
> In **`polls.test.ts`**, the cross-office 403 case for poll response downloads now seeds the foreign poll’s organization and elected office under a **second user**, while the default test user still calls the API with their own `x-organization-slug` header and gets **403** on ownership.
> 
> In **`annotationAttachments.controller.test.ts`**, `seedBriefingAndNote` gains an optional **`authorUserId`** so the download-url 403 test can keep the default user as annotation author while the briefing sits on another user’s office. The scenario is renamed to assert **briefing access** (not author ownership): attachment is created directly in the DB, and the caller uses their own office header against another user’s briefing.
> 
> **No production code changes**—test fixtures only, aligned with existing patterns in `annotations.controller.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0a99b6eb4cb659a2ffee2dbe44f5f6cc9af476. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->