### PR TITLE
fix(experiment-runs): resume parked runs under a new run_id

### DIFF
--- a/src/agentExperiments/services/experimentRuns.service.test.ts
+++ b/src/agentExperiments/services/experimentRuns.service.test.ts
@@ -358,6 +358,28 @@ describe('ExperimentRunsService', () => {
     )
 
     it(
+      'terminalizes the old row as FAILED (superseded) after a ' +
+        'successful resume dispatch',
+      async () => {
+        sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-1' })
+        mockModel.updateMany.mockResolvedValue({ count: 1 })
+
+        await service.resumeRun(awaitingRun)
+
+        expect(mockModel.updateMany).toHaveBeenCalledWith({
+          where: {
+            runId: awaitingRun.runId,
+            status: ExperimentRunStatus.AWAITING_RESUME,
+          },
+          data: {
+            status: ExperimentRunStatus.FAILED,
+            error: 'Superseded by resumed run',
+          },
+        })
+      },
+    )
+
+    it(
       'claims the old row by nulling resumeScheduledFor (guarded on ' +
         'AWAITING_RESUME and resumeScheduledFor not null)',
       async () => {
@@ -474,15 +496,33 @@ describe('ExperimentRunsService', () => {
       },
     )
 
-    it('does not send SQS when AGENT_DISPATCH_QUEUE_NAME is unset', async () => {
-      delete process.env.AGENT_DISPATCH_QUEUE_NAME
-      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' })
+    it(
+      'releases the claim (does not supersede) when ' +
+        'AGENT_DISPATCH_QUEUE_NAME is unset',
+      async () => {
+        delete process.env.AGENT_DISPATCH_QUEUE_NAME
+        sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' })
+        mockModel.updateMany.mockResolvedValue({ count: 1 })
 
-      await service.resumeRun(awaitingRun)
+        await service.resumeRun(awaitingRun)
 
-      expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
-      expect(mockModel.create).not.toHaveBeenCalled()
-    })
+        expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
+        expect(mockModel.create).not.toHaveBeenCalled()
+        // claim succeeded but no successor was created → release, not supersede
+        expect(mockModel.updateMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: { resumeScheduledFor: expect.any(Date) },
+          }),
+        )
+        expect(mockModel.updateMany).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              error: 'Superseded by resumed run',
+            }),
+          }),
+        )
+      },
+    )
 
     it('resolves the queue url once and caches it across resumes', async () => {
       sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' })
@@ -608,5 +648,19 @@ describe('ExperimentRunsService', () => {
         expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
       },
     )
+
+    it('isolates a throwing resumeRun so the rest of the batch still runs', async () => {
+      const run1 = makeRun({ runId: 'run-sweep-throw', resumeAttempts: 1 })
+      const run2 = makeRun({ runId: 'run-sweep-ok', resumeAttempts: 1 })
+      mockModel.findMany.mockResolvedValue([run1, run2])
+      const resumeSpy = vi
+        .spyOn(service, 'resumeRun')
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce(undefined)
+
+      await expect(service.sweepResumableRuns()).resolves.toBeUndefined()
+
+      expect(resumeSpy).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/src/agentExperiments/services/experimentRuns.service.test.ts
+++ b/src/agentExperiments/services/experimentRuns.service.test.ts
@@ -319,8 +319,47 @@ describe('ExperimentRunsService', () => {
     }
 
     it(
-      'atomically claims the row and sends SQS with the same run_id ' +
-        'and trigger=recovery_resume',
+      'mints a NEW run_id, creates a RUNNING row with incremented ' +
+        'resumeAttempts, and sends SQS with the new run_id and ' +
+        'trigger=recovery_resume',
+      async () => {
+        sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-1' })
+        mockModel.updateMany.mockResolvedValue({ count: 1 })
+
+        await service.resumeRun(awaitingRun)
+
+        expect(mockModel.create).toHaveBeenCalledOnce()
+        const createCall = mockModel.create.mock.calls[0][0] as {
+          data: Record<string, unknown>
+        }
+        expect(createCall.data.runId).toBeDefined()
+        expect(createCall.data.runId).not.toBe(awaitingRun.runId)
+        expect(createCall.data.status).toBe(ExperimentRunStatus.RUNNING)
+        expect(createCall.data.experimentType).toBe(awaitingRun.experimentType)
+        expect(createCall.data.resumeAttempts).toBe(
+          awaitingRun.resumeAttempts + 1,
+        )
+
+        const [call] = sqsMock.commandCalls(SendMessageCommand)
+        expect(call).toBeDefined()
+        const body = JSON.parse(
+          call.args[0].input.MessageBody as string,
+        ) as Record<string, unknown>
+        expect(body.run_id).toBe(createCall.data.runId)
+        expect(body.run_id).not.toBe(awaitingRun.runId)
+        expect((body.params as Record<string, unknown>).trigger).toBe(
+          'recovery_resume',
+        )
+        expect((body.params as Record<string, unknown>).clerk_user_id).toBe(
+          'user_clerk_123',
+        )
+        expect(body.clerk_user_id).toBe('user_clerk_123')
+      },
+    )
+
+    it(
+      'claims the old row by nulling resumeScheduledFor (guarded on ' +
+        'AWAITING_RESUME and resumeScheduledFor not null)',
       async () => {
         sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-1' })
         mockModel.updateMany.mockResolvedValue({ count: 1 })
@@ -331,29 +370,15 @@ describe('ExperimentRunsService', () => {
           where: {
             runId: awaitingRun.runId,
             status: ExperimentRunStatus.AWAITING_RESUME,
+            resumeScheduledFor: { not: null },
           },
-          data: {
-            status: ExperimentRunStatus.RUNNING,
-            resumeAttempts: { increment: 1 },
-            resumeScheduledFor: null,
-          },
+          data: { resumeScheduledFor: null },
         })
-
-        const [call] = sqsMock.commandCalls(SendMessageCommand)
-        expect(call).toBeDefined()
-        const body = JSON.parse(
-          call.args[0].input.MessageBody as string,
-        ) as Record<string, unknown>
-        expect(body.run_id).toBe(awaitingRun.runId)
-        expect((body.params as Record<string, unknown>).trigger).toBe(
-          'recovery_resume',
-        )
-        expect(body.clerk_user_id).toBe('user_clerk_123')
       },
     )
 
     it(
-      'sends the clerk_user_id from params.clerk_user_id in the SQS body, ' +
+      'sends the clerk_user_id from params in the new run SQS body, ' +
         'not an empty string',
       async () => {
         sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-2' })
@@ -383,7 +408,6 @@ describe('ExperimentRunsService', () => {
         'message when params has no clerk_user_id',
       async () => {
         sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-3' })
-        mockModel.updateMany.mockResolvedValue({ count: 1 })
 
         await service.resumeRun({
           runId: 'run-missing-user',
@@ -404,13 +428,7 @@ describe('ExperimentRunsService', () => {
             error: expect.stringContaining('clerk_user_id'),
           },
         })
-        expect(mockModel.updateMany).not.toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.objectContaining({
-              status: ExperimentRunStatus.RUNNING,
-            }),
-          }),
-        )
+        expect(mockModel.create).not.toHaveBeenCalled()
         expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
         expect(logger.error).toHaveBeenCalledWith(
           expect.objectContaining({ runId: 'run-missing-user' }),
@@ -419,33 +437,42 @@ describe('ExperimentRunsService', () => {
       },
     )
 
-    it('does not send SQS when the atomic claim is lost (count 0)', async () => {
-      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-1' })
-      mockModel.updateMany.mockResolvedValue({ count: 0 })
+    it(
+      'does not create a new run or send SQS when the claim is lost ' +
+        '(updateMany returns count 0)',
+      async () => {
+        sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-1' })
+        mockModel.updateMany.mockResolvedValue({ count: 0 })
 
-      await service.resumeRun(awaitingRun)
+        await service.resumeRun(awaitingRun)
 
-      expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
-    })
+        expect(mockModel.create).not.toHaveBeenCalled()
+        expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
+      },
+    )
 
-    it('releases the claim back to AWAITING_RESUME when SQS send throws', async () => {
-      sqsMock.on(SendMessageCommand).rejects(new Error('SQS down'))
-      mockModel.updateMany.mockResolvedValue({ count: 1 })
+    it(
+      'releases the claim (restores resumeScheduledFor on old row) ' +
+        'when SQS send throws, and does not rethrow',
+      async () => {
+        sqsMock.on(SendMessageCommand).rejects(new Error('SQS down'))
+        mockModel.updateMany.mockResolvedValue({ count: 1 })
 
-      await service.resumeRun(awaitingRun)
+        await expect(service.resumeRun(awaitingRun)).resolves.toBeUndefined()
 
-      expect(mockModel.updateMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: {
-            runId: awaitingRun.runId,
-            status: ExperimentRunStatus.RUNNING,
-          },
-          data: expect.objectContaining({
-            status: ExperimentRunStatus.AWAITING_RESUME,
+        expect(mockModel.updateMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              runId: awaitingRun.runId,
+              status: ExperimentRunStatus.AWAITING_RESUME,
+            }),
+            data: expect.objectContaining({
+              resumeScheduledFor: expect.any(Date),
+            }),
           }),
-        }),
-      )
-    })
+        )
+      },
+    )
 
     it('does not send SQS when AGENT_DISPATCH_QUEUE_NAME is unset', async () => {
       delete process.env.AGENT_DISPATCH_QUEUE_NAME
@@ -454,7 +481,7 @@ describe('ExperimentRunsService', () => {
       await service.resumeRun(awaitingRun)
 
       expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
-      expect(mockModel.updateMany).not.toHaveBeenCalled()
+      expect(mockModel.create).not.toHaveBeenCalled()
     })
 
     it('resolves the queue url once and caches it across resumes', async () => {

--- a/src/agentExperiments/services/experimentRuns.service.test.ts
+++ b/src/agentExperiments/services/experimentRuns.service.test.ts
@@ -339,6 +339,7 @@ describe('ExperimentRunsService', () => {
         expect(createCall.data.resumeAttempts).toBe(
           awaitingRun.resumeAttempts + 1,
         )
+        expect(createCall.data.stage).toBe(awaitingRun.stage)
 
         const [call] = sqsMock.commandCalls(SendMessageCommand)
         expect(call).toBeDefined()
@@ -482,15 +483,28 @@ describe('ExperimentRunsService', () => {
 
         await expect(service.resumeRun(awaitingRun)).resolves.toBeUndefined()
 
+        // The successor row was created then flipped to FAILED inside
+        // createAndEnqueueRun's catch before the throw bubbled up.
+        expect(mockModel.create).toHaveBeenCalledOnce()
+        expect(mockModel.update).toHaveBeenCalledWith({
+          where: { runId: expect.any(String) },
+          data: {
+            status: ExperimentRunStatus.FAILED,
+            error: 'SQS dispatch failed',
+          },
+        })
+        // The original row is released AND its attempt counter advanced so
+        // MAX_RESUME_ATTEMPTS can eventually terminate a persistent failure.
         expect(mockModel.updateMany).toHaveBeenCalledWith(
           expect.objectContaining({
             where: expect.objectContaining({
               runId: awaitingRun.runId,
               status: ExperimentRunStatus.AWAITING_RESUME,
             }),
-            data: expect.objectContaining({
+            data: {
               resumeScheduledFor: expect.any(Date),
-            }),
+              resumeAttempts: { increment: 1 },
+            },
           }),
         )
       },
@@ -511,7 +525,9 @@ describe('ExperimentRunsService', () => {
         // claim succeeded but no successor was created → release, not supersede
         expect(mockModel.updateMany).toHaveBeenCalledWith(
           expect.objectContaining({
-            data: { resumeScheduledFor: expect.any(Date) },
+            data: expect.objectContaining({
+              resumeScheduledFor: expect.any(Date),
+            }),
           }),
         )
         expect(mockModel.updateMany).not.toHaveBeenCalledWith(

--- a/src/agentExperiments/services/experimentRuns.service.ts
+++ b/src/agentExperiments/services/experimentRuns.service.ts
@@ -96,6 +96,7 @@ export class ExperimentRunsService extends createPrismaBase(
     clerkUserId: string
     params: Prisma.InputJsonValue
     resumeAttempts?: number
+    stage?: string | null
   }): Promise<ExperimentRun | undefined> {
     const queueUrl = await this.resolveQueueUrl()
     if (!queueUrl) {
@@ -113,6 +114,7 @@ export class ExperimentRunsService extends createPrismaBase(
         status: ExperimentRunStatus.RUNNING,
         params: input.params,
         resumeAttempts: input.resumeAttempts ?? 0,
+        stage: input.stage ?? null,
       },
     })
     try {
@@ -221,6 +223,7 @@ export class ExperimentRunsService extends createPrismaBase(
         clerkUserId,
         params: resumeParams,
         resumeAttempts: run.resumeAttempts + 1,
+        stage: run.stage,
       })
     } catch (error) {
       this.logger.error(
@@ -233,15 +236,20 @@ export class ExperimentRunsService extends createPrismaBase(
     if (!dispatched) {
       // Dispatch threw, or no queue is configured (preview env) so no successor
       // was created. Release the claim so the row returns to the sweep instead
-      // of being orphaned or falsely marked superseded. Wrap the release so a
-      // transient DB error here is logged rather than left silently stuck.
+      // of being orphaned or falsely marked superseded — but still increment
+      // resumeAttempts so MAX_RESUME_ATTEMPTS eventually terminates it (e.g. a
+      // prolonged SQS outage would otherwise re-dispatch forever). Wrap the
+      // release so a transient DB error here is logged rather than left stuck.
       try {
         await this.model.updateMany({
           where: {
             runId: run.runId,
             status: ExperimentRunStatus.AWAITING_RESUME,
           },
-          data: { resumeScheduledFor: new Date() },
+          data: {
+            resumeScheduledFor: new Date(),
+            resumeAttempts: { increment: 1 },
+          },
         })
       } catch (releaseError) {
         this.logger.error(

--- a/src/agentExperiments/services/experimentRuns.service.ts
+++ b/src/agentExperiments/services/experimentRuns.service.ts
@@ -2,7 +2,11 @@ import { BadGatewayException, Injectable } from '@nestjs/common'
 import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
 import { v7 as uuidv7 } from 'uuid'
 import { SQS } from '@aws-sdk/client-sqs'
-import { ExperimentRunStatus, Prisma } from '../../generated/prisma'
+import {
+  ExperimentRun,
+  ExperimentRunStatus,
+  Prisma,
+} from '../../generated/prisma'
 import { Cron } from '@nestjs/schedule'
 import { randomUUID } from 'crypto'
 import { subMinutes } from 'date-fns'
@@ -86,34 +90,36 @@ export class ExperimentRunsService extends createPrismaBase(
     })
   }
 
-  async dispatchRun<ExperimentType extends keyof AgentJobContracts>(
-    input: ExperimentRunDispatchInput<ExperimentType>,
-  ) {
-    const QueueUrl = await this.resolveQueueUrl()
-    if (!QueueUrl) {
+  private async createAndEnqueueRun(input: {
+    experimentType: string
+    organizationSlug: string
+    clerkUserId: string
+    params: Prisma.InputJsonValue
+    resumeAttempts?: number
+  }): Promise<ExperimentRun | undefined> {
+    const queueUrl = await this.resolveQueueUrl()
+    if (!queueUrl) {
       this.logger.warn(
         'No Queue Url found for agent dispatch, not configured for this environment',
       )
       return
     }
-
     const runId = uuidv7()
-
     const result = await this.model.create({
       data: {
         runId,
-        experimentType: input.type,
+        experimentType: input.experimentType,
         organizationSlug: input.organizationSlug,
         status: ExperimentRunStatus.RUNNING,
         params: input.params,
+        resumeAttempts: input.resumeAttempts ?? 0,
       },
     })
-
     try {
-      await this.enqueueDispatch(QueueUrl, {
+      await this.enqueueDispatch(queueUrl, {
         runId,
         organizationSlug: input.organizationSlug,
-        experimentType: input.type,
+        experimentType: input.experimentType,
         clerkUserId: input.clerkUserId,
         params: input.params,
       })
@@ -122,42 +128,49 @@ export class ExperimentRunsService extends createPrismaBase(
         {
           error,
           runId,
-          experimentType: input.type,
+          experimentType: input.experimentType,
           organizationSlug: input.organizationSlug,
         },
         'Failed to send dispatch message to SQS',
       )
       await this.model.update({
         where: { runId },
-        data: { status: 'FAILED', error: 'SQS dispatch failed' },
+        data: {
+          status: ExperimentRunStatus.FAILED,
+          error: 'SQS dispatch failed',
+        },
       })
       throw new BadGatewayException(
         'Failed to dispatch experiment. Please try again.',
       )
     }
-
     this.logger.info(
       {
         runId,
-        experimentType: input.type,
+        experimentType: input.experimentType,
         organizationSlug: input.organizationSlug,
       },
       'Experiment dispatched',
     )
-
     return result
   }
 
-  async resumeRun(run: ResumeRunInput) {
-    const QueueUrl = await this.resolveQueueUrl()
-    if (!QueueUrl) {
-      this.logger.warn(
-        { runId: run.runId },
-        'No Queue Url configured — cannot resume run in this environment',
-      )
-      return
-    }
+  async dispatchRun<ExperimentType extends keyof AgentJobContracts>(
+    input: ExperimentRunDispatchInput<ExperimentType>,
+  ) {
+    return this.createAndEnqueueRun({
+      experimentType: input.type,
+      organizationSlug: input.organizationSlug,
+      clerkUserId: input.clerkUserId,
+      // AgentJobContracts inputs are JSON-serializable objects validated by Zod;
+      // the assertion bridges the structural index-signature gap that InputJsonObject
+      // requires but the generated contract types don't declare.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      params: input.params as Prisma.InputJsonObject,
+    })
+  }
 
+  async resumeRun(run: ResumeRunInput) {
     const clerkUserId =
       isJsonObject(run.params) &&
       typeof run.params['clerk_user_id'] === 'string'
@@ -186,46 +199,39 @@ export class ExperimentRunsService extends createPrismaBase(
       where: {
         runId: run.runId,
         status: ExperimentRunStatus.AWAITING_RESUME,
+        resumeScheduledFor: { not: null },
       },
-      data: {
-        status: ExperimentRunStatus.RUNNING,
-        resumeAttempts: { increment: 1 },
-        resumeScheduledFor: null,
-      },
+      data: { resumeScheduledFor: null },
     })
 
     if (claimed.count === 0) {
       return
     }
 
-    const resumeParams =
-      typeof run.params === 'object' && run.params !== null
-        ? { ...run.params, trigger: 'recovery_resume' }
-        : { trigger: 'recovery_resume' }
+    const resumeParams = {
+      ...(isJsonObject(run.params) ? run.params : {}),
+      trigger: 'recovery_resume',
+    } as Prisma.InputJsonObject
 
     try {
-      await this.enqueueDispatch(QueueUrl, {
-        runId: run.runId,
-        organizationSlug: run.organizationSlug,
+      await this.createAndEnqueueRun({
         experimentType: run.experimentType,
+        organizationSlug: run.organizationSlug,
         clerkUserId,
         params: resumeParams,
+        resumeAttempts: run.resumeAttempts + 1,
       })
     } catch (error) {
       this.logger.error(
         { error, runId: run.runId },
-        'Failed to re-enqueue resumed run — releasing claim',
+        'Failed to dispatch resumed run — releasing claim',
       )
       await this.model.updateMany({
         where: {
           runId: run.runId,
-          status: ExperimentRunStatus.RUNNING,
-        },
-        data: {
           status: ExperimentRunStatus.AWAITING_RESUME,
-          resumeAttempts: { decrement: 1 },
-          resumeScheduledFor: new Date(),
         },
+        data: { resumeScheduledFor: new Date() },
       })
     }
   }

--- a/src/agentExperiments/services/experimentRuns.service.ts
+++ b/src/agentExperiments/services/experimentRuns.service.ts
@@ -213,8 +213,9 @@ export class ExperimentRunsService extends createPrismaBase(
       trigger: 'recovery_resume',
     } as Prisma.InputJsonObject
 
+    let dispatched: ExperimentRun | undefined
     try {
-      await this.createAndEnqueueRun({
+      dispatched = await this.createAndEnqueueRun({
         experimentType: run.experimentType,
         organizationSlug: run.organizationSlug,
         clerkUserId,
@@ -224,15 +225,52 @@ export class ExperimentRunsService extends createPrismaBase(
     } catch (error) {
       this.logger.error(
         { error, runId: run.runId },
-        'Failed to dispatch resumed run — releasing claim',
+        'Failed to dispatch resumed run',
       )
+      dispatched = undefined
+    }
+
+    if (!dispatched) {
+      // Dispatch threw, or no queue is configured (preview env) so no successor
+      // was created. Release the claim so the row returns to the sweep instead
+      // of being orphaned or falsely marked superseded. Wrap the release so a
+      // transient DB error here is logged rather than left silently stuck.
+      try {
+        await this.model.updateMany({
+          where: {
+            runId: run.runId,
+            status: ExperimentRunStatus.AWAITING_RESUME,
+          },
+          data: { resumeScheduledFor: new Date() },
+        })
+      } catch (releaseError) {
+        this.logger.error(
+          { releaseError, runId: run.runId },
+          'Failed to release resume claim — row stuck AWAITING_RESUME with no schedule',
+        )
+      }
+      return
+    }
+
+    // A successor run was created; terminalize the old row so it can't linger
+    // forever as a non-terminal orphan (the resume sweep ignores a null
+    // resumeScheduledFor, and the stale sweep only touches RUNNING).
+    try {
       await this.model.updateMany({
         where: {
           runId: run.runId,
           status: ExperimentRunStatus.AWAITING_RESUME,
         },
-        data: { resumeScheduledFor: new Date() },
+        data: {
+          status: ExperimentRunStatus.FAILED,
+          error: 'Superseded by resumed run',
+        },
       })
+    } catch (supersedeError) {
+      this.logger.error(
+        { supersedeError, runId: run.runId },
+        'Failed to terminalize superseded run — left as AWAITING_RESUME orphan',
+      )
     }
   }
 
@@ -264,7 +302,16 @@ export class ExperimentRunsService extends createPrismaBase(
           },
         })
       } else {
-        await this.resumeRun(run)
+        // Isolate each run: a throw from one resume must not abort the rest of
+        // the batch (the remaining due runs would be skipped until next tick).
+        try {
+          await this.resumeRun(run)
+        } catch (error) {
+          this.logger.error(
+            { error, runId: run.runId },
+            'resumeRun threw during sweep — continuing with remaining runs',
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem

The compliance recovery sweeper (ENG-7554) resumed parked (`AWAITING_RESUME`) runs **in place, reusing the same `run_id`**. The agent broker publishes each run's artifact write-once — `broker/endpoints/artifact_publish.py` writes `{experiment_id}/{run_id}/artifact.json` with S3 `IfNoneMatch="*"`. The first (parked) publish already wrote that key, so the resumed run's second publish 412s and the broker returns **409 Conflict**, failing the run.

Confirmed in prod: run `019e99b4-7d4d-7bb7-946a-ba09c35b0a44` (campaign 323388) failed with `409 Conflict for url '.../artifact/publish'`. The manual admin **Retry** avoids this because `dispatchRun` mints a new `run_id`; the automatic sweeper did not. QA never caught it because `verifyLive` is stubbed there, so runs never park → never resume → never double-publish.

## Fix

- Extract the shared "mint a fresh `run_id` + create a RUNNING row + enqueue" logic into `createAndEnqueueRun` (with an optional `resumeAttempts` seed). `dispatchRun` delegates to it — public behavior unchanged.
- `resumeRun` now dispatches a **new `run_id`** per resume via `createAndEnqueueRun`, carrying `resumeAttempts + 1` so the attempt cap still accumulates across the resume chain. The parked row is de-queued by nulling `resumeScheduledFor` (atomic claim guarded on `resumeScheduledFor: { not: null }`); on dispatch failure the claim is released so the next tick retries.
- Net: a `run_id` is never published twice, so the broker 409 cannot recur — the sweeper now mirrors the working admin-retry path.

## Notes

- No migration, no admin/contracts changes.
- Follow-up (out of scope): a `successorRunId` column to link a parked row to its resume successor for dashboard clarity (needs a migration).

## Test

`tsc` clean, 22/22 tests pass (`experimentRuns.service.test.ts`), eslint 0 errors. New tests assert resume mints a new `run_id` (not reuse), seeds `resumeAttempts + 1`, carries `clerk_user_id`, claims by nulling `resumeScheduledFor`, releases on enqueue failure, and fails on missing `clerk_user_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production recovery sweeper dispatch semantics and DB row lifecycle for parked runs; behavior is well-tested but affects compliance experiment recovery in prod.
> 
> **Overview**
> Fixes automatic recovery resumes reusing the same `run_id`, which caused a second artifact publish to 409 against the broker’s write-once S3 key.
> 
> **`resumeRun`** no longer flips the parked row to `RUNNING` and re-enqueues the same id. It atomically **claims** the parked row by nulling `resumeScheduledFor` (only when `AWAITING_RESUME` and `resumeScheduledFor` is set), then calls a new **`createAndEnqueueRun`** helper that mints a fresh `run_id`, inserts a new `RUNNING` row with `resumeAttempts + 1`, and sends SQS with `trigger: recovery_resume`. On enqueue failure it restores `resumeScheduledFor` on the old row instead of toggling status/`resumeAttempts` on that row. **`dispatchRun`** delegates to the same helper so initial dispatch behavior stays the same.
> 
> Tests now assert the new run id, claim semantics, no create/SQS on lost claim or missing `clerk_user_id`, and claim release on SQS errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95f5d652c8535f5e9cfb99c519220949fc5a5922. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->