### PR TITLE
chore(migrations): deduplicate elected office entries by keeping the …

### DIFF
--- a/prisma/schema/migrations/20260604172543_elected_office_unique_user_id/migration.sql
+++ b/prisma/schema/migrations/20260604172543_elected_office_unique_user_id/migration.sql
@@ -1,5 +1,42 @@
+-- Guard: abort if any duplicate row slated for deletion has child records.
+-- Poll, PollIndividualMessage, MeetingBriefing and MeetingResourceLocation all
+-- cascade-delete from elected_office, so deleting a duplicate with children
+-- would silently destroy real data. If this fires, re-parent or remove the
+-- children manually before re-running.
+DO $$
+DECLARE
+  with_children int;
+BEGIN
+  SELECT count(*) INTO with_children
+  FROM "elected_office" eo
+  WHERE eo.id NOT IN (
+    SELECT DISTINCT ON (user_id) id
+    FROM "elected_office"
+    ORDER BY user_id, created_at ASC
+  )
+  AND (
+    EXISTS (SELECT 1 FROM "poll" t WHERE t.elected_office_id = eo.id)
+    OR EXISTS (
+      SELECT 1 FROM "poll_individual_message" t
+      WHERE t.elected_office_id = eo.id
+    )
+    OR EXISTS (
+      SELECT 1 FROM "meeting_briefing" t WHERE t.elected_office_id = eo.id
+    )
+    OR EXISTS (
+      SELECT 1 FROM "meeting_resource_location" t
+      WHERE t.elected_office_id = eo.id
+    )
+  );
+
+  IF with_children > 0 THEN
+    RAISE EXCEPTION
+      'Dedup aborted: % duplicate elected_office row(s) have child records; re-parent or remove them before applying.',
+      with_children;
+  END IF;
+END $$;
+
 -- Dedup: keep the earliest row per user_id, delete duplicates
--- (child rows cascade via onDelete: Cascade) so the unique index can be built
 DELETE FROM "elected_office"
 WHERE id NOT IN (
   SELECT DISTINCT ON (user_id) id

--- a/prisma/schema/migrations/20260604172543_elected_office_unique_user_id/migration.sql
+++ b/prisma/schema/migrations/20260604172543_elected_office_unique_user_id/migration.sql
@@ -1,3 +1,12 @@
+-- Dedup: keep the earliest row per user_id, delete duplicates
+-- (child rows cascade via onDelete: Cascade) so the unique index can be built
+DELETE FROM "elected_office"
+WHERE id NOT IN (
+  SELECT DISTINCT ON (user_id) id
+  FROM "elected_office"
+  ORDER BY user_id, created_at ASC
+);
+
 -- DropIndex
 DROP INDEX "elected_office_user_id_idx";
 


### PR DESCRIPTION
…earliest row per user_id

Added a SQL command to delete duplicate entries in the "elected_office" table, ensuring that only the earliest entry per user_id is retained. This change supports the creation of a unique index on user_id. Updated the subproject commit reference in ai-rules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production data is deleted during migration; incorrect retention logic or unexpected FK cascades could remove related polls/briefings tied to dropped rows.
> 
> **Overview**
> Adds a **pre-index data cleanup** to the `elected_office` `user_id` uniqueness migration: before swapping indexes, it deletes duplicate `elected_office` rows so only the **earliest** row per `user_id` (`created_at ASC`) remains, relying on **cascade deletes** on child relations so the new unique index can be applied safely.
> 
> The migration then **drops** the non-unique `elected_office_user_id_idx` and **creates** `elected_office_user_id_key` as a unique index on `user_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116fa498303d3d66f463f8eee68690d3b93feeb1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->