### PR TITLE
Admin briefing review: review annotations + admin briefings endpoint

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @goodparty_org/contracts
 
+## 0.13.0
+
+### Minor Changes
+
+- `AnnotationKind` gains a `review` value for admin QA review comments.
+  `Annotation` gains an optional `review` block (`id`, `body`,
+  `reviewer_email`, timestamps); `reviewer_clerk_sub` is intentionally
+  not exposed. `CreateAnnotationRequest` gains a `review` variant
+  (`{ kind: 'review', anchor, payload: { body } }`). Review annotations
+  are admin-only: creatable only inside an impersonation session and
+  withheld from non-impersonated callers by a server-side default-deny.
+  Additive and non-breaking for existing `note` / `bug_report` / `chat`
+  consumers.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodparty_org/contracts",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Shared Zod schemas and TypeScript types for the GoodParty API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/contracts/src/adminBriefings/AdminBriefing.schema.ts
+++ b/contracts/src/adminBriefings/AdminBriefing.schema.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+import { PaginationOptionsSchema } from '../shared/Pagination.schema'
+
+// Mirrors the gp-api admin user-list DateRangeFilter values. Duplicated here
+// (not imported) because contracts cannot depend on gp-api src, and this filter
+// now crosses the boundary into gp-admin's table UI. Filters on meeting_date.
+export const BRIEFING_DATE_RANGE_VALUES = [
+  'All time',
+  'last 12 months',
+  'last 30 days',
+  'last week',
+] as const
+export const BriefingDateRangeFilterSchema = z.enum(BRIEFING_DATE_RANGE_VALUES)
+export type BriefingDateRangeFilter = z.infer<
+  typeof BriefingDateRangeFilterSchema
+>
+
+export const BriefingAdminListQuerySchema = PaginationOptionsSchema.extend({
+  // Fuzzy match across the owning user's first name, last name, and email.
+  q: z.string().optional(),
+  dateRange: BriefingDateRangeFilterSchema.optional(),
+})
+export type BriefingAdminListQuery = z.infer<
+  typeof BriefingAdminListQuerySchema
+>
+
+// The elected office has no name/type columns of its own — it is identified by
+// its organization slug and the org's custom position name (when set).
+export const BriefingAdminRowSchema = z.object({
+  briefingId: z.string(),
+  // The gp-webapp briefing route slug is the meeting date (YYYY-MM-DD).
+  meetingDate: z.string(),
+  // Read from the briefing artifact JSON; absent until a briefing is produced.
+  meetingName: z.string().nullable(),
+  user: z.object({
+    id: z.number().int(),
+    firstName: z.string().nullable(),
+    lastName: z.string().nullable(),
+    email: z.string(),
+  }),
+  electedOffice: z.object({
+    id: z.string(),
+    organizationSlug: z.string(),
+    positionName: z.string().nullable(),
+  }),
+  updatedAt: z.coerce.date(),
+})
+export type BriefingAdminRow = z.infer<typeof BriefingAdminRowSchema>

--- a/contracts/src/annotations/Annotation.schema.ts
+++ b/contracts/src/annotations/Annotation.schema.ts
@@ -10,10 +10,17 @@ import { z } from 'zod'
  *     Both null when jsonPath is null.
  *
  * Only the `note` and `bug_report` kinds are wired in v1. `chat` is
- * reserved for Collin's eventual chat module.
+ * reserved for Collin's eventual chat module. `review` is admin-only:
+ * it can only be created inside an impersonation session and is never
+ * returned to non-impersonated callers (server-side default-deny).
  */
 
-export const ANNOTATION_KIND_VALUES = ['note', 'chat', 'bug_report'] as const
+export const ANNOTATION_KIND_VALUES = [
+  'note',
+  'chat',
+  'bug_report',
+  'review',
+] as const
 export const AnnotationKindSchema = z.enum(ANNOTATION_KIND_VALUES)
 export type AnnotationKind = z.infer<typeof AnnotationKindSchema>
 
