### PR TITLE
feat(campaigns): filing office contact on metrics + email-this-to-me (ENG-10325)

### DIFF
--- a/contracts/.changeset/eng-10325-filing-office-contact.md
+++ b/contracts/.changeset/eng-10325-filing-office-contact.md
@@ -1,0 +1,17 @@
+---
+'@goodparty_org/contracts': minor
+---
+
+`RaceTargetMetricsSchema` / `RaceTargetMetrics` gain three nullable
+filing-office-contact fields, sourced from BallotReady via election-api's
+`/races/by-br-hash-id/:hash/filing-fee` lookup:
+
+- `filingOfficeAddress` — free-text address block (line 1/2, city, state, zip)
+  where candidacy paperwork is submitted.
+- `filingPhoneNumber` — phone for the local election authority.
+- `paperworkInstructions` — BallotReady's narrative on the local election
+  authority a candidate contacts for filing procedures.
+
+All `null` when BallotReady has no office data for the race. Powers the
+"filing office" block on the Pro-upgrade filing-instructions screen
+(ENG-10325). Additive and non-breaking — existing consumers are unaffected.

--- a/contracts/src/campaigns/RaceTargetMetrics.schema.ts
+++ b/contracts/src/campaigns/RaceTargetMetrics.schema.ts
@@ -67,6 +67,18 @@ export const RaceTargetMetricsSchema = z.object({
    * when `filingFee` is null. `null` when BallotReady has no data.
    */
   filingRequirementsText: z.string().nullable(),
+  /**
+   * Structured filing-office contact for the race, sourced from BallotReady
+   * via election-api's `/races/by-br-hash-id/:hash/filing-fee` lookup. Powers
+   * the "filing office" block on the Pro-upgrade filing-instructions screen.
+   * `filingOfficeAddress` is a single free-text block (address line 1/2, city,
+   * state, zip); `paperworkInstructions` is BallotReady's narrative on the
+   * local election authority a candidate contacts. All `null` when BallotReady
+   * has no office data for the race.
+   */
+  filingOfficeAddress: z.string().nullable(),
+  filingPhoneNumber: z.string().nullable(),
+  paperworkInstructions: z.string().nullable(),
   // The fields below come straight from election-api's
   // /campaign-strategy-context endpoint. All nullable — null when the race
   // hash didn't resolve to a Position+District or the upstream data is

--- a/src/campaigns/campaigns.controller.test.ts
+++ b/src/campaigns/campaigns.controller.test.ts
@@ -14,6 +14,7 @@ import { CampaignsController } from './campaigns.controller'
 import { CreateCampaignSchema } from './schemas/updateCampaign.schema'
 import { CampaignPlanVersionsService } from './services/campaignPlanVersions.service'
 import { CampaignsService } from './services/campaigns.service'
+import { FilingInstructionsService } from './filingInstructions/filingInstructions.service'
 import { CampaignWith } from './campaigns.types'
 
 const CREATED_AT = '2025-01-01'
@@ -22,6 +23,9 @@ const CREATED_AT = '2025-01-01'
 // fetchLiveRaceTargetMetrics started consuming /campaign-strategy-context.
 // Tests that don't care about these can spread this into their fixture.
 const EMPTY_RACE_CONTEXT_FIELDS = {
+  filingOfficeAddress: null,
+  filingPhoneNumber: null,
+  paperworkInstructions: null,
   registeredVoters: null,
   uniqueCellphones: null,
   uniqueLandlines: null,
@@ -122,6 +126,7 @@ describe('CampaignsController', () => {
   let slackService: SlackService
   let organizationsService: OrganizationsService
   let analyticsService: AnalyticsService
+  let filingInstructionsService: FilingInstructionsService
 
   beforeEach(() => {
     const campaignsServiceMock: Partial<CampaignsService> = {
@@ -167,12 +172,19 @@ describe('CampaignsController', () => {
     }
     analyticsService = analyticsServiceMock as AnalyticsService
 
+    const filingInstructionsServiceMock: Partial<FilingInstructionsService> = {
+      emailToCandidate: vi.fn(),
+    }
+    filingInstructionsService =
+      filingInstructionsServiceMock as FilingInstructionsService
+
     controller = new CampaignsController(
       campaignsService,
       planVersionsService,
       slackService,
       organizationsService,
       analyticsService,
+      filingInstructionsService,
       createMockLogger(),
     )
   })
@@ -316,6 +328,21 @@ describe('CampaignsController', () => {
 
       expect(campaignsService.getStatus).toHaveBeenCalledWith(undefined)
       expect(result).toEqual({ status: false })
+    })
+  })
+
+  describe('emailFilingInstructions', () => {
+    it('emails the candidate their filing instructions and returns success', async () => {
+      const result = await controller.emailFilingInstructions(
+        mockCampaign,
+        mockUser,
+      )
+
+      expect(filingInstructionsService.emailToCandidate).toHaveBeenCalledWith(
+        mockCampaign,
+        mockUser,
+      )
+      expect(result).toEqual({ success: true })
     })
   })
 

--- a/src/campaigns/campaigns.controller.ts
+++ b/src/campaigns/campaigns.controller.ts
@@ -48,6 +48,7 @@ import {
 } from './schemas/updateCampaign.schema'
 import { CampaignPlanVersionsService } from './services/campaignPlanVersions.service'
 import { CampaignsService } from './services/campaigns.service'
+import { FilingInstructionsService } from './filingInstructions/filingInstructions.service'
 import { CampaignWith } from './campaigns.types'
 
 class ListCampaignsPaginationDto extends createZodDto(
@@ -66,6 +67,7 @@ export class CampaignsController {
     private readonly slack: SlackService,
     private readonly organizations: OrganizationsService,
     private readonly analytics: AnalyticsService,
+    private readonly filingInstructions: FilingInstructionsService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(CampaignsController.name)
@@ -131,6 +133,17 @@ export class CampaignsController {
     if (!version) throw new NotFoundException('No plan version found')
 
     return version.data
+  }
+
+  @Post('mine/filing-instructions/email')
+  @UseCampaign()
+  @HttpCode(HttpStatus.OK)
+  async emailFilingInstructions(
+    @ReqCampaign() campaign: Campaign,
+    @ReqUser() user: User,
+  ) {
+    await this.filingInstructions.emailToCandidate(campaign, user)
+    return { success: true }
   }
 
   @Get('slug/:slug')

--- a/src/campaigns/campaigns.controller.ts
+++ b/src/campaigns/campaigns.controller.ts
@@ -135,6 +135,12 @@ export class CampaignsController {
     return version.data
   }
 
+  // Intentionally @UseCampaign()-only, no isPro guard: the filing-instructions
+  // screen is a PRE-payment step of the pro-upgrade wizard, so its audience is
+  // by definition not-yet-Pro — an isPro gate would 403 the exact users it
+  // serves. The payload is public BallotReady data already shown free in
+  // onboarding (SuccessPage), and @UseCampaign() scopes the send to the
+  // caller's own campaign + their own email. Per ENG-10325 AC.
   @Post('mine/filing-instructions/email')
   @UseCampaign()
   @HttpCode(HttpStatus.OK)

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -19,6 +19,7 @@ import { StripeModule } from '../vendors/stripe/stripe.module'
 import { WebsitesModule } from '../websites/websites.module'
 import { CampaignsAiModule } from './ai/campaignsAi.module'
 import { CampaignsController } from './campaigns.controller'
+import { FilingInstructionsService } from './filingInstructions/filingInstructions.service'
 import { CampaignPositionsController } from './positions/campaignPositions.controller'
 import { CampaignPositionsService } from './positions/campaignPositions.service'
 import { CampaignPlanVersionsService } from './services/campaignPlanVersions.service'
@@ -70,6 +71,7 @@ import { CampaignUpdateHistoryService } from './updateHistory/campaignUpdateHist
   ],
   providers: [
     CampaignsService,
+    FilingInstructionsService,
     CampaignPlanVersionsService,
     CampaignPositionsService,
     CampaignUpdateHistoryService,

--- a/src/campaigns/filingInstructions/filingInstructions.service.test.ts
+++ b/src/campaigns/filingInstructions/filingInstructions.service.test.ts
@@ -1,0 +1,81 @@
+import { BadGatewayException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { EmailService } from 'src/email/email.service'
+import { Campaign, User } from 'src/generated/prisma'
+import type { RaceTargetMetrics } from '@goodparty_org/contracts'
+import { CampaignsService } from '../services/campaigns.service'
+import { FilingInstructionsService } from './filingInstructions.service'
+
+const campaign = {
+  id: 1,
+  details: { filingPeriodsStart: '2026-06-01', filingPeriodsEnd: '2026-06-15' },
+} as unknown as Campaign
+
+const user = { id: 7, email: 'candidate@example.com' } as unknown as User
+
+const metrics = {
+  filingFee: 100,
+  filingRequirementsText: 'Filing fee: $100.',
+  filingOfficeAddress: '500 Election Way, Sacramento, CA 95814',
+  filingPhoneNumber: '(916) 555-0199',
+  paperworkInstructions: 'Submit to the city clerk.',
+} as RaceTargetMetrics
+
+describe('FilingInstructionsService.emailToCandidate', () => {
+  let service: FilingInstructionsService
+  let sendEmail: ReturnType<typeof vi.fn>
+  let fetchLiveRaceTargetMetrics: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    sendEmail = vi.fn().mockResolvedValue({ id: 'mailgun-id' })
+    fetchLiveRaceTargetMetrics = vi.fn().mockResolvedValue(metrics)
+    service = new FilingInstructionsService(
+      { fetchLiveRaceTargetMetrics } as unknown as CampaignsService,
+      { sendEmail } as unknown as EmailService,
+      createMockLogger(),
+    )
+  })
+
+  it('emails the candidate the rendered filing instructions', async () => {
+    await service.emailToCandidate(campaign, user)
+
+    expect(fetchLiveRaceTargetMetrics).toHaveBeenCalledWith(campaign)
+    expect(sendEmail).toHaveBeenCalledTimes(1)
+    const payload = sendEmail.mock.calls[0][0]
+    expect(payload.to).toBe(user.email)
+    expect(payload.subject).toBe('Your filing instructions - GoodParty.org')
+    expect(payload.message).toContain(
+      'Filing window: June 1, 2026 – June 15, 2026',
+    )
+    expect(payload.message).toContain('Filing fee: $100')
+    expect(payload.message).toContain(
+      'Address: 500 Election Way, Sacramento, CA 95814',
+    )
+    expect(payload.message).toContain('Phone: (916) 555-0199')
+  })
+
+  it('still sends with just the window when live metrics are unavailable', async () => {
+    fetchLiveRaceTargetMetrics.mockResolvedValue(null)
+
+    await service.emailToCandidate(campaign, user)
+
+    const payload = sendEmail.mock.calls[0][0]
+    expect(payload.to).toBe(user.email)
+    expect(payload.message).toContain(
+      'Filing window: June 1, 2026 – June 15, 2026',
+    )
+    expect(payload.message).not.toContain('Filing fee:')
+    expect(payload.message).not.toContain('Filing office')
+  })
+
+  it('propagates the email-service failure (does not swallow)', async () => {
+    sendEmail.mockRejectedValue(
+      new BadGatewayException('error communicating w/ mail service'),
+    )
+
+    await expect(service.emailToCandidate(campaign, user)).rejects.toThrow(
+      BadGatewayException,
+    )
+  })
+})

--- a/src/campaigns/filingInstructions/filingInstructions.service.ts
+++ b/src/campaigns/filingInstructions/filingInstructions.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common'
+import { PinoLogger } from 'nestjs-pino'
+import { EmailService } from 'src/email/email.service'
+import { Campaign, User } from 'src/generated/prisma'
+import { CampaignsService } from '../services/campaigns.service'
+import { renderFilingInstructionsEmail } from './filingInstructions.util'
+
+@Injectable()
+export class FilingInstructionsService {
+  constructor(
+    private readonly campaigns: CampaignsService,
+    private readonly email: EmailService,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(FilingInstructionsService.name)
+  }
+
+  async emailToCandidate(campaign: Campaign, user: User) {
+    const metrics = await this.campaigns.fetchLiveRaceTargetMetrics(campaign)
+    const message = renderFilingInstructionsEmail(campaign, metrics)
+    return this.email.sendEmail({
+      to: user.email,
+      subject: 'Your filing instructions - GoodParty.org',
+      message,
+    })
+  }
+}

--- a/src/campaigns/filingInstructions/filingInstructions.util.test.ts
+++ b/src/campaigns/filingInstructions/filingInstructions.util.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { Campaign } from 'src/generated/prisma'
+import type { RaceTargetMetrics } from '@goodparty_org/contracts'
+import { renderFilingInstructionsEmail } from './filingInstructions.util'
+
+const campaignWith = (details: object): Campaign =>
+  ({ details }) as unknown as Campaign
+
+const metricsWith = (
+  overrides: Partial<RaceTargetMetrics>,
+): RaceTargetMetrics =>
+  ({
+    filingFee: null,
+    filingRequirementsText: null,
+    filingOfficeAddress: null,
+    filingPhoneNumber: null,
+    paperworkInstructions: null,
+    ...overrides,
+  }) as RaceTargetMetrics
+
+describe('renderFilingInstructionsEmail', () => {
+  it('renders window, fee, requirements, and office contact when all present', () => {
+    const body = renderFilingInstructionsEmail(
+      campaignWith({
+        filingPeriodsStart: '2026-06-01',
+        filingPeriodsEnd: '2026-06-15',
+      }),
+      metricsWith({
+        filingFee: 100,
+        filingRequirementsText: 'Filing fee: $100.',
+        filingOfficeAddress: '500 Election Way, Sacramento, CA 95814',
+        filingPhoneNumber: '(916) 555-0199',
+        paperworkInstructions: 'Submit to the city clerk.',
+      }),
+    )
+
+    expect(body).toContain('Filing window: June 1, 2026 – June 15, 2026')
+    expect(body).toContain('Filing fee: $100')
+    expect(body).toContain('Filing requirements: Filing fee: $100.')
+    expect(body).toContain('Filing office')
+    expect(body).toContain('Address: 500 Election Way, Sacramento, CA 95814')
+    expect(body).toContain('Phone: (916) 555-0199')
+    expect(body).toContain('Instructions: Submit to the city clerk.')
+  })
+
+  it('omits fee, requirements, and the office block when metrics are null', () => {
+    const body = renderFilingInstructionsEmail(
+      campaignWith({
+        filingPeriodsStart: '2026-06-01',
+        filingPeriodsEnd: '2026-06-15',
+      }),
+      null,
+    )
+
+    expect(body).toContain('Filing window: June 1, 2026 – June 15, 2026')
+    expect(body).not.toContain('Filing fee:')
+    expect(body).not.toContain('Filing requirements:')
+    expect(body).not.toContain('Filing office')
+  })
+
+  it('renders a $0 fee (fee present but zero is not "no data")', () => {
+    const body = renderFilingInstructionsEmail(
+      campaignWith({}),
+      metricsWith({ filingFee: 0 }),
+    )
+
+    expect(body).toContain('Filing fee: $0')
+  })
+
+  it('shows "Not yet available" when the filing window is missing', () => {
+    const body = renderFilingInstructionsEmail(campaignWith({}), null)
+
+    expect(body).toContain('Filing window: Not yet available')
+  })
+
+  it('falls back to the raw value when a filing date is not parseable', () => {
+    const body = renderFilingInstructionsEmail(
+      campaignWith({ filingPeriodsStart: 'rolling', filingPeriodsEnd: null }),
+      null,
+    )
+
+    expect(body).toContain('Filing window: rolling')
+  })
+})

--- a/src/campaigns/filingInstructions/filingInstructions.util.ts
+++ b/src/campaigns/filingInstructions/filingInstructions.util.ts
@@ -25,10 +25,11 @@ const formatFilingWindow = (
 }
 
 /**
- * Renders the plain-text "email this to me" body for the Pro-upgrade
- * filing-instructions screen: filing window (from `campaign.details`), plus
- * fee / requirements / office contact (from the live race-target metrics).
- * Sections with no data are omitted so the candidate never sees empty labels.
+ * Renders the plain-text "email this to me" body for the pre-payment
+ * pro-upgrade wizard's filing-instructions screen (shown to candidates before
+ * they subscribe): filing window (from `campaign.details`), plus fee /
+ * requirements / office contact (from the live race-target metrics). Sections
+ * with no data are omitted so the candidate never sees empty labels.
  */
 export const renderFilingInstructionsEmail = (
   campaign: Campaign,

--- a/src/campaigns/filingInstructions/filingInstructions.util.ts
+++ b/src/campaigns/filingInstructions/filingInstructions.util.ts
@@ -1,0 +1,67 @@
+import { format, isValid, parseISO } from 'date-fns'
+import { Campaign } from 'src/generated/prisma'
+import type { RaceTargetMetrics } from '@goodparty_org/contracts'
+
+// details.filingPeriods* are ISO date strings written by the filing-data
+// pipeline, but `details` is a loosely-typed JSON column edited by several
+// writers — an unparseable value would throw in `format` and 500 the email
+// route, so fall back to the raw string rather than failing the send.
+const formatFilingDate = (value: string | null | undefined): string | null => {
+  if (!value) return null
+  const parsed = parseISO(value)
+  return isValid(parsed) ? format(parsed, 'MMMM d, yyyy') : value
+}
+
+const formatFilingWindow = (
+  start: string | null | undefined,
+  end: string | null | undefined,
+): string => {
+  const formattedStart = formatFilingDate(start)
+  const formattedEnd = formatFilingDate(end)
+  if (formattedStart && formattedEnd) {
+    return `${formattedStart} – ${formattedEnd}`
+  }
+  return formattedStart ?? formattedEnd ?? 'Not yet available'
+}
+
+/**
+ * Renders the plain-text "email this to me" body for the Pro-upgrade
+ * filing-instructions screen: filing window (from `campaign.details`), plus
+ * fee / requirements / office contact (from the live race-target metrics).
+ * Sections with no data are omitted so the candidate never sees empty labels.
+ */
+export const renderFilingInstructionsEmail = (
+  campaign: Campaign,
+  metrics: RaceTargetMetrics | null,
+): string => {
+  const { filingPeriodsStart, filingPeriodsEnd } = campaign.details ?? {}
+
+  const lines: string[] = [
+    'Here are the filing instructions for your campaign.',
+    '',
+    `Filing window: ${formatFilingWindow(filingPeriodsStart, filingPeriodsEnd)}`,
+  ]
+
+  if (metrics?.filingFee != null) {
+    lines.push(`Filing fee: $${metrics.filingFee}`)
+  }
+  if (metrics?.filingRequirementsText) {
+    lines.push(`Filing requirements: ${metrics.filingRequirementsText}`)
+  }
+
+  const officeLines: string[] = []
+  if (metrics?.filingOfficeAddress) {
+    officeLines.push(`Address: ${metrics.filingOfficeAddress}`)
+  }
+  if (metrics?.filingPhoneNumber) {
+    officeLines.push(`Phone: ${metrics.filingPhoneNumber}`)
+  }
+  if (metrics?.paperworkInstructions) {
+    officeLines.push(`Instructions: ${metrics.paperworkInstructions}`)
+  }
+  if (officeLines.length > 0) {
+    lines.push('', 'Filing office', ...officeLines)
+  }
+
+  return lines.join('\n')
+}

--- a/src/campaigns/services/campaigns.service.test.ts
+++ b/src/campaigns/services/campaigns.service.test.ts
@@ -36,6 +36,9 @@ const BR_POSITION_ID = 'br-position-456'
 // (overrideDistrictId, position-based) emit these as null; tests for those
 // paths spread this into their expected result.
 const EMPTY_RACE_CONTEXT_FIELDS = {
+  filingOfficeAddress: null,
+  filingPhoneNumber: null,
+  paperworkInstructions: null,
   registeredVoters: null,
   uniqueCellphones: null,
   uniqueLandlines: null,
@@ -1138,11 +1141,14 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
       })
     })
 
-    it('prefers race-hash result over position-side filingFee', async () => {
+    it('prefers race-hash result over position-side filingFee and surfaces office contact', async () => {
       vi.mocked(mockElections.fetchFilingFeeByRaceHash!).mockResolvedValue({
         filingFee: 75,
         filingRequirementsText: 'BR-hash text.',
         extractionSource: 'direct_dollar',
+        filingOfficeAddress: '123 Main St, Springfield, IL 62701',
+        filingPhoneNumber: '(217) 555-0100',
+        paperworkInstructions: 'File with the county clerk in person.',
       })
 
       const result =
@@ -1158,6 +1164,9 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
         filingFee: 75,
         filingRequirementsText: 'BR-hash text.',
         ...EMPTY_RACE_CONTEXT_FIELDS,
+        filingOfficeAddress: '123 Main St, Springfield, IL 62701',
+        filingPhoneNumber: '(217) 555-0100',
+        paperworkInstructions: 'File with the county clerk in person.',
       })
     })
 
@@ -1170,6 +1179,9 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
         filingFee: null,
         filingRequirementsText: 'Fee varies; see BR.',
         extractionSource: 'multi_value',
+        filingOfficeAddress: null,
+        filingPhoneNumber: null,
+        paperworkInstructions: null,
       })
 
       const result =
@@ -1219,6 +1231,9 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
         filingFee: 50,
         filingRequirementsText: 'BR-hash text.',
         extractionSource: 'direct_dollar',
+        filingOfficeAddress: null,
+        filingPhoneNumber: null,
+        paperworkInstructions: null,
       })
 
       const result =
