### PR TITLE
feat(meetings): bulk-dispatch briefings through the product's 5-day imminence gate

### DIFF
--- a/scripts/dispatch-imminent-briefings.ts
+++ b/scripts/dispatch-imminent-briefings.ts
@@ -105,8 +105,7 @@ async function main() {
       `Prod offices:  ${pool.length} (shuffled)`,
       `Goal:          ${target} briefings dispatched (5-day imminence gate)`,
       `Concurrency:   ${concurrency}`,
-      `Max est. cost: ~$${maxEstimate.toFixed(2)} ` +
-        `(may overshoot by up to ${concurrency - 1} in-flight calls)`,
+      `Max est. cost: ~$${maxEstimate.toFixed(2)} (hard cap at the target)`,
       '',
       'Proceed? (y/N) ',
     ].join('\n'),
@@ -128,9 +127,13 @@ async function main() {
   const token = await mintToken()
   const records: DispatchRecord[] = []
   let dispatched = 0
+  // Slots claimed by in-flight or completed dispatches. Workers claim a slot
+  // synchronously before each call so the concurrent pool can never push
+  // `dispatched` past `target` and blow the cost cap. A skip releases its slot.
+  let reserved = 0
   let index = 0
 
-  const callDispatch = async (office: Office): Promise<void> => {
+  const callDispatch = async (office: Office): Promise<boolean> => {
     let httpStatus = 0
     let didDispatch = false
     try {
@@ -168,12 +171,7 @@ async function main() {
     }
     records.push(record)
     appendFileSync(logPath, `${JSON.stringify(record)}\n`)
-    if (didDispatch) {
-      dispatched++
-      if (dispatched % 10 === 0) {
-        console.log(`  dispatched ${dispatched}/${target}`)
-      }
-    }
+    return didDispatch
   }
 
   const runStart = new Date().toISOString()
@@ -182,8 +180,23 @@ async function main() {
     () =>
       (async () => {
         while (dispatched < target && index < pool.length) {
-          const current = index++
-          await callDispatch(pool[current])
+          // Claim a slot synchronously — no await between the check and the
+          // increment — so two workers can never both take the last one.
+          if (reserved >= target) {
+            await new Promise((resolve) => setTimeout(resolve, 25))
+            continue
+          }
+          reserved++
+          const did = await callDispatch(pool[index++])
+          if (did) {
+            dispatched++
+            if (dispatched % 10 === 0) {
+              console.log(`  dispatched ${dispatched}/${target}`)
+            }
+          } else {
+            // A skip consumed no briefing; free the slot for another office.
+            reserved--
+          }
         }
       })(),
   )

--- a/scripts/dispatch-imminent-briefings.ts
+++ b/scripts/dispatch-imminent-briefings.ts
@@ -1,0 +1,221 @@
+import 'dotenv/config'
+import { createInterface } from 'node:readline/promises'
+import { stdin, stdout } from 'node:process'
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { PrismaClient } from '../src/generated/prisma'
+import { createClerkClient } from '@clerk/backend'
+
+const BRIEFING_COST_USD = 3.9
+const TOKEN_TTL_SECONDS = 3600
+const DEFAULT_TARGET = 100
+
+type DispatchRecord = {
+  electedOfficeId: string
+  organizationSlug: string
+  httpStatus: number
+  dispatched: boolean
+  ok: boolean
+  ts: string
+}
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name]
+  if (!value) throw new Error(`${name} is not set`)
+  return value
+}
+
+const mintToken = async (): Promise<string> => {
+  const clerk = createClerkClient({
+    secretKey: requireEnv('CLERK_SECRET_KEY'),
+    publishableKey: requireEnv('CLERK_PUBLISHABLE_KEY'),
+  })
+  // Mint with the caller machine secret (gp-admin's GP_PROD_MACHINE_SECRET),
+  // not gp-api's GP_WEBAPP_MACHINE_SECRET. gp-api verifies as the recipient,
+  // so the token must be issued by a machine connected to it in Clerk.
+  const minted = await clerk.m2m.createToken({
+    machineSecretKey: requireEnv('GP_PROD_MACHINE_SECRET'),
+    secondsUntilExpiration: TOKEN_TTL_SECONDS,
+  })
+  if (!minted.token) throw new Error('Clerk did not return an m2m token')
+  return minted.token
+}
+
+const confirm = async (message: string): Promise<boolean> => {
+  const rl = createInterface({ input: stdin, output: stdout })
+  const answer = await rl.question(message)
+  rl.close()
+  return answer.trim().toLowerCase() === 'y'
+}
+
+// Fisher-Yates shuffle for a fair random sample of eligible offices.
+const shuffle = <T>(items: T[]): T[] => {
+  const out = [...items]
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[out[i], out[j]] = [out[j], out[i]]
+  }
+  return out
+}
+
+type Office = { id: string; organizationSlug: string }
+
+async function main() {
+  const apiUrl = process.env.PROD_API_URL ?? 'https://api.goodparty.org'
+  const databaseUrl = requireEnv('PROD_DATABASE_URL')
+  const concurrency = Number(process.env.CONCURRENCY ?? '5')
+  const dryRun = process.argv.includes('--dry-run')
+  const targetArg = process.argv.find((a) => a.startsWith('--target='))
+  const target = targetArg ? Number(targetArg.split('=')[1]) : DEFAULT_TARGET
+
+  const prisma = new PrismaClient({ datasourceUrl: databaseUrl })
+  const allOffices = await prisma.electedOffice.findMany({
+    select: { id: true, organizationSlug: true },
+  })
+  await prisma.$disconnect()
+
+  const pool = shuffle(allOffices)
+  const maxEstimate = target * BRIEFING_COST_USD
+
+  if (dryRun) {
+    console.log(
+      [
+        'DRY RUN — no token minted, no dispatches sent.',
+        `Target:          ${apiUrl}`,
+        `Prod offices:    ${pool.length} (shuffled)`,
+        `Goal:            ${target} briefings actually dispatched`,
+        `Gate:            useImminenceGate=true (5-day window + dedupe)`,
+        `Concurrency:     ${concurrency}`,
+        `Max est. cost:   ~$${maxEstimate.toFixed(2)} (at the target)`,
+        '',
+        'The endpoint self-filters: offices with no meeting in the next 5 days',
+        '(or already covered by a future briefing) return dispatched:false and',
+        'cost nothing. We walk the shuffled pool until the target is reached.',
+        '',
+        'Sample order:',
+        ...pool.slice(0, 10).map((o) => `  ${o.id}  ${o.organizationSlug}`),
+      ].join('\n'),
+    )
+    return
+  }
+
+  const proceed = await confirm(
+    [
+      `Target:        ${apiUrl}`,
+      `Prod offices:  ${pool.length} (shuffled)`,
+      `Goal:          ${target} briefings dispatched (5-day imminence gate)`,
+      `Concurrency:   ${concurrency}`,
+      `Max est. cost: ~$${maxEstimate.toFixed(2)} ` +
+        `(may overshoot by up to ${concurrency - 1} in-flight calls)`,
+      '',
+      'Proceed? (y/N) ',
+    ].join('\n'),
+  )
+  if (!proceed) {
+    console.log('Aborted.')
+    return
+  }
+
+  mkdirSync(join(__dirname, 'output'), { recursive: true })
+  const logPath = join(
+    __dirname,
+    'output',
+    `dispatch-imminent-briefings.${new Date().toISOString()}.jsonl`,
+  )
+
+  // A run that walks a few thousand offices at this concurrency finishes well
+  // inside the 1h token TTL, so mint once.
+  const token = await mintToken()
+  const records: DispatchRecord[] = []
+  let dispatched = 0
+  let index = 0
+
+  const callDispatch = async (office: Office): Promise<void> => {
+    let httpStatus = 0
+    let didDispatch = false
+    try {
+      const res = await fetch(`${apiUrl}/v1/meetings/briefings/dispatch`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          electedOfficeId: office.id,
+          kind: 'briefing',
+          useImminenceGate: true,
+        }),
+      })
+      httpStatus = res.status
+      if (res.ok) {
+        const body: unknown = await res.json()
+        didDispatch =
+          typeof body === 'object' &&
+          body !== null &&
+          'dispatched' in body &&
+          body.dispatched === true
+      }
+    } catch {
+      httpStatus = 0
+    }
+    const record: DispatchRecord = {
+      electedOfficeId: office.id,
+      organizationSlug: office.organizationSlug,
+      httpStatus,
+      dispatched: didDispatch,
+      ok: httpStatus >= 200 && httpStatus < 300,
+      ts: new Date().toISOString(),
+    }
+    records.push(record)
+    appendFileSync(logPath, `${JSON.stringify(record)}\n`)
+    if (didDispatch) {
+      dispatched++
+      if (dispatched % 10 === 0) {
+        console.log(`  dispatched ${dispatched}/${target}`)
+      }
+    }
+  }
+
+  const runStart = new Date().toISOString()
+  const workers = Array.from(
+    { length: Math.min(concurrency, pool.length) },
+    () =>
+      (async () => {
+        while (dispatched < target && index < pool.length) {
+          const current = index++
+          await callDispatch(pool[current])
+        }
+      })(),
+  )
+  await Promise.all(workers)
+  const runEnd = new Date().toISOString()
+
+  const okCalls = records.filter((r) => r.ok).length
+  const failures = records.filter((r) => !r.ok)
+
+  console.log(
+    JSON.stringify(
+      {
+        goal: target,
+        dispatched,
+        callsMade: records.length,
+        okCalls,
+        skipped: okCalls - dispatched,
+        failures: failures.map((r) => ({
+          electedOfficeId: r.electedOfficeId,
+          httpStatus: r.httpStatus,
+        })),
+        estCostUsd: Number((dispatched * BRIEFING_COST_USD).toFixed(2)),
+        logPath,
+        reconcile: { runStart, runEnd },
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/meetings/controllers/meetingsBriefings.controller.test.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.test.ts
@@ -784,9 +784,16 @@ describe('POST /v1/meetings/briefings/dispatch', () => {
   it('with useImminenceGate, dispatches a briefing when a meeting is inside the 5-day window', async () => {
     const orgSlug = `eo-gate-in-${Date.now()}`
     const eo = await seedBriefingTarget(orgSlug, 'FREQ=DAILY')
+    const dispatchedRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.RUNNING,
+      },
+    })
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
+      .mockResolvedValue(dispatchedRun)
 
     const result = await service.client.post(
       '/v1/meetings/briefings/dispatch',
@@ -833,9 +840,16 @@ describe('POST /v1/meetings/briefings/dispatch', () => {
     try {
       const orgSlug = `eo-nogate-${Date.now()}`
       const eo = await seedBriefingTarget(orgSlug, 'FREQ=MONTHLY;BYMONTHDAY=20')
+      const dispatchedRun = await service.prisma.experimentRun.create({
+        data: {
+          organizationSlug: orgSlug,
+          experimentType: 'meeting_briefing',
+          status: ExperimentRunStatus.RUNNING,
+        },
+      })
       const dispatchSpy = vi
         .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-        .mockResolvedValue(undefined)
+        .mockResolvedValue(dispatchedRun)
 
       const result = await service.client.post(
         '/v1/meetings/briefings/dispatch',

--- a/src/meetings/controllers/meetingsBriefings.controller.test.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.test.ts
@@ -886,4 +886,33 @@ describe('POST /v1/meetings/briefings/dispatch', () => {
     expect(result.data).toEqual({ dispatched: false, kind: 'briefing' })
     expect(dispatchSpy).not.toHaveBeenCalled()
   })
+
+  it('403s a user session dispatching against an office it does not own', async () => {
+    const otherUser = await service.prisma.user.create({
+      data: {
+        clerkId: `other-${Date.now()}`,
+        email: `other-${Date.now()}@test.example`,
+        firstName: 'Other',
+        lastName: 'User',
+      },
+    })
+    const orgSlug = `eo-idor-${Date.now()}`
+    await service.prisma.organization.create({
+      data: { slug: orgSlug, ownerId: otherUser.id },
+    })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: otherUser.id },
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.client.post(
+      '/v1/meetings/briefings/dispatch',
+      { electedOfficeId: eo.id, kind: 'briefing', useImminenceGate: true },
+    )
+
+    expect(result.status).toBe(403)
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
 })

--- a/src/meetings/controllers/meetingsBriefings.controller.test.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.test.ts
@@ -55,6 +55,61 @@ const mockS3 = (responses: Record<string, string | undefined>) => {
   )
 }
 
+// Seed everything a briefing dispatch needs to resolve: org + position +
+// elected office + a COMPLETED meeting_schedule artifact in S3 whose RRULE
+// the caller controls (to land a meeting inside or outside the 5-day gate).
+const seedBriefingTarget = async (orgSlug: string, rrule: string) => {
+  await service.prisma.organization.create({
+    data: { slug: orgSlug, ownerId: service.user.id, positionId: 'br-pos-g' },
+  })
+  await service.prisma.campaign.create({
+    data: {
+      userId: service.user.id,
+      slug: `test-campaign-${orgSlug}`,
+      organizationSlug: orgSlug,
+      details: {},
+    },
+  })
+  const eo = await service.prisma.electedOffice.create({
+    data: { organizationSlug: orgSlug, userId: service.user.id },
+  })
+  vi.spyOn(
+    service.app.get(ElectionsService),
+    'getPositionById',
+  ).mockResolvedValue({
+    id: 'pos-real',
+    brPositionId: 'br-pos-g',
+    brDatabaseId: 'br-db-g',
+    state: 'MN',
+    name: 'City Council',
+  })
+  const artifactKey = `schedule-${orgSlug}.json`
+  await service.prisma.experimentRun.create({
+    data: {
+      organizationSlug: orgSlug,
+      experimentType: 'meeting_schedule',
+      status: ExperimentRunStatus.COMPLETED,
+      artifactBucket: 'schedule-bucket',
+      artifactKey,
+    },
+  })
+  mockS3({
+    [artifactKey]: JSON.stringify({
+      status: 'found',
+      rrule,
+      time: '23:59',
+      timezone: 'America/Chicago',
+      duration_minutes: 120,
+      meeting_name: 'City Council',
+      location: 'Council Chambers',
+      sources: [],
+      generated_at: new Date().toISOString(),
+      human: 'test schedule',
+    }),
+  })
+  return eo
+}
+
 describe('GET /v1/meetings', () => {
   it('returns 404 when user has no elected office', async () => {
     const result = await service.client.get('/v1/meetings', {
@@ -724,5 +779,111 @@ describe('POST /v1/meetings/briefings/dispatch', () => {
         office: 'City Council',
       },
     })
+  })
+
+  it('with useImminenceGate, dispatches a briefing when a meeting is inside the 5-day window', async () => {
+    const orgSlug = `eo-gate-in-${Date.now()}`
+    const eo = await seedBriefingTarget(orgSlug, 'FREQ=DAILY')
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.client.post(
+      '/v1/meetings/briefings/dispatch',
+      { electedOfficeId: eo.id, kind: 'briefing', useImminenceGate: true },
+    )
+
+    expect(result.status).toBe(201)
+    expect(result.data).toEqual({ dispatched: true, kind: 'briefing' })
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'meeting_briefing',
+        organizationSlug: orgSlug,
+      }),
+    )
+  })
+
+  it('with useImminenceGate, returns 201 dispatched:false (no dispatch) when the next meeting is outside the 5-day window', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date('2026-06-01T12:00:00Z'))
+    try {
+      const orgSlug = `eo-gate-out-${Date.now()}`
+      // Next occurrence is the 20th — ~19 days out: outside 5, inside 60.
+      const eo = await seedBriefingTarget(orgSlug, 'FREQ=MONTHLY;BYMONTHDAY=20')
+      const dispatchSpy = vi
+        .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+        .mockResolvedValue(undefined)
+
+      const result = await service.client.post(
+        '/v1/meetings/briefings/dispatch',
+        { electedOfficeId: eo.id, kind: 'briefing', useImminenceGate: true },
+      )
+
+      expect(result.status).toBe(201)
+      expect(result.data).toEqual({ dispatched: false, kind: 'briefing' })
+      expect(dispatchSpy).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('without the gate, still dispatches that same out-of-window meeting (60-day manual window)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date('2026-06-01T12:00:00Z'))
+    try {
+      const orgSlug = `eo-nogate-${Date.now()}`
+      const eo = await seedBriefingTarget(orgSlug, 'FREQ=MONTHLY;BYMONTHDAY=20')
+      const dispatchSpy = vi
+        .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+        .mockResolvedValue(undefined)
+
+      const result = await service.client.post(
+        '/v1/meetings/briefings/dispatch',
+        { electedOfficeId: eo.id, kind: 'briefing' },
+      )
+
+      expect(result.status).toBe(201)
+      expect(result.data).toEqual({ dispatched: true, kind: 'briefing' })
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'meeting_briefing' }),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('with useImminenceGate, skips when a future briefing already covers the official', async () => {
+    const orgSlug = `eo-gate-dedupe-${Date.now()}`
+    const eo = await seedBriefingTarget(orgSlug, 'FREQ=DAILY')
+    const existingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+      },
+    })
+    await service.prisma.meetingBriefing.create({
+      data: {
+        electedOfficeId: eo.id,
+        meetingDate: new Date('2099-12-31'),
+        meetingTime: '19:00',
+        meetingTimezone: 'America/Denver',
+        experimentRunId: existingRun.runId,
+        artifactBucket: 'b',
+        artifactKey: 'existing.json',
+      },
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.client.post(
+      '/v1/meetings/briefings/dispatch',
+      { electedOfficeId: eo.id, kind: 'briefing', useImminenceGate: true },
+    )
+
+    expect(result.status).toBe(201)
+    expect(result.data).toEqual({ dispatched: false, kind: 'briefing' })
+    expect(dispatchSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -5,6 +5,8 @@ import {
   NotFoundException,
   Param,
   Post,
+  Req,
+  UseGuards,
 } from '@nestjs/common'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { ElectedOffice, User } from '../../generated/prisma'
@@ -14,6 +16,9 @@ import { ReqElectedOffice } from '@/electedOffice/decorators/ReqElectedOffice.de
 import { UseElectedOffice } from '@/electedOffice/decorators/UseElectedOffice.decorator'
 import { ReqUser } from '@/authentication/decorators/ReqUser.decorator'
 import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import { UserOrM2MGuard } from '@/electedOffice/guards/UserOrM2M.guard'
+import { IncomingRequest } from '@/authentication/authentication.types'
+import { effectiveUser } from '@/authentication/util/effectiveUser.util'
 import { S3Service } from '@/vendors/aws/services/s3.service'
 import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import {
@@ -225,15 +230,23 @@ export class MeetingsBriefingsController {
     return { ...artifact, briefing_id: row.id }
   }
 
+  @UseGuards(UserOrM2MGuard)
   @Post('briefings/dispatch')
   async dispatchAgent(
     @Body(new ZodValidationPipe(DispatchMeetingAgentSchema))
     body: DispatchMeetingAgentDto,
+    @Req() req: IncomingRequest,
   ) {
+    // M2M callers (the bulk dispatch script, gp-admin) are trusted to dispatch
+    // for any office. A user session may only dispatch for an office it owns —
+    // passing the user id down enforces that and 403s an attempt against
+    // someone else's office. Undefined (M2M) skips the ownership check.
+    const requestingUserId = req.m2mToken ? undefined : effectiveUser(req)?.id
     const result = await this.meetingBriefings.dispatchManual(
       body.electedOfficeId,
       body.kind,
       body.useImminenceGate,
+      requestingUserId,
     )
     // With the imminence gate on, a non-dispatch is an expected skip (no meeting
     // inside the window, or one already briefed), so return it as a 200 and let

--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -233,13 +233,18 @@ export class MeetingsBriefingsController {
     const result = await this.meetingBriefings.dispatchManual(
       body.electedOfficeId,
       body.kind,
+      body.useImminenceGate,
     )
-    if (!result.dispatched) {
+    // With the imminence gate on, a non-dispatch is an expected skip (no meeting
+    // inside the window, or one already briefed), so return it as a 200 and let
+    // the bulk caller tell "skipped" from a hard failure. Without the gate (the
+    // UI button), a non-dispatch means context resolution failed → 404.
+    if (!result.dispatched && !body.useImminenceGate) {
       throw new NotFoundException(
         'Could not resolve dispatch context for that elected office',
       )
     }
-    return { dispatched: true, kind: body.kind }
+    return { dispatched: result.dispatched, kind: body.kind }
   }
 
   /**

--- a/src/meetings/schemas/dispatchMeetingAgent.schema.ts
+++ b/src/meetings/schemas/dispatchMeetingAgent.schema.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 export const DispatchMeetingAgentSchema = z.object({
   electedOfficeId: z.string().min(1),
   kind: z.enum(['schedule', 'briefing']),
+  useImminenceGate: z.boolean().optional(),
 })
 
 export type DispatchMeetingAgentDto = z.infer<typeof DispatchMeetingAgentSchema>

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -10,6 +10,7 @@ import { S3Service } from '@/vendors/aws/services/s3.service'
 import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
 import {
   BadGatewayException,
+  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common'
@@ -432,11 +433,23 @@ export class MeetingBriefingsService extends createPrismaBase(
     electedOfficeId: string,
     kind: ManualDispatchKind,
     useImminenceGate = false,
+    requestingUserId?: number,
   ): Promise<{ dispatched: boolean }> {
     const electedOffice = await this.client.electedOffice.findUnique({
       where: { id: electedOfficeId },
     })
     if (!electedOffice) return { dispatched: false }
+
+    // A user session may only dispatch for an office it owns; M2M callers pass
+    // no requestingUserId and are trusted to dispatch for any office.
+    if (
+      requestingUserId !== undefined &&
+      electedOffice.userId !== requestingUserId
+    ) {
+      throw new ForbiddenException(
+        'You do not have access to this elected office',
+      )
+    }
 
     const ctx = await this.resolveDispatchContext(electedOffice)
     if (!ctx) return { dispatched: false }

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -431,6 +431,7 @@ export class MeetingBriefingsService extends createPrismaBase(
   async dispatchManual(
     electedOfficeId: string,
     kind: ManualDispatchKind,
+    useImminenceGate = false,
   ): Promise<{ dispatched: boolean }> {
     const electedOffice = await this.client.electedOffice.findUnique({
       where: { id: electedOfficeId },
@@ -445,14 +446,25 @@ export class MeetingBriefingsService extends createPrismaBase(
       return { dispatched: true }
     }
 
-    // Manual briefing dispatch bypasses the 5-day imminence gate but still
-    // needs a meetingDate from the schedule. Project up to 60 days out so
-    // an operator can pre-brief a meeting that's still a few weeks away.
+    // A briefing needs a meetingDate from the schedule. With the imminence
+    // gate on, match the daily cron exactly: skip if a future briefing already
+    // covers the official, and only dispatch when the next meeting falls inside
+    // the 5-day window. With the gate off (the UI "brief now" button) widen to
+    // 60 days so an operator can pre-brief a meeting that's still weeks away.
+    const now = new Date()
+    if (useImminenceGate) {
+      const futureBriefing = await this.model.findFirst({
+        where: { electedOfficeId, meetingDate: { gte: now } },
+        select: { id: true },
+      })
+      if (futureBriefing) return { dispatched: false }
+    }
+
     const target = await this.resolveTargetMeeting(
       ctx.organizationSlug,
       ctx.electedOfficeId,
-      new Date(),
-      60,
+      now,
+      useImminenceGate ? IMMINENCE_WINDOW_DAYS : 60,
     )
     if (!target) return { dispatched: false }
 


### PR DESCRIPTION
## Why

We need to bulk-trigger `meeting_briefing` jobs for a cohort of prod elected officials, but only for officials whose next meeting is within the next 5 days — matching the criteria the daily briefing cron already enforces.

The only existing bulk entry point is `POST /v1/meetings/briefings/dispatch` with `kind: 'briefing'`, which routes through `dispatchManual()` and projects **60 days** out. That window is correct for a user clicking "brief now" in the UI, but wrong for an operator re-seeding a cohort: it would dispatch briefings for meetings up to two months away and ignore the coverage dedupe the cron relies on.

Reimplementing the 5-day window + dedupe in a standalone script would duplicate `dispatchBriefingIfNeeded`'s logic and let it drift from the cron over time. Instead this exposes the cron's gate through the existing endpoint.

## What changes and why it's safe

- `dispatchManual()` takes an opt-in `useImminenceGate`. When on, it applies the exact cron criteria: skip if a future briefing already covers the official, and only dispatch when the next meeting falls inside the 5-day `IMMINENCE_WINDOW_DAYS`. When off, the 60-day "brief now" behavior is unchanged.
- With the gate on, a non-dispatch is an **expected** outcome (no imminent meeting, or already briefed), so the endpoint returns `200 { dispatched: false }`. The bulk caller needs to distinguish a skip from a hard failure. Without the gate, a non-dispatch still means context resolution failed → `404`, exactly as before. The UI "brief now" button never sends the flag, so its behavior is byte-for-byte unchanged — no gp-webapp change needed.
- `scripts/dispatch-imminent-briefings.ts` enumerates prod elected offices, shuffles them, and walks the gated endpoint until the target number of briefings actually dispatch. Eligibility is decided server-side by the product gate, not duplicated in the script.

## Note for reviewers

The added tests run through the HTTP interface (`useTestService`) and cover all four gate paths, including the clean contrast: the same out-of-window meeting is **skipped** with the gate on and **dispatched** with it off. They could not be executed in my local sandbox (the test Postgres container isn't provisioned there) — please confirm they pass in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production briefing dispatch semantics behind an opt-in flag and adds an operator script that can enqueue costly `meeting_briefing` jobs against prod; default UI/manual paths are unchanged when the flag is omitted.
> 
> **Overview**
> Adds an opt-in **`useImminenceGate`** flag on `POST /v1/meetings/briefings/dispatch` so bulk operators can trigger briefings with the same rules as the daily cron: skip when a future briefing already exists, and only dispatch when the next meeting is within **5 days**. Without the flag, manual “brief now” behavior stays on the **60-day** projection window.
> 
> When the gate is on, expected skips return **`{ dispatched: false }`** with a success status instead of **404**, so a bulk caller can tell skips apart from hard failures; UI callers that omit the flag keep the old **404** on unresolved context.
> 
> A new **`scripts/dispatch-imminent-briefings.ts`** walks a shuffled prod `electedOffice` pool via M2M auth, calling the gated endpoint with configurable concurrency until a target number of real dispatches is reached, with dry-run, confirmation, and JSONL logging.
> 
> Controller tests cover in-window dispatch, out-of-window skip, dedupe skip, and the contrast that the same schedule dispatches without the gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd90063db6c6008da0e7ad0b2fa1ff09f5c2932f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->