### PR TITLE
feat(payments): embedded Stripe checkout for Pro subscription [ENG-10324]

### DIFF
--- a/src/payments/purchase.controller.test.ts
+++ b/src/payments/purchase.controller.test.ts
@@ -41,6 +41,7 @@ describe('PurchaseController', () => {
   let controller: PurchaseController
   let stripeService: {
     createCheckoutSession: ReturnType<typeof vi.fn>
+    createEmbeddedProSubscriptionCheckoutSession: ReturnType<typeof vi.fn>
     createPortalSession: ReturnType<typeof vi.fn>
   }
   let usersService: { patchUserMetaData: ReturnType<typeof vi.fn> }
@@ -53,6 +54,7 @@ describe('PurchaseController', () => {
   beforeEach(() => {
     stripeService = {
       createCheckoutSession: vi.fn(),
+      createEmbeddedProSubscriptionCheckoutSession: vi.fn(),
       createPortalSession: vi.fn(),
     }
     usersService = { patchUserMetaData: vi.fn() }
@@ -71,9 +73,11 @@ describe('PurchaseController', () => {
   })
 
   describe('createProCheckoutSession', () => {
+    const redirectUrl = 'https://stripe.test/checkout'
+
     it('creates the session and persists checkoutSessionId on the user', async () => {
       stripeService.createCheckoutSession.mockResolvedValue({
-        redirectUrl: 'https://stripe.test/checkout',
+        redirectUrl,
         checkoutSessionId: 'cs_test_123',
       })
 
@@ -86,7 +90,48 @@ describe('PurchaseController', () => {
       expect(usersService.patchUserMetaData).toHaveBeenCalledWith(userId, {
         checkoutSessionId: 'cs_test_123',
       })
-      expect(result).toEqual({ redirectUrl: 'https://stripe.test/checkout' })
+      expect(result).toEqual({ redirectUrl })
+    })
+
+    it('returns a client_secret and persists checkoutSessionId for the embedded path', async () => {
+      stripeService.createEmbeddedProSubscriptionCheckoutSession.mockResolvedValue(
+        {
+          clientSecret: 'cs_test_secret_abc',
+          checkoutSessionId: 'cs_test_embedded',
+        },
+      )
+
+      const result = await controller.createProCheckoutSession(mockUser, {
+        embedded: true,
+        returnUrl: 'https://app.test/dashboard/pro-upgrade',
+      })
+
+      expect(
+        stripeService.createEmbeddedProSubscriptionCheckoutSession,
+      ).toHaveBeenCalledWith(
+        userId,
+        mockUser.email,
+        'https://app.test/dashboard/pro-upgrade',
+      )
+      expect(stripeService.createCheckoutSession).not.toHaveBeenCalled()
+      expect(usersService.patchUserMetaData).toHaveBeenCalledWith(userId, {
+        checkoutSessionId: 'cs_test_embedded',
+      })
+      expect(result).toEqual({ clientSecret: 'cs_test_secret_abc' })
+    })
+
+    it('falls back to the redirect path when no body is supplied', async () => {
+      stripeService.createCheckoutSession.mockResolvedValue({
+        redirectUrl,
+        checkoutSessionId: 'cs_test_123',
+      })
+
+      const result = await controller.createProCheckoutSession(mockUser)
+
+      expect(
+        stripeService.createEmbeddedProSubscriptionCheckoutSession,
+      ).not.toHaveBeenCalled()
+      expect(result).toEqual({ redirectUrl })
     })
   })
 

--- a/src/payments/purchase.controller.ts
+++ b/src/payments/purchase.controller.ts
@@ -11,6 +11,7 @@ import {
   CompleteCheckoutSessionDto,
   CompleteFreePurchaseDto,
   CreateCheckoutSessionDto,
+  CreateProCheckoutSessionDto,
 } from './purchase.types'
 import { PurchaseService } from './services/purchase.service'
 import { UseOrganization } from '@/organizations/decorators/UseOrganization.decorator'
@@ -28,8 +29,25 @@ export class PurchaseController {
   }
 
   @Post('checkout-session')
-  async createProCheckoutSession(@ReqUser() user: User) {
+  async createProCheckoutSession(
+    @ReqUser() user: User,
+    @Body() dto: CreateProCheckoutSessionDto = {},
+  ) {
     const { email } = user
+
+    if (dto.embedded) {
+      const { clientSecret, checkoutSessionId } =
+        await this.stripeService.createEmbeddedProSubscriptionCheckoutSession(
+          user.id,
+          email,
+          dto.returnUrl,
+        )
+
+      await this.usersService.patchUserMetaData(user.id, { checkoutSessionId })
+
+      return { clientSecret }
+    }
+
     const { redirectUrl, checkoutSessionId } =
       await this.stripeService.createCheckoutSession(user.id, email)
 

--- a/src/payments/purchase.types.ts
+++ b/src/payments/purchase.types.ts
@@ -21,6 +21,14 @@ export interface CompleteCheckoutSessionDto {
   checkoutSessionId: string
 }
 
+export interface CreateProCheckoutSessionDto {
+  // When true, returns a client_secret for an in-wizard embedded checkout
+  //  instead of a redirect url (pro-upgrade3 cohort). isPro is still flipped
+  //  only by the checkout.session.completed webhook regardless of this flag.
+  embedded?: boolean
+  returnUrl?: string
+}
+
 export type FreePurchaseMetadata =
   | OutreachPurchaseMetadata
   | DomainPurchaseMetadata

--- a/src/vendors/stripe/services/stripe.service.test.ts
+++ b/src/vendors/stripe/services/stripe.service.test.ts
@@ -1,0 +1,92 @@
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { BadGatewayException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SlackService } from 'src/vendors/slack/services/slack.service'
+import { StripeService } from './stripe.service'
+
+const { sessionsCreate, productsRetrieve } = vi.hoisted(() => ({
+  sessionsCreate: vi.fn(),
+  productsRetrieve: vi.fn(),
+}))
+
+vi.mock('stripe', () => ({
+  default: class {
+    checkout = { sessions: { create: sessionsCreate } }
+    products = { retrieve: productsRetrieve }
+  },
+}))
+
+const userId = 7
+const email = 'buyer@example.com'
+const priceId = 'price_test_pro'
+
+describe('StripeService Pro subscription checkout', () => {
+  let service: StripeService
+
+  beforeEach(() => {
+    productsRetrieve.mockResolvedValue({ default_price: priceId })
+    service = new StripeService(
+      {} as unknown as SlackService,
+      createMockLogger(),
+    )
+  })
+
+  describe('createEmbeddedProSubscriptionCheckoutSession', () => {
+    it('builds an embedded subscription session and returns the client_secret', async () => {
+      sessionsCreate.mockResolvedValue({
+        id: 'cs_test_embedded',
+        client_secret: 'cs_test_embedded_secret_abc',
+      })
+
+      const result = await service.createEmbeddedProSubscriptionCheckoutSession(
+        userId,
+        email,
+        'https://app.test/dashboard/pro-upgrade?session_id={CHECKOUT_SESSION_ID}',
+      )
+
+      const args = sessionsCreate.mock.calls[0][0]
+      expect(args.ui_mode).toBe('custom')
+      expect(args.mode).toBe('subscription')
+      expect(args.return_url).toBe(
+        'https://app.test/dashboard/pro-upgrade?session_id={CHECKOUT_SESSION_ID}',
+      )
+      expect(args.success_url).toBeUndefined()
+      expect(args.metadata).toEqual({ userId })
+      expect(args.line_items).toEqual([{ price: priceId, quantity: 1 }])
+
+      expect(result).toEqual({
+        clientSecret: 'cs_test_embedded_secret_abc',
+        checkoutSessionId: 'cs_test_embedded',
+      })
+    })
+
+    it('throws BadGatewayException when Stripe returns no client_secret', async () => {
+      sessionsCreate.mockResolvedValue({
+        id: 'cs_test_embedded',
+        client_secret: null,
+      })
+
+      await expect(
+        service.createEmbeddedProSubscriptionCheckoutSession(userId, email),
+      ).rejects.toThrow(BadGatewayException)
+    })
+
+    it('carries the same userId metadata as the redirect subscription session', async () => {
+      sessionsCreate.mockResolvedValue({
+        id: 'cs_test',
+        client_secret: 'cs_test_secret',
+        url: 'https://stripe.test/checkout',
+      })
+
+      await service.createCheckoutSession(userId, email)
+      const redirectArgs = sessionsCreate.mock.calls[0][0]
+
+      await service.createEmbeddedProSubscriptionCheckoutSession(userId, email)
+      const embeddedArgs = sessionsCreate.mock.calls[1][0]
+
+      expect(embeddedArgs.metadata).toEqual(redirectArgs.metadata)
+      expect(embeddedArgs.mode).toBe(redirectArgs.mode)
+      expect(embeddedArgs.line_items).toEqual(redirectArgs.line_items)
+    })
+  })
+})

--- a/src/vendors/stripe/services/stripe.service.ts
+++ b/src/vendors/stripe/services/stripe.service.ts
@@ -2,6 +2,7 @@ import { BadGatewayException, Injectable } from '@nestjs/common'
 import { User } from '../../../generated/prisma'
 import { PinoLogger } from 'nestjs-pino'
 import {
+  CheckoutSessionMode,
   CustomCheckoutSessionPayload,
   PaymentIntentPayload,
   PaymentType,
@@ -89,37 +90,76 @@ export class StripeService {
     return await this.stripe.checkout.sessions.retrieve(sessionId)
   }
 
+  // Shared params for the Pro subscription Checkout Session, used by both the
+  //  redirect flow (createCheckoutSession) and the embedded flow
+  //  (createEmbeddedProSubscriptionCheckoutSession). The webhook
+  //  (checkout.session.completed) identifies the campaign and sets isPro from
+  //  metadata.userId, so both flows must carry it identically.
+  private getProSubscriptionSessionParams = async (
+    userId: number,
+    email: string | null,
+  ): Promise<Stripe.Checkout.SessionCreateParams> => ({
+    metadata: {
+      userId,
+    },
+    ...(email ? { customer_email: email } : {}),
+    billing_address_collection: 'auto',
+    line_items: [
+      {
+        // We should never have more than 1 price for Pro. But if we do, this
+        //  will need to be more intelligent.
+        // Stripe SDK uses broad union types — default_price is string | Price | null
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        price: (await this.getPrice()) as string,
+        quantity: 1,
+      },
+    ],
+    mode: CheckoutSessionMode.SUBSCRIPTION,
+    allow_promotion_codes: true,
+    // Expanding for Segment / analytics
+    expand: [
+      'subscription',
+      'subscription.items.data.price',
+      'payment_intent.payment_method',
+    ],
+  })
+
   async createCheckoutSession(userId: number, email: string | null = null) {
     const session = await this.stripe.checkout.sessions.create({
-      metadata: {
-        userId,
-      },
-      ...(email ? { customer_email: email } : {}),
-      billing_address_collection: 'auto',
-      line_items: [
-        {
-          // We should never have more than 1 price for Pro. But if we do, this
-          //  will need to be more intelligent.
-          // Stripe SDK uses broad union types — e.g. customer can be string | Customer | DeletedCustomer
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          price: (await this.getPrice()) as string,
-          quantity: 1,
-        },
-      ],
-      mode: 'subscription',
-      allow_promotion_codes: true,
-      // Expanding for Segment / analytics
-      expand: [
-        'subscription',
-        'subscription.items.data.price',
-        'payment_intent.payment_method',
-      ],
+      ...(await this.getProSubscriptionSessionParams(userId, email)),
       success_url: `${WEBAPP_ROOT_URL}/dashboard/pro-sign-up/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${WEBAPP_ROOT_URL}/dashboard`,
     })
 
     const { url: redirectUrl, id: checkoutSessionId } = session
     return { redirectUrl, checkoutSessionId }
+  }
+
+  // Embedded (in-wizard) variant of the Pro subscription checkout. Mirrors the
+  //  one-time embedded path (createCustomCheckoutSession): ui_mode 'custom' +
+  //  return_url, returns a client_secret instead of a redirect url. isPro is
+  //  still flipped only by the checkout.session.completed webhook.
+  async createEmbeddedProSubscriptionCheckoutSession(
+    userId: number,
+    email: string | null = null,
+    returnUrl: string = `${WEBAPP_ROOT_URL}/dashboard/pro-upgrade?session_id={CHECKOUT_SESSION_ID}`,
+  ) {
+    const session = await this.stripe.checkout.sessions.create({
+      ...(await this.getProSubscriptionSessionParams(userId, email)),
+      ui_mode: 'custom',
+      return_url: returnUrl,
+    })
+
+    if (!session.client_secret) {
+      throw new BadGatewayException(
+        'Failed to create checkout session: no client_secret returned',
+      )
+    }
+
+    return {
+      clientSecret: session.client_secret,
+      checkoutSessionId: session.id,
+    }
   }
 
   async createCustomCheckoutSession(


### PR DESCRIPTION
## What

Adds an embedded (in-wizard) variant of the Pro $10/mo subscription checkout for the `pro-upgrade3` cohort. Today the Pro subscription returns a redirect `url`; only one-time payments use embedded mode. This lets the Phase 3 wizard's payment step (task 13) mount Stripe's embedded checkout and stay in-app.

ClickUp: [ENG-10324](https://app.clickup.com/t/86ahxptfh) (Epic: Phase 3+4 Pro Upgrade Flow & 10DLC Approval)

## Changes

- **`stripe.service.ts`** — extracted a shared private `getProSubscriptionSessionParams` (subscription `mode`, `metadata.userId`, `line_items`, `expand`). The redirect `createCheckoutSession` keeps identical behavior. New `createEmbeddedProSubscriptionCheckoutSession` builds an embedded session (`ui_mode: 'custom'` + `return_url`, no `success_url`) and returns the `client_secret`, throwing `BadGatewayException` if Stripe returns none.
- **`purchase.controller.ts`** — extended `POST /payments/purchase/checkout-session` with an optional body `{ embedded?, returnUrl? }`. `embedded: true` → `{ clientSecret }`; no/falsy body → `{ redirectUrl }`, unchanged.
- **`purchase.types.ts`** — `CreateProCheckoutSessionDto`.

## Design note

The ticket suggested extending `create-checkout-session`, but that path is the one-time `PurchaseType`-handler flow (DOMAIN/TEXT/POLL) and doesn't fit a fixed-price subscription. The genuine Pro-subscription sibling is `/checkout-session`, so I extended that and shared the session-params builder to avoid the duplicated-controller pattern.

## Safety

- `isPro` is still flipped **only** by the `checkout.session.completed` webhook — the client never sets it. Webhook code is unchanged.
- Both flows carry identical `metadata: { userId }`, which the webhook reads to identify the campaign and set `isPro`.
- Legacy redirect endpoint behavior is preserved for the `pro-upgrade3 = off` cohort.

## Tests

New `stripe.service.test.ts` mocks the Stripe SDK and asserts the create-session args (`ui_mode: 'custom'`, `mode: 'subscription'`, `return_url`, no `success_url`, `metadata` parity with the redirect session) and the returned `client_secret`. Extended `purchase.controller.test.ts` covers the embedded and redirect-fallback branches. 19 tests pass; lint + tsc + prettier clean.

Manual verification (Stripe test mode → mount embedded checkout → complete test payment → confirm webhook flips `isPro`) is pending and depends on task 13's frontend mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription checkout and payment session creation, but legacy redirect is preserved and entitlement still depends on the unchanged webhook.
> 
> **Overview**
> Adds an **embedded in-app** path for Pro subscription checkout alongside the existing Stripe redirect flow, for the pro-upgrade wizard cohort.
> 
> **`StripeService`** pulls shared Pro subscription session fields into `getProSubscriptionSessionParams` and refactors redirect `createCheckoutSession` to use it unchanged. New **`createEmbeddedProSubscriptionCheckoutSession`** creates a subscription session with `ui_mode: 'custom'` and `return_url` (no `success_url`), returns **`clientSecret`**, and throws **`BadGatewayException`** if Stripe omits a secret.
> 
> **`POST /payments/purchase/checkout-session`** accepts optional **`CreateProCheckoutSessionDto`** (`embedded`, `returnUrl`). When `embedded: true`, the handler returns `{ clientSecret }` and still persists `checkoutSessionId` on the user; otherwise behavior stays **`{ redirectUrl }`**.
> 
> New unit tests cover Stripe session args/metadata parity and controller embedded vs redirect branches. **`isPro`** remains webhook-only; both flows keep the same **`metadata.userId`** for `checkout.session.completed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af847d2f7d0c34d1ccbf8a5b923de1dccfba8ffd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->