@@ -1298,6 +1313,9 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
         filingFee: 100,
         filingRequirementsText: 'Filing fee: $100.',
         extractionSource: 'direct_dollar',
+        filingOfficeAddress: '500 Election Way, Sacramento, CA 95814',
+        filingPhoneNumber: '(916) 555-0199',
+        paperworkInstructions: 'Submit candidacy paperwork to the city clerk.',
       })
       vi.mocked(mockBallotReady.fetchMilestones!).mockResolvedValue({
         voter_registration: { start: '2026-06-01', end: '2026-10-19' },
@@ -1314,6 +1332,9 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
         projectedTurnout: 1200,
         filingFee: 100,
         filingRequirementsText: 'Filing fee: $100.',
+        filingOfficeAddress: '500 Election Way, Sacramento, CA 95814',
+        filingPhoneNumber: '(916) 555-0199',
+        paperworkInstructions: 'Submit candidacy paperwork to the city clerk.',
         registeredVoters: 5500,
         uniqueCellphones: 3300,
         uniqueLandlines: 1800,

--- a/src/campaigns/services/campaigns.service.ts
+++ b/src/campaigns/services/campaigns.service.ts
@@ -831,6 +831,10 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
         filingFee: filingFeeFromRaceHash?.filingFee ?? null,
         filingRequirementsText:
           filingFeeFromRaceHash?.filingRequirementsText ?? null,
+        filingOfficeAddress: filingFeeFromRaceHash?.filingOfficeAddress ?? null,
+        filingPhoneNumber: filingFeeFromRaceHash?.filingPhoneNumber ?? null,
+        paperworkInstructions:
+          filingFeeFromRaceHash?.paperworkInstructions ?? null,
         milestones,
       }
     }