@@ -45,8 +52,7 @@ export const AnnotationAnchorSchema = z
   })
   .refine(
     (a) => {
-      const passage =
-        a.json_path !== null && a.start !== null && a.end !== null
+      const passage = a.json_path !== null && a.start !== null && a.end !== null
       const cardLevel =
         a.json_path !== null && a.start === null && a.end === null
       const briefingWide =
@@ -118,6 +124,17 @@ export const AnnotationChatSchema = z.object({
 })
 export type AnnotationChat = z.infer<typeof AnnotationChatSchema>
 
+// reviewer_clerk_sub is intentionally omitted — the admin's Clerk subject
+// is internal reviewer attribution and never leaves the server.
+export const AnnotationReviewSchema = z.object({
+  id: z.string(),
+  body: z.string(),
+  reviewer_email: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+export type AnnotationReview = z.infer<typeof AnnotationReviewSchema>
+
 // ---------------------------------------------------------------------------
 // The annotation row as returned by the API
 // ---------------------------------------------------------------------------
@@ -136,6 +153,7 @@ export const AnnotationSchema = z.object({
   note: AnnotationNoteSchema.optional(),
   chat: AnnotationChatSchema.optional(),
   bug_report: AnnotationBugReportSchema.optional(),
+  review: AnnotationReviewSchema.optional(),
 })
 export type Annotation = z.infer<typeof AnnotationSchema>
 
@@ -145,6 +163,7 @@ export type Annotation = z.infer<typeof AnnotationSchema>
 
 const noteBodySchema = z.string().min(1).max(10_000)
 const bugReportDescriptionSchema = z.string().min(1).max(4_000)
+const reviewBodySchema = z.string().min(1).max(10_000)
 
 export const CreateAnnotationRequestSchema = z.discriminatedUnion('kind', [
   z.object({
@@ -161,6 +180,13 @@ export const CreateAnnotationRequestSchema = z.discriminatedUnion('kind', [
     anchor: AnnotationAnchorSchema,
     payload: z.object({
       description: bugReportDescriptionSchema,
+    }),
+  }),
+  z.object({
+    kind: z.literal('review'),
+    anchor: AnnotationAnchorSchema,
+    payload: z.object({
+      body: reviewBodySchema,
     }),
   }),
 ])

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -318,6 +318,8 @@ export {
   type AnnotationBugReport,
   AnnotationChatSchema,
   type AnnotationChat,
+  AnnotationReviewSchema,
+  type AnnotationReview,
   AnnotationSchema,
   type Annotation,
   CreateAnnotationRequestSchema,
@@ -365,3 +367,13 @@ export {
   AgentRunDetailSchema,
   type AgentRunDetail,
 } from './agentRuns/AgentRun.schema'
+
+export {
+  BRIEFING_DATE_RANGE_VALUES,
+  BriefingDateRangeFilterSchema,
+  type BriefingDateRangeFilter,
+  BriefingAdminListQuerySchema,
+  type BriefingAdminListQuery,
+  BriefingAdminRowSchema,
+  type BriefingAdminRow,
+} from './adminBriefings/AdminBriefing.schema'

--- a/prisma/schema/annotation.prisma
+++ b/prisma/schema/annotation.prisma
@@ -2,6 +2,7 @@ enum AnnotationKind {
   note
   chat
   bug_report
+  review
 }
 
 // The type of resource about which
@@ -33,6 +34,8 @@ model Annotation {
   chatConversationId    String?              @unique @map("chat_conversation_id")
   bugReport             AnnotationBugReport? @relation(fields: [annotationBugReportId], references: [id])
   annotationBugReportId String?              @unique @map("annotation_bug_report_id")
+  annotationReview      AnnotationReview?    @relation(fields: [annotationReviewId], references: [id])
+  annotationReviewId    String?              @unique @map("annotation_review_id")
 
   @@index([authorUserId])
   @@index([authorUserId, resourceType, resourceId, kind])

--- a/prisma/schema/annotationReview.prisma
+++ b/prisma/schema/annotationReview.prisma
@@ -1,0 +1,18 @@
+// Reviewer identity lives here, not on the parent Annotation row.
+// Annotation.authorUserId stays = the impersonated (reviewed) user;
+// reviewerClerkSub (from the impersonation actor) is the real reviewer.
+model AnnotationReview {
+  id String @id @default(cuid())
+
+  body String @db.Text
+
+  reviewerClerkSub String  @map("reviewer_clerk_sub")
+  reviewerEmail    String? @map("reviewer_email")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  annotation Annotation?
+
+  @@map("annotation_review")
+}

--- a/prisma/schema/migrations/20260605190035_add_annotation_review/migration.sql
+++ b/prisma/schema/migrations/20260605190035_add_annotation_review/migration.sql
@@ -1,0 +1,23 @@
+-- AlterEnum
+ALTER TYPE "AnnotationKind" ADD VALUE 'review';
+
+-- AlterTable
+ALTER TABLE "annotation" ADD COLUMN     "annotation_review_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "annotation_review" (
+    "id" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "reviewer_clerk_sub" TEXT NOT NULL,
+    "reviewer_email" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "annotation_review_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "annotation_annotation_review_id_key" ON "annotation"("annotation_review_id");
+
+-- AddForeignKey
+ALTER TABLE "annotation" ADD CONSTRAINT "annotation_annotation_review_id_fkey" FOREIGN KEY ("annotation_review_id") REFERENCES "annotation_review"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -10,6 +10,8 @@ import { AdminCampaignsService } from './campaigns/adminCampaigns.service'
 import { AdminUsersController } from './users/adminUsers.controller'
 import { AdminAgentRunsController } from './agentRuns/adminAgentRuns.controller'
 import { AdminAgentRunsService } from './agentRuns/services/adminAgentRuns.service'
+import { AdminBriefingsController } from './briefings/adminBriefings.controller'
+import { AdminBriefingsService } from './briefings/services/adminBriefings.service'
 
 @Module({
   imports: [
@@ -24,7 +26,12 @@ import { AdminAgentRunsService } from './agentRuns/services/adminAgentRuns.servi
     AdminCampaignsController,
     AdminUsersController,
     AdminAgentRunsController,
+    AdminBriefingsController,
   ],
-  providers: [AdminCampaignsService, AdminAgentRunsService],
+  providers: [
+    AdminCampaignsService,
+    AdminAgentRunsService,
+    AdminBriefingsService,
+  ],
 })
 export class AdminModule {}

--- a/src/admin/briefings/adminBriefings.controller.ts
+++ b/src/admin/briefings/adminBriefings.controller.ts
@@ -1,0 +1,37 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  UsePipes,
+} from '@nestjs/common'
+import { ZodValidationPipe } from 'nestjs-zod'
+import { M2MOnly } from '@/authentication/guards/M2MOnly.guard'
+import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import { PaginatedResponseSchema } from '@/shared/schemas/PaginatedResponse.schema'
+import { AdminBriefingsService } from './services/adminBriefings.service'
+import {
+  AdminBriefingListQueryDto,
+  BriefingAdminRowSchema,
+} from './schemas/adminBriefings.schema'
+
+@Controller('admin/briefings')
+@UsePipes(ZodValidationPipe)
+export class AdminBriefingsController {
+  constructor(private readonly briefings: AdminBriefingsService) {}
+
+  @Get()
+  @UseGuards(M2MOnly)
+  @ResponseSchema(PaginatedResponseSchema(BriefingAdminRowSchema))
+  list(@Query() query: AdminBriefingListQueryDto) {
+    return this.briefings.list(query)
+  }
+
+  @Get(':id')
+  @UseGuards(M2MOnly)
+  @ResponseSchema(BriefingAdminRowSchema)
+  get(@Param('id') id: string) {
+    return this.briefings.get(id)
+  }
+}

--- a/src/admin/briefings/adminBriefings.service.test.ts
+++ b/src/admin/briefings/adminBriefings.service.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { ExperimentRunStatus } from '../../generated/prisma'
+import { useTestService } from '@/test-service'
+import { AdminBriefingsService } from './services/adminBriefings.service'
+
+const service = useTestService()
+
+const seedBriefing = async ({
+  orgSlug,
+  userId,
+  meetingDate,
+  meetingName,
+  customPositionName,
+}: {
+  orgSlug: string
+  userId: number
+  meetingDate: string
+  meetingName?: string
+  customPositionName?: string
+}) => {
+  await service.prisma.organization.create({
+    data: { slug: orgSlug, ownerId: userId, customPositionName },
+  })
+  const eo = await service.prisma.electedOffice.create({
+    data: { organizationSlug: orgSlug, userId },
+  })
+  const run = await service.prisma.experimentRun.create({
+    data: {
+      organizationSlug: orgSlug,
+      experimentType: 'meeting_briefing',
+      status: ExperimentRunStatus.COMPLETED,
+    },
+  })
+  return service.prisma.meetingBriefing.create({
+    data: {
+      electedOfficeId: eo.id,
+      meetingDate: new Date(meetingDate + 'T00:00:00Z'),
+      meetingTime: '19:00',
+      meetingTimezone: 'America/Denver',
+      experimentRunId: run.runId,
+      artifactBucket: 'b',
+      artifactKey: `${meetingDate}.json`,
+      artifact: meetingName ? { meeting_name: meetingName } : undefined,
+    },
+  })
+}
+
+describe('AdminBriefingsService.list', () => {
+  it('returns rows joined to the owning user and office', async () => {
+    const briefings = service.app.get(AdminBriefingsService)
+    const briefing = await seedBriefing({
+      orgSlug: 'eo-admin-list',
+      userId: service.user.id,
+      meetingDate: '2026-06-09',
+      meetingName: 'City Council Regular Session',
+      customPositionName: 'City Council Member',
+    })
+
+    const result = await briefings.list({})
+
+    const row = result.data.find((r) => r.briefingId === briefing.id)
+    expect(row).toBeDefined()
+    expect(row?.meetingDate).toBe('2026-06-09')
+    expect(row?.meetingName).toBe('City Council Regular Session')
+    expect(row?.user.id).toBe(service.user.id)
+    expect(row?.electedOffice.organizationSlug).toBe('eo-admin-list')
+    expect(row?.electedOffice.positionName).toBe('City Council Member')
+  })
+
+  it('filters by fuzzy name/email query', async () => {
+    const briefings = service.app.get(AdminBriefingsService)
+    const match = await service.prisma.user.create({
+      data: {
+        clerkId: 'admin_q_match',
+        email: 'zelda@goodparty.org',
+        firstName: 'Zelda',
+        lastName: 'Fitzgerald',
+      },
+    })
+    await seedBriefing({
+      orgSlug: 'eo-q-match',
+      userId: match.id,
+      meetingDate: '2026-06-10',
+    })
+
+    const result = await briefings.list({ q: 'zelda' })
+
+    expect(result.data.length).toBeGreaterThan(0)
+    expect(
+      result.data.every((r) => r.user.email === 'zelda@goodparty.org'),
+    ).toBe(true)
+  })
+})

--- a/src/admin/briefings/schemas/adminBriefings.schema.ts
+++ b/src/admin/briefings/schemas/adminBriefings.schema.ts
@@ -1,0 +1,13 @@
+import { createZodDto } from 'nestjs-zod'
+import { BriefingAdminListQuerySchema } from '@goodparty_org/contracts'
+
+export class AdminBriefingListQueryDto extends createZodDto(
+  BriefingAdminListQuerySchema,
+) {}
+
+export {
+  BriefingAdminRowSchema,
+  type BriefingAdminRow,
+  BriefingDateRangeFilterSchema,
+  type BriefingDateRangeFilter,
+} from '@goodparty_org/contracts'

--- a/src/admin/briefings/services/adminBriefings.service.ts
+++ b/src/admin/briefings/services/adminBriefings.service.ts
@@ -1,0 +1,134 @@
+import { Injectable, NotFoundException } from '@nestjs/common'
+import { subDays, subMonths } from 'date-fns'
+import { formatInTimeZone } from 'date-fns-tz'
+import { Prisma } from '@/generated/prisma'
+import {
+  BriefingAdminListQuery,
+  BriefingAdminRow,
+  BriefingDateRangeFilter,
+  PaginatedList,
+} from '@goodparty_org/contracts'
+import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
+import { DEFAULT_PAGINATION_OFFSET } from '@/shared/constants/paginationOptions.consts'
+
+const DEFAULT_LIMIT = 25
+const MAX_LIMIT = 100
+
+type BriefingWithRelations = Prisma.MeetingBriefingGetPayload<{
+  include: {
+    electedOffice: { include: { user: true; organization: true } }
+  }
+}>
+
+// user is typed nullable because ElectedOffice.user is an optional relation,
+// but the userId FK is required — a briefing without an owner is impossible.
+// The null branch is defensive and drops nothing in practice.
+const toRow = (b: BriefingWithRelations): BriefingAdminRow | null => {
+  const user = b.electedOffice.user
+  if (!user) return null
+  return {
+    briefingId: b.id,
+    meetingDate: formatInTimeZone(b.meetingDate, 'UTC', 'yyyy-MM-dd'),
+    meetingName: b.artifact?.meeting_name ?? null,
+    user: {
+      id: user.id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      email: user.email,
+    },
+    electedOffice: {
+      id: b.electedOffice.id,
+      organizationSlug: b.electedOffice.organizationSlug,
+      positionName: b.electedOffice.organization.customPositionName,
+    },
+    updatedAt: b.updatedAt,
+  }
+}
+
+@Injectable()
+export class AdminBriefingsService extends createPrismaBase(
+  MODELS.MeetingBriefing,
+) {
+  async list({
+    offset = DEFAULT_PAGINATION_OFFSET,
+    limit = DEFAULT_LIMIT,
+    q,
+    dateRange,
+  }: BriefingAdminListQuery): Promise<PaginatedList<BriefingAdminRow>> {
+    const take = Math.min(limit, MAX_LIMIT)
+    const where: Prisma.MeetingBriefingWhereInput = {
+      ...(q
+        ? {
+            electedOffice: {
+              user: {
+                OR: [
+                  {
+                    firstName: {
+                      contains: q,
+                      mode: Prisma.QueryMode.insensitive,
+                    },
+                  },
+                  {
+                    lastName: {
+                      contains: q,
+                      mode: Prisma.QueryMode.insensitive,
+                    },
+                  },
+                  {
+                    email: { contains: q, mode: Prisma.QueryMode.insensitive },
+                  },
+                ],
+              },
+            },
+          }
+        : {}),
+      ...dateRangeWhere(dateRange),
+    }
+
+    const [briefings, total] = await Promise.all([
+      this.model.findMany({
+        where,
+        orderBy: { updatedAt: Prisma.SortOrder.desc },
+        skip: offset,
+        take,
+        include: {
+          electedOffice: { include: { user: true, organization: true } },
+        },
+      }),
+      this.model.count({ where }),
+    ])
+
+    return {
+      data: briefings
+        .map(toRow)
+        .filter((r): r is BriefingAdminRow => r !== null),
+      meta: { total, offset, limit: take },
+    }
+  }
+
+  async get(id: string): Promise<BriefingAdminRow> {
+    const briefing = await this.model.findUnique({
+      where: { id },
+      include: {
+        electedOffice: { include: { user: true, organization: true } },
+      },
+    })
+    const row = briefing ? toRow(briefing) : null
+    if (!row) throw new NotFoundException('Briefing not found')
+    return row
+  }
+}
+
+const dateRangeWhere = (
+  dateRange?: BriefingDateRangeFilter,
+): Prisma.MeetingBriefingWhereInput => {
+  if (!dateRange || dateRange === 'All time') return {}
+  const now = new Date()
+  const since =
+    dateRange === 'last 12 months'
+      ? subMonths(now, 12)
+      : dateRange === 'last 30 days'
+        ? subDays(now, 30)
+        : subDays(now, 7)
+  return { meetingDate: { gte: since } }
+}

--- a/src/annotations/controllers/annotations.controller.ts
+++ b/src/annotations/controllers/annotations.controller.ts
@@ -7,9 +7,11 @@ import {
   Param,
   Post,
   Put,
+  Req,
 } from '@nestjs/common'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { ElectedOffice, User } from '../../generated/prisma'
+import { IncomingRequest } from '@/authentication/authentication.types'
 import {
   AnnotationResponseSchema,
   AttachmentDownloadUrlResponseSchema,
@@ -55,14 +57,40 @@ export class AnnotationsController {
   }
 
   @UseElectedOffice()
+  @Put(':annotationId/review')
+  @ResponseSchema(AnnotationResponseSchema)
+  async updateReview(
+    @Param('annotationId') annotationId: string,
+    @ReqUser() user: User,
+    @ReqElectedOffice() electedOffice: ElectedOffice,
+    @Body(new ZodValidationPipe(UpdateNoteRequestSchema))
+    body: UpdateNoteRequest,
+    @Req() req: IncomingRequest,
+  ) {
+    return this.annotations.updateReviewBody(
+      annotationId,
+      user.id,
+      electedOffice,
+      req.actorSub ?? null,
+      body.body,
+    )
+  }
+
+  @UseElectedOffice()
   @Delete(':annotationId')
   @HttpCode(204)
   async remove(
     @Param('annotationId') annotationId: string,
     @ReqUser() user: User,
     @ReqElectedOffice() electedOffice: ElectedOffice,
+    @Req() req: IncomingRequest,
   ): Promise<void> {
-    await this.annotations.deleteOne(annotationId, user.id, electedOffice)
+    await this.annotations.deleteOne(
+      annotationId,
+      user.id,
+      electedOffice,
+      req.actorSub ?? null,
+    )
   }
 
   @UseElectedOffice()

--- a/src/annotations/controllers/briefingAnnotations.controller.ts
+++ b/src/annotations/controllers/briefingAnnotations.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common'
+import { Body, Controller, Get, Param, Post, Query, Req } from '@nestjs/common'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { ElectedOffice, User } from '../../generated/prisma'
 import {
@@ -11,11 +11,16 @@ import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
 import { ReqElectedOffice } from '@/electedOffice/decorators/ReqElectedOffice.decorator'
 import { UseElectedOffice } from '@/electedOffice/decorators/UseElectedOffice.decorator'
 import { ReqUser } from '@/authentication/decorators/ReqUser.decorator'
+import { IncomingRequest } from '@/authentication/authentication.types'
 import {
   MeetingDateParam,
   MeetingDateParamSchema,
 } from '@/meetings/schemas/meetingDateParam.schema'
 import { AnnotationsService } from '../services/annotations.service'
+import {
+  ListAnnotationsQuery,
+  ListAnnotationsQuerySchema,
+} from '../schemas/listAnnotationsQuery.schema'
 
 /**
  * Briefing-scoped annotation routes.
@@ -35,13 +40,18 @@ export class BriefingAnnotationsController {
   async list(
     @Param(new ZodValidationPipe(MeetingDateParamSchema))
     { date }: MeetingDateParam,
+    @Query(new ZodValidationPipe(ListAnnotationsQuerySchema))
+    { kinds }: ListAnnotationsQuery,
     @ReqUser() user: User,
     @ReqElectedOffice() electedOffice: ElectedOffice,
+    @Req() req: IncomingRequest,
   ) {
     const annotations = await this.annotations.listForBriefing(
       date,
       user.id,
       electedOffice,
+      req.actorSub ?? null,
+      kinds,
     )
     return { annotations }
   }
@@ -56,12 +66,15 @@ export class BriefingAnnotationsController {
     @ReqElectedOffice() electedOffice: ElectedOffice,
     @Body(new ZodValidationPipe(CreateAnnotationRequestSchema))
     body: CreateAnnotationRequest,
+    @Req() req: IncomingRequest,
   ) {
     return this.annotations.createForBriefing(
       date,
       user.id,
       electedOffice,
       body,
+      req.actorSub ?? null,
+      req.actorUser ?? null,
     )
   }
 }

--- a/src/annotations/schemas/listAnnotationsQuery.schema.ts
+++ b/src/annotations/schemas/listAnnotationsQuery.schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+import { AnnotationKindSchema } from '@goodparty_org/contracts'
+
+// `kinds` arrives either as a comma-separated string (?kinds=review) or a
+// repeated query param (?kinds=note&kinds=chat). Normalize both to an array
+// and validate each value against AnnotationKind.
+export const ListAnnotationsQuerySchema = z.object({
+  kinds: z
+    .preprocess(
+      (v) => (typeof v === 'string' && v.length > 0 ? v.split(',') : v),
+      z.array(AnnotationKindSchema),
+    )
+    .optional(),
+})
+
+export type ListAnnotationsQuery = z.infer<typeof ListAnnotationsQuerySchema>

--- a/src/annotations/services/annotations.service.ts
+++ b/src/annotations/services/annotations.service.ts
@@ -3,7 +3,12 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common'
-import { AnnotationKind, ElectedOffice, Prisma } from '../../generated/prisma'
+import {
+  AnnotationKind,
+  ElectedOffice,
+  Prisma,
+  User,
+} from '../../generated/prisma'
 import {
   Annotation as AnnotationDTO,
   CreateAnnotationRequest,
@@ -24,7 +29,17 @@ const ANNOTATION_INCLUDE = {
   },
   bugReport: true,
   chat: true,
+  annotationReview: true,
 } satisfies Prisma.AnnotationInclude
+
+// Everything a normal (non-impersonated) caller may see. `review` is excluded
+// by default; it is only returned when a caller explicitly requests it AND
+// carries an impersonation actor (server-side default-deny — see listForBriefing).
+const NON_REVIEW_KINDS = [
+  AnnotationKind.note,
+  AnnotationKind.chat,
+  AnnotationKind.bug_report,
+] as const
 
 type AnnotationWithRelations = Prisma.AnnotationGetPayload<{
   include: typeof ANNOTATION_INCLUDE
@@ -77,6 +92,15 @@ function toDTO(row: AnnotationWithRelations): AnnotationDTO {
       created_at: row.chat.createdAt.toISOString(),
     }
   }
+  if (row.annotationReview) {
+    base.review = {
+      id: row.annotationReview.id,
+      body: row.annotationReview.body,
+      reviewer_email: row.annotationReview.reviewerEmail,
+      created_at: row.annotationReview.createdAt.toISOString(),
+      updated_at: row.annotationReview.updatedAt.toISOString(),
+    }
+  }
   return base
 }
 
@@ -112,7 +136,17 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
     meetingDate: string,
     userId: number,
     electedOffice: ElectedOffice,
+    actorSub: string | null,
+    kinds?: AnnotationKind[],
   ): Promise<AnnotationDTO[]> {
+    // Default-deny: omitting `kinds` returns everything except `review`. Asking
+    // for `review` requires an impersonation actor — without one we 403 rather
+    // than silently returning an empty list, so the boundary is unambiguous.
+    const effectiveKinds: AnnotationKind[] = kinds ?? [...NON_REVIEW_KINDS]
+    if (effectiveKinds.includes(AnnotationKind.review) && actorSub === null) {
+      throw new ForbiddenException('review_requires_impersonation')
+    }
+
     const briefingId = await resolveBriefingId(
       this.client,
       meetingDate,
@@ -123,6 +157,7 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
         resourceType: 'briefing',
         resourceId: briefingId,
         authorUserId: userId,
+        kind: { in: effectiveKinds },
       },
       orderBy: { createdAt: 'asc' },
       include: ANNOTATION_INCLUDE,
@@ -135,7 +170,14 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
     userId: number,
     electedOffice: ElectedOffice,
     input: CreateAnnotationRequest,
+    actorSub: string | null,
+    actorUser: User | null,
   ): Promise<AnnotationDTO> {
+    // Review annotations can only be authored inside an impersonation session.
+    if (input.kind === 'review' && actorSub === null) {
+      throw new ForbiddenException('review_requires_impersonation')
+    }
+
     const briefingId = await resolveBriefingId(
       this.client,
       meetingDate,
@@ -177,6 +219,34 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
             include: ANNOTATION_INCLUDE,
           })
         }
+
+        if (input.kind === 'review') {
+          // Guaranteed non-null by the pre-transaction guard; re-checked here
+          // to narrow for the type checker.
+          if (actorSub === null) {
+            throw new ForbiddenException('review_requires_impersonation')
+          }
+          // author stays the impersonated (reviewed) user; the admin's
+          // identity lives on the AnnotationReview child via reviewerClerkSub.
+          return tx.annotation.create({
+            data: {
+              author: { connect: { id: userId } },
+              kind: AnnotationKind.review,
+              resourceType: 'briefing',
+              resourceId: briefingId,
+              ...anchorFields,
+              annotationReview: {
+                create: {
+                  body: input.payload.body,
+                  reviewerClerkSub: actorSub,
+                  reviewerEmail: actorUser?.email ?? null,
+                },
+              },
+            },
+            include: ANNOTATION_INCLUDE,
+          })
+        }
+
         return tx.annotation.create({
           data: {
             author: { connect: { id: userId } },
@@ -223,10 +293,44 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
     return toDTO(updated)
   }
 
+  async updateReviewBody(
+    annotationId: string,
+    userId: number,
+    electedOffice: ElectedOffice,
+    actorSub: string | null,
+    body: string,
+  ): Promise<AnnotationDTO> {
+    if (actorSub === null) {
+      throw new ForbiddenException('review_requires_impersonation')
+    }
+    const row = await this.client.annotation.findUnique({
+      where: { id: annotationId },
+      include: ANNOTATION_INCLUDE,
+    })
+    if (!row) throw new NotFoundException('annotation_not_found')
+    if (row.authorUserId !== userId) {
+      throw new ForbiddenException('annotation_not_yours')
+    }
+    if (row.kind !== AnnotationKind.review || !row.annotationReview) {
+      throw new ForbiddenException('not_a_review')
+    }
+    await this.assertAnnotationBriefingAccess(row.resourceId, electedOffice)
+
+    const updated = await this.client.annotation.update({
+      where: { id: annotationId },
+      data: {
+        annotationReview: { update: { body } },
+      },
+      include: ANNOTATION_INCLUDE,
+    })
+    return toDTO(updated)
+  }
+
   async deleteOne(
     annotationId: string,
     userId: number,
     electedOffice: ElectedOffice,
+    actorSub: string | null,
   ): Promise<void> {
     const row = await this.client.annotation.findUnique({
       where: { id: annotationId },
@@ -238,6 +342,7 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
         noteId: true,
         annotationBugReportId: true,
         chatConversationId: true,
+        annotationReviewId: true,
         note: {
           select: {
             attachments: { select: { storageKey: true } },
@@ -248,6 +353,11 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
     if (!row) throw new NotFoundException('annotation_not_found')
     if (row.authorUserId !== userId) {
       throw new ForbiddenException('annotation_not_yours')
+    }
+    // Review rows are authored as the impersonated user, so the author check
+    // alone would let that user delete an admin's review. Gate on the actor.
+    if (row.kind === AnnotationKind.review && actorSub === null) {
+      throw new ForbiddenException('review_requires_impersonation')
     }
     await this.assertAnnotationBriefingAccess(row.resourceId, electedOffice)
 
@@ -261,6 +371,11 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
       if (row.annotationBugReportId) {
         await tx.annotationBugReport.delete({
           where: { id: row.annotationBugReportId },
+        })
+      }
+      if (row.annotationReviewId) {
+        await tx.annotationReview.delete({
+          where: { id: row.annotationReviewId },
         })
       }
       // Chat soft-delete is the responsibility of Collin's chat service.

--- a/src/annotations/tests/annotations.controller.test.ts
+++ b/src/annotations/tests/annotations.controller.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { ExperimentRunStatus } from '../../generated/prisma'
 import { useTestService } from '@/test-service'
 import { S3Service } from '@/vendors/aws/services/s3.service'
+import { AnnotationsService } from '../services/annotations.service'
 
 const service = useTestService()
 
@@ -79,6 +80,16 @@ const bugReport = {
     end: 15,
   },
   payload: { description: 'This figure looks wrong.' },
+}
+
+const reviewComment = {
+  kind: 'review' as const,
+  anchor: {
+    json_path: '/items/0/display/summary',
+    start: 0,
+    end: 10,
+  },
+  payload: { body: 'Reviewer note: fix this.' },
 }
 
 describe('POST /v1/meetings/:date/briefing/annotations', () => {
@@ -570,5 +581,158 @@ describe('DELETE /v1/annotations/:annotationId', () => {
     )
 
     expect(result.status).toBe(403)
+  })
+})
+
+// The HTTP client authenticates as a normal user with no impersonation actor,
+// so these exercise the default-deny boundary exactly as a real user would hit
+// it. Review rows must never leak to or be mutated by a non-impersonated user.
+describe('review annotations — default-deny over HTTP (no actor)', () => {
+  it('rejects creating a review without an impersonation actor', async () => {
+    const orgSlug = 'eo-review-noactor'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, '2026-06-08')
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-06-08/briefing/annotations',
+      reviewComment,
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(403)
+  })
+
+  it('rejects listing kinds=review without an impersonation actor', async () => {
+    const orgSlug = 'eo-review-list-noactor'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, '2026-06-08')
+
+    const result = await service.client.get(
+      '/v1/meetings/2026-06-08/briefing/annotations?kinds=review',
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(403)
+  })
+
+  it('omits review rows from a normal list', async () => {
+    const orgSlug = 'eo-review-leak'
+    const eo = await seedElectedOffice(orgSlug)
+    const briefing = await seedBriefing(eo.id, orgSlug, '2026-06-08')
+
+    await service.prisma.annotation.create({
+      data: {
+        author: { connect: { id: service.user.id } },
+        kind: 'note',
+        resourceType: 'briefing',
+        resourceId: briefing.id,
+        note: { create: { body: 'visible note' } },
+      },
+    })
+    await service.prisma.annotation.create({
+      data: {
+        author: { connect: { id: service.user.id } },
+        kind: 'review',
+        resourceType: 'briefing',
+        resourceId: briefing.id,
+        annotationReview: {
+          create: { body: 'secret review', reviewerClerkSub: 'user_admin' },
+        },
+      },
+    })
+
+    const result = await service.client.get(
+      '/v1/meetings/2026-06-08/briefing/annotations',
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data.annotations).toHaveLength(1)
+    expect(result.data.annotations[0].kind).toBe('note')
+  })
+
+  it('rejects deleting a review row without an impersonation actor', async () => {
+    const orgSlug = 'eo-review-del-noactor'
+    const eo = await seedElectedOffice(orgSlug)
+    const briefing = await seedBriefing(eo.id, orgSlug, '2026-06-08')
+
+    const review = await service.prisma.annotation.create({
+      data: {
+        author: { connect: { id: service.user.id } },
+        kind: 'review',
+        resourceType: 'briefing',
+        resourceId: briefing.id,
+        annotationReview: {
+          create: { body: 'x', reviewerClerkSub: 'user_admin' },
+        },
+      },
+    })
+
+    const result = await service.client.delete(
+      `/v1/annotations/${review.id}`,
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(403)
+  })
+})
+
+// The service takes actorSub/actorUser as explicit args (the guard populates
+// them in production). Driving the real service against the real DB is the
+// closest we can get to the impersonation path without minting an actor JWT.
+describe('AnnotationsService — review behavior with an actor', () => {
+  const ACTOR_SUB = 'user_admin_123'
+
+  it('persists reviewer attribution and lists reviews back', async () => {
+    const annotations = service.app.get(AnnotationsService)
+    const orgSlug = 'eo-review-svc'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, '2026-06-08')
+
+    const admin = await service.prisma.user.create({
+      data: {
+        clerkId: ACTOR_SUB,
+        email: 'admin-reviewer@goodparty.org',
+        firstName: 'Admin',
+        lastName: 'Reviewer',
+      },
+    })
+
+    const created = await annotations.createForBriefing(
+      '2026-06-08',
+      service.user.id,
+      eo,
+      reviewComment,
+      ACTOR_SUB,
+      admin,
+    )
+
+    expect(created.kind).toBe('review')
+    expect(created.author_user_id).toBe(service.user.id)
+    expect(created.review?.body).toBe('Reviewer note: fix this.')
+    expect(created.review?.reviewer_email).toBe('admin-reviewer@goodparty.org')
+
+    const dbReview = await service.prisma.annotationReview.findFirst({
+      where: { id: created.review?.id },
+    })
+    expect(dbReview?.reviewerClerkSub).toBe(ACTOR_SUB)
+
+    const listedWithActor = await annotations.listForBriefing(
+      '2026-06-08',
+      service.user.id,
+      eo,
+      ACTOR_SUB,
+      ['review'],
+    )
+    expect(listedWithActor).toHaveLength(1)
+    expect(listedWithActor[0].kind).toBe('review')
+
+    const listedNormally = await annotations.listForBriefing(
+      '2026-06-08',
+      service.user.id,
+      eo,
+      null,
+    )
+    expect(listedNormally).toHaveLength(0)
   })
 })

--- a/src/chats/briefing-chats/evals/fixtures/hendersonvilleBriefing.fixture.ts
+++ b/src/chats/briefing-chats/evals/fixtures/hendersonvilleBriefing.fixture.ts
@@ -38,6 +38,7 @@ const annotation: Annotation = {
   noteId: null,
   chatConversationId: 'conv-hville-1',
   annotationBugReportId: null,
+  annotationReviewId: null,
 }
 
 const artifactContent = `# Briefing: Hendersonville, NC — Regular Council Meeting

--- a/src/chats/briefing-chats/services/systemPromptBuilder.test.ts
+++ b/src/chats/briefing-chats/services/systemPromptBuilder.test.ts
@@ -43,6 +43,7 @@ const baseAnnotation: Annotation = {
   noteId: null,
   chatConversationId: 'conv-1',
   annotationBugReportId: null,
+  annotationReviewId: null,
 }
 
 const artifactContent =


### PR DESCRIPTION
## Why

GoodParty admins need an internal QA workflow to review the AI-generated meeting briefings produced for elected officials, and to leave structured comments on them. Those comments have to be a first-class concept that is **distinct from the user's own annotations** (notes / chat / bug reports) and, critically, **must never be visible to the briefing's owner**.

This is the gp-api half of that feature (the data model + API). The gp-webapp review UI and the gp-admin table land in companion PRs.

## Approach and the one security invariant that matters

- Admin-ness is proven by the **presence of an impersonation actor**, not a role. Review actions gate on `req.actorSub`, which only the gp-admin permission-gated impersonation flow can produce.
- Reviewer identity lives on the new `AnnotationReview` child row (`reviewerClerkSub` / `reviewerEmail`). The parent `Annotation.authorUserId` deliberately stays the *impersonated* user to avoid making a non-null FK nullable across every existing query.
- Because the review's author is the reviewed user, a naive list would hand the user their own review rows. So the list path is **default-deny**: omitting `kinds` returns everything except `review`; asking for `review` without an actor is a 403, not an empty list. Edit/delete of review rows are actor-gated too, so the user can't mutate admin reviews even with an id. Every annotation read path was audited, not just the briefing list.

## Notes for reviewers

- New admin route is `GET /admin/briefings` (+`/:id`), M2M-guarded, mirroring the existing `admin/agent-runs` resource. `BriefingAdminRow` is built from real columns — `meetingName` comes from the briefing artifact JSON, and the elected office is identified by org slug + `customPositionName` (it has no name/type of its own).
- Contracts bumped to 0.13.0 (additive: `review` kind, optional `review` response block with no `reviewer_clerk_sub` exposed, review create variant, admin briefings schemas).
- Companion PRs: gp-webapp (review UI + parallel route tree), gp-admin (briefings table), gp-sdk (exposes `client.admin.briefings`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-sensitive annotation visibility and authorization depend on impersonation `actorSub`; a bug could leak or let users mutate admin review comments. New admin M2M routes and a DB migration add operational surface area.
> 
> **Overview**
> Adds **admin QA review comments** on briefing annotations and an **M2M admin briefings catalog**, with contracts bumped to **0.13.0**.
> 
> **Review annotations (`kind: review`)** — New `AnnotationReview` table and Prisma `review` enum value. Contracts expose a `review` create variant and optional `review` response block (`body`, `reviewer_email`; `reviewer_clerk_sub` stays server-only). Create/list/update/delete are gated on **`req.actorSub`** (impersonation actor): normal lists **exclude** `review` by default; `?kinds=review` without an actor returns **403**; delete/update of review rows also require an actor so the briefing owner cannot remove admin comments.
> 
> **Admin briefings** — `GET /admin/briefings` and `GET /admin/briefings/:id` (M2M-only) return paginated `BriefingAdminRow` data with fuzzy user search and meeting-date range filters, backed by shared `BriefingAdminListQuery` / `BriefingAdminRow` schemas.
> 
> Tests cover default-deny HTTP behavior and service-level review attribution with an actor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06d4481a936e04d6f304fa779a47cbc8dd0d0642. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->