### PR TITLE
ENG-10323: fire compliance_setup dispatch on payment success, not on submit

### DIFF
--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -49,6 +49,7 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
     delete: ReturnType<typeof vi.fn>
     deleteMany: ReturnType<typeof vi.fn>
     update: ReturnType<typeof vi.fn>
+    updateMany: ReturnType<typeof vi.fn>
   }
   let mockPrisma: {
     tcrCompliance: typeof mockModel
@@ -56,9 +57,12 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
   }
 
   const user = createMockUser({ clerkId: 'user_clerk_abc' })
+  // isPro: true — these cases exercise the already-Pro path, where the kickoff
+  // is enqueued immediately on submit (pro-upgrade1, post-payment resubmit).
   const campaign = createMockCampaign({
     userId: user.id,
     formattedAddress: '123 Main St',
+    isPro: true,
   })
 
   const basePayload = {
@@ -98,6 +102,7 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
       delete: vi.fn().mockResolvedValue(undefined),
       deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
       update: vi.fn().mockResolvedValue(undefined),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
     }
     mockPrisma = {
       tcrCompliance: mockModel,
@@ -170,13 +175,21 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
     })
   })
 
-  it('stamps kickoffSentAt after a successful kickoff send', async () => {
+  it('claims kickoffSentAt atomically before sending the kickoff', async () => {
     await service.createAgentic(user, campaign, basePayload)
 
-    expect(mockModel.update).toHaveBeenCalledWith({
-      where: { id: 'tcr-new' },
+    expect(mockModel.updateMany).toHaveBeenCalledWith({
+      where: { id: 'tcr-new', kickoffSentAt: null },
       data: { kickoffSentAt: expect.any(Date) },
     })
+  })
+
+  it('does not enqueue a second kickoff when the claim is already taken', async () => {
+    mockModel.updateMany.mockResolvedValueOnce({ count: 0 })
+
+    await service.createAgentic(user, campaign, basePayload)
+
+    expect(mockQueue.sendMessage).not.toHaveBeenCalled()
   })
 
   it('marks the record error and re-throws if SQS sendMessage fails', async () => {
@@ -187,6 +200,11 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
       service.createAgentic(user, campaign, basePayload),
     ).rejects.toBe(sqsErr)
 
+    // Claim is rolled back (kickoffSentAt back to null) so the sweep can retry
+    expect(mockModel.updateMany).toHaveBeenCalledWith({
+      where: { id: 'tcr-new', kickoffSentAt: expect.any(Date) },
+      data: { kickoffSentAt: null },
+    })
     expect(mockModel.update).toHaveBeenCalledWith({
       where: { id: 'tcr-new' },
       data: { status: TcrComplianceStatus.error },
@@ -388,6 +406,85 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
     await expect(
       service.createAgentic(userWithoutClerk, campaign, basePayload),
     ).rejects.toThrow(BadRequestException)
+  })
+
+  it('persists the record but defers the kickoff when the campaign is not Pro', async () => {
+    const nonProCampaign = createMockCampaign({
+      userId: user.id,
+      formattedAddress: '123 Main St',
+      isPro: false,
+    })
+
+    const result = await service.createAgentic(
+      user,
+      nonProCampaign,
+      basePayload,
+    )
+
+    expect(result.created).toBe(true)
+    expect(mockModel.create).toHaveBeenCalledTimes(1)
+    expect(mockModel.updateMany).not.toHaveBeenCalled()
+    expect(mockQueue.sendMessage).not.toHaveBeenCalled()
+  })
+
+  describe('enqueueAgenticKickoffIfNeeded', () => {
+    const paidRecord = {
+      id: 'tcr-paid',
+      campaignId: campaign.id,
+      kickoffSentAt: null,
+    }
+    const campaignWithClerk = { ...campaign, user: { clerkId: 'clerk_paid' } }
+
+    it('enqueues exactly one kickoff after payment for a deferred record', async () => {
+      mockModel.findUnique.mockResolvedValueOnce(paidRecord)
+      mockCampaigns.findUnique.mockResolvedValueOnce(campaignWithClerk)
+
+      await service.enqueueAgenticKickoffIfNeeded(campaign.id)
+
+      expect(mockModel.updateMany).toHaveBeenCalledWith({
+        where: { id: 'tcr-paid', kickoffSentAt: null },
+        data: { kickoffSentAt: expect.any(Date) },
+      })
+      expect(mockQueue.sendMessage).toHaveBeenCalledTimes(1)
+      const [message] = mockQueue.sendMessage.mock.calls[0]
+      expect(message.data).toEqual({
+        campaignId: campaign.id,
+        tcrComplianceId: 'tcr-paid',
+        clerkUserId: 'clerk_paid',
+      })
+    })
+
+    it('does not enqueue a second kickoff when the claim is already taken (replay)', async () => {
+      mockModel.findUnique.mockResolvedValueOnce(paidRecord)
+      mockCampaigns.findUnique.mockResolvedValueOnce(campaignWithClerk)
+      mockModel.updateMany.mockResolvedValueOnce({ count: 0 })
+
+      await service.enqueueAgenticKickoffIfNeeded(campaign.id)
+
+      expect(mockQueue.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when no TCR record exists yet (paid before filing)', async () => {
+      mockModel.findUnique.mockResolvedValueOnce(null)
+
+      await service.enqueueAgenticKickoffIfNeeded(campaign.id)
+
+      expect(mockModel.updateMany).not.toHaveBeenCalled()
+      expect(mockQueue.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when the campaign has no Clerk user', async () => {
+      mockModel.findUnique.mockResolvedValueOnce(paidRecord)
+      mockCampaigns.findUnique.mockResolvedValueOnce({
+        ...campaign,
+        user: { clerkId: null },
+      })
+
+      await service.enqueueAgenticKickoffIfNeeded(campaign.id)
+
+      expect(mockModel.updateMany).not.toHaveBeenCalled()
+      expect(mockQueue.sendMessage).not.toHaveBeenCalled()
+    })
   })
 
   describe('sweepStrandedAgenticKickoffs', () => {

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -513,6 +513,7 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
             peerlyIdentityId: null,
             kickoffSentAt: null,
             createdAt: { lt: expect.any(Date) },
+            campaign: { isPro: true },
           },
         }),
       )
@@ -593,6 +594,18 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
 
       expect(mockQueue.sendMessage).not.toHaveBeenCalled()
       expect(mockModel.update).not.toHaveBeenCalled()
+    })
+
+    it('only sweeps Pro campaigns so pre-payment submissions are not dispatched', async () => {
+      mockModel.findMany.mockResolvedValueOnce([])
+
+      await sweep(service)
+
+      expect(mockModel.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ campaign: { isPro: true } }),
+        }),
+      )
     })
   })
 })

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -104,6 +104,10 @@ export class CampaignTcrComplianceService extends createPrismaBase(
         peerlyIdentityId: null,
         kickoffSentAt: null,
         createdAt: { lt: cutoff },
+        // Pre-payment (pro-upgrade3) submissions intentionally sit with
+        // kickoffSentAt null until payment; only sweep campaigns that are
+        // already Pro so the agent never runs before the candidate pays.
+        campaign: { isPro: true },
       },
       include: {
         campaign: { include: { user: true } },

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -675,41 +675,28 @@ export class CampaignTcrComplianceService extends createPrismaBase(
       throw err
     }
 
-    try {
-      await this.queueService.sendMessage(
-        {
-          type: QueueType.AGENTIC_COMPLIANCE_KICKOFF,
-          data: {
-            campaignId: campaign.id,
-            tcrComplianceId: record.id,
-            clerkUserId: user.clerkId,
-          },
-        },
-        `${MessageGroup.agenticComplianceKickoff}-${campaign.id}`,
-        {
-          deduplicationId: `agentic-compliance-${record.id}`,
-          throwOnError: true,
-        },
-      )
-    } catch (err) {
+    // Pre-payment (pro-upgrade3) submissions defer dispatch to the payment
+    // webhook so the agent never provisions a domain/site for an unpaid
+    // candidate. Already-Pro submissions (pro-upgrade1, post-payment
+    // resubmission) enqueue immediately, as before.
+    if (campaign.isPro) {
       try {
-        await this.model.update({
-          where: { id: record.id },
-          data: { status: TcrComplianceStatus.error },
-        })
-      } catch (updateErr) {
-        this.logger.error(
-          { updateErr, tcrComplianceId: record.id },
-          '[TCR Compliance] Failed to mark record as error after SQS send failure; sweep will recover',
-        )
+        await this.claimAndEnqueueKickoff(record, user.clerkId)
+      } catch (err) {
+        try {
+          await this.model.update({
+            where: { id: record.id },
+            data: { status: TcrComplianceStatus.error },
+          })
+        } catch (updateErr) {
+          this.logger.error(
+            { updateErr, tcrComplianceId: record.id },
+            '[TCR Compliance] Failed to mark record as error after SQS send failure; sweep will recover',
+          )
+        }
+        throw err
       }
-      throw err
     }
-
-    await this.model.update({
-      where: { id: record.id },
-      data: { kickoffSentAt: new Date() },
-    })
 
     try {
       await this.crmCampaignsService.trackCampaign(campaign.id)
@@ -725,6 +712,82 @@ export class CampaignTcrComplianceService extends createPrismaBase(
     )
 
     return { record, created: true }
+  }
+
+  // Webhook entry point: enqueue the compliance_setup kickoff for a campaign
+  // that has already submitted its TCR record but deferred dispatch until
+  // payment (pro-upgrade3). No-ops when no record exists yet (candidate paid
+  // before filing) — the eventual createAgentic submit will enqueue because
+  // the campaign is now Pro.
+  async enqueueAgenticKickoffIfNeeded(campaignId: number) {
+    const record = await this.fetchByCampaignId(campaignId)
+    if (!record) {
+      return
+    }
+
+    const campaign = await this.campaignsService.findUnique({
+      where: { id: campaignId },
+      include: { user: true },
+    })
+    const clerkUserId = campaign?.user?.clerkId
+    if (!clerkUserId) {
+      this.logger.error(
+        { campaignId, tcrComplianceId: record.id },
+        '[TCR Compliance] Cannot enqueue agentic kickoff: ' +
+          'campaign has no Clerk user',
+      )
+      return
+    }
+
+    await this.claimAndEnqueueKickoff(record, clerkUserId)
+  }
+
+  // Single source of the kickoff SQS message shape, shared by createAgentic
+  // (already-Pro submit) and the payment webhook. The atomic claim on
+  // kickoffSentAt is the idempotency guard: a webhook replay or a
+  // submit->pay->submit race finds it already set and short-circuits, so the
+  // agent is dispatched exactly once.
+  private async claimAndEnqueueKickoff(
+    record: TcrCompliance,
+    clerkUserId: string,
+  ) {
+    // Claim before the send so concurrent callers can't both enqueue. Only the
+    // caller that flips kickoffSentAt from null wins the claim.
+    const claimTimestamp = new Date()
+    const claim = await this.model.updateMany({
+      where: { id: record.id, kickoffSentAt: null },
+      data: { kickoffSentAt: claimTimestamp },
+    })
+    if (claim.count === 0) {
+      return
+    }
+
+    try {
+      await this.queueService.sendMessage(
+        {
+          type: QueueType.AGENTIC_COMPLIANCE_KICKOFF,
+          data: {
+            campaignId: record.campaignId,
+            tcrComplianceId: record.id,
+            clerkUserId,
+          },
+        },
+        `${MessageGroup.agenticComplianceKickoff}-${record.campaignId}`,
+        {
+          deduplicationId: `agentic-compliance-${record.id}`,
+          throwOnError: true,
+        },
+      )
+    } catch (err) {
+      // Roll back only this caller's claim by matching the exact timestamp we
+      // wrote, leaving kickoffSentAt null so the stranded-kickoff sweep can
+      // re-enqueue it.
+      await this.model.updateMany({
+        where: { id: record.id, kickoffSentAt: claimTimestamp },
+        data: { kickoffSentAt: null },
+      })
+      throw err
+    }
   }
 
   async handleAgenticKickoff(message: AgenticComplianceKickoffMessage) {

--- a/src/payments/services/paymentEventsService.test.ts
+++ b/src/payments/services/paymentEventsService.test.ts
@@ -30,6 +30,7 @@ describe('PaymentEventsService', () => {
     resolvePositionNameByOrganizationSlug: vi.fn(),
   }
   const crm = { getCrmCompanyOwnerName: vi.fn() }
+  const tcrComplianceService = { enqueueAgenticKickoffIfNeeded: vi.fn() }
 
   const mockUser = { id: 1, email: 'test@example.com' } as User
   const mockCampaign = {
@@ -65,6 +66,9 @@ describe('PaymentEventsService', () => {
     analytics.track.mockResolvedValue(undefined)
     slackService.message.mockResolvedValue(undefined)
     voterFileDownloadAccess.downloadAccessAlert.mockResolvedValue(undefined)
+    tcrComplianceService.enqueueAgenticKickoffIfNeeded.mockResolvedValue(
+      undefined,
+    )
 
     service = new PaymentEventsService(
       usersService as never,
@@ -77,6 +81,7 @@ describe('PaymentEventsService', () => {
       {} as never,
       analytics as never,
       {} as never,
+      tcrComplianceService as never,
       logger,
     )
   })
@@ -118,6 +123,38 @@ describe('PaymentEventsService', () => {
         EVENTS.Account.ProUpgradeComplete,
         { pro: true },
       )
+    })
+
+    it('enqueues the agentic kickoff after marking the campaign Pro', async () => {
+      await service.handleEvent(subscriptionEvent)
+
+      expect(campaignsService.setIsPro).toHaveBeenCalledWith(mockCampaign.id)
+      expect(
+        tcrComplianceService.enqueueAgenticKickoffIfNeeded,
+      ).toHaveBeenCalledExactlyOnceWith(mockCampaign.id)
+      expect(
+        campaignsService.setIsPro.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        tcrComplianceService.enqueueAgenticKickoffIfNeeded.mock
+          .invocationCallOrder[0],
+      )
+    })
+
+    it('does not fail the webhook when the kickoff enqueue throws', async () => {
+      const enqueueError = new Error('SQS down')
+      tcrComplianceService.enqueueAgenticKickoffIfNeeded.mockRejectedValueOnce(
+        enqueueError,
+      )
+
+      await expect(
+        service.handleEvent(subscriptionEvent),
+      ).resolves.not.toThrow()
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ error: enqueueError }),
+        expect.stringContaining('agentic compliance kickoff'),
+      )
+      expect(usersService.patchUserMetaData).toHaveBeenCalled()
     })
   })
 })