@@ -869,6 +873,10 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
         filingFeeFromRaceHash !== null
           ? filingFeeFromRaceHash.filingRequirementsText
           : (filingRequirementsText ?? null),
+      filingOfficeAddress: filingFeeFromRaceHash?.filingOfficeAddress ?? null,
+      filingPhoneNumber: filingFeeFromRaceHash?.filingPhoneNumber ?? null,
+      paperworkInstructions:
+        filingFeeFromRaceHash?.paperworkInstructions ?? null,
       milestones,
     }
   }
@@ -892,6 +900,10 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
       filingFee: filingFeeFromRaceHash?.filingFee ?? null,
       filingRequirementsText:
         filingFeeFromRaceHash?.filingRequirementsText ?? null,
+      filingOfficeAddress: filingFeeFromRaceHash?.filingOfficeAddress ?? null,
+      filingPhoneNumber: filingFeeFromRaceHash?.filingPhoneNumber ?? null,
+      paperworkInstructions:
+        filingFeeFromRaceHash?.paperworkInstructions ?? null,
       registeredVoters: context.registered_voters,
       uniqueCellphones: context.unique_cellphones,
       uniqueLandlines: context.unique_landlines,
@@ -971,6 +983,9 @@ const emptyContextFields = (): Omit<
   | 'voterContactGoal'
   | 'filingFee'
   | 'filingRequirementsText'
