### PR TITLE
Briefing agenda file upload

### DIFF
--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -130,6 +130,15 @@ export = async () => {
       ? 'annotation-attachments-dev'
       : createAnnotationAttachmentsBucket({ environment }).bucket.bucket
 
+  // Private bucket for user-supplied inputs to agent experiment runs (first
+  // use: agenda packets uploaded from /briefings). Browser PUTs via presigned
+  // URL; the broker reads on the runner's behalf via /inputs/read. Created
+  // and owned by gp-ai-projects Terraform (modules/agent-run-inputs); gp-api
+  // references by name only. Preview environments share the dev bucket.
+  const agentRunInputsBucketName = `gp-agent-run-inputs-${
+    environment === 'preview' ? 'dev' : environment
+  }`
+
   // Shared bucket between the external meeting_pipeline (writes briefings)
   // and gp-api TextToSpeechService (caches Polly audio under speech/synth/,
   // then hands the browser presigned GETs). Dev bucket exists out-of-band
@@ -414,6 +423,7 @@ export = async () => {
       TEVYN_POLL_CSVS_BUCKET: tevynPollCsvsBucket.bucket,
       ZIP_TO_AREA_CODE_BUCKET: zipToAreaCodeBucket.bucket,
       ANNOTATION_ATTACHMENTS_BUCKET: annotationAttachmentsBucketName,
+      AGENT_RUN_INPUTS_BUCKET: agentRunInputsBucketName,
       DB_HOST: rdsCluster.endpoint,
       DB_USER: rdsCluster.masterUsername,
       DB_NAME: rdsCluster.databaseName,

--- a/prisma/schema/electedOffice.prisma
+++ b/prisma/schema/electedOffice.prisma
@@ -18,6 +18,7 @@ model ElectedOffice {
   pollIndividualMessages   PollIndividualMessage[]
   meetingBriefings         MeetingBriefing[]
   meetingResourceLocations MeetingResourceLocation[]
+  userAgendaUploads        UserAgendaUpload[]
 
   @@unique([userId])
   @@index([campaignId])

--- a/prisma/schema/experimentRun.prisma
+++ b/prisma/schema/experimentRun.prisma
@@ -33,6 +33,7 @@ model ExperimentRun {
 
   meetingBriefings         MeetingBriefing[]
   meetingResourceLocations MeetingResourceLocation[]
+  userAgendaUploads        UserAgendaUpload[]
 
   @@index([organizationSlug, experimentType])
   @@index([status, resumeScheduledFor])

--- a/prisma/schema/migrations/20260605150356_add_user_agenda_upload/migration.sql
+++ b/prisma/schema/migrations/20260605150356_add_user_agenda_upload/migration.sql
@@ -1,0 +1,36 @@
+-- CreateEnum
+CREATE TYPE "UserAgendaSource" AS ENUM ('URL', 'UPLOAD');
+
+-- CreateTable
+CREATE TABLE "user_agenda_upload" (
+    "id" TEXT NOT NULL,
+    "elected_office_id" TEXT NOT NULL,
+    "meeting_date" DATE NOT NULL,
+    "source" "UserAgendaSource" NOT NULL,
+    "source_url" TEXT,
+    "upload_bucket" TEXT,
+    "upload_key" TEXT,
+    "content_type" TEXT,
+    "byte_size" INTEGER,
+    "uploaded_by_user_id" INTEGER NOT NULL,
+    "experiment_run_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_agenda_upload_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_agenda_upload_uploaded_by_user_id_idx" ON "user_agenda_upload"("uploaded_by_user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_agenda_upload_elected_office_id_meeting_date_key" ON "user_agenda_upload"("elected_office_id", "meeting_date");
+
+-- AddForeignKey
+ALTER TABLE "user_agenda_upload" ADD CONSTRAINT "user_agenda_upload_elected_office_id_fkey" FOREIGN KEY ("elected_office_id") REFERENCES "elected_office"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_agenda_upload" ADD CONSTRAINT "user_agenda_upload_uploaded_by_user_id_fkey" FOREIGN KEY ("uploaded_by_user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_agenda_upload" ADD CONSTRAINT "user_agenda_upload_experiment_run_id_fkey" FOREIGN KEY ("experiment_run_id") REFERENCES "experiment_run"("run_id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -32,6 +32,7 @@ model User {
   annotations           Annotation[]
   chatConversations     ChatConversation[]
   artifactFeedbacks     ArtifactFeedback[]
+  userAgendaUploads     UserAgendaUpload[]
 
   @@index([firstName])
   @@index([lastName])

--- a/prisma/schema/userAgendaUpload.prisma
+++ b/prisma/schema/userAgendaUpload.prisma
@@ -1,0 +1,33 @@
+enum UserAgendaSource {
+  URL
+  UPLOAD
+}
+
+model UserAgendaUpload {
+  id String @id @default(uuid(7))
+
+  electedOfficeId String        @map("elected_office_id")
+  electedOffice   ElectedOffice @relation(fields: [electedOfficeId], references: [id], onDelete: Cascade)
+
+  meetingDate DateTime @map("meeting_date") @db.Date
+
+  source       UserAgendaSource
+  sourceUrl    String?          @map("source_url")
+  uploadBucket String?          @map("upload_bucket")
+  uploadKey    String?          @map("upload_key")
+  contentType  String?          @map("content_type")
+  byteSize     Int?             @map("byte_size")
+
+  uploadedByUserId Int  @map("uploaded_by_user_id")
+  uploadedByUser   User @relation(fields: [uploadedByUserId], references: [id], onDelete: Restrict)
+
+  experimentRunId String?        @map("experiment_run_id")
+  experimentRun   ExperimentRun? @relation(fields: [experimentRunId], references: [runId], onDelete: SetNull)
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([electedOfficeId, meetingDate])
+  @@index([uploadedByUserId])
+  @@map("user_agenda_upload")
+}

--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -7,11 +7,13 @@ import {
   Post,
 } from '@nestjs/common'
 import { ZodValidationPipe } from 'nestjs-zod'
-import { ElectedOffice } from '../../generated/prisma'
+import { ElectedOffice, User } from '../../generated/prisma'
 import { addMonths, subDays } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
 import { ReqElectedOffice } from '@/electedOffice/decorators/ReqElectedOffice.decorator'
 import { UseElectedOffice } from '@/electedOffice/decorators/UseElectedOffice.decorator'
+import { ReqUser } from '@/authentication/decorators/ReqUser.decorator'
+import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
 import { S3Service } from '@/vendors/aws/services/s3.service'
 import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import {
@@ -22,7 +24,18 @@ import {
   DispatchMeetingAgentDto,
   DispatchMeetingAgentSchema,
 } from '../schemas/dispatchMeetingAgent.schema'
+import {
+  UserAgendaFinalizeRequest,
+  UserAgendaFinalizeRequestSchema,
+  UserAgendaFinalizeResponseSchema,
+  UserAgendaPresignRequest,
+  UserAgendaPresignRequestSchema,
+  UserAgendaPresignResponseSchema,
+} from '../schemas/userAgendaUpload.schema'
 import { MeetingBriefingsService } from '../services/meetingBriefings.service'
+import { UserAgendaUploadService } from '../services/userAgendaUpload.service'
+
+type UserAgendaStatus = 'processing' | 'failed' | 'completed' | 'unknown'
 
 type MeetingListItem = {
   meetingDate: string
@@ -32,12 +45,14 @@ type MeetingListItem = {
   meetingName: string
   location: string
   hasBriefing: boolean
+  userAgendaStatus: UserAgendaStatus | null
 }
 
 @Controller('meetings')
 export class MeetingsBriefingsController {
   constructor(
     private readonly meetingBriefings: MeetingBriefingsService,
+    private readonly userAgendaUploads: UserAgendaUploadService,
     private readonly s3: S3Service,
   ) {}
 
@@ -90,6 +105,7 @@ export class MeetingsBriefingsController {
           meetingName: knownSchedule.meeting_name,
           location: knownSchedule.location,
           hasBriefing: false,
+          userAgendaStatus: null,
         })
       }
     }
@@ -116,6 +132,43 @@ export class MeetingsBriefingsController {
           knownSchedule?.location ||
           '',
         hasBriefing: true,
+        userAgendaStatus: existing?.userAgendaStatus ?? null,
+      })
+    }
+
+    // Layer in user-agenda statuses last so the GET row reflects the latest
+    // user-upload state regardless of whether a briefing row exists yet
+    // (the briefing row appears only AFTER the dispatched run completes).
+    // The query is scoped to the same window as the meeting projection so
+    // upload rows for off-list dates (no projected schedule entry, no
+    // briefing row yet) still appear as their own list rows. Past-date
+    // uploads within the window are also surfaced — the presign/finalize
+    // endpoints accept any meetingDate, so a user who uploaded for a
+    // recent meeting must still see its status (otherwise their submission
+    // silently disappears from the list).
+    const userAgendaStatuses =
+      await this.userAgendaUploads.getStatusForMeetings(electedOffice.id, {
+        from: windowFrom,
+        to: windowTo,
+      })
+    for (const [date, status] of userAgendaStatuses) {
+      const existing = byDate.get(date)
+      if (existing) {
+        byDate.set(date, { ...existing, userAgendaStatus: status })
+        continue
+      }
+      // Off-list date: user uploaded an agenda for a meeting we don't have a
+      // schedule entry or briefing row for. Surface as a row so the agenda is
+      // visible — fill the schedule-only fields with placeholders.
+      byDate.set(date, {
+        meetingDate: date,
+        meetingTime: '',
+        meetingTimezone: '',
+        durationMinutes: 0,
+        meetingName: '',
+        location: '',
+        hasBriefing: false,
+        userAgendaStatus: status,
       })
     }
 
@@ -187,5 +240,50 @@ export class MeetingsBriefingsController {
       )
     }
     return { dispatched: true, kind: body.kind }
+  }
+
+  /**
+   * Step 1 of user-supplied agenda upload: returns a presigned S3 PUT URL
+   * the browser uses to upload the PDF directly to the agent-run-inputs
+   * bucket. No DB row is created here — finalizeUserAgenda creates the row
+   * after the upload completes.
+   */
+  @UseElectedOffice()
+  @Post(':date/briefing/agenda/presign')
+  @ResponseSchema(UserAgendaPresignResponseSchema)
+  async presignUserAgenda(
+    @ReqElectedOffice() electedOffice: ElectedOffice,
+    @Param(new ZodValidationPipe(MeetingDateParamSchema))
+    { date }: MeetingDateParam,
+    @Body(new ZodValidationPipe(UserAgendaPresignRequestSchema))
+    body: UserAgendaPresignRequest,
+  ) {
+    return this.userAgendaUploads.createUploadPresign(electedOffice, date, body)
+  }
+
+  /**
+   * Step 2 of user-supplied agenda upload (or sole step for URL paste):
+   * persists the upload metadata and dispatches a fresh briefing run with
+   * `agendaPacketUrl` set.
+   */
+  @UseElectedOffice()
+  @Post(':date/briefing/agenda')
+  @ResponseSchema(UserAgendaFinalizeResponseSchema)
+  async finalizeUserAgenda(
+    @ReqElectedOffice() electedOffice: ElectedOffice,
+    @ReqUser() user: User,
+    @Param(new ZodValidationPipe(MeetingDateParamSchema))
+    { date }: MeetingDateParam,
+    @Body(new ZodValidationPipe(UserAgendaFinalizeRequestSchema))
+    body: UserAgendaFinalizeRequest,
+  ) {
+    const { experimentRunId } =
+      await this.userAgendaUploads.finalizeAndDispatch(
+        electedOffice,
+        user.id,
+        date,
+        body,
+      )
+    return { experimentRunId, status: 'processing' as const }
   }
 }

--- a/src/meetings/meetings.module.ts
+++ b/src/meetings/meetings.module.ts
@@ -11,6 +11,7 @@ import { BriefingsPdfRateLimitGuard } from './controllers/briefingsPdfRateLimit.
 import { MeetingsBriefingsController } from './controllers/meetingsBriefings.controller'
 import { BriefingPdfService } from './services/briefingPdf.service'
 import { MeetingBriefingsService } from './services/meetingBriefings.service'
+import { UserAgendaUploadService } from './services/userAgendaUpload.service'
 
 @Module({
   imports: [
@@ -25,9 +26,10 @@ import { MeetingBriefingsService } from './services/meetingBriefings.service'
   controllers: [MeetingsBriefingsController, BriefingsPdfController],
   providers: [
     MeetingBriefingsService,
+    UserAgendaUploadService,
     BriefingPdfService,
     BriefingsPdfRateLimitGuard,
   ],
-  exports: [MeetingBriefingsService],
+  exports: [MeetingBriefingsService, UserAgendaUploadService],
 })
 export class MeetingsModule {}

--- a/src/meetings/schemas/userAgendaUpload.schema.ts
+++ b/src/meetings/schemas/userAgendaUpload.schema.ts
@@ -1,0 +1,66 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+export const USER_AGENDA_MAX_BYTES = 75 * 1024 * 1024 // 75 MB
+
+const ALLOWED_CONTENT_TYPES = ['application/pdf'] as const
+
+export const UserAgendaPresignRequestSchema = z.object({
+  contentType: z.enum(ALLOWED_CONTENT_TYPES),
+  byteSize: z
+    .number()
+    .int()
+    .positive()
+    .max(USER_AGENDA_MAX_BYTES, {
+      message: `byteSize exceeds ${USER_AGENDA_MAX_BYTES} (75 MB)`,
+    }),
+})
+export type UserAgendaPresignRequest = z.infer<
+  typeof UserAgendaPresignRequestSchema
+>
+export class UserAgendaPresignRequestDto extends createZodDto(
+  UserAgendaPresignRequestSchema,
+) {}
+
+export const UserAgendaPresignResponseSchema = z.object({
+  uploadId: z.string(),
+  uploadKey: z.string(),
+  uploadUrl: z.string().url(),
+  expiresAt: z.string().datetime(),
+})
+
+/**
+ * The finalize endpoint takes EITHER a pasted URL OR a completed S3 upload —
+ * never both. discriminatedUnion enforces this at the schema level.
+ *
+ * Note: no `createZodDto` wrapper because nestjs-zod's DTO base requires a
+ * single ZodObject; a discriminated union doesn't fit that constraint.
+ * Controllers consume this via `@Body(new ZodValidationPipe(Schema)) body: Type`.
+ */
+export const UserAgendaFinalizeRequestSchema = z.discriminatedUnion('source', [
+  z
+    .object({
+      source: z.literal('URL'),
+      sourceUrl: z.string().url().max(2048),
+    })
+    .strict(),
+  z
+    .object({
+      source: z.literal('UPLOAD'),
+      // uploadId is the UUID returned by the presign endpoint. The server
+      // reconstructs the full S3 key from electedOffice.id + meetingDate +
+      // uploadId — never trust a client-supplied key, that's an IDOR vector.
+      // .strict() below rejects any extra field (e.g. a smuggled uploadKey)
+      // at the validation layer for fail-fast feedback.
+      uploadId: z.string().uuid(),
+    })
+    .strict(),
+])
+export type UserAgendaFinalizeRequest = z.infer<
+  typeof UserAgendaFinalizeRequestSchema
+>
+
+export const UserAgendaFinalizeResponseSchema = z.object({
+  experimentRunId: z.string(),
+  status: z.literal('processing'),
+})

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -1,4 +1,5 @@
 import {
+  ExperimentRun,
   ExperimentRunStatus,
   MeetingResourceLocationType,
 } from '../../generated/prisma'
@@ -499,6 +500,53 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
     expect(row).toBeNull()
   })
 
+  it('writes the row for agenda_provided_by_user even when meeting_time is empty', async () => {
+    const orgSlug = `eo-user-agenda-${Date.now()}`
+    await service.prisma.organization.create({
+      data: { slug: orgSlug, ownerId: service.user.id },
+    })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing.json',
+        params: { elected_office_id: eo.id },
+      },
+    })
+    mockS3({
+      'briefing.json': JSON.stringify({
+        briefing_status: 'agenda_provided_by_user',
+        meeting_date: '2026-06-08',
+        meeting_time: '',
+        meeting_timezone: '',
+        meeting_name: 'Special Session',
+      }),
+    })
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(briefingRun)
+
+    const row = await service.prisma.meetingBriefing.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: eo.id,
+          meetingDate: new Date('2026-06-08'),
+        },
+      },
+    })
+    expect(row).not.toBeNull()
+    expect(row?.meetingTime).toBe('')
+    expect(row?.meetingTimezone).toBe('')
+    expect(row?.experimentRunId).toBe(briefingRun.runId)
+    expect(row?.artifact?.meeting_name).toBe('Special Session')
+  })
+
   it('does not write a MeetingBriefing row for placeholder briefing_status (awaiting_agenda)', async () => {
     const orgSlug = `eo-awaiting-${Date.now()}`
     await service.prisma.organization.create({
@@ -967,7 +1015,7 @@ describe('MeetingBriefingsService.dispatchManual', () => {
     await seedScheduleForOrg(orgSlug)
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
+      .mockResolvedValue({ runId: 'manual-dispatch-run' } as ExperimentRun)
 
     const result = await service.app
       .get(MeetingBriefingsService)
@@ -1034,7 +1082,7 @@ describe('MeetingBriefingsService.dispatchManual', () => {
     await seedScheduleForOrg(orgSlug)
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
+      .mockResolvedValue({ runId: 'manual-dispatch-run' } as ExperimentRun)
 
     const result = await service.app
       .get(MeetingBriefingsService)
@@ -1073,7 +1121,7 @@ describe('MeetingBriefingsService.dispatchManual', () => {
     await seedScheduleForOrg(orgSlug)
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
+      .mockResolvedValue({ runId: 'manual-dispatch-run' } as ExperimentRun)
 
     const result = await service.app
       .get(MeetingBriefingsService)
@@ -1193,7 +1241,7 @@ describe('MeetingBriefingsService location hints', () => {
     await seedScheduleForOrg(orgSlug)
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
+      .mockResolvedValue({ runId: 'manual-dispatch-run' } as ExperimentRun)
 
     await service.app
       .get(MeetingBriefingsService)

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -456,8 +456,10 @@ export class MeetingBriefingsService extends createPrismaBase(
     )
     if (!target) return { dispatched: false }
 
-    await this.dispatchBriefing(ctx, target)
-    return { dispatched: true }
+    // dispatchBriefing returns undefined when the run wasn't enqueued (queue
+    // not configured); don't report success in that case.
+    const result = await this.dispatchBriefing(ctx, target)
+    return { dispatched: !!result }
   }
 
   async onExperimentRunCompleted(run: ExperimentRun): Promise<void> {
@@ -779,6 +781,48 @@ export class MeetingBriefingsService extends createPrismaBase(
     })
   }
 
+  // Resolve the (meetingTime, meetingTimezone) to persist. The platform path
+  // requires a valid HH:MM time and a timezone and returns null (skip the row)
+  // when either is malformed. The user-agenda path dispatches without those
+  // PARAMS — the meeting often isn't on any platform for the agent to read a
+  // time from (ad-hoc / small-jurisdiction meetings are the whole point of
+  // letting a user supply the packet) — so it persists with empty values
+  // rather than skipping. Blocking there would strand the user on a perpetual
+  // "processing" pill for exactly the meetings this feature targets.
+  private resolveMeetingTimeFields(
+    artifact: PrismaJson.MeetingBriefingArtifact,
+    userSuppliedAgenda: boolean,
+    runId: string,
+  ): { meetingTime: string; meetingTimezone: string } | null {
+    const rawTime =
+      typeof artifact.meeting_time === 'string' ? artifact.meeting_time : ''
+    const timeValid = /^([01][0-9]|2[0-3]):[0-5][0-9]$/.test(rawTime)
+    if (!timeValid && !userSuppliedAgenda) {
+      this.logger.error(
+        { runId, meetingTime: rawTime },
+        'meeting_briefing artifact has invalid meeting_time',
+      )
+      return null
+    }
+
+    const rawTimezone =
+      typeof artifact.meeting_timezone === 'string'
+        ? artifact.meeting_timezone
+        : ''
+    if (!rawTimezone && !userSuppliedAgenda) {
+      this.logger.error(
+        { runId },
+        'meeting_briefing artifact missing meeting_timezone',
+      )
+      return null
+    }
+
+    return {
+      meetingTime: timeValid ? rawTime : '',
+      meetingTimezone: rawTimezone,
+    }
+  }
+
   private async writeBriefingRowFromArtifact(
     run: ExperimentRun,
     electedOffice: { id: string; userId: number },
@@ -822,27 +866,13 @@ export class MeetingBriefingsService extends createPrismaBase(
       return
     }
 
-    const meetingTime =
-      typeof artifact.meeting_time === 'string' ? artifact.meeting_time : ''
-    if (!/^([01][0-9]|2[0-3]):[0-5][0-9]$/.test(meetingTime)) {
-      this.logger.error(
-        { runId: run.runId, meetingTime },
-        'meeting_briefing artifact has invalid meeting_time',
-      )
-      return
-    }
-
-    const meetingTimezone =
-      typeof artifact.meeting_timezone === 'string'
-        ? artifact.meeting_timezone
-        : ''
-    if (!meetingTimezone) {
-      this.logger.error(
-        { runId: run.runId },
-        'meeting_briefing artifact missing meeting_timezone',
-      )
-      return
-    }
+    const resolved = this.resolveMeetingTimeFields(
+      artifact,
+      briefingStatus === 'agenda_provided_by_user',
+      run.runId,
+    )
+    if (!resolved) return
+    const { meetingTime, meetingTimezone } = resolved
 
     const electedOfficeId = electedOffice.id
     await this.model.upsert({

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -8,7 +8,11 @@ import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import { getUserFullName } from '@/users/util/users.util'
 import { S3Service } from '@/vendors/aws/services/s3.service'
 import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
-import { Injectable } from '@nestjs/common'
+import {
+  BadGatewayException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
 import { Cron } from '@nestjs/schedule'
 import {
   ElectedOffice,
@@ -133,8 +137,8 @@ const IMMINENCE_WINDOW_DAYS = 5
 
 type TargetMeeting = {
   meetingDate: string // YYYY-MM-DD
-  meetingTime: string // HH:MM
-  meetingTimezone: string // IANA
+  meetingTime?: string // HH:MM (optional — user-supplied agenda path leaves it to the agent)
+  meetingTimezone?: string // IANA (optional — same reason)
 }
 
 @Injectable()
@@ -279,12 +283,22 @@ export class MeetingBriefingsService extends createPrismaBase(
   private async dispatchBriefing(
     ctx: DispatchContext,
     meeting: TargetMeeting,
-  ): Promise<void> {
+    options: {
+      // URL-paste path: user gave us a URL to an agenda. Travels in params as
+      // an ordinary string the agent reads + cites.
+      agendaPacketUrl?: string
+      // UPLOAD path: user uploaded a file. Travels in params under the
+      // reserved `_input_files` envelope key; the dispatch handler strips it
+      // out of params before agent validation/PARAMS_JSON and uses it to
+      // tell the runner to pre-fetch via the broker into /workspace/input/.
+      inputFiles?: Array<{ bucket: string; key: string; dest: string }>
+    } = {},
+  ): Promise<{ runId: string } | undefined> {
     const hint = await this.loadLocationHint(
       ctx.electedOfficeId,
       MeetingResourceLocationType.AGENDA,
     )
-    await this.experimentRuns.dispatchRun({
+    const run = await this.experimentRuns.dispatchRun({
       type: BRIEFING_EXPERIMENT_TYPE,
       organizationSlug: ctx.organizationSlug,
       clerkUserId: ctx.clerkUserId,
@@ -293,13 +307,74 @@ export class MeetingBriefingsService extends createPrismaBase(
         state: ctx.state,
         positionName: ctx.positionName,
         meetingDate: meeting.meetingDate,
-        meetingTime: meeting.meetingTime,
-        meetingTimezone: meeting.meetingTimezone,
+        ...(meeting.meetingTime ? { meetingTime: meeting.meetingTime } : {}),
+        ...(meeting.meetingTimezone
+          ? { meetingTimezone: meeting.meetingTimezone }
+          : {}),
         ...(ctx.l2DistrictType ? { l2DistrictType: ctx.l2DistrictType } : {}),
         ...(ctx.l2DistrictName ? { l2DistrictName: ctx.l2DistrictName } : {}),
         ...(hint ? { knownAgendaLocation: hint } : {}),
+        ...(options.agendaPacketUrl
+          ? { agendaPacketUrl: options.agendaPacketUrl }
+          : {}),
+        ...(options.inputFiles && options.inputFiles.length > 0
+          ? { _input_files: options.inputFiles }
+          : {}),
       },
     })
+    return run ? { runId: run.runId } : undefined
+  }
+
+  /**
+   * Public entry point for user-supplied agenda runs. Bypasses the imminence
+   * gate and the schedule lookup — the user is telling us "brief THIS meeting
+   * with THIS agenda." We still resolve the dispatch context (officialName,
+   * state, etc.) the normal way; the only PARAMS differences are
+   * `agendaPacketUrl` or `_input_files` set and `meetingTime`/`meetingTimezone`
+   * left to the agent to discover from the platform (we don't reliably know
+   * them for arbitrary user-supplied dates).
+   *
+   * Caller supplies exactly one of `agendaPacketUrl` (URL-paste path; user's
+   * own URL — never a presigned one) or `inputFiles` (UPLOAD path; runner
+   * pre-fetches via the broker before the agent boots). Not validated here:
+   * the caller is the upload service, which always sets exactly one.
+   */
+  async dispatchBriefingWithUserAgenda(args: {
+    electedOfficeId: string
+    meetingDate: string
+    agendaPacketUrl?: string
+    inputFiles?: Array<{ bucket: string; key: string; dest: string }>
+  }): Promise<{ runId: string }> {
+    const electedOffice = await this.client.electedOffice.findUnique({
+      where: { id: args.electedOfficeId },
+    })
+    if (!electedOffice) {
+      throw new NotFoundException(
+        `electedOffice not found: ${args.electedOfficeId}`,
+      )
+    }
+    const ctx = await this.resolveDispatchContext(electedOffice)
+    if (!ctx) {
+      throw new NotFoundException(
+        `could not resolve dispatch context for electedOffice ${args.electedOfficeId}`,
+      )
+    }
+    const result = await this.dispatchBriefing(
+      ctx,
+      { meetingDate: args.meetingDate },
+      {
+        ...(args.agendaPacketUrl
+          ? { agendaPacketUrl: args.agendaPacketUrl }
+          : {}),
+        ...(args.inputFiles ? { inputFiles: args.inputFiles } : {}),
+      },
+    )
+    if (!result) {
+      throw new BadGatewayException(
+        'dispatch queue not configured; briefing run was not enqueued',
+      )
+    }
+    return result
   }
 
   /**

--- a/src/meetings/services/userAgendaUpload.controller.test.ts
+++ b/src/meetings/services/userAgendaUpload.controller.test.ts
@@ -1,0 +1,542 @@
+import { randomUUID } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ExperimentRunStatus, UserAgendaSource } from '../../generated/prisma'
+import { useTestService } from '@/test-service'
+import { S3Service } from '@/vendors/aws/services/s3.service'
+import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
+import { OrganizationsService } from '@/organizations/services/organizations.service'
+
+const service = useTestService()
+
+const orgHeader = (slug: string) => ({
+  headers: { 'x-organization-slug': slug },
+})
+
+const seedOrgAndElectedOffice = async (orgSlug: string) => {
+  await service.prisma.organization.create({
+    data: { slug: orgSlug, ownerId: service.user.id },
+  })
+  await service.prisma.campaign.create({
+    data: {
+      userId: service.user.id,
+      slug: `test-campaign-${orgSlug}`,
+      organizationSlug: orgSlug,
+      details: {},
+    },
+  })
+  return service.prisma.electedOffice.create({
+    data: { organizationSlug: orgSlug, userId: service.user.id },
+  })
+}
+
+const mockS3 = (opts?: {
+  objectExists?: boolean
+  contentLength?: number | null
+}) => {
+  const s3 = service.app.get(S3Service)
+  const headResult: { contentLength: number | null } | null =
+    opts?.objectExists === false
+      ? null
+      : { contentLength: opts?.contentLength ?? 1024 }
+  return {
+    upload: vi
+      .spyOn(s3, 'getSignedUrlForUpload')
+      .mockResolvedValue('https://s3.example/upload-url'),
+    view: vi
+      .spyOn(s3, 'getSignedUrlForViewing')
+      .mockResolvedValue('https://s3.example/view-url'),
+    exists: vi
+      .spyOn(s3, 'objectExists')
+      .mockResolvedValue(opts?.objectExists ?? true),
+    head: vi.spyOn(s3, 'headObject').mockResolvedValue(headResult),
+  }
+}
+
+const mockResolveServeContext = () => {
+  vi.spyOn(
+    service.app.get(OrganizationsService),
+    'resolveServeContext',
+  ).mockResolvedValue({
+    state: 'MN',
+    positionName: 'City Council',
+  })
+}
+
+const mockDispatchRun = () => {
+  const runs = service.app.get(ExperimentRunsService)
+  return vi.spyOn(runs, 'dispatchRun').mockImplementation(
+    // dispatchRun normally creates the row, enqueues to SQS, returns the row.
+    // We bypass SQS by creating the row directly and returning it.
+    async (input) => {
+      const runId = `test-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      return service.prisma.experimentRun.create({
+        data: {
+          runId,
+          experimentType: input.type,
+          organizationSlug: input.organizationSlug,
+          status: ExperimentRunStatus.RUNNING,
+          params: input.params,
+        },
+      })
+    },
+  )
+}
+
+beforeEach(() => {
+  vi.stubEnv('AGENT_RUN_INPUTS_BUCKET', 'gp-agent-run-inputs-test')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('POST /v1/meetings/:date/briefing/agenda/presign', () => {
+  it('returns a signed PUT URL with uploadId and uploadKey', async () => {
+    const orgSlug = `presign-ok-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    const s3 = mockS3()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda/presign',
+      { contentType: 'application/pdf', byteSize: 1_048_576 },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(201)
+    expect(result.data).toMatchObject({
+      uploadUrl: 'https://s3.example/upload-url',
+    })
+    expect(typeof result.data.uploadId).toBe('string')
+    expect(result.data.uploadKey).toContain(
+      `agendas/${result.data.uploadKey.split('/')[1]}/2026-07-15/`,
+    )
+    expect(s3.upload).toHaveBeenCalledOnce()
+  })
+
+  it('rejects byteSize over the 75 MB cap', async () => {
+    const orgSlug = `presign-too-big-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    mockS3()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda/presign',
+      { contentType: 'application/pdf', byteSize: 80 * 1024 * 1024 },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('rejects non-PDF content types', async () => {
+    const orgSlug = `presign-bad-type-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    mockS3()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda/presign',
+      { contentType: 'image/png', byteSize: 1024 },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('does NOT create a UserAgendaUpload row at presign time', async () => {
+    const orgSlug = `presign-no-row-${Date.now()}`
+    const eo = await seedOrgAndElectedOffice(orgSlug)
+    mockS3()
+
+    await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda/presign',
+      { contentType: 'application/pdf', byteSize: 1024 },
+      orgHeader(orgSlug),
+    )
+
+    const rows = await service.prisma.userAgendaUpload.findMany({
+      where: { electedOfficeId: eo.id },
+    })
+    expect(rows).toHaveLength(0)
+  })
+})
+
+describe('POST /v1/meetings/:date/briefing/agenda — UPLOAD source', () => {
+  it('creates the row, dispatches a briefing run, returns experimentRunId', async () => {
+    const orgSlug = `finalize-upload-${Date.now()}`
+    const eo = await seedOrgAndElectedOffice(orgSlug)
+    mockResolveServeContext()
+    mockS3({ objectExists: true })
+    const dispatchSpy = mockDispatchRun()
+    const uploadId = randomUUID()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'UPLOAD', uploadId },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(201)
+    expect(result.data).toMatchObject({ status: 'processing' })
+    expect(typeof result.data.experimentRunId).toBe('string')
+
+    const row = await service.prisma.userAgendaUpload.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: eo.id,
+          meetingDate: new Date('2026-07-15'),
+        },
+      },
+    })
+    expect(row).toMatchObject({
+      source: UserAgendaSource.UPLOAD,
+      // Server reconstructs the key from electedOffice.id + meetingDate +
+      // uploadId — the client never supplies it.
+      uploadKey: `agendas/${eo.id}/2026-07-15/${uploadId}.pdf`,
+      experimentRunId: result.data.experimentRunId,
+    })
+    // UPLOAD path sends `_input_files` envelope refs (stripped from params
+    // by the dispatch handler before agent boot) — never `agendaPacketUrl`,
+    // which would otherwise be a presigned URL vulnerable to IAM rotation.
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'meeting_briefing',
+        params: expect.objectContaining({
+          meetingDate: '2026-07-15',
+          _input_files: [
+            {
+              bucket: 'gp-agent-run-inputs-test',
+              key: `agendas/${eo.id}/2026-07-15/${uploadId}.pdf`,
+              dest: 'agenda.pdf',
+            },
+          ],
+        }),
+      }),
+    )
+    const params = dispatchSpy.mock.calls[0][0].params as Record<
+      string,
+      unknown
+    >
+    expect(params).not.toHaveProperty('agendaPacketUrl')
+  })
+
+  it('rejects a non-UUID uploadId', async () => {
+    const orgSlug = `finalize-bad-uuid-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    mockS3()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'UPLOAD', uploadId: 'not-a-uuid' },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('rejects a client-supplied uploadKey (IDOR defense)', async () => {
+    // additionalProperties on the discriminated union schema means any extra
+    // fields the caller appends (including a cross-office uploadKey) are
+    // rejected at the validation layer. Locks the contract: the server is
+    // the only producer of the S3 key.
+    const orgSlug = `finalize-extra-key-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    mockS3()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      {
+        source: 'UPLOAD',
+        uploadId: randomUUID(),
+        uploadKey: 'agendas/victim-office/2026-07-15/leaked.pdf',
+      },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('returns 400 when the S3 object does not exist', async () => {
+    const orgSlug = `finalize-no-s3-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    mockResolveServeContext()
+    mockS3({ objectExists: false })
+    mockDispatchRun()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'UPLOAD', uploadId: randomUUID() },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('returns 400 when the actual S3 object size exceeds the 75 MB cap', async () => {
+    // Defense against a malformed client uploading a body larger than the
+    // presigned byteSize. The presign-time Zod cap covers the REQUESTED
+    // size; this finalize-time HEAD check covers the ACTUAL size.
+    const orgSlug = `finalize-too-large-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    mockResolveServeContext()
+    mockS3({ objectExists: true, contentLength: 80 * 1024 * 1024 })
+    const dispatchSpy = mockDispatchRun()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'UPLOAD', uploadId: randomUUID() },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+    // No dispatch — we rejected before reaching the dispatch step.
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('re-finalizing replaces the prior row and dispatches a new run', async () => {
+    const orgSlug = `finalize-reupload-${Date.now()}`
+    const eo = await seedOrgAndElectedOffice(orgSlug)
+    mockResolveServeContext()
+    mockS3({ objectExists: true })
+    mockDispatchRun()
+    const firstId = randomUUID()
+    const secondId = randomUUID()
+
+    const first = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'UPLOAD', uploadId: firstId },
+      orgHeader(orgSlug),
+    )
+    expect(first.status).toBe(201)
+
+    const second = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'UPLOAD', uploadId: secondId },
+      orgHeader(orgSlug),
+    )
+    expect(second.status).toBe(201)
+    expect(second.data.experimentRunId).not.toBe(first.data.experimentRunId)
+
+    const rows = await service.prisma.userAgendaUpload.findMany({
+      where: { electedOfficeId: eo.id },
+    })
+    expect(rows).toHaveLength(1)
+    expect(rows[0].uploadKey).toBe(
+      `agendas/${eo.id}/2026-07-15/${secondId}.pdf`,
+    )
+    expect(rows[0].experimentRunId).toBe(second.data.experimentRunId)
+  })
+})
+
+describe('POST /v1/meetings/:date/briefing/agenda — URL source', () => {
+  // Note: this endpoint deliberately does NOT HEAD-check the user-supplied
+  // URL. SSRF defense lives at the broker's egress-restricted network where
+  // the agent actually fetches the URL at run-time, not at gp-api's network
+  // position. Bad URLs (404, non-PDF, oversize) surface as a FAILED agent
+  // run rather than an immediate 400, which getStatusForMeetings reports as
+  // `status='failed'` so the user can retry.
+
+  it('dispatches with sourceUrl as agendaPacketUrl; no HEAD check', async () => {
+    const orgSlug = `finalize-url-${Date.now()}`
+    const eo = await seedOrgAndElectedOffice(orgSlug)
+    mockResolveServeContext()
+    mockS3()
+    const dispatchSpy = mockDispatchRun()
+    const fetchSpy = vi.spyOn(global, 'fetch')
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      {
+        source: 'URL',
+        sourceUrl: 'https://example.gov/agendas/2026-07-15-packet.pdf',
+      },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(201)
+    // Critical: gp-api must NOT fetch the user-supplied URL itself. SSRF
+    // defense lives at the broker. fetchSpy catches background calls
+    // (Clerk, etc.), so filter by URL to assert only the user URL wasn't hit.
+    const calledWithUserUrl = fetchSpy.mock.calls.some((call) => {
+      const arg0 = call[0]
+      const requestUrl =
+        typeof arg0 === 'string'
+          ? arg0
+          : arg0 instanceof URL
+            ? arg0.toString()
+            : ''
+      return requestUrl.startsWith('https://example.gov/')
+    })
+    expect(calledWithUserUrl).toBe(false)
+
+    const row = await service.prisma.userAgendaUpload.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: eo.id,
+          meetingDate: new Date('2026-07-15'),
+        },
+      },
+    })
+    expect(row).toMatchObject({
+      source: UserAgendaSource.URL,
+      sourceUrl: 'https://example.gov/agendas/2026-07-15-packet.pdf',
+      // contentType/byteSize stay null for URL source — without HEADing the
+      // URL we don't know them, and we intentionally don't fetch.
+      contentType: null,
+      byteSize: null,
+    })
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          agendaPacketUrl: 'https://example.gov/agendas/2026-07-15-packet.pdf',
+        }),
+      }),
+    )
+    // URL paste path passes the user's own URL through; the envelope-strip
+    // `_input_files` key belongs to the UPLOAD path and must not appear here.
+    const params = dispatchSpy.mock.calls[0][0].params as Record<
+      string,
+      unknown
+    >
+    expect(params).not.toHaveProperty('_input_files')
+  })
+
+  it('rejects a non-URL string at the Zod boundary', async () => {
+    const orgSlug = `finalize-url-malformed-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'URL', sourceUrl: 'not-a-url' },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('rejects an oversized URL at the Zod boundary', async () => {
+    const orgSlug = `finalize-url-toolong-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      {
+        source: 'URL',
+        sourceUrl: 'https://example.gov/' + 'a'.repeat(2100),
+      },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+})
+
+describe('GET /v1/meetings userAgendaStatus derivation', () => {
+  it('returns null userAgendaStatus when no upload exists', async () => {
+    const orgSlug = `gm-no-upload-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    // Seed a schedule so the date appears in the meetings list at all.
+    const scheduleRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_schedule',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'schedule-bucket',
+        artifactKey: 'schedule.json',
+      },
+    })
+    vi.spyOn(service.app.get(S3Service), 'getFile').mockResolvedValue(
+      JSON.stringify({
+        status: 'found',
+        rrule: 'FREQ=DAILY',
+        time: '19:00',
+        timezone: 'America/Chicago',
+        duration_minutes: 120,
+        meeting_name: 'City Council',
+        location: 'Council Chambers',
+        sources: [],
+        generated_at: new Date().toISOString(),
+        human: 'Daily',
+      }),
+    )
+    expect(scheduleRun.runId).toBeTruthy()
+
+    const result = await service.client.get('/v1/meetings', orgHeader(orgSlug))
+    expect(result.status).toBe(200)
+    for (const meeting of result.data.meetings) {
+      expect(meeting.userAgendaStatus).toBeNull()
+    }
+  })
+
+  it('surfaces processing/failed/completed from the linked ExperimentRun', async () => {
+    const orgSlug = `gm-statuses-${Date.now()}`
+    const eo = await seedOrgAndElectedOffice(orgSlug)
+    // Schedule (FREQ=DAILY so several dates are projected)
+    await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_schedule',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'schedule-bucket',
+        artifactKey: 'schedule.json',
+      },
+    })
+    vi.spyOn(service.app.get(S3Service), 'getFile').mockResolvedValue(
+      JSON.stringify({
+        status: 'found',
+        rrule: 'FREQ=DAILY',
+        time: '19:00',
+        timezone: 'America/Chicago',
+        duration_minutes: 120,
+        meeting_name: 'City Council',
+        location: 'Council Chambers',
+        sources: [],
+        generated_at: new Date().toISOString(),
+        human: 'Daily',
+      }),
+    )
+
+    // Three upload rows linked to runs at three different statuses.
+    const today = new Date()
+    const inDays = (n: number) => {
+      const d = new Date(today)
+      d.setUTCDate(d.getUTCDate() + n)
+      d.setUTCHours(0, 0, 0, 0)
+      return d
+    }
+    const seedUpload = async (date: Date, runStatus: ExperimentRunStatus) => {
+      const run = await service.prisma.experimentRun.create({
+        data: {
+          organizationSlug: orgSlug,
+          experimentType: 'meeting_briefing',
+          status: runStatus,
+        },
+      })
+      await service.prisma.userAgendaUpload.create({
+        data: {
+          electedOfficeId: eo.id,
+          meetingDate: date,
+          source: UserAgendaSource.UPLOAD,
+          uploadBucket: 'gp-agent-run-inputs-test',
+          uploadKey: `agendas/${eo.id}/x.pdf`,
+          uploadedByUserId: service.user.id,
+          experimentRunId: run.runId,
+        },
+      })
+      return run.runId
+    }
+    await seedUpload(inDays(1), ExperimentRunStatus.RUNNING)
+    await seedUpload(inDays(2), ExperimentRunStatus.FAILED)
+    await seedUpload(inDays(3), ExperimentRunStatus.COMPLETED)
+
+    const result = await service.client.get('/v1/meetings', orgHeader(orgSlug))
+    expect(result.status).toBe(200)
+
+    const byDate = new Map<string, string | null>()
+    for (const m of result.data.meetings) {
+      byDate.set(m.meetingDate, m.userAgendaStatus)
+    }
+    const iso = (d: Date) => d.toISOString().slice(0, 10)
+    expect(byDate.get(iso(inDays(1)))).toBe('processing')
+    expect(byDate.get(iso(inDays(2)))).toBe('failed')
+    expect(byDate.get(iso(inDays(3)))).toBe('completed')
+  })
+})

--- a/src/meetings/services/userAgendaUpload.service.ts
+++ b/src/meetings/services/userAgendaUpload.service.ts
@@ -1,0 +1,324 @@
+import { randomUUID } from 'node:crypto'
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common'
+import { ElectedOffice, UserAgendaSource } from '../../generated/prisma'
+import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
+import { S3Service } from '@/vendors/aws/services/s3.service'
+import { parseIsoDateAsUTC } from '@/shared/util/date.util'
+import {
+  USER_AGENDA_MAX_BYTES,
+  UserAgendaFinalizeRequest,
+  UserAgendaPresignRequest,
+} from '../schemas/userAgendaUpload.schema'
+import { MeetingBriefingsService } from './meetingBriefings.service'
+
+const PRESIGN_PUT_EXPIRES_IN = 60 * 15 // 15 min — upload itself
+
+// Canonical workspace path the agent reads. The runner pre-fetches each
+// authorized input file under /workspace/input/<dest>; instruction.md tells
+// the agent to read from that path. Hardcoded because meeting_briefing has
+// exactly one user-supplied input (the agenda).
+const AGENDA_WORKSPACE_DEST = 'agenda.pdf'
+
+@Injectable()
+export class UserAgendaUploadService extends createPrismaBase(
+  MODELS.UserAgendaUpload,
+) {
+  constructor(
+    private readonly s3: S3Service,
+    private readonly meetings: MeetingBriefingsService,
+  ) {
+    super()
+  }
+
+  private get bucket(): string {
+    const bucket = process.env.AGENT_RUN_INPUTS_BUCKET
+    if (!bucket) {
+      throw new InternalServerErrorException(
+        'AGENT_RUN_INPUTS_BUCKET is not configured',
+      )
+    }
+    return bucket
+  }
+
+  private buildUploadKey(
+    electedOfficeId: string,
+    meetingDate: string,
+    uploadId: string,
+  ): string {
+    return `agendas/${electedOfficeId}/${meetingDate}/${uploadId}.pdf`
+  }
+
+  /**
+   * Returns a presigned PUT URL for the browser to upload directly to S3.
+   * The row is created on finalize, not here — an abandoned presign leaves
+   * no DB row (only an orphan S3 object, which lifecycle cleans up).
+   */
+  async createUploadPresign(
+    electedOffice: ElectedOffice,
+    meetingDate: string,
+    input: UserAgendaPresignRequest,
+  ): Promise<{
+    uploadId: string
+    uploadKey: string
+    uploadUrl: string
+    expiresAt: string
+  }> {
+    // Defense in depth — Zod already caps byteSize, but keep the runtime
+    // assertion in case the schema relaxes.
+    if (input.byteSize > USER_AGENDA_MAX_BYTES) {
+      throw new BadRequestException('file_too_large')
+    }
+
+    const uploadId = randomUUID()
+    const uploadKey = this.buildUploadKey(
+      electedOffice.id,
+      meetingDate,
+      uploadId,
+    )
+
+    const uploadUrl = await this.s3.getSignedUrlForUpload(
+      this.bucket,
+      uploadKey,
+      {
+        expiresIn: PRESIGN_PUT_EXPIRES_IN,
+        contentType: input.contentType,
+      },
+    )
+
+    return {
+      uploadId,
+      uploadKey,
+      uploadUrl,
+      expiresAt: new Date(
+        Date.now() + PRESIGN_PUT_EXPIRES_IN * 1000,
+      ).toISOString(),
+    }
+  }
+
+  /**
+   * Persists the upload metadata (URL paste or completed S3 upload) and
+   * dispatches a fresh briefing run. The dispatch carries either
+   * `agendaPacketUrl` (URL paste; agent fetches the user's own URL via the
+   * broker proxy) or `_input_files` envelope refs (UPLOAD; the runner
+   * pre-fetches via broker /inputs/read and writes to /workspace/input/
+   * before the agent boots). The previous run's MeetingBriefing row (if any)
+   * is left in place and gets overwritten by the existing upsert path when
+   * the new run completes.
+   *
+   * Idempotent on (electedOfficeId, meetingDate) — re-finalizing replaces
+   * the prior upload row and dispatches a new run.
+   *
+   * NOTE: the URL-paste path does not HEAD-check the user-supplied URL.
+   * SSRF defense lives at the broker — the broker is the actual fetcher
+   * at agent-run time and runs in an egress-restricted network. Doing the
+   * pre-flight check at gp-api duplicated that defense in a less-secure
+   * network position. Bad URLs surface as a FAILED agent run, which
+   * `getStatusForMeetings` reports as `status='failed'` so the user can
+   * retry by re-uploading.
+   */
+  async finalizeAndDispatch(
+    electedOffice: ElectedOffice,
+    userId: number,
+    meetingDate: string,
+    input: UserAgendaFinalizeRequest,
+  ): Promise<{ experimentRunId: string }> {
+    const meetingDateUtc = parseIsoDateAsUTC(meetingDate)
+
+    let source: UserAgendaSource
+    let sourceUrl: string | null = null
+    let uploadBucket: string | null = null
+    let uploadKey: string | null = null
+    let contentType: string | null = null
+    let byteSize: number | null = null
+
+    if (input.source === 'URL') {
+      // No HEAD pre-flight — see method docstring. contentType/byteSize stay
+      // null for URL source; we don't know them without fetching, and we
+      // intentionally don't fetch.
+      source = UserAgendaSource.URL
+      sourceUrl = input.sourceUrl
+    } else {
+      // UPLOAD — reconstruct the key server-side from trusted parts. Never
+      // accept a client-supplied key: doing so would let one office claim
+      // another office's S3 object (IDOR). The uploadId is the only piece
+      // the client controls, and it's a UUID the server minted at presign.
+      const reconstructedKey = this.buildUploadKey(
+        electedOffice.id,
+        meetingDate,
+        input.uploadId,
+      )
+      // HEAD the object to verify existence AND validate its actual size
+      // against the 75 MB cap. The Zod schema at presign time enforces a
+      // byteSize cap on the REQUESTED size, but presigned PUTs don't
+      // intrinsically restrict the uploaded body to the requested size — a
+      // malformed client could upload a 500 MB file using a presign issued
+      // for 1 MB. Re-checking ContentLength here closes that gap before
+      // we hand the object off to the agent.
+      const head = await this.s3.headObject(this.bucket, reconstructedKey)
+      if (!head) {
+        throw new BadRequestException('upload_not_received')
+      }
+      if (
+        head.contentLength !== null &&
+        head.contentLength > USER_AGENDA_MAX_BYTES
+      ) {
+        throw new BadRequestException({
+          error: 'upload_too_large',
+          message:
+            `Uploaded file exceeds ${USER_AGENDA_MAX_BYTES}-byte cap ` +
+            `(actual size=${head.contentLength})`,
+        })
+      }
+      source = UserAgendaSource.UPLOAD
+      uploadBucket = this.bucket
+      uploadKey = reconstructedKey
+      contentType = 'application/pdf'
+      byteSize = head.contentLength
+    }
+
+    // Persist the upload row BEFORE dispatching the run. If we dispatched
+    // first and then the upsert threw, the run would be live with no
+    // tracking row — invisible to GET /meetings and impossible to clean up
+    // on re-finalize. Upsert with a null run-id, dispatch, then patch the
+    // run-id back in.
+    const upload = await this.client.userAgendaUpload.upsert({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: electedOffice.id,
+          meetingDate: meetingDateUtc,
+        },
+      },
+      create: {
+        electedOfficeId: electedOffice.id,
+        meetingDate: meetingDateUtc,
+        source,
+        sourceUrl,
+        uploadBucket,
+        uploadKey,
+        contentType,
+        byteSize,
+        uploadedByUserId: userId,
+        experimentRunId: null,
+      },
+      update: {
+        source,
+        sourceUrl,
+        uploadBucket,
+        uploadKey,
+        contentType,
+        byteSize,
+        uploadedByUserId: userId,
+        experimentRunId: null,
+      },
+      select: { id: true },
+    })
+
+    const { runId } = await this.meetings.dispatchBriefingWithUserAgenda({
+      electedOfficeId: electedOffice.id,
+      meetingDate,
+      ...(source === UserAgendaSource.URL && sourceUrl
+        ? { agendaPacketUrl: sourceUrl }
+        : {}),
+      ...(source === UserAgendaSource.UPLOAD && uploadBucket && uploadKey
+        ? {
+            inputFiles: [
+              {
+                bucket: uploadBucket,
+                key: uploadKey,
+                dest: AGENDA_WORKSPACE_DEST,
+              },
+            ],
+          }
+        : {}),
+    })
+
+    // Conditional update: only set our runId if the row's experimentRunId
+    // is still null. A concurrent finalize call (same office + date) would
+    // have raced past us — its upsert ran AFTER ours, then it dispatched
+    // and patched the row first. In that case our run is orphan-but-bounded:
+    // it'll run to completion, FAILED, or AWAITING_RESUME timeout as normal,
+    // but won't be tracked by an upload row. We can't kill it from here
+    // (the agent's already in flight); log the orphan for observability
+    // and return the row's winning runId so the caller polls the right run.
+    const claim = await this.client.userAgendaUpload.updateMany({
+      where: { id: upload.id, experimentRunId: null },
+      data: { experimentRunId: runId },
+    })
+    if (claim.count === 0) {
+      const winner = await this.client.userAgendaUpload.findUnique({
+        where: { id: upload.id },
+        select: { experimentRunId: true },
+      })
+      this.logger.warn(
+        {
+          orphanedRunId: runId,
+          winningRunId: winner?.experimentRunId,
+          uploadId: upload.id,
+          electedOfficeId: electedOffice.id,
+          meetingDate,
+        },
+        'agenda finalize lost concurrency race; orphan run dispatched',
+      )
+      if (winner?.experimentRunId) {
+        return { experimentRunId: winner.experimentRunId }
+      }
+    }
+
+    return { experimentRunId: runId }
+  }
+
+  /**
+   * Surfaces a row-status string for GET /meetings consumers. Returns the
+   * map keyed by meeting date (YYYY-MM-DD) for every upload row in the window
+   * — including upload rows for meeting dates the caller didn't pre-list
+   * (off-list dates the user uploaded an agenda for despite there being no
+   * scheduled meeting / briefing row yet).
+   */
+  async getStatusForMeetings(
+    electedOfficeId: string,
+    window: { from: Date; to: Date },
+  ): Promise<Map<string, 'processing' | 'failed' | 'completed' | 'unknown'>> {
+    const rows = await this.client.userAgendaUpload.findMany({
+      where: {
+        electedOfficeId,
+        meetingDate: { gte: window.from, lte: window.to },
+      },
+      select: {
+        meetingDate: true,
+        experimentRunId: true,
+        experimentRun: { select: { status: true } },
+      },
+    })
+    const out = new Map<
+      string,
+      'processing' | 'failed' | 'completed' | 'unknown'
+    >()
+    for (const row of rows) {
+      const date = row.meetingDate.toISOString().slice(0, 10)
+      const runStatus = row.experimentRun?.status
+      if (runStatus === 'RUNNING' || runStatus === 'AWAITING_RESUME') {
+        out.set(date, 'processing')
+      } else if (runStatus === 'FAILED') {
+        out.set(date, 'failed')
+      } else if (runStatus === 'COMPLETED') {
+        out.set(date, 'completed')
+      } else if (row.experimentRunId === null) {
+        // Upload row exists with no run linked: dispatch failed (or is racing
+        // mid-finalize). From the user's POV the upload didn't kick off a
+        // briefing, so surface as `failed` rather than `unknown` — the modal
+        // re-opens for a retry. The brief window between row upsert and run
+        // linkage during a successful finalize is short; users seeing a
+        // momentary `failed` that flips to `processing` on next refresh is
+        // acceptable.
+        out.set(date, 'failed')
+      } else {
+        out.set(date, 'unknown')
+      }
+    }
+    return out
+  }
+}

--- a/src/vendors/aws/services/s3.service.ts
+++ b/src/vendors/aws/services/s3.service.ts
@@ -216,6 +216,31 @@ export class S3Service extends AwsService {
     }, 'objectExists')
   }
 
+  /**
+   * HEAD an object. Returns the object's metadata when present, null when
+   * absent. Useful for validating both existence AND properties (like size)
+   * in a single round-trip — callers that only need a boolean should use
+   * `objectExists` instead.
+   */
+  async headObject(
+    bucket: string,
+    key: string,
+  ): Promise<{ contentLength: number | null } | null> {
+    return this.executeAwsOperation(async () => {
+      try {
+        const { HeadObjectCommand } = await import('@aws-sdk/client-s3')
+        const response = await this.s3Client.send(
+          new HeadObjectCommand({ Bucket: bucket, Key: key }),
+        )
+        return { contentLength: response.ContentLength ?? null }
+      } catch (error: unknown) {
+        if (error instanceof NoSuchKey) return null
+        if (isHttpStatusError(error, 404)) return null
+        throw error
+      }
+    }, 'headObject')
+  }
+
   getFileUrl(
     bucket: string,
     key: string,


### PR DESCRIPTION
…ker pre-fetch dispatch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches experiment dispatch, user-controlled URLs/files, and S3 access patterns; mitigations include server-side key construction, strict Zod unions, and deferring URL fetch to the broker. Requires DB migration and correct `AGENT_RUN_INPUTS_BUCKET` in each environment.
> 
> **Overview**
> Adds **user-supplied agenda packets** for meeting briefings: officials can paste a URL or upload a PDF, which kicks off a `meeting_briefing` experiment run with that agenda.
> 
> **Infrastructure:** Deploy wires `AGENT_RUN_INPUTS_BUCKET` (`gp-agent-run-inputs-{env}`) for browser presigned PUTs and broker/runner reads.
> 
> **Data:** New `user_agenda_upload` table (one row per elected office + meeting date) linked to `ExperimentRun`, with `URL` vs `UPLOAD` source metadata.
> 
> **API:** `POST …/briefing/agenda/presign` (PDF only, 75 MB cap, no DB row until finalize) and `POST …/briefing/agenda` (URL or `uploadId` from presign). Upload finalize **rebuilds the S3 key server-side** from office id + date + UUID to block IDOR. **GET /meetings** gains `userAgendaStatus` (`processing` / `failed` / `completed`) and can show off-schedule dates when the user uploaded for a date not on the projected list.
> 
> **Dispatch:** `dispatchBriefingWithUserAgenda` skips the imminence gate; runs pass either `agendaPacketUrl` (URL — **no fetch at gp-api**, SSRF handled at broker) or `_input_files` for broker pre-fetch of the uploaded object. Re-finalize upserts the upload row and dispatches a new run.
> 
> **Tests:** Integration coverage for presign/finalize validation, dispatch params, and list status derivation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22c9a6a7cd02c31238acef23acfeef0fd87081d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->