### PR TITLE
fix(meetings): use Together-hosted model for agenda hook

### DIFF
--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -892,7 +892,7 @@ export class MeetingBriefingsService extends createPrismaBase(
         () =>
           this.llm.chatCompletion({
             messages,
-            models: ['claude-haiku-4-5', 'claude-sonnet-4-6'],
+            models: ['deepseek-ai/DeepSeek-V4-Pro'],
             temperature: 0.4,
             maxTokens: 200,
             userId: String(userId),


### PR DESCRIPTION
## Why

`generateAgendaHook` (the `execSummary` for the `Briefing Assistant - Agenda Created` event) calls `LlmService.chatCompletion`. The non-streaming completion methods (`chatCompletion`, `jsonCompletion`, `getChatToolCompletion`) all route through an OpenAI client hard-pointed at `https://api.together.xyz/v1` — Together.ai only. Only the streaming path (`streamText`/`resolveChatModel`) routes `claude-*` models to Anthropic.

So `claude-haiku-4-5` — and the `claude-sonnet-4-6` fallback — 404 against Together (`Unable to access model ...`), and the hook hits its catch and returns the `lead_in` fallback. In prod every `Agenda Created` event has been shipping with the fallback string instead of a generated hook.

This swaps to `deepseek-ai/DeepSeek-V4-Pro`, the Together-hosted model already used on this same path by onboarding's `localNews.service`.

A proper Claude-on-this-path fix (moving the hook to the streaming API) is the larger follow-up; this restores the feature with a one-line change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-model swap on an existing LLM path with unchanged fallback behavior; no auth or data-layer changes.
> 
> **Overview**
> **Fixes broken LLM calls for the agenda “exec summary” hook** by changing the model list in `generateAgendaHook` from `claude-haiku-4-5` / `claude-sonnet-4-6` to **`deepseek-ai/DeepSeek-V4-Pro`**.
> 
> Non-streaming `LlmService.chatCompletion` only talks to Together.ai, so the previous Claude models 404’d and every **Briefing Assistant - Agenda Created** event fell back to `lead_in` instead of a generated hook. The new model is already used elsewhere on the same Together path (e.g. onboarding local news).
> 
> No prompt, tracing, or Segment payload shape changes—only which model serves the hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ac9712f03fd6c6c8f081bd7ccb466d61793a18. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->