+  | 'filingOfficeAddress'
+  | 'filingPhoneNumber'
+  | 'paperworkInstructions'
 > => ({
   registeredVoters: null,
   uniqueCellphones: null,

--- a/src/elections/types/elections.types.ts
+++ b/src/elections/types/elections.types.ts
@@ -158,14 +158,19 @@ export type PositionWithOptionalDistrict = {
 
 /**
  * Shape returned by election-api `GET /races/by-br-hash-id/:hashId/filing-fee`.
- * Mirrors `FilingFeeResult` on the election-api side so the shapes stay
- * aligned. `extractionSource` is informational (audit / debugging) and not
- * surfaced to clients today.
+ * Mirrors `FilingDetailsByBrHashResult` on the election-api side so the shapes
+ * stay aligned. `extractionSource` is informational (audit / debugging) and not
+ * surfaced to clients today. The three `filing*`/`paperwork*` office-contact
+ * fields are sourced straight off the matched BallotReady race row and feed the
+ * Pro-upgrade filing-instructions screen.
  */
 export type FilingFeeByBrHashResult = {
   filingFee: number | null
   filingRequirementsText: string | null
   extractionSource: string | null
+  filingOfficeAddress: string | null
+  filingPhoneNumber: string | null
+  paperworkInstructions: string | null
 }
 
 /**


### PR DESCRIPTION
## What

ENG-10325 — backend for the Pro-upgrade filing-instructions screen (task 04). Two pieces:

**1. Filing office contact on `RaceTargetMetrics`**
- Adds nullable `filingOfficeAddress` / `filingPhoneNumber` / `paperworkInstructions` to `RaceTargetMetricsSchema` (contracts, minor changeset).
- Threads them from election-api's `by-br-hash-id` filing-fee lookup through `FilingFeeByBrHashResult` and all three metrics-mapping paths (context / overrideDistrict / position).
- Returned on the same `GET /campaigns/mine`, `/:id`, `/slug/:slug` responses that already carry `raceTargetMetrics` — no separate fetch.

**2. "Email this to me"**
- New `FilingInstructionsService` + `renderFilingInstructionsEmail` util compose the filing window (`campaign.details.filingPeriods*`) + fee + requirements + office contact into a plain-text body. Sections with no data are omitted.
- `POST /v1/campaigns/mine/filing-instructions/email` (`@UseCampaign()`-guarded) sends it to the candidate via the existing `EmailService` and returns `{ success: true }`.

## Cross-repo

Depends on **election-api PR #191**, which exposes the three office fields on the filing-fee endpoint. (The ticket assumed this data flowed from gp-api's own BallotReady GraphQL queries; it actually comes from election-api — hence the companion PR.) Until #191 ships, these fields resolve to `null` — safe and additive.

## Testing

- `campaigns.service.test.ts` — office fields asserted on the context + race-hash paths (populated and null). 42/42.
- `filingInstructions/` — render util (5) + service (3, incl. real email-failure propagation, asserting the sent payload not just the mock call).
- `campaigns.controller.test.ts` — new endpoint delegates + returns success. 44/44.
- `tsc` clean; prettier clean; eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive contract fields and a new email route behind existing campaign auth; degrades to null office data and partial email content when upstream metrics are missing.
> 
> **Overview**
> Adds **nullable filing-office contact** (`filingOfficeAddress`, `filingPhoneNumber`, `paperworkInstructions`) to **`RaceTargetMetrics`** in contracts and threads them from election-api’s race-hash filing-fee lookup through **`fetchLiveRaceTargetMetrics`** (context, override-district, and position paths). Existing campaign reads that already return `raceTargetMetrics` pick up the new fields with no new endpoint.
> 
> Introduces **“email this to me”** for Pro filing instructions: **`FilingInstructionsService`** loads live metrics, **`renderFilingInstructionsEmail`** builds plain text (filing window from `campaign.details`, fee/requirements/office blocks omitted when empty, safe date formatting), and **`POST /campaigns/mine/filing-instructions/email`** sends via **`EmailService`** and returns `{ success: true }`. Office contact fields stay `null` until the companion election-api change ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c09d7f5aaf130a9afd6127b7a2c902cec1068c71. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->