### PR TITLE
fix(meetings): route Agenda Created event through AnalyticsService

### DIFF
--- a/src/meetings/meetings.module.ts
+++ b/src/meetings/meetings.module.ts
@@ -4,7 +4,6 @@ import { ElectedOfficeModule } from '@/electedOffice/electedOffice.module'
 import { ElectionsModule } from '@/elections/elections.module'
 import { OrganizationsModule } from '@/organizations/organizations.module'
 import { AwsModule } from '@/vendors/aws/aws.module'
-import { SegmentModule } from '@/vendors/segment/segment.module'
 import { LlmModule } from '@/llm/llm.module'
 import { CronModule } from '@/cron/cron.module'
 import { BriefingsPdfController } from './controllers/briefingsPdf.controller'
@@ -20,7 +19,6 @@ import { MeetingBriefingsService } from './services/meetingBriefings.service'
     ElectionsModule,
     OrganizationsModule,
     AwsModule,
-    SegmentModule,
     LlmModule,
     CronModule,
   ],

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -1,4 +1,5 @@
 import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
+import { AnalyticsService } from '@/analytics/analytics.service'
 import { CronLockService } from '@/cron/services/cronLock.service'
 import { MeetingSchedule } from '@/generated/agent-job-contracts'
 import { LlmService } from '@/llm/services/llm.service'
@@ -7,7 +8,6 @@ import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import { getUserFullName } from '@/users/util/users.util'
 import { S3Service } from '@/vendors/aws/services/s3.service'
 import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
-import { SegmentService } from '@/vendors/segment/segment.service'
 import { Injectable } from '@nestjs/common'
 import { Cron } from '@nestjs/schedule'
 import {
@@ -145,7 +145,7 @@ export class MeetingBriefingsService extends createPrismaBase(
     private readonly s3: S3Service,
     private readonly organizations: OrganizationsService,
     private readonly experimentRuns: ExperimentRunsService,
-    private readonly segment: SegmentService,
+    private readonly analytics: AnalyticsService,
     private readonly llm: LlmService,
     private readonly braintrust: BraintrustService,
     private readonly cronLock: CronLockService,
@@ -830,7 +830,7 @@ export class MeetingBriefingsService extends createPrismaBase(
     })
 
     try {
-      await this.segment.trackEvent(
+      await this.analytics.track(
         userId,
         'Briefing Assistant - Agenda Created',
         {


### PR DESCRIPTION
## Why

The `Briefing Assistant - Agenda Created` event (fired in `MeetingBriefingsService.trackAgendaPickedUp`) was the only analytics event in the codebase emitted by calling `SegmentService.trackEvent` directly, bypassing `AnalyticsService`.

`AnalyticsService.track` is the layer every other event goes through. It enriches the event with the user's `email` and `hubspotId` (via `getUserContext`) and the current impersonation state, and passes that `userContext` down so Segment receives it as `context.traits`. Downstream Segment destinations rely on email/hubspotId to attribute an event to a known contact.

Calling `SegmentService` directly sends the event with only a numeric `userId` and no identity traits, so destinations that key on email don't associate it with the contact — which is why these events were effectively missing where they were expected, even though gp-api logged them as tracked.

This switches the call to `this.analytics.track(...)` (same arguments), drops the now-unused `SegmentService` injection, and removes the `SegmentModule` import from `MeetingsModule` (`AnalyticsModule` is `@Global`, so no new import is needed).

No behavior change to the gating: the event still only fires for `briefing_ready` / `agenda_provided_by_user` runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single analytics call-site swap with no change to when the event fires or what properties are sent beyond standard identity enrichment.
> 
> **Overview**
> **Briefing Assistant - Agenda Created** is now emitted through **`AnalyticsService.track`** in `trackAgendaPickedUp` instead of calling **`SegmentService.trackEvent`** directly.
> 
> That aligns this event with the rest of the app so Segment gets enriched **`context.traits`** (email, hubspotId, impersonation) for downstream attribution. Event name and payload are unchanged; it still only fires after a successful briefing row write for **`briefing_ready`** / **`agenda_provided_by_user`**.
> 
> **`SegmentService`** injection and **`SegmentModule`** on **`MeetingsModule`** are removed; **`AnalyticsModule`** is already global.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c6ecaa3fccaff72e3d6c089ec657754fe34796a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->