--- a/src/payments/services/paymentEventsService.ts
+++ b/src/payments/services/paymentEventsService.ts
@@ -27,6 +27,7 @@ import { EVENTS } from 'src/vendors/segment/segment.types'
 import { WrapperType } from 'src/shared/types/utility.types'
 import { PurchaseService } from './purchase.service'
 import { PinoLogger } from 'nestjs-pino'
+import { CampaignTcrComplianceService } from '../../campaigns/tcrCompliance/services/campaignTcrCompliance.service'
 
 const { STRIPE_WEBSOCKET_SECRET } = process.env
 if (!STRIPE_WEBSOCKET_SECRET) {
@@ -47,6 +48,7 @@ export class PaymentEventsService {
     private readonly analytics: AnalyticsService,
     @Inject(forwardRef(() => PurchaseService))
     private readonly purchaseService: WrapperType<PurchaseService>,
+    private readonly tcrComplianceService: CampaignTcrComplianceService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(PaymentEventsService.name)
@@ -255,6 +257,19 @@ export class PaymentEventsService {
       subscriptionId: subscriptionId as string,
     })
     await this.campaignsService.setIsPro(campaignId)
+
+    // Pre-payment (pro-upgrade3) submissions defer the compliance_setup agent
+    // kickoff to here. No-ops when the candidate has no TCR record yet or the
+    // kickoff was already enqueued. Best-effort: a failure here must not fail
+    // the webhook (the stranded-kickoff sweep recovers a rolled-back claim).
+    try {
+      await this.tcrComplianceService.enqueueAgenticKickoffIfNeeded(campaignId)
+    } catch (error) {
+      this.logger.error(
+        { error },
+        `[WEBHOOK] Failed to enqueue agentic compliance kickoff - Campaign: ${campaignId}`,
+      )
+    }
 
     // Track analytics with proper error handling
     try {


### PR DESCRIPTION
## What

[ENG-10323](https://app.clickup.com/t/86ahxptfe) — under the pro-upgrade3 Epic ([ENG-7508](https://app.clickup.com/t/86ah2ezny)).

In pro-upgrade3 the candidate submits filing details **before** paying (wizard order: filing-details → candidate-profile → payment). Today `createAgentic` enqueues the `compliance_setup` kickoff on submit — which provisions a domain, publishes a website, and submits to Peerly. We must not start that for an unpaid candidate. This moves the trigger to payment success while preserving the existing already-Pro (pro-upgrade1) behavior.

## Changes

- **`campaignTcrCompliance.service.ts`**
  - `createAgentic` enqueues the kickoff only when `campaign.isPro`. Non-Pro submits persist the TCR record and defer dispatch.
  - Extracted the SQS message shape + idempotent claim into a private `claimAndEnqueueKickoff(record, clerkUserId)` (single source, no cross-file drift).
  - Added public `enqueueAgenticKickoffIfNeeded(campaignId)` for the webhook.
- **`paymentEventsService.ts`** — after `setIsPro` in the `checkout.session.completed` subscription handler, call `enqueueAgenticKickoffIfNeeded` (best-effort; a failure logs but does not fail the webhook — the stranded-kickoff sweep recovers a rolled-back claim).

## Idempotency

Atomic claim on the existing `TcrCompliance.kickoffSentAt` (`updateMany WHERE kickoffSentAt IS NULL`) **before** the SQS send; on send failure the claim is rolled back scoped to the exact timestamp. This makes the kickoff fire exactly once across:
- a duplicate/replayed `checkout.session.completed`, and
- the submit → pay → submit-again race (the resubmit finds the claim taken and skips).

No migration; no change to `handleAgenticKickoff` or the agent runbook — only the trigger point moves.

## Tests

`npx vitest run src/payments src/campaigns/tcrCompliance` → **140 passed**. `tsc --noEmit` clean, ESLint 0 errors, Prettier clean.

Covers all 5 acceptance criteria: non-Pro defer, webhook enqueue-after-setIsPro (exactly one), already-Pro immediate enqueue, replayed-webhook short-circuit, and the submit→pay→resubmit guard. Idempotency tests exercise the real `claim.count === 0` branch (the guard is not mocked away).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when compliance provisioning starts relative to Stripe webhooks and TCR submit; failures are mitigated by claim rollback and stranded-kickoff sweep, but ordering after setIsPro matters for pro-upgrade3.
> 
> **Overview**
> Moves the **compliance_setup** agent kickoff so unpaid pro-upgrade3 candidates no longer trigger domain/site provisioning on TCR submit.
> 
> **`createAgentic`** still persists the TCR record for everyone, but only calls the new **`claimAndEnqueueKickoff`** when `campaign.isPro` is true. Non-Pro submits skip SQS entirely until payment.
> 
> Kickoff enqueue is centralized in **`claimAndEnqueueKickoff`**: atomic `updateMany` on `kickoffSentAt` before `sendMessage`, rollback of the claim on SQS failure, and no-op when the claim is already taken (webhook replay / races). **`enqueueAgenticKickoffIfNeeded(campaignId)`** exposes that path for the Stripe subscription checkout handler, which runs **after** `setIsPro` in a best-effort try/catch so webhook success does not depend on SQS.
> 
> Tests cover defer-on-non-Pro, post-payment enqueue ordering, idempotency, and webhook resilience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2645ec10932080cea09ad1c3ec45b6272495d96c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->