### PR TITLE
Prod <- QA

### DIFF
--- a/contracts/.changeset/eng-10325-filing-office-contact.md
+++ b/contracts/.changeset/eng-10325-filing-office-contact.md
@@ -1,0 +1,17 @@
+---
+'@goodparty_org/contracts': minor
+---
+
+`RaceTargetMetricsSchema` / `RaceTargetMetrics` gain three nullable
+filing-office-contact fields, sourced from BallotReady via election-api's
+`/races/by-br-hash-id/:hash/filing-fee` lookup:
+
+- `filingOfficeAddress` — free-text address block (line 1/2, city, state, zip)
+  where candidacy paperwork is submitted.
+- `filingPhoneNumber` — phone for the local election authority.
+- `paperworkInstructions` — BallotReady's narrative on the local election
+  authority a candidate contacts for filing procedures.
+
+All `null` when BallotReady has no office data for the race. Powers the
+"filing office" block on the Pro-upgrade filing-instructions screen
+(ENG-10325). Additive and non-breaking — existing consumers are unaffected.

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @goodparty_org/contracts
 
+## 0.13.0
+
+### Minor Changes
+
+- `AnnotationKind` gains a `review` value for admin QA review comments.
+  `Annotation` gains an optional `review` block (`id`, `body`,
+  `reviewer_email`, timestamps); `reviewer_clerk_sub` is intentionally
+  not exposed. `CreateAnnotationRequest` gains a `review` variant
+  (`{ kind: 'review', anchor, payload: { body } }`). Review annotations
+  are admin-only: creatable only inside an impersonation session and
+  withheld from non-impersonated callers by a server-side default-deny.
+  Additive and non-breaking for existing `note` / `bug_report` / `chat`
+  consumers.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodparty_org/contracts",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Shared Zod schemas and TypeScript types for the GoodParty API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/contracts/src/adminBriefings/AdminBriefing.schema.ts
+++ b/contracts/src/adminBriefings/AdminBriefing.schema.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+import { PaginationOptionsSchema } from '../shared/Pagination.schema'
+
+// Mirrors the gp-api admin user-list DateRangeFilter values. Duplicated here
+// (not imported) because contracts cannot depend on gp-api src, and this filter
+// now crosses the boundary into gp-admin's table UI. Filters on meeting_date.
+export const BRIEFING_DATE_RANGE_VALUES = [
+  'All time',
+  'last 12 months',
+  'last 30 days',
+  'last week',
+] as const
+export const BriefingDateRangeFilterSchema = z.enum(BRIEFING_DATE_RANGE_VALUES)
+export type BriefingDateRangeFilter = z.infer<
+  typeof BriefingDateRangeFilterSchema
+>
+
+export const BriefingAdminListQuerySchema = PaginationOptionsSchema.extend({
+  // Fuzzy match across the owning user's first name, last name, and email.
+  q: z.string().optional(),
+  dateRange: BriefingDateRangeFilterSchema.optional(),
+})
+export type BriefingAdminListQuery = z.infer<
+  typeof BriefingAdminListQuerySchema
+>
+
+// The elected office has no name/type columns of its own — it is identified by
+// its organization slug and the org's custom position name (when set).
+export const BriefingAdminRowSchema = z.object({
+  briefingId: z.string(),
+  // The gp-webapp briefing route slug is the meeting date (YYYY-MM-DD).
+  meetingDate: z.string(),
+  // Read from the briefing artifact JSON; absent until a briefing is produced.
+  meetingName: z.string().nullable(),
+  user: z.object({
+    id: z.number().int(),
+    firstName: z.string().nullable(),
+    lastName: z.string().nullable(),
+    email: z.string(),
+  }),
+  electedOffice: z.object({
+    id: z.string(),
+    organizationSlug: z.string(),
+    positionName: z.string().nullable(),
+  }),
+  updatedAt: z.coerce.date(),
+})
+export type BriefingAdminRow = z.infer<typeof BriefingAdminRowSchema>

--- a/contracts/src/annotations/Annotation.schema.ts
+++ b/contracts/src/annotations/Annotation.schema.ts
@@ -10,10 +10,17 @@ import { z } from 'zod'
  *     Both null when jsonPath is null.
  *
  * Only the `note` and `bug_report` kinds are wired in v1. `chat` is
- * reserved for Collin's eventual chat module.
+ * reserved for Collin's eventual chat module. `review` is admin-only:
+ * it can only be created inside an impersonation session and is never
+ * returned to non-impersonated callers (server-side default-deny).
  */
 
-export const ANNOTATION_KIND_VALUES = ['note', 'chat', 'bug_report'] as const
+export const ANNOTATION_KIND_VALUES = [
+  'note',
+  'chat',
+  'bug_report',
+  'review',
+] as const
 export const AnnotationKindSchema = z.enum(ANNOTATION_KIND_VALUES)
 export type AnnotationKind = z.infer<typeof AnnotationKindSchema>
 
@@ -45,8 +52,7 @@ export const AnnotationAnchorSchema = z
   })
   .refine(
     (a) => {
-      const passage =
-        a.json_path !== null && a.start !== null && a.end !== null
+      const passage = a.json_path !== null && a.start !== null && a.end !== null
       const cardLevel =
         a.json_path !== null && a.start === null && a.end === null
       const briefingWide =
@@ -118,6 +124,17 @@ export const AnnotationChatSchema = z.object({
 })
 export type AnnotationChat = z.infer<typeof AnnotationChatSchema>
 
+// reviewer_clerk_sub is intentionally omitted — the admin's Clerk subject
+// is internal reviewer attribution and never leaves the server.
+export const AnnotationReviewSchema = z.object({
+  id: z.string(),
+  body: z.string(),
+  reviewer_email: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+export type AnnotationReview = z.infer<typeof AnnotationReviewSchema>
+
 // ---------------------------------------------------------------------------
 // The annotation row as returned by the API
 // ---------------------------------------------------------------------------
@@ -136,6 +153,7 @@ export const AnnotationSchema = z.object({
   note: AnnotationNoteSchema.optional(),
   chat: AnnotationChatSchema.optional(),
   bug_report: AnnotationBugReportSchema.optional(),
+  review: AnnotationReviewSchema.optional(),
 })
 export type Annotation = z.infer<typeof AnnotationSchema>
 
@@ -145,6 +163,7 @@ export type Annotation = z.infer<typeof AnnotationSchema>
 
 const noteBodySchema = z.string().min(1).max(10_000)
 const bugReportDescriptionSchema = z.string().min(1).max(4_000)
+const reviewBodySchema = z.string().min(1).max(10_000)
 
 export const CreateAnnotationRequestSchema = z.discriminatedUnion('kind', [
   z.object({
@@ -161,6 +180,13 @@ export const CreateAnnotationRequestSchema = z.discriminatedUnion('kind', [
     anchor: AnnotationAnchorSchema,
     payload: z.object({
       description: bugReportDescriptionSchema,
+    }),
+  }),
+  z.object({
+    kind: z.literal('review'),
+    anchor: AnnotationAnchorSchema,
+    payload: z.object({
+      body: reviewBodySchema,
     }),
   }),
 ])

--- a/contracts/src/campaigns/RaceTargetMetrics.schema.ts
+++ b/contracts/src/campaigns/RaceTargetMetrics.schema.ts
@@ -67,6 +67,18 @@ export const RaceTargetMetricsSchema = z.object({
    * when `filingFee` is null. `null` when BallotReady has no data.
    */
   filingRequirementsText: z.string().nullable(),
+  /**
+   * Structured filing-office contact for the race, sourced from BallotReady
+   * via election-api's `/races/by-br-hash-id/:hash/filing-fee` lookup. Powers
+   * the "filing office" block on the Pro-upgrade filing-instructions screen.
+   * `filingOfficeAddress` is a single free-text block (address line 1/2, city,
+   * state, zip); `paperworkInstructions` is BallotReady's narrative on the
+   * local election authority a candidate contacts. All `null` when BallotReady
+   * has no office data for the race.
+   */
+  filingOfficeAddress: z.string().nullable(),
+  filingPhoneNumber: z.string().nullable(),
+  paperworkInstructions: z.string().nullable(),
   // The fields below come straight from election-api's
   // /campaign-strategy-context endpoint. All nullable — null when the race
   // hash didn't resolve to a Position+District or the upstream data is

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -318,6 +318,8 @@ export {
   type AnnotationBugReport,
   AnnotationChatSchema,
   type AnnotationChat,
+  AnnotationReviewSchema,
+  type AnnotationReview,
   AnnotationSchema,
   type Annotation,
   CreateAnnotationRequestSchema,
@@ -365,3 +367,13 @@ export {
   AgentRunDetailSchema,
   type AgentRunDetail,
 } from './agentRuns/AgentRun.schema'
+
+export {
+  BRIEFING_DATE_RANGE_VALUES,
+  BriefingDateRangeFilterSchema,
+  type BriefingDateRangeFilter,
+  BriefingAdminListQuerySchema,
+  type BriefingAdminListQuery,
+  BriefingAdminRowSchema,
+  type BriefingAdminRow,
+} from './adminBriefings/AdminBriefing.schema'

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -130,6 +130,15 @@ export = async () => {
       ? 'annotation-attachments-dev'
       : createAnnotationAttachmentsBucket({ environment }).bucket.bucket
 
+  // Private bucket for user-supplied inputs to agent experiment runs (first
+  // use: agenda packets uploaded from /briefings). Browser PUTs via presigned
+  // URL; the broker reads on the runner's behalf via /inputs/read. Created
+  // and owned by gp-ai-projects Terraform (modules/agent-run-inputs); gp-api
+  // references by name only. Preview environments share the dev bucket.
+  const agentRunInputsBucketName = `gp-agent-run-inputs-${
+    environment === 'preview' ? 'dev' : environment
+  }`
+
   // Shared bucket between the external meeting_pipeline (writes briefings)
   // and gp-api TextToSpeechService (caches Polly audio under speech/synth/,
   // then hands the browser presigned GETs). Dev bucket exists out-of-band
@@ -414,6 +423,7 @@ export = async () => {
       TEVYN_POLL_CSVS_BUCKET: tevynPollCsvsBucket.bucket,
       ZIP_TO_AREA_CODE_BUCKET: zipToAreaCodeBucket.bucket,
       ANNOTATION_ATTACHMENTS_BUCKET: annotationAttachmentsBucketName,
+      AGENT_RUN_INPUTS_BUCKET: agentRunInputsBucketName,
       DB_HOST: rdsCluster.endpoint,
       DB_USER: rdsCluster.masterUsername,
       DB_NAME: rdsCluster.databaseName,

--- a/prisma/schema/annotation.prisma
+++ b/prisma/schema/annotation.prisma
@@ -2,6 +2,7 @@ enum AnnotationKind {
   note
   chat
   bug_report
+  review
 }
 
 // The type of resource about which
@@ -33,6 +34,8 @@ model Annotation {
   chatConversationId    String?              @unique @map("chat_conversation_id")
   bugReport             AnnotationBugReport? @relation(fields: [annotationBugReportId], references: [id])
   annotationBugReportId String?              @unique @map("annotation_bug_report_id")
+  annotationReview      AnnotationReview?    @relation(fields: [annotationReviewId], references: [id])
+  annotationReviewId    String?              @unique @map("annotation_review_id")
 
   @@index([authorUserId])
   @@index([authorUserId, resourceType, resourceId, kind])

--- a/prisma/schema/annotationReview.prisma
+++ b/prisma/schema/annotationReview.prisma
@@ -1,0 +1,18 @@
+// Reviewer identity lives here, not on the parent Annotation row.
+// Annotation.authorUserId stays = the impersonated (reviewed) user;
+// reviewerClerkSub (from the impersonation actor) is the real reviewer.
+model AnnotationReview {
+  id String @id @default(cuid())
+
+  body String @db.Text
+
+  reviewerClerkSub String  @map("reviewer_clerk_sub")
+  reviewerEmail    String? @map("reviewer_email")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  annotation Annotation?
+
+  @@map("annotation_review")
+}

--- a/prisma/schema/electedOffice.prisma
+++ b/prisma/schema/electedOffice.prisma
@@ -18,6 +18,7 @@ model ElectedOffice {
   pollIndividualMessages   PollIndividualMessage[]
   meetingBriefings         MeetingBriefing[]
   meetingResourceLocations MeetingResourceLocation[]
+  userAgendaUploads        UserAgendaUpload[]
 
   @@unique([userId])
   @@index([campaignId])

--- a/prisma/schema/experimentRun.prisma
+++ b/prisma/schema/experimentRun.prisma
@@ -33,6 +33,7 @@ model ExperimentRun {
 
   meetingBriefings         MeetingBriefing[]
   meetingResourceLocations MeetingResourceLocation[]
+  userAgendaUploads        UserAgendaUpload[]
 
   @@index([organizationSlug, experimentType])
   @@index([status, resumeScheduledFor])

--- a/prisma/schema/migrations/20260605150356_add_user_agenda_upload/migration.sql
+++ b/prisma/schema/migrations/20260605150356_add_user_agenda_upload/migration.sql
@@ -1,0 +1,36 @@
+-- CreateEnum
+CREATE TYPE "UserAgendaSource" AS ENUM ('URL', 'UPLOAD');
+
+-- CreateTable
+CREATE TABLE "user_agenda_upload" (
+    "id" TEXT NOT NULL,
+    "elected_office_id" TEXT NOT NULL,
+    "meeting_date" DATE NOT NULL,
+    "source" "UserAgendaSource" NOT NULL,
+    "source_url" TEXT,
+    "upload_bucket" TEXT,
+    "upload_key" TEXT,
+    "content_type" TEXT,
+    "byte_size" INTEGER,
+    "uploaded_by_user_id" INTEGER NOT NULL,
+    "experiment_run_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_agenda_upload_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_agenda_upload_uploaded_by_user_id_idx" ON "user_agenda_upload"("uploaded_by_user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_agenda_upload_elected_office_id_meeting_date_key" ON "user_agenda_upload"("elected_office_id", "meeting_date");
+
+-- AddForeignKey
+ALTER TABLE "user_agenda_upload" ADD CONSTRAINT "user_agenda_upload_elected_office_id_fkey" FOREIGN KEY ("elected_office_id") REFERENCES "elected_office"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_agenda_upload" ADD CONSTRAINT "user_agenda_upload_uploaded_by_user_id_fkey" FOREIGN KEY ("uploaded_by_user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_agenda_upload" ADD CONSTRAINT "user_agenda_upload_experiment_run_id_fkey" FOREIGN KEY ("experiment_run_id") REFERENCES "experiment_run"("run_id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema/migrations/20260605190035_add_annotation_review/migration.sql
+++ b/prisma/schema/migrations/20260605190035_add_annotation_review/migration.sql
@@ -1,0 +1,23 @@
+-- AlterEnum
+ALTER TYPE "AnnotationKind" ADD VALUE 'review';
+
+-- AlterTable
+ALTER TABLE "annotation" ADD COLUMN     "annotation_review_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "annotation_review" (
+    "id" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "reviewer_clerk_sub" TEXT NOT NULL,
+    "reviewer_email" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "annotation_review_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "annotation_annotation_review_id_key" ON "annotation"("annotation_review_id");
+
+-- AddForeignKey
+ALTER TABLE "annotation" ADD CONSTRAINT "annotation_annotation_review_id_fkey" FOREIGN KEY ("annotation_review_id") REFERENCES "annotation_review"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -32,6 +32,7 @@ model User {
   annotations           Annotation[]
   chatConversations     ChatConversation[]
   artifactFeedbacks     ArtifactFeedback[]
+  userAgendaUploads     UserAgendaUpload[]
 
   @@index([firstName])
   @@index([lastName])

--- a/prisma/schema/userAgendaUpload.prisma
+++ b/prisma/schema/userAgendaUpload.prisma
@@ -1,0 +1,33 @@
+enum UserAgendaSource {
+  URL
+  UPLOAD
+}
+
+model UserAgendaUpload {
+  id String @id @default(uuid(7))
+
+  electedOfficeId String        @map("elected_office_id")
+  electedOffice   ElectedOffice @relation(fields: [electedOfficeId], references: [id], onDelete: Cascade)
+
+  meetingDate DateTime @map("meeting_date") @db.Date
+
+  source       UserAgendaSource
+  sourceUrl    String?          @map("source_url")
+  uploadBucket String?          @map("upload_bucket")
+  uploadKey    String?          @map("upload_key")
+  contentType  String?          @map("content_type")
+  byteSize     Int?             @map("byte_size")
+
+  uploadedByUserId Int  @map("uploaded_by_user_id")
+  uploadedByUser   User @relation(fields: [uploadedByUserId], references: [id], onDelete: Restrict)
+
+  experimentRunId String?        @map("experiment_run_id")
+  experimentRun   ExperimentRun? @relation(fields: [experimentRunId], references: [runId], onDelete: SetNull)
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([electedOfficeId, meetingDate])
+  @@index([uploadedByUserId])
+  @@map("user_agenda_upload")
+}

--- a/scripts/dispatch-imminent-briefings.ts
+++ b/scripts/dispatch-imminent-briefings.ts
@@ -105,8 +105,7 @@ async function main() {
       `Prod offices:  ${pool.length} (shuffled)`,
       `Goal:          ${target} briefings dispatched (5-day imminence gate)`,
       `Concurrency:   ${concurrency}`,
-      `Max est. cost: ~$${maxEstimate.toFixed(2)} ` +
-        `(may overshoot by up to ${concurrency - 1} in-flight calls)`,
+      `Max est. cost: ~$${maxEstimate.toFixed(2)} (hard cap at the target)`,
       '',
       'Proceed? (y/N) ',
     ].join('\n'),
@@ -128,9 +127,13 @@ async function main() {
   const token = await mintToken()
   const records: DispatchRecord[] = []
   let dispatched = 0
+  // Slots claimed by in-flight or completed dispatches. Workers claim a slot
+  // synchronously before each call so the concurrent pool can never push
+  // `dispatched` past `target` and blow the cost cap. A skip releases its slot.
+  let reserved = 0
   let index = 0
 
-  const callDispatch = async (office: Office): Promise<void> => {
+  const callDispatch = async (office: Office): Promise<boolean> => {
     let httpStatus = 0
     let didDispatch = false
     try {
@@ -168,12 +171,7 @@ async function main() {
     }
     records.push(record)
     appendFileSync(logPath, `${JSON.stringify(record)}\n`)
-    if (didDispatch) {
-      dispatched++
-      if (dispatched % 10 === 0) {
-        console.log(`  dispatched ${dispatched}/${target}`)
-      }
-    }
+    return didDispatch
   }
 
   const runStart = new Date().toISOString()
@@ -182,8 +180,23 @@ async function main() {
     () =>
       (async () => {
         while (dispatched < target && index < pool.length) {
-          const current = index++
-          await callDispatch(pool[current])
+          // Claim a slot synchronously — no await between the check and the
+          // increment — so two workers can never both take the last one.
+          if (reserved >= target) {
+            await new Promise((resolve) => setTimeout(resolve, 25))
+            continue
+          }
+          reserved++
+          const did = await callDispatch(pool[index++])
+          if (did) {
+            dispatched++
+            if (dispatched % 10 === 0) {
+              console.log(`  dispatched ${dispatched}/${target}`)
+            }
+          } else {
+            // A skip consumed no briefing; free the slot for another office.
+            reserved--
+          }
         }
       })(),
   )

--- a/scripts/dispatch-imminent-briefings.ts
+++ b/scripts/dispatch-imminent-briefings.ts
@@ -1,0 +1,221 @@
+import 'dotenv/config'
+import { createInterface } from 'node:readline/promises'
+import { stdin, stdout } from 'node:process'
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { PrismaClient } from '../src/generated/prisma'
+import { createClerkClient } from '@clerk/backend'
+
+const BRIEFING_COST_USD = 3.9
+const TOKEN_TTL_SECONDS = 3600
+const DEFAULT_TARGET = 100
+
+type DispatchRecord = {
+  electedOfficeId: string
+  organizationSlug: string
+  httpStatus: number
+  dispatched: boolean
+  ok: boolean
+  ts: string
+}
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name]
+  if (!value) throw new Error(`${name} is not set`)
+  return value
+}
+
+const mintToken = async (): Promise<string> => {
+  const clerk = createClerkClient({
+    secretKey: requireEnv('CLERK_SECRET_KEY'),
+    publishableKey: requireEnv('CLERK_PUBLISHABLE_KEY'),
+  })
+  // Mint with the caller machine secret (gp-admin's GP_PROD_MACHINE_SECRET),
+  // not gp-api's GP_WEBAPP_MACHINE_SECRET. gp-api verifies as the recipient,
+  // so the token must be issued by a machine connected to it in Clerk.
+  const minted = await clerk.m2m.createToken({
+    machineSecretKey: requireEnv('GP_PROD_MACHINE_SECRET'),
+    secondsUntilExpiration: TOKEN_TTL_SECONDS,
+  })
+  if (!minted.token) throw new Error('Clerk did not return an m2m token')
+  return minted.token
+}
+
+const confirm = async (message: string): Promise<boolean> => {
+  const rl = createInterface({ input: stdin, output: stdout })
+  const answer = await rl.question(message)
+  rl.close()
+  return answer.trim().toLowerCase() === 'y'
+}
+
+// Fisher-Yates shuffle for a fair random sample of eligible offices.
+const shuffle = <T>(items: T[]): T[] => {
+  const out = [...items]
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[out[i], out[j]] = [out[j], out[i]]
+  }
+  return out
+}
+
+type Office = { id: string; organizationSlug: string }
+
+async function main() {
+  const apiUrl = process.env.PROD_API_URL ?? 'https://api.goodparty.org'
+  const databaseUrl = requireEnv('PROD_DATABASE_URL')
+  const concurrency = Number(process.env.CONCURRENCY ?? '5')
+  const dryRun = process.argv.includes('--dry-run')
+  const targetArg = process.argv.find((a) => a.startsWith('--target='))
+  const target = targetArg ? Number(targetArg.split('=')[1]) : DEFAULT_TARGET
+
+  const prisma = new PrismaClient({ datasourceUrl: databaseUrl })
+  const allOffices = await prisma.electedOffice.findMany({
+    select: { id: true, organizationSlug: true },
+  })
+  await prisma.$disconnect()
+
+  const pool = shuffle(allOffices)
+  const maxEstimate = target * BRIEFING_COST_USD
+
+  if (dryRun) {
+    console.log(
+      [
+        'DRY RUN — no token minted, no dispatches sent.',
+        `Target:          ${apiUrl}`,
+        `Prod offices:    ${pool.length} (shuffled)`,
+        `Goal:            ${target} briefings actually dispatched`,
+        `Gate:            useImminenceGate=true (5-day window + dedupe)`,
+        `Concurrency:     ${concurrency}`,
+        `Max est. cost:   ~$${maxEstimate.toFixed(2)} (at the target)`,
+        '',
+        'The endpoint self-filters: offices with no meeting in the next 5 days',
+        '(or already covered by a future briefing) return dispatched:false and',
+        'cost nothing. We walk the shuffled pool until the target is reached.',
+        '',
+        'Sample order:',
+        ...pool.slice(0, 10).map((o) => `  ${o.id}  ${o.organizationSlug}`),
+      ].join('\n'),
+    )
+    return
+  }
+
+  const proceed = await confirm(
+    [
+      `Target:        ${apiUrl}`,
+      `Prod offices:  ${pool.length} (shuffled)`,
+      `Goal:          ${target} briefings dispatched (5-day imminence gate)`,
+      `Concurrency:   ${concurrency}`,
+      `Max est. cost: ~$${maxEstimate.toFixed(2)} ` +
+        `(may overshoot by up to ${concurrency - 1} in-flight calls)`,
+      '',
+      'Proceed? (y/N) ',
+    ].join('\n'),
+  )
+  if (!proceed) {
+    console.log('Aborted.')
+    return
+  }
+
+  mkdirSync(join(__dirname, 'output'), { recursive: true })
+  const logPath = join(
+    __dirname,
+    'output',
+    `dispatch-imminent-briefings.${new Date().toISOString()}.jsonl`,
+  )
+
+  // A run that walks a few thousand offices at this concurrency finishes well
+  // inside the 1h token TTL, so mint once.
+  const token = await mintToken()
+  const records: DispatchRecord[] = []
+  let dispatched = 0
+  let index = 0
+
+  const callDispatch = async (office: Office): Promise<void> => {
+    let httpStatus = 0
+    let didDispatch = false
+    try {
+      const res = await fetch(`${apiUrl}/v1/meetings/briefings/dispatch`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          electedOfficeId: office.id,
+          kind: 'briefing',
+          useImminenceGate: true,
+        }),
+      })
+      httpStatus = res.status
+      if (res.ok) {
+        const body: unknown = await res.json()
+        didDispatch =
+          typeof body === 'object' &&
+          body !== null &&
+          'dispatched' in body &&
+          body.dispatched === true
+      }
+    } catch {
+      httpStatus = 0
+    }
+    const record: DispatchRecord = {
+      electedOfficeId: office.id,
+      organizationSlug: office.organizationSlug,
+      httpStatus,
+      dispatched: didDispatch,
+      ok: httpStatus >= 200 && httpStatus < 300,
+      ts: new Date().toISOString(),
+    }
+    records.push(record)
+    appendFileSync(logPath, `${JSON.stringify(record)}\n`)
+    if (didDispatch) {
+      dispatched++
+      if (dispatched % 10 === 0) {
+        console.log(`  dispatched ${dispatched}/${target}`)
+      }
+    }
+  }
+
+  const runStart = new Date().toISOString()
+  const workers = Array.from(
+    { length: Math.min(concurrency, pool.length) },
+    () =>
+      (async () => {
+        while (dispatched < target && index < pool.length) {
+          const current = index++
+          await callDispatch(pool[current])
+        }
+      })(),
+  )
+  await Promise.all(workers)
+  const runEnd = new Date().toISOString()
+
+  const okCalls = records.filter((r) => r.ok).length
+  const failures = records.filter((r) => !r.ok)
+
+  console.log(
+    JSON.stringify(
+      {
+        goal: target,
+        dispatched,
+        callsMade: records.length,
+        okCalls,
+        skipped: okCalls - dispatched,
+        failures: failures.map((r) => ({
+          electedOfficeId: r.electedOfficeId,
+          httpStatus: r.httpStatus,
+        })),
+        estCostUsd: Number((dispatched * BRIEFING_COST_USD).toFixed(2)),
+        logPath,
+        reconcile: { runStart, runEnd },
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -10,6 +10,8 @@ import { AdminCampaignsService } from './campaigns/adminCampaigns.service'
 import { AdminUsersController } from './users/adminUsers.controller'
 import { AdminAgentRunsController } from './agentRuns/adminAgentRuns.controller'
 import { AdminAgentRunsService } from './agentRuns/services/adminAgentRuns.service'
+import { AdminBriefingsController } from './briefings/adminBriefings.controller'
+import { AdminBriefingsService } from './briefings/services/adminBriefings.service'
 
 @Module({
   imports: [
@@ -24,7 +26,12 @@ import { AdminAgentRunsService } from './agentRuns/services/adminAgentRuns.servi
     AdminCampaignsController,
     AdminUsersController,
     AdminAgentRunsController,
+    AdminBriefingsController,
   ],
-  providers: [AdminCampaignsService, AdminAgentRunsService],
+  providers: [
+    AdminCampaignsService,
+    AdminAgentRunsService,
+    AdminBriefingsService,
+  ],
 })
 export class AdminModule {}

--- a/src/admin/briefings/adminBriefings.controller.ts
+++ b/src/admin/briefings/adminBriefings.controller.ts
@@ -1,0 +1,37 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  UsePipes,
+} from '@nestjs/common'
+import { ZodValidationPipe } from 'nestjs-zod'
+import { M2MOnly } from '@/authentication/guards/M2MOnly.guard'
+import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import { PaginatedResponseSchema } from '@/shared/schemas/PaginatedResponse.schema'
+import { AdminBriefingsService } from './services/adminBriefings.service'
+import {
+  AdminBriefingListQueryDto,
+  BriefingAdminRowSchema,
+} from './schemas/adminBriefings.schema'
+
+@Controller('admin/briefings')
+@UsePipes(ZodValidationPipe)
+export class AdminBriefingsController {
+  constructor(private readonly briefings: AdminBriefingsService) {}
+
+  @Get()
+  @UseGuards(M2MOnly)
+  @ResponseSchema(PaginatedResponseSchema(BriefingAdminRowSchema))
+  list(@Query() query: AdminBriefingListQueryDto) {
+    return this.briefings.list(query)
+  }
+
+  @Get(':id')
+  @UseGuards(M2MOnly)
+  @ResponseSchema(BriefingAdminRowSchema)
+  get(@Param('id') id: string) {
+    return this.briefings.get(id)
+  }
+}

--- a/src/admin/briefings/adminBriefings.service.test.ts
+++ b/src/admin/briefings/adminBriefings.service.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { ExperimentRunStatus } from '../../generated/prisma'
+import { useTestService } from '@/test-service'
+import { AdminBriefingsService } from './services/adminBriefings.service'
+
+const service = useTestService()
+
+const seedBriefing = async ({
+  orgSlug,
+  userId,
+  meetingDate,
+  meetingName,
+  customPositionName,
+}: {
+  orgSlug: string
+  userId: number
+  meetingDate: string
+  meetingName?: string
+  customPositionName?: string
+}) => {
+  await service.prisma.organization.create({
+    data: { slug: orgSlug, ownerId: userId, customPositionName },
+  })
+  const eo = await service.prisma.electedOffice.create({
+    data: { organizationSlug: orgSlug, userId },
+  })
+  const run = await service.prisma.experimentRun.create({
+    data: {
+      organizationSlug: orgSlug,
+      experimentType: 'meeting_briefing',
+      status: ExperimentRunStatus.COMPLETED,
+    },
+  })
+  return service.prisma.meetingBriefing.create({
+    data: {
+      electedOfficeId: eo.id,
+      meetingDate: new Date(meetingDate + 'T00:00:00Z'),
+      meetingTime: '19:00',
+      meetingTimezone: 'America/Denver',
+      experimentRunId: run.runId,
+      artifactBucket: 'b',
+      artifactKey: `${meetingDate}.json`,
+      artifact: meetingName ? { meeting_name: meetingName } : undefined,
+    },
+  })
+}
+
+describe('AdminBriefingsService.list', () => {
+  it('returns rows joined to the owning user and office', async () => {
+    const briefings = service.app.get(AdminBriefingsService)
+    const briefing = await seedBriefing({
+      orgSlug: 'eo-admin-list',
+      userId: service.user.id,
+      meetingDate: '2026-06-09',
+      meetingName: 'City Council Regular Session',
+      customPositionName: 'City Council Member',
+    })
+
+    const result = await briefings.list({})
+
+    const row = result.data.find((r) => r.briefingId === briefing.id)
+    expect(row).toBeDefined()
+    expect(row?.meetingDate).toBe('2026-06-09')
+    expect(row?.meetingName).toBe('City Council Regular Session')
+    expect(row?.user.id).toBe(service.user.id)
+    expect(row?.electedOffice.organizationSlug).toBe('eo-admin-list')
+    expect(row?.electedOffice.positionName).toBe('City Council Member')
+  })
+
+  it('filters by fuzzy name/email query', async () => {
+    const briefings = service.app.get(AdminBriefingsService)
+    const match = await service.prisma.user.create({
+      data: {
+        clerkId: 'admin_q_match',
+        email: 'zelda@goodparty.org',
+        firstName: 'Zelda',
+        lastName: 'Fitzgerald',
+      },
+    })
+    await seedBriefing({
+      orgSlug: 'eo-q-match',
+      userId: match.id,
+      meetingDate: '2026-06-10',
+    })
+
+    const result = await briefings.list({ q: 'zelda' })
+
+    expect(result.data.length).toBeGreaterThan(0)
+    expect(
+      result.data.every((r) => r.user.email === 'zelda@goodparty.org'),
+    ).toBe(true)
+  })
+})

--- a/src/admin/briefings/schemas/adminBriefings.schema.ts
+++ b/src/admin/briefings/schemas/adminBriefings.schema.ts
@@ -1,0 +1,13 @@
+import { createZodDto } from 'nestjs-zod'
+import { BriefingAdminListQuerySchema } from '@goodparty_org/contracts'
+
+export class AdminBriefingListQueryDto extends createZodDto(
+  BriefingAdminListQuerySchema,
+) {}
+
+export {
+  BriefingAdminRowSchema,
+  type BriefingAdminRow,
+  BriefingDateRangeFilterSchema,
+  type BriefingDateRangeFilter,
+} from '@goodparty_org/contracts'

--- a/src/admin/briefings/services/adminBriefings.service.ts
+++ b/src/admin/briefings/services/adminBriefings.service.ts
@@ -1,0 +1,134 @@
+import { Injectable, NotFoundException } from '@nestjs/common'
+import { subDays, subMonths } from 'date-fns'
+import { formatInTimeZone } from 'date-fns-tz'
+import { Prisma } from '@/generated/prisma'
+import {
+  BriefingAdminListQuery,
+  BriefingAdminRow,
+  BriefingDateRangeFilter,
+  PaginatedList,
+} from '@goodparty_org/contracts'
+import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
+import { DEFAULT_PAGINATION_OFFSET } from '@/shared/constants/paginationOptions.consts'
+
+const DEFAULT_LIMIT = 25
+const MAX_LIMIT = 100
+
+type BriefingWithRelations = Prisma.MeetingBriefingGetPayload<{
+  include: {
+    electedOffice: { include: { user: true; organization: true } }
+  }
+}>
+
+// user is typed nullable because ElectedOffice.user is an optional relation,
+// but the userId FK is required — a briefing without an owner is impossible.
+// The null branch is defensive and drops nothing in practice.
+const toRow = (b: BriefingWithRelations): BriefingAdminRow | null => {
+  const user = b.electedOffice.user
+  if (!user) return null
+  return {
+    briefingId: b.id,
+    meetingDate: formatInTimeZone(b.meetingDate, 'UTC', 'yyyy-MM-dd'),
+    meetingName: b.artifact?.meeting_name ?? null,
+    user: {
+      id: user.id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      email: user.email,
+    },
+    electedOffice: {
+      id: b.electedOffice.id,
+      organizationSlug: b.electedOffice.organizationSlug,
+      positionName: b.electedOffice.organization.customPositionName,
+    },
+    updatedAt: b.updatedAt,
+  }
+}
+
+@Injectable()
+export class AdminBriefingsService extends createPrismaBase(
+  MODELS.MeetingBriefing,
+) {
+  async list({
+    offset = DEFAULT_PAGINATION_OFFSET,
+    limit = DEFAULT_LIMIT,
+    q,
+    dateRange,
+  }: BriefingAdminListQuery): Promise<PaginatedList<BriefingAdminRow>> {
+    const take = Math.min(limit, MAX_LIMIT)
+    const where: Prisma.MeetingBriefingWhereInput = {
+      ...(q
+        ? {
+            electedOffice: {
+              user: {
+                OR: [
+                  {
+                    firstName: {
+                      contains: q,
+                      mode: Prisma.QueryMode.insensitive,
+                    },
+                  },
+                  {
+                    lastName: {
+                      contains: q,
+                      mode: Prisma.QueryMode.insensitive,
+                    },
+                  },
+                  {
+                    email: { contains: q, mode: Prisma.QueryMode.insensitive },
+                  },
+                ],
+              },
+            },
+          }
+        : {}),
+      ...dateRangeWhere(dateRange),
+    }
+
+    const [briefings, total] = await Promise.all([
+      this.model.findMany({
+        where,
+        orderBy: { updatedAt: Prisma.SortOrder.desc },
+        skip: offset,
+        take,
+        include: {
+          electedOffice: { include: { user: true, organization: true } },
+        },
+      }),
+      this.model.count({ where }),
+    ])
+
+    return {
+      data: briefings
+        .map(toRow)
+        .filter((r): r is BriefingAdminRow => r !== null),
+      meta: { total, offset, limit: take },
+    }
+  }
+
+  async get(id: string): Promise<BriefingAdminRow> {
+    const briefing = await this.model.findUnique({
+      where: { id },
+      include: {
+        electedOffice: { include: { user: true, organization: true } },
+      },
+    })
+    const row = briefing ? toRow(briefing) : null
+    if (!row) throw new NotFoundException('Briefing not found')
+    return row
+  }
+}
+
+const dateRangeWhere = (
+  dateRange?: BriefingDateRangeFilter,
+): Prisma.MeetingBriefingWhereInput => {
+  if (!dateRange || dateRange === 'All time') return {}
+  const now = new Date()
+  const since =
+    dateRange === 'last 12 months'
+      ? subMonths(now, 12)
+      : dateRange === 'last 30 days'
+        ? subDays(now, 30)
+        : subDays(now, 7)
+  return { meetingDate: { gte: since } }
+}

--- a/src/agentExperiments/services/experimentRuns.service.test.ts
+++ b/src/agentExperiments/services/experimentRuns.service.test.ts
@@ -358,6 +358,28 @@ describe('ExperimentRunsService', () => {
     )
 
     it(
+      'terminalizes the old row as FAILED (superseded) after a ' +
+        'successful resume dispatch',
+      async () => {
+        sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-1' })
+        mockModel.updateMany.mockResolvedValue({ count: 1 })
+
+        await service.resumeRun(awaitingRun)
+
+        expect(mockModel.updateMany).toHaveBeenCalledWith({
+          where: {
+            runId: awaitingRun.runId,
+            status: ExperimentRunStatus.AWAITING_RESUME,
+          },
+          data: {
+            status: ExperimentRunStatus.FAILED,
+            error: 'Superseded by resumed run',
+          },
+        })
+      },
+    )
+
+    it(
       'claims the old row by nulling resumeScheduledFor (guarded on ' +
         'AWAITING_RESUME and resumeScheduledFor not null)',
       async () => {
@@ -474,15 +496,33 @@ describe('ExperimentRunsService', () => {
       },
     )
 
-    it('does not send SQS when AGENT_DISPATCH_QUEUE_NAME is unset', async () => {
-      delete process.env.AGENT_DISPATCH_QUEUE_NAME
-      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' })
+    it(
+      'releases the claim (does not supersede) when ' +
+        'AGENT_DISPATCH_QUEUE_NAME is unset',
+      async () => {
+        delete process.env.AGENT_DISPATCH_QUEUE_NAME
+        sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' })
+        mockModel.updateMany.mockResolvedValue({ count: 1 })
 
-      await service.resumeRun(awaitingRun)
+        await service.resumeRun(awaitingRun)
 
-      expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
-      expect(mockModel.create).not.toHaveBeenCalled()
-    })
+        expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
+        expect(mockModel.create).not.toHaveBeenCalled()
+        // claim succeeded but no successor was created → release, not supersede
+        expect(mockModel.updateMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: { resumeScheduledFor: expect.any(Date) },
+          }),
+        )
+        expect(mockModel.updateMany).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              error: 'Superseded by resumed run',
+            }),
+          }),
+        )
+      },
+    )
 
     it('resolves the queue url once and caches it across resumes', async () => {
       sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' })
@@ -608,5 +648,19 @@ describe('ExperimentRunsService', () => {
         expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
       },
     )
+
+    it('isolates a throwing resumeRun so the rest of the batch still runs', async () => {
+      const run1 = makeRun({ runId: 'run-sweep-throw', resumeAttempts: 1 })
+      const run2 = makeRun({ runId: 'run-sweep-ok', resumeAttempts: 1 })
+      mockModel.findMany.mockResolvedValue([run1, run2])
+      const resumeSpy = vi
+        .spyOn(service, 'resumeRun')
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce(undefined)
+
+      await expect(service.sweepResumableRuns()).resolves.toBeUndefined()
+
+      expect(resumeSpy).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/src/agentExperiments/services/experimentRuns.service.test.ts
+++ b/src/agentExperiments/services/experimentRuns.service.test.ts
@@ -319,8 +319,47 @@ describe('ExperimentRunsService', () => {
     }
 
     it(
-      'atomically claims the row and sends SQS with the same run_id ' +
-        'and trigger=recovery_resume',
+      'mints a NEW run_id, creates a RUNNING row with incremented ' +
+        'resumeAttempts, and sends SQS with the new run_id and ' +
+        'trigger=recovery_resume',
+      async () => {
+        sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-1' })
+        mockModel.updateMany.mockResolvedValue({ count: 1 })
+
+        await service.resumeRun(awaitingRun)
+
+        expect(mockModel.create).toHaveBeenCalledOnce()
+        const createCall = mockModel.create.mock.calls[0][0] as {
+          data: Record<string, unknown>
+        }
+        expect(createCall.data.runId).toBeDefined()
+        expect(createCall.data.runId).not.toBe(awaitingRun.runId)
+        expect(createCall.data.status).toBe(ExperimentRunStatus.RUNNING)
+        expect(createCall.data.experimentType).toBe(awaitingRun.experimentType)
+        expect(createCall.data.resumeAttempts).toBe(
+          awaitingRun.resumeAttempts + 1,
+        )
+
+        const [call] = sqsMock.commandCalls(SendMessageCommand)
+        expect(call).toBeDefined()
+        const body = JSON.parse(
+          call.args[0].input.MessageBody as string,
+        ) as Record<string, unknown>
+        expect(body.run_id).toBe(createCall.data.runId)
+        expect(body.run_id).not.toBe(awaitingRun.runId)
+        expect((body.params as Record<string, unknown>).trigger).toBe(
+          'recovery_resume',
+        )
+        expect((body.params as Record<string, unknown>).clerk_user_id).toBe(
+          'user_clerk_123',
+        )
+        expect(body.clerk_user_id).toBe('user_clerk_123')
+      },
+    )
+
+    it(
+      'claims the old row by nulling resumeScheduledFor (guarded on ' +
+        'AWAITING_RESUME and resumeScheduledFor not null)',
       async () => {
         sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-1' })
         mockModel.updateMany.mockResolvedValue({ count: 1 })
@@ -331,29 +370,15 @@ describe('ExperimentRunsService', () => {
           where: {
             runId: awaitingRun.runId,
             status: ExperimentRunStatus.AWAITING_RESUME,
+            resumeScheduledFor: { not: null },
           },
-          data: {
-            status: ExperimentRunStatus.RUNNING,
-            resumeAttempts: { increment: 1 },
-            resumeScheduledFor: null,
-          },
+          data: { resumeScheduledFor: null },
         })
-
-        const [call] = sqsMock.commandCalls(SendMessageCommand)
-        expect(call).toBeDefined()
-        const body = JSON.parse(
-          call.args[0].input.MessageBody as string,
-        ) as Record<string, unknown>
-        expect(body.run_id).toBe(awaitingRun.runId)
-        expect((body.params as Record<string, unknown>).trigger).toBe(
-          'recovery_resume',
-        )
-        expect(body.clerk_user_id).toBe('user_clerk_123')
       },
     )
 
     it(
-      'sends the clerk_user_id from params.clerk_user_id in the SQS body, ' +
+      'sends the clerk_user_id from params in the new run SQS body, ' +
         'not an empty string',
       async () => {
         sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-2' })
@@ -383,7 +408,6 @@ describe('ExperimentRunsService', () => {
         'message when params has no clerk_user_id',
       async () => {
         sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-3' })
-        mockModel.updateMany.mockResolvedValue({ count: 1 })
 
         await service.resumeRun({
           runId: 'run-missing-user',
@@ -404,13 +428,7 @@ describe('ExperimentRunsService', () => {
             error: expect.stringContaining('clerk_user_id'),
           },
         })
-        expect(mockModel.updateMany).not.toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.objectContaining({
-              status: ExperimentRunStatus.RUNNING,
-            }),
-          }),
-        )
+        expect(mockModel.create).not.toHaveBeenCalled()
         expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
         expect(logger.error).toHaveBeenCalledWith(
           expect.objectContaining({ runId: 'run-missing-user' }),
@@ -419,33 +437,42 @@ describe('ExperimentRunsService', () => {
       },
     )
 
-    it('does not send SQS when the atomic claim is lost (count 0)', async () => {
-      sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-1' })
-      mockModel.updateMany.mockResolvedValue({ count: 0 })
+    it(
+      'does not create a new run or send SQS when the claim is lost ' +
+        '(updateMany returns count 0)',
+      async () => {
+        sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-resume-1' })
+        mockModel.updateMany.mockResolvedValue({ count: 0 })
 
-      await service.resumeRun(awaitingRun)
+        await service.resumeRun(awaitingRun)
 
-      expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
-    })
+        expect(mockModel.create).not.toHaveBeenCalled()
+        expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
+      },
+    )
 
-    it('releases the claim back to AWAITING_RESUME when SQS send throws', async () => {
-      sqsMock.on(SendMessageCommand).rejects(new Error('SQS down'))
-      mockModel.updateMany.mockResolvedValue({ count: 1 })
+    it(
+      'releases the claim (restores resumeScheduledFor on old row) ' +
+        'when SQS send throws, and does not rethrow',
+      async () => {
+        sqsMock.on(SendMessageCommand).rejects(new Error('SQS down'))
+        mockModel.updateMany.mockResolvedValue({ count: 1 })
 
-      await service.resumeRun(awaitingRun)
+        await expect(service.resumeRun(awaitingRun)).resolves.toBeUndefined()
 
-      expect(mockModel.updateMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: {
-            runId: awaitingRun.runId,
-            status: ExperimentRunStatus.RUNNING,
-          },
-          data: expect.objectContaining({
-            status: ExperimentRunStatus.AWAITING_RESUME,
+        expect(mockModel.updateMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              runId: awaitingRun.runId,
+              status: ExperimentRunStatus.AWAITING_RESUME,
+            }),
+            data: expect.objectContaining({
+              resumeScheduledFor: expect.any(Date),
+            }),
           }),
-        }),
-      )
-    })
+        )
+      },
+    )
 
     it('does not send SQS when AGENT_DISPATCH_QUEUE_NAME is unset', async () => {
       delete process.env.AGENT_DISPATCH_QUEUE_NAME
@@ -454,7 +481,7 @@ describe('ExperimentRunsService', () => {
       await service.resumeRun(awaitingRun)
 
       expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0)
-      expect(mockModel.updateMany).not.toHaveBeenCalled()
+      expect(mockModel.create).not.toHaveBeenCalled()
     })
 
     it('resolves the queue url once and caches it across resumes', async () => {

--- a/src/agentExperiments/services/experimentRuns.service.test.ts
+++ b/src/agentExperiments/services/experimentRuns.service.test.ts
@@ -339,6 +339,7 @@ describe('ExperimentRunsService', () => {
         expect(createCall.data.resumeAttempts).toBe(
           awaitingRun.resumeAttempts + 1,
         )
+        expect(createCall.data.stage).toBe(awaitingRun.stage)
 
         const [call] = sqsMock.commandCalls(SendMessageCommand)
         expect(call).toBeDefined()
@@ -482,15 +483,28 @@ describe('ExperimentRunsService', () => {
 
         await expect(service.resumeRun(awaitingRun)).resolves.toBeUndefined()
 
+        // The successor row was created then flipped to FAILED inside
+        // createAndEnqueueRun's catch before the throw bubbled up.
+        expect(mockModel.create).toHaveBeenCalledOnce()
+        expect(mockModel.update).toHaveBeenCalledWith({
+          where: { runId: expect.any(String) },
+          data: {
+            status: ExperimentRunStatus.FAILED,
+            error: 'SQS dispatch failed',
+          },
+        })
+        // The original row is released AND its attempt counter advanced so
+        // MAX_RESUME_ATTEMPTS can eventually terminate a persistent failure.
         expect(mockModel.updateMany).toHaveBeenCalledWith(
           expect.objectContaining({
             where: expect.objectContaining({
               runId: awaitingRun.runId,
               status: ExperimentRunStatus.AWAITING_RESUME,
             }),
-            data: expect.objectContaining({
+            data: {
               resumeScheduledFor: expect.any(Date),
-            }),
+              resumeAttempts: { increment: 1 },
+            },
           }),
         )
       },
@@ -511,7 +525,9 @@ describe('ExperimentRunsService', () => {
         // claim succeeded but no successor was created → release, not supersede
         expect(mockModel.updateMany).toHaveBeenCalledWith(
           expect.objectContaining({
-            data: { resumeScheduledFor: expect.any(Date) },
+            data: expect.objectContaining({
+              resumeScheduledFor: expect.any(Date),
+            }),
           }),
         )
         expect(mockModel.updateMany).not.toHaveBeenCalledWith(

--- a/src/agentExperiments/services/experimentRuns.service.ts
+++ b/src/agentExperiments/services/experimentRuns.service.ts
@@ -96,6 +96,7 @@ export class ExperimentRunsService extends createPrismaBase(
     clerkUserId: string
     params: Prisma.InputJsonValue
     resumeAttempts?: number
+    stage?: string | null
   }): Promise<ExperimentRun | undefined> {
     const queueUrl = await this.resolveQueueUrl()
     if (!queueUrl) {
@@ -113,6 +114,7 @@ export class ExperimentRunsService extends createPrismaBase(
         status: ExperimentRunStatus.RUNNING,
         params: input.params,
         resumeAttempts: input.resumeAttempts ?? 0,
+        stage: input.stage ?? null,
       },
     })
     try {
@@ -221,6 +223,7 @@ export class ExperimentRunsService extends createPrismaBase(
         clerkUserId,
         params: resumeParams,
         resumeAttempts: run.resumeAttempts + 1,
+        stage: run.stage,
       })
     } catch (error) {
       this.logger.error(
@@ -233,15 +236,20 @@ export class ExperimentRunsService extends createPrismaBase(
     if (!dispatched) {
       // Dispatch threw, or no queue is configured (preview env) so no successor
       // was created. Release the claim so the row returns to the sweep instead
-      // of being orphaned or falsely marked superseded. Wrap the release so a
-      // transient DB error here is logged rather than left silently stuck.
+      // of being orphaned or falsely marked superseded — but still increment
+      // resumeAttempts so MAX_RESUME_ATTEMPTS eventually terminates it (e.g. a
+      // prolonged SQS outage would otherwise re-dispatch forever). Wrap the
+      // release so a transient DB error here is logged rather than left stuck.
       try {
         await this.model.updateMany({
           where: {
             runId: run.runId,
             status: ExperimentRunStatus.AWAITING_RESUME,
           },
-          data: { resumeScheduledFor: new Date() },
+          data: {
+            resumeScheduledFor: new Date(),
+            resumeAttempts: { increment: 1 },
+          },
         })
       } catch (releaseError) {
         this.logger.error(

--- a/src/agentExperiments/services/experimentRuns.service.ts
+++ b/src/agentExperiments/services/experimentRuns.service.ts
@@ -2,7 +2,11 @@ import { BadGatewayException, Injectable } from '@nestjs/common'
 import { createPrismaBase, MODELS } from '@/prisma/util/prisma.util'
 import { v7 as uuidv7 } from 'uuid'
 import { SQS } from '@aws-sdk/client-sqs'
-import { ExperimentRunStatus, Prisma } from '../../generated/prisma'
+import {
+  ExperimentRun,
+  ExperimentRunStatus,
+  Prisma,
+} from '../../generated/prisma'
 import { Cron } from '@nestjs/schedule'
 import { randomUUID } from 'crypto'
 import { subMinutes } from 'date-fns'
@@ -86,34 +90,36 @@ export class ExperimentRunsService extends createPrismaBase(
     })
   }
 
-  async dispatchRun<ExperimentType extends keyof AgentJobContracts>(
-    input: ExperimentRunDispatchInput<ExperimentType>,
-  ) {
-    const QueueUrl = await this.resolveQueueUrl()
-    if (!QueueUrl) {
+  private async createAndEnqueueRun(input: {
+    experimentType: string
+    organizationSlug: string
+    clerkUserId: string
+    params: Prisma.InputJsonValue
+    resumeAttempts?: number
+  }): Promise<ExperimentRun | undefined> {
+    const queueUrl = await this.resolveQueueUrl()
+    if (!queueUrl) {
       this.logger.warn(
         'No Queue Url found for agent dispatch, not configured for this environment',
       )
       return
     }
-
     const runId = uuidv7()
-
     const result = await this.model.create({
       data: {
         runId,
-        experimentType: input.type,
+        experimentType: input.experimentType,
         organizationSlug: input.organizationSlug,
         status: ExperimentRunStatus.RUNNING,
         params: input.params,
+        resumeAttempts: input.resumeAttempts ?? 0,
       },
     })
-
     try {
-      await this.enqueueDispatch(QueueUrl, {
+      await this.enqueueDispatch(queueUrl, {
         runId,
         organizationSlug: input.organizationSlug,
-        experimentType: input.type,
+        experimentType: input.experimentType,
         clerkUserId: input.clerkUserId,
         params: input.params,
       })
@@ -122,42 +128,49 @@ export class ExperimentRunsService extends createPrismaBase(
         {
           error,
           runId,
-          experimentType: input.type,
+          experimentType: input.experimentType,
           organizationSlug: input.organizationSlug,
         },
         'Failed to send dispatch message to SQS',
       )
       await this.model.update({
         where: { runId },
-        data: { status: 'FAILED', error: 'SQS dispatch failed' },
+        data: {
+          status: ExperimentRunStatus.FAILED,
+          error: 'SQS dispatch failed',
+        },
       })
       throw new BadGatewayException(
         'Failed to dispatch experiment. Please try again.',
       )
     }
-
     this.logger.info(
       {
         runId,
-        experimentType: input.type,
+        experimentType: input.experimentType,
         organizationSlug: input.organizationSlug,
       },
       'Experiment dispatched',
     )
-
     return result
   }
 
-  async resumeRun(run: ResumeRunInput) {
-    const QueueUrl = await this.resolveQueueUrl()
-    if (!QueueUrl) {
-      this.logger.warn(
-        { runId: run.runId },
-        'No Queue Url configured — cannot resume run in this environment',
-      )
-      return
-    }
+  async dispatchRun<ExperimentType extends keyof AgentJobContracts>(
+    input: ExperimentRunDispatchInput<ExperimentType>,
+  ) {
+    return this.createAndEnqueueRun({
+      experimentType: input.type,
+      organizationSlug: input.organizationSlug,
+      clerkUserId: input.clerkUserId,
+      // AgentJobContracts inputs are JSON-serializable objects validated by Zod;
+      // the assertion bridges the structural index-signature gap that InputJsonObject
+      // requires but the generated contract types don't declare.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      params: input.params as Prisma.InputJsonObject,
+    })
+  }
 
+  async resumeRun(run: ResumeRunInput) {
     const clerkUserId =
       isJsonObject(run.params) &&
       typeof run.params['clerk_user_id'] === 'string'
@@ -186,46 +199,39 @@ export class ExperimentRunsService extends createPrismaBase(
       where: {
         runId: run.runId,
         status: ExperimentRunStatus.AWAITING_RESUME,
+        resumeScheduledFor: { not: null },
       },
-      data: {
-        status: ExperimentRunStatus.RUNNING,
-        resumeAttempts: { increment: 1 },
-        resumeScheduledFor: null,
-      },
+      data: { resumeScheduledFor: null },
     })
 
     if (claimed.count === 0) {
       return
     }
 
-    const resumeParams =
-      typeof run.params === 'object' && run.params !== null
-        ? { ...run.params, trigger: 'recovery_resume' }
-        : { trigger: 'recovery_resume' }
+    const resumeParams = {
+      ...(isJsonObject(run.params) ? run.params : {}),
+      trigger: 'recovery_resume',
+    } as Prisma.InputJsonObject
 
     try {
-      await this.enqueueDispatch(QueueUrl, {
-        runId: run.runId,
-        organizationSlug: run.organizationSlug,
+      await this.createAndEnqueueRun({
         experimentType: run.experimentType,
+        organizationSlug: run.organizationSlug,
         clerkUserId,
         params: resumeParams,
+        resumeAttempts: run.resumeAttempts + 1,
       })
     } catch (error) {
       this.logger.error(
         { error, runId: run.runId },
-        'Failed to re-enqueue resumed run — releasing claim',
+        'Failed to dispatch resumed run — releasing claim',
       )
       await this.model.updateMany({
         where: {
           runId: run.runId,
-          status: ExperimentRunStatus.RUNNING,
-        },
-        data: {
           status: ExperimentRunStatus.AWAITING_RESUME,
-          resumeAttempts: { decrement: 1 },
-          resumeScheduledFor: new Date(),
         },
+        data: { resumeScheduledFor: new Date() },
       })
     }
   }

--- a/src/agentExperiments/services/experimentRuns.service.ts
+++ b/src/agentExperiments/services/experimentRuns.service.ts
@@ -213,8 +213,9 @@ export class ExperimentRunsService extends createPrismaBase(
       trigger: 'recovery_resume',
     } as Prisma.InputJsonObject
 
+    let dispatched: ExperimentRun | undefined
     try {
-      await this.createAndEnqueueRun({
+      dispatched = await this.createAndEnqueueRun({
         experimentType: run.experimentType,
         organizationSlug: run.organizationSlug,
         clerkUserId,
@@ -224,15 +225,52 @@ export class ExperimentRunsService extends createPrismaBase(
     } catch (error) {
       this.logger.error(
         { error, runId: run.runId },
-        'Failed to dispatch resumed run — releasing claim',
+        'Failed to dispatch resumed run',
       )
+      dispatched = undefined
+    }
+
+    if (!dispatched) {
+      // Dispatch threw, or no queue is configured (preview env) so no successor
+      // was created. Release the claim so the row returns to the sweep instead
+      // of being orphaned or falsely marked superseded. Wrap the release so a
+      // transient DB error here is logged rather than left silently stuck.
+      try {
+        await this.model.updateMany({
+          where: {
+            runId: run.runId,
+            status: ExperimentRunStatus.AWAITING_RESUME,
+          },
+          data: { resumeScheduledFor: new Date() },
+        })
+      } catch (releaseError) {
+        this.logger.error(
+          { releaseError, runId: run.runId },
+          'Failed to release resume claim — row stuck AWAITING_RESUME with no schedule',
+        )
+      }
+      return
+    }
+
+    // A successor run was created; terminalize the old row so it can't linger
+    // forever as a non-terminal orphan (the resume sweep ignores a null
+    // resumeScheduledFor, and the stale sweep only touches RUNNING).
+    try {
       await this.model.updateMany({
         where: {
           runId: run.runId,
           status: ExperimentRunStatus.AWAITING_RESUME,
         },
-        data: { resumeScheduledFor: new Date() },
+        data: {
+          status: ExperimentRunStatus.FAILED,
+          error: 'Superseded by resumed run',
+        },
       })
+    } catch (supersedeError) {
+      this.logger.error(
+        { supersedeError, runId: run.runId },
+        'Failed to terminalize superseded run — left as AWAITING_RESUME orphan',
+      )
     }
   }
 
@@ -264,7 +302,16 @@ export class ExperimentRunsService extends createPrismaBase(
           },
         })
       } else {
-        await this.resumeRun(run)
+        // Isolate each run: a throw from one resume must not abort the rest of
+        // the batch (the remaining due runs would be skipped until next tick).
+        try {
+          await this.resumeRun(run)
+        } catch (error) {
+          this.logger.error(
+            { error, runId: run.runId },
+            'resumeRun threw during sweep — continuing with remaining runs',
+          )
+        }
       }
     }
   }

--- a/src/annotations/controllers/annotations.controller.ts
+++ b/src/annotations/controllers/annotations.controller.ts
@@ -7,9 +7,11 @@ import {
   Param,
   Post,
   Put,
+  Req,
 } from '@nestjs/common'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { ElectedOffice, User } from '../../generated/prisma'
+import { IncomingRequest } from '@/authentication/authentication.types'
 import {
   AnnotationResponseSchema,
   AttachmentDownloadUrlResponseSchema,
@@ -55,14 +57,40 @@ export class AnnotationsController {
   }
 
   @UseElectedOffice()
+  @Put(':annotationId/review')
+  @ResponseSchema(AnnotationResponseSchema)
+  async updateReview(
+    @Param('annotationId') annotationId: string,
+    @ReqUser() user: User,
+    @ReqElectedOffice() electedOffice: ElectedOffice,
+    @Body(new ZodValidationPipe(UpdateNoteRequestSchema))
+    body: UpdateNoteRequest,
+    @Req() req: IncomingRequest,
+  ) {
+    return this.annotations.updateReviewBody(
+      annotationId,
+      user.id,
+      electedOffice,
+      req.actorSub ?? null,
+      body.body,
+    )
+  }
+
+  @UseElectedOffice()
   @Delete(':annotationId')
   @HttpCode(204)
   async remove(
     @Param('annotationId') annotationId: string,
     @ReqUser() user: User,
     @ReqElectedOffice() electedOffice: ElectedOffice,
+    @Req() req: IncomingRequest,
   ): Promise<void> {
-    await this.annotations.deleteOne(annotationId, user.id, electedOffice)
+    await this.annotations.deleteOne(
+      annotationId,
+      user.id,
+      electedOffice,
+      req.actorSub ?? null,
+    )
   }
 
   @UseElectedOffice()

--- a/src/annotations/controllers/briefingAnnotations.controller.ts
+++ b/src/annotations/controllers/briefingAnnotations.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common'
+import { Body, Controller, Get, Param, Post, Query, Req } from '@nestjs/common'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { ElectedOffice, User } from '../../generated/prisma'
 import {
@@ -11,11 +11,16 @@ import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
 import { ReqElectedOffice } from '@/electedOffice/decorators/ReqElectedOffice.decorator'
 import { UseElectedOffice } from '@/electedOffice/decorators/UseElectedOffice.decorator'
 import { ReqUser } from '@/authentication/decorators/ReqUser.decorator'
+import { IncomingRequest } from '@/authentication/authentication.types'
 import {
   MeetingDateParam,
   MeetingDateParamSchema,
 } from '@/meetings/schemas/meetingDateParam.schema'
 import { AnnotationsService } from '../services/annotations.service'
+import {
+  ListAnnotationsQuery,
+  ListAnnotationsQuerySchema,
+} from '../schemas/listAnnotationsQuery.schema'
 
 /**
  * Briefing-scoped annotation routes.
@@ -35,13 +40,18 @@ export class BriefingAnnotationsController {
   async list(
     @Param(new ZodValidationPipe(MeetingDateParamSchema))
     { date }: MeetingDateParam,
+    @Query(new ZodValidationPipe(ListAnnotationsQuerySchema))
+    { kinds }: ListAnnotationsQuery,
     @ReqUser() user: User,
     @ReqElectedOffice() electedOffice: ElectedOffice,
+    @Req() req: IncomingRequest,
   ) {
     const annotations = await this.annotations.listForBriefing(
       date,
       user.id,
       electedOffice,
+      req.actorSub ?? null,
+      kinds,
     )
     return { annotations }
   }
@@ -56,12 +66,15 @@ export class BriefingAnnotationsController {
     @ReqElectedOffice() electedOffice: ElectedOffice,
     @Body(new ZodValidationPipe(CreateAnnotationRequestSchema))
     body: CreateAnnotationRequest,
+    @Req() req: IncomingRequest,
   ) {
     return this.annotations.createForBriefing(
       date,
       user.id,
       electedOffice,
       body,
+      req.actorSub ?? null,
+      req.actorUser ?? null,
     )
   }
 }

--- a/src/annotations/schemas/listAnnotationsQuery.schema.ts
+++ b/src/annotations/schemas/listAnnotationsQuery.schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+import { AnnotationKindSchema } from '@goodparty_org/contracts'
+
+// `kinds` arrives either as a comma-separated string (?kinds=review) or a
+// repeated query param (?kinds=note&kinds=chat). Normalize both to an array
+// and validate each value against AnnotationKind.
+export const ListAnnotationsQuerySchema = z.object({
+  kinds: z
+    .preprocess(
+      (v) => (typeof v === 'string' && v.length > 0 ? v.split(',') : v),
+      z.array(AnnotationKindSchema),
+    )
+    .optional(),
+})
+
+export type ListAnnotationsQuery = z.infer<typeof ListAnnotationsQuerySchema>

--- a/src/annotations/services/annotations.service.ts
+++ b/src/annotations/services/annotations.service.ts
@@ -3,7 +3,12 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common'
-import { AnnotationKind, ElectedOffice, Prisma } from '../../generated/prisma'
+import {
+  AnnotationKind,
+  ElectedOffice,
+  Prisma,
+  User,
+} from '../../generated/prisma'
 import {
   Annotation as AnnotationDTO,
   CreateAnnotationRequest,
@@ -24,7 +29,17 @@ const ANNOTATION_INCLUDE = {
   },
   bugReport: true,
   chat: true,
+  annotationReview: true,
 } satisfies Prisma.AnnotationInclude
+
+// Everything a normal (non-impersonated) caller may see. `review` is excluded
+// by default; it is only returned when a caller explicitly requests it AND
+// carries an impersonation actor (server-side default-deny — see listForBriefing).
+const NON_REVIEW_KINDS = [
+  AnnotationKind.note,
+  AnnotationKind.chat,
+  AnnotationKind.bug_report,
+] as const
 
 type AnnotationWithRelations = Prisma.AnnotationGetPayload<{
   include: typeof ANNOTATION_INCLUDE
@@ -77,6 +92,15 @@ function toDTO(row: AnnotationWithRelations): AnnotationDTO {
       created_at: row.chat.createdAt.toISOString(),
     }
   }
+  if (row.annotationReview) {
+    base.review = {
+      id: row.annotationReview.id,
+      body: row.annotationReview.body,
+      reviewer_email: row.annotationReview.reviewerEmail,
+      created_at: row.annotationReview.createdAt.toISOString(),
+      updated_at: row.annotationReview.updatedAt.toISOString(),
+    }
+  }
   return base
 }
 
@@ -112,7 +136,17 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
     meetingDate: string,
     userId: number,
     electedOffice: ElectedOffice,
+    actorSub: string | null,
+    kinds?: AnnotationKind[],
   ): Promise<AnnotationDTO[]> {
+    // Default-deny: omitting `kinds` returns everything except `review`. Asking
+    // for `review` requires an impersonation actor — without one we 403 rather
+    // than silently returning an empty list, so the boundary is unambiguous.
+    const effectiveKinds: AnnotationKind[] = kinds ?? [...NON_REVIEW_KINDS]
+    if (effectiveKinds.includes(AnnotationKind.review) && actorSub === null) {
+      throw new ForbiddenException('review_requires_impersonation')
+    }
+
     const briefingId = await resolveBriefingId(
       this.client,
       meetingDate,
@@ -123,6 +157,7 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
         resourceType: 'briefing',
         resourceId: briefingId,
         authorUserId: userId,
+        kind: { in: effectiveKinds },
       },
       orderBy: { createdAt: 'asc' },
       include: ANNOTATION_INCLUDE,
@@ -135,7 +170,14 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
     userId: number,
     electedOffice: ElectedOffice,
     input: CreateAnnotationRequest,
+    actorSub: string | null,
+    actorUser: User | null,
   ): Promise<AnnotationDTO> {
+    // Review annotations can only be authored inside an impersonation session.
+    if (input.kind === 'review' && actorSub === null) {
+      throw new ForbiddenException('review_requires_impersonation')
+    }
+
     const briefingId = await resolveBriefingId(
       this.client,
       meetingDate,
@@ -177,6 +219,34 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
             include: ANNOTATION_INCLUDE,
           })
         }
+
+        if (input.kind === 'review') {
+          // Guaranteed non-null by the pre-transaction guard; re-checked here
+          // to narrow for the type checker.
+          if (actorSub === null) {
+            throw new ForbiddenException('review_requires_impersonation')
+          }
+          // author stays the impersonated (reviewed) user; the admin's
+          // identity lives on the AnnotationReview child via reviewerClerkSub.
+          return tx.annotation.create({
+            data: {
+              author: { connect: { id: userId } },
+              kind: AnnotationKind.review,
+              resourceType: 'briefing',
+              resourceId: briefingId,
+              ...anchorFields,
+              annotationReview: {
+                create: {
+                  body: input.payload.body,
+                  reviewerClerkSub: actorSub,
+                  reviewerEmail: actorUser?.email ?? null,
+                },
+              },
+            },
+            include: ANNOTATION_INCLUDE,
+          })
+        }
+
         return tx.annotation.create({
           data: {
             author: { connect: { id: userId } },
@@ -223,10 +293,44 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
     return toDTO(updated)
   }
 
+  async updateReviewBody(
+    annotationId: string,
+    userId: number,
+    electedOffice: ElectedOffice,
+    actorSub: string | null,
+    body: string,
+  ): Promise<AnnotationDTO> {
+    if (actorSub === null) {
+      throw new ForbiddenException('review_requires_impersonation')
+    }
+    const row = await this.client.annotation.findUnique({
+      where: { id: annotationId },
+      include: ANNOTATION_INCLUDE,
+    })
+    if (!row) throw new NotFoundException('annotation_not_found')
+    if (row.authorUserId !== userId) {
+      throw new ForbiddenException('annotation_not_yours')
+    }
+    if (row.kind !== AnnotationKind.review || !row.annotationReview) {
+      throw new ForbiddenException('not_a_review')
+    }
+    await this.assertAnnotationBriefingAccess(row.resourceId, electedOffice)
+
+    const updated = await this.client.annotation.update({
+      where: { id: annotationId },
+      data: {
+        annotationReview: { update: { body } },
+      },
+      include: ANNOTATION_INCLUDE,
+    })
+    return toDTO(updated)
+  }
+
   async deleteOne(
     annotationId: string,
     userId: number,
     electedOffice: ElectedOffice,
+    actorSub: string | null,
   ): Promise<void> {
     const row = await this.client.annotation.findUnique({
       where: { id: annotationId },
@@ -238,6 +342,7 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
         noteId: true,
         annotationBugReportId: true,
         chatConversationId: true,
+        annotationReviewId: true,
         note: {
           select: {
             attachments: { select: { storageKey: true } },
@@ -248,6 +353,11 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
     if (!row) throw new NotFoundException('annotation_not_found')
     if (row.authorUserId !== userId) {
       throw new ForbiddenException('annotation_not_yours')
+    }
+    // Review rows are authored as the impersonated user, so the author check
+    // alone would let that user delete an admin's review. Gate on the actor.
+    if (row.kind === AnnotationKind.review && actorSub === null) {
+      throw new ForbiddenException('review_requires_impersonation')
     }
     await this.assertAnnotationBriefingAccess(row.resourceId, electedOffice)
 
@@ -261,6 +371,11 @@ export class AnnotationsService extends createPrismaBase(MODELS.Annotation) {
       if (row.annotationBugReportId) {
         await tx.annotationBugReport.delete({
           where: { id: row.annotationBugReportId },
+        })
+      }
+      if (row.annotationReviewId) {
+        await tx.annotationReview.delete({
+          where: { id: row.annotationReviewId },
         })
       }
       // Chat soft-delete is the responsibility of Collin's chat service.

--- a/src/annotations/tests/annotations.controller.test.ts
+++ b/src/annotations/tests/annotations.controller.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { ExperimentRunStatus } from '../../generated/prisma'
 import { useTestService } from '@/test-service'
 import { S3Service } from '@/vendors/aws/services/s3.service'
+import { AnnotationsService } from '../services/annotations.service'
 
 const service = useTestService()
 
@@ -79,6 +80,16 @@ const bugReport = {
     end: 15,
   },
   payload: { description: 'This figure looks wrong.' },
+}
+
+const reviewComment = {
+  kind: 'review' as const,
+  anchor: {
+    json_path: '/items/0/display/summary',
+    start: 0,
+    end: 10,
+  },
+  payload: { body: 'Reviewer note: fix this.' },
 }
 
 describe('POST /v1/meetings/:date/briefing/annotations', () => {
@@ -570,5 +581,158 @@ describe('DELETE /v1/annotations/:annotationId', () => {
     )
 
     expect(result.status).toBe(403)
+  })
+})
+
+// The HTTP client authenticates as a normal user with no impersonation actor,
+// so these exercise the default-deny boundary exactly as a real user would hit
+// it. Review rows must never leak to or be mutated by a non-impersonated user.
+describe('review annotations — default-deny over HTTP (no actor)', () => {
+  it('rejects creating a review without an impersonation actor', async () => {
+    const orgSlug = 'eo-review-noactor'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, '2026-06-08')
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-06-08/briefing/annotations',
+      reviewComment,
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(403)
+  })
+
+  it('rejects listing kinds=review without an impersonation actor', async () => {
+    const orgSlug = 'eo-review-list-noactor'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, '2026-06-08')
+
+    const result = await service.client.get(
+      '/v1/meetings/2026-06-08/briefing/annotations?kinds=review',
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(403)
+  })
+
+  it('omits review rows from a normal list', async () => {
+    const orgSlug = 'eo-review-leak'
+    const eo = await seedElectedOffice(orgSlug)
+    const briefing = await seedBriefing(eo.id, orgSlug, '2026-06-08')
+
+    await service.prisma.annotation.create({
+      data: {
+        author: { connect: { id: service.user.id } },
+        kind: 'note',
+        resourceType: 'briefing',
+        resourceId: briefing.id,
+        note: { create: { body: 'visible note' } },
+      },
+    })
+    await service.prisma.annotation.create({
+      data: {
+        author: { connect: { id: service.user.id } },
+        kind: 'review',
+        resourceType: 'briefing',
+        resourceId: briefing.id,
+        annotationReview: {
+          create: { body: 'secret review', reviewerClerkSub: 'user_admin' },
+        },
+      },
+    })
+
+    const result = await service.client.get(
+      '/v1/meetings/2026-06-08/briefing/annotations',
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data.annotations).toHaveLength(1)
+    expect(result.data.annotations[0].kind).toBe('note')
+  })
+
+  it('rejects deleting a review row without an impersonation actor', async () => {
+    const orgSlug = 'eo-review-del-noactor'
+    const eo = await seedElectedOffice(orgSlug)
+    const briefing = await seedBriefing(eo.id, orgSlug, '2026-06-08')
+
+    const review = await service.prisma.annotation.create({
+      data: {
+        author: { connect: { id: service.user.id } },
+        kind: 'review',
+        resourceType: 'briefing',
+        resourceId: briefing.id,
+        annotationReview: {
+          create: { body: 'x', reviewerClerkSub: 'user_admin' },
+        },
+      },
+    })
+
+    const result = await service.client.delete(
+      `/v1/annotations/${review.id}`,
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(403)
+  })
+})
+
+// The service takes actorSub/actorUser as explicit args (the guard populates
+// them in production). Driving the real service against the real DB is the
+// closest we can get to the impersonation path without minting an actor JWT.
+describe('AnnotationsService — review behavior with an actor', () => {
+  const ACTOR_SUB = 'user_admin_123'
+
+  it('persists reviewer attribution and lists reviews back', async () => {
+    const annotations = service.app.get(AnnotationsService)
+    const orgSlug = 'eo-review-svc'
+    const eo = await seedElectedOffice(orgSlug)
+    await seedBriefing(eo.id, orgSlug, '2026-06-08')
+
+    const admin = await service.prisma.user.create({
+      data: {
+        clerkId: ACTOR_SUB,
+        email: 'admin-reviewer@goodparty.org',
+        firstName: 'Admin',
+        lastName: 'Reviewer',
+      },
+    })
+
+    const created = await annotations.createForBriefing(
+      '2026-06-08',
+      service.user.id,
+      eo,
+      reviewComment,
+      ACTOR_SUB,
+      admin,
+    )
+
+    expect(created.kind).toBe('review')
+    expect(created.author_user_id).toBe(service.user.id)
+    expect(created.review?.body).toBe('Reviewer note: fix this.')
+    expect(created.review?.reviewer_email).toBe('admin-reviewer@goodparty.org')
+
+    const dbReview = await service.prisma.annotationReview.findFirst({
+      where: { id: created.review?.id },
+    })
+    expect(dbReview?.reviewerClerkSub).toBe(ACTOR_SUB)
+
+    const listedWithActor = await annotations.listForBriefing(
+      '2026-06-08',
+      service.user.id,
+      eo,
+      ACTOR_SUB,
+      ['review'],
+    )
+    expect(listedWithActor).toHaveLength(1)
+    expect(listedWithActor[0].kind).toBe('review')
+
+    const listedNormally = await annotations.listForBriefing(
+      '2026-06-08',
+      service.user.id,
+      eo,
+      null,
+    )
+    expect(listedNormally).toHaveLength(0)
   })
 })

--- a/src/campaigns/campaigns.controller.test.ts
+++ b/src/campaigns/campaigns.controller.test.ts
@@ -14,6 +14,7 @@ import { CampaignsController } from './campaigns.controller'
 import { CreateCampaignSchema } from './schemas/updateCampaign.schema'
 import { CampaignPlanVersionsService } from './services/campaignPlanVersions.service'
 import { CampaignsService } from './services/campaigns.service'
+import { FilingInstructionsService } from './filingInstructions/filingInstructions.service'
 import { CampaignWith } from './campaigns.types'
 
 const CREATED_AT = '2025-01-01'
@@ -22,6 +23,9 @@ const CREATED_AT = '2025-01-01'
 // fetchLiveRaceTargetMetrics started consuming /campaign-strategy-context.
 // Tests that don't care about these can spread this into their fixture.
 const EMPTY_RACE_CONTEXT_FIELDS = {
+  filingOfficeAddress: null,
+  filingPhoneNumber: null,
+  paperworkInstructions: null,
   registeredVoters: null,
   uniqueCellphones: null,
   uniqueLandlines: null,
@@ -122,6 +126,7 @@ describe('CampaignsController', () => {
   let slackService: SlackService
   let organizationsService: OrganizationsService
   let analyticsService: AnalyticsService
+  let filingInstructionsService: FilingInstructionsService
 
   beforeEach(() => {
     const campaignsServiceMock: Partial<CampaignsService> = {
@@ -167,12 +172,19 @@ describe('CampaignsController', () => {
     }
     analyticsService = analyticsServiceMock as AnalyticsService
 
+    const filingInstructionsServiceMock: Partial<FilingInstructionsService> = {
+      emailToCandidate: vi.fn(),
+    }
+    filingInstructionsService =
+      filingInstructionsServiceMock as FilingInstructionsService
+
     controller = new CampaignsController(
       campaignsService,
       planVersionsService,
       slackService,
       organizationsService,
       analyticsService,
+      filingInstructionsService,
       createMockLogger(),
     )
   })
@@ -316,6 +328,21 @@ describe('CampaignsController', () => {
 
       expect(campaignsService.getStatus).toHaveBeenCalledWith(undefined)
       expect(result).toEqual({ status: false })
+    })
+  })
+
+  describe('emailFilingInstructions', () => {
+    it('emails the candidate their filing instructions and returns success', async () => {
+      const result = await controller.emailFilingInstructions(
+        mockCampaign,
+        mockUser,
+      )
+
+      expect(filingInstructionsService.emailToCandidate).toHaveBeenCalledWith(
+        mockCampaign,
+        mockUser,
+      )
+      expect(result).toEqual({ success: true })
     })
   })
 

--- a/src/campaigns/campaigns.controller.ts
+++ b/src/campaigns/campaigns.controller.ts
@@ -48,6 +48,7 @@ import {
 } from './schemas/updateCampaign.schema'
 import { CampaignPlanVersionsService } from './services/campaignPlanVersions.service'
 import { CampaignsService } from './services/campaigns.service'
+import { FilingInstructionsService } from './filingInstructions/filingInstructions.service'
 import { CampaignWith } from './campaigns.types'
 
 class ListCampaignsPaginationDto extends createZodDto(
@@ -66,6 +67,7 @@ export class CampaignsController {
     private readonly slack: SlackService,
     private readonly organizations: OrganizationsService,
     private readonly analytics: AnalyticsService,
+    private readonly filingInstructions: FilingInstructionsService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(CampaignsController.name)
@@ -131,6 +133,17 @@ export class CampaignsController {
     if (!version) throw new NotFoundException('No plan version found')
 
     return version.data
+  }
+
+  @Post('mine/filing-instructions/email')
+  @UseCampaign()
+  @HttpCode(HttpStatus.OK)
+  async emailFilingInstructions(
+    @ReqCampaign() campaign: Campaign,
+    @ReqUser() user: User,
+  ) {
+    await this.filingInstructions.emailToCandidate(campaign, user)
+    return { success: true }
   }
 
   @Get('slug/:slug')

--- a/src/campaigns/campaigns.controller.ts
+++ b/src/campaigns/campaigns.controller.ts
@@ -135,6 +135,12 @@ export class CampaignsController {
     return version.data
   }
 
+  // Intentionally @UseCampaign()-only, no isPro guard: the filing-instructions
+  // screen is a PRE-payment step of the pro-upgrade wizard, so its audience is
+  // by definition not-yet-Pro — an isPro gate would 403 the exact users it
+  // serves. The payload is public BallotReady data already shown free in
+  // onboarding (SuccessPage), and @UseCampaign() scopes the send to the
+  // caller's own campaign + their own email. Per ENG-10325 AC.
   @Post('mine/filing-instructions/email')
   @UseCampaign()
   @HttpCode(HttpStatus.OK)

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -19,6 +19,7 @@ import { StripeModule } from '../vendors/stripe/stripe.module'
 import { WebsitesModule } from '../websites/websites.module'
 import { CampaignsAiModule } from './ai/campaignsAi.module'
 import { CampaignsController } from './campaigns.controller'
+import { FilingInstructionsService } from './filingInstructions/filingInstructions.service'
 import { CampaignPositionsController } from './positions/campaignPositions.controller'
 import { CampaignPositionsService } from './positions/campaignPositions.service'
 import { CampaignPlanVersionsService } from './services/campaignPlanVersions.service'
@@ -70,6 +71,7 @@ import { CampaignUpdateHistoryService } from './updateHistory/campaignUpdateHist
   ],
   providers: [
     CampaignsService,
+    FilingInstructionsService,
     CampaignPlanVersionsService,
     CampaignPositionsService,
     CampaignUpdateHistoryService,

--- a/src/campaigns/filingInstructions/filingInstructions.service.test.ts
+++ b/src/campaigns/filingInstructions/filingInstructions.service.test.ts
@@ -1,0 +1,81 @@
+import { BadGatewayException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { EmailService } from 'src/email/email.service'
+import { Campaign, User } from 'src/generated/prisma'
+import type { RaceTargetMetrics } from '@goodparty_org/contracts'
+import { CampaignsService } from '../services/campaigns.service'
+import { FilingInstructionsService } from './filingInstructions.service'
+
+const campaign = {
+  id: 1,
+  details: { filingPeriodsStart: '2026-06-01', filingPeriodsEnd: '2026-06-15' },
+} as unknown as Campaign
+
+const user = { id: 7, email: 'candidate@example.com' } as unknown as User
+
+const metrics = {
+  filingFee: 100,
+  filingRequirementsText: 'Filing fee: $100.',
+  filingOfficeAddress: '500 Election Way, Sacramento, CA 95814',
+  filingPhoneNumber: '(916) 555-0199',
+  paperworkInstructions: 'Submit to the city clerk.',
+} as RaceTargetMetrics
+
+describe('FilingInstructionsService.emailToCandidate', () => {
+  let service: FilingInstructionsService
+  let sendEmail: ReturnType<typeof vi.fn>
+  let fetchLiveRaceTargetMetrics: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    sendEmail = vi.fn().mockResolvedValue({ id: 'mailgun-id' })
+    fetchLiveRaceTargetMetrics = vi.fn().mockResolvedValue(metrics)
+    service = new FilingInstructionsService(
+      { fetchLiveRaceTargetMetrics } as unknown as CampaignsService,
+      { sendEmail } as unknown as EmailService,
+      createMockLogger(),
+    )
+  })
+
+  it('emails the candidate the rendered filing instructions', async () => {
+    await service.emailToCandidate(campaign, user)
+
+    expect(fetchLiveRaceTargetMetrics).toHaveBeenCalledWith(campaign)
+    expect(sendEmail).toHaveBeenCalledTimes(1)
+    const payload = sendEmail.mock.calls[0][0]
+    expect(payload.to).toBe(user.email)
+    expect(payload.subject).toBe('Your filing instructions - GoodParty.org')
+    expect(payload.message).toContain(
+      'Filing window: June 1, 2026 – June 15, 2026',
+    )
+    expect(payload.message).toContain('Filing fee: $100')
+    expect(payload.message).toContain(
+      'Address: 500 Election Way, Sacramento, CA 95814',
+    )
+    expect(payload.message).toContain('Phone: (916) 555-0199')
+  })
+
+  it('still sends with just the window when live metrics are unavailable', async () => {
+    fetchLiveRaceTargetMetrics.mockResolvedValue(null)
+
+    await service.emailToCandidate(campaign, user)
+
+    const payload = sendEmail.mock.calls[0][0]
+    expect(payload.to).toBe(user.email)
+    expect(payload.message).toContain(
+      'Filing window: June 1, 2026 – June 15, 2026',
+    )
+    expect(payload.message).not.toContain('Filing fee:')
+    expect(payload.message).not.toContain('Filing office')
+  })
+
+  it('propagates the email-service failure (does not swallow)', async () => {
+    sendEmail.mockRejectedValue(
+      new BadGatewayException('error communicating w/ mail service'),
+    )
+
+    await expect(service.emailToCandidate(campaign, user)).rejects.toThrow(
+      BadGatewayException,
+    )
+  })
+})

--- a/src/campaigns/filingInstructions/filingInstructions.service.ts
+++ b/src/campaigns/filingInstructions/filingInstructions.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common'
+import { PinoLogger } from 'nestjs-pino'
+import { EmailService } from 'src/email/email.service'
+import { Campaign, User } from 'src/generated/prisma'
+import { CampaignsService } from '../services/campaigns.service'
+import { renderFilingInstructionsEmail } from './filingInstructions.util'
+
+@Injectable()
+export class FilingInstructionsService {
+  constructor(
+    private readonly campaigns: CampaignsService,
+    private readonly email: EmailService,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(FilingInstructionsService.name)
+  }
+
+  async emailToCandidate(campaign: Campaign, user: User) {
+    const metrics = await this.campaigns.fetchLiveRaceTargetMetrics(campaign)
+    const message = renderFilingInstructionsEmail(campaign, metrics)
+    return this.email.sendEmail({
+      to: user.email,
+      subject: 'Your filing instructions - GoodParty.org',
+      message,
+    })
+  }
+}

--- a/src/campaigns/filingInstructions/filingInstructions.util.test.ts
+++ b/src/campaigns/filingInstructions/filingInstructions.util.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { Campaign } from 'src/generated/prisma'
+import type { RaceTargetMetrics } from '@goodparty_org/contracts'
+import { renderFilingInstructionsEmail } from './filingInstructions.util'
+
+const campaignWith = (details: object): Campaign =>
+  ({ details }) as unknown as Campaign
+
+const metricsWith = (
+  overrides: Partial<RaceTargetMetrics>,
+): RaceTargetMetrics =>
+  ({
+    filingFee: null,
+    filingRequirementsText: null,
+    filingOfficeAddress: null,
+    filingPhoneNumber: null,
+    paperworkInstructions: null,
+    ...overrides,
+  }) as RaceTargetMetrics
+
+describe('renderFilingInstructionsEmail', () => {
+  it('renders window, fee, requirements, and office contact when all present', () => {
+    const body = renderFilingInstructionsEmail(
+      campaignWith({
+        filingPeriodsStart: '2026-06-01',
+        filingPeriodsEnd: '2026-06-15',
+      }),
+      metricsWith({
+        filingFee: 100,
+        filingRequirementsText: 'Filing fee: $100.',
+        filingOfficeAddress: '500 Election Way, Sacramento, CA 95814',
+        filingPhoneNumber: '(916) 555-0199',
+        paperworkInstructions: 'Submit to the city clerk.',
+      }),
+    )
+
+    expect(body).toContain('Filing window: June 1, 2026 – June 15, 2026')
+    expect(body).toContain('Filing fee: $100')
+    expect(body).toContain('Filing requirements: Filing fee: $100.')
+    expect(body).toContain('Filing office')
+    expect(body).toContain('Address: 500 Election Way, Sacramento, CA 95814')
+    expect(body).toContain('Phone: (916) 555-0199')
+    expect(body).toContain('Instructions: Submit to the city clerk.')
+  })
+
+  it('omits fee, requirements, and the office block when metrics are null', () => {
+    const body = renderFilingInstructionsEmail(
+      campaignWith({
+        filingPeriodsStart: '2026-06-01',
+        filingPeriodsEnd: '2026-06-15',
+      }),
+      null,
+    )
+
+    expect(body).toContain('Filing window: June 1, 2026 – June 15, 2026')
+    expect(body).not.toContain('Filing fee:')
+    expect(body).not.toContain('Filing requirements:')
+    expect(body).not.toContain('Filing office')
+  })
+
+  it('renders a $0 fee (fee present but zero is not "no data")', () => {
+    const body = renderFilingInstructionsEmail(
+      campaignWith({}),
+      metricsWith({ filingFee: 0 }),
+    )
+
+    expect(body).toContain('Filing fee: $0')
+  })
+
+  it('shows "Not yet available" when the filing window is missing', () => {
+    const body = renderFilingInstructionsEmail(campaignWith({}), null)
+
+    expect(body).toContain('Filing window: Not yet available')
+  })
+
+  it('falls back to the raw value when a filing date is not parseable', () => {
+    const body = renderFilingInstructionsEmail(
+      campaignWith({ filingPeriodsStart: 'rolling', filingPeriodsEnd: null }),
+      null,
+    )
+
+    expect(body).toContain('Filing window: rolling')
+  })
+})

--- a/src/campaigns/filingInstructions/filingInstructions.util.ts
+++ b/src/campaigns/filingInstructions/filingInstructions.util.ts
@@ -25,10 +25,11 @@ const formatFilingWindow = (
 }
 
 /**
- * Renders the plain-text "email this to me" body for the Pro-upgrade
- * filing-instructions screen: filing window (from `campaign.details`), plus
- * fee / requirements / office contact (from the live race-target metrics).
- * Sections with no data are omitted so the candidate never sees empty labels.
+ * Renders the plain-text "email this to me" body for the pre-payment
+ * pro-upgrade wizard's filing-instructions screen (shown to candidates before
+ * they subscribe): filing window (from `campaign.details`), plus fee /
+ * requirements / office contact (from the live race-target metrics). Sections
+ * with no data are omitted so the candidate never sees empty labels.
  */
 export const renderFilingInstructionsEmail = (
   campaign: Campaign,

--- a/src/campaigns/filingInstructions/filingInstructions.util.ts
+++ b/src/campaigns/filingInstructions/filingInstructions.util.ts
@@ -1,0 +1,67 @@
+import { format, isValid, parseISO } from 'date-fns'
+import { Campaign } from 'src/generated/prisma'
+import type { RaceTargetMetrics } from '@goodparty_org/contracts'
+
+// details.filingPeriods* are ISO date strings written by the filing-data
+// pipeline, but `details` is a loosely-typed JSON column edited by several
+// writers — an unparseable value would throw in `format` and 500 the email
+// route, so fall back to the raw string rather than failing the send.
+const formatFilingDate = (value: string | null | undefined): string | null => {
+  if (!value) return null
+  const parsed = parseISO(value)
+  return isValid(parsed) ? format(parsed, 'MMMM d, yyyy') : value
+}
+
+const formatFilingWindow = (
+  start: string | null | undefined,
+  end: string | null | undefined,
+): string => {
+  const formattedStart = formatFilingDate(start)
+  const formattedEnd = formatFilingDate(end)
+  if (formattedStart && formattedEnd) {
+    return `${formattedStart} – ${formattedEnd}`
+  }
+  return formattedStart ?? formattedEnd ?? 'Not yet available'
+}
+
+/**
+ * Renders the plain-text "email this to me" body for the Pro-upgrade
+ * filing-instructions screen: filing window (from `campaign.details`), plus
+ * fee / requirements / office contact (from the live race-target metrics).
+ * Sections with no data are omitted so the candidate never sees empty labels.
+ */
+export const renderFilingInstructionsEmail = (
+  campaign: Campaign,
+  metrics: RaceTargetMetrics | null,
+): string => {
+  const { filingPeriodsStart, filingPeriodsEnd } = campaign.details ?? {}
+
+  const lines: string[] = [
+    'Here are the filing instructions for your campaign.',
+    '',
+    `Filing window: ${formatFilingWindow(filingPeriodsStart, filingPeriodsEnd)}`,
+  ]
+
+  if (metrics?.filingFee != null) {
+    lines.push(`Filing fee: $${metrics.filingFee}`)
+  }
+  if (metrics?.filingRequirementsText) {
+    lines.push(`Filing requirements: ${metrics.filingRequirementsText}`)
+  }
+
+  const officeLines: string[] = []
+  if (metrics?.filingOfficeAddress) {
+    officeLines.push(`Address: ${metrics.filingOfficeAddress}`)
+  }
+  if (metrics?.filingPhoneNumber) {
+    officeLines.push(`Phone: ${metrics.filingPhoneNumber}`)
+  }
+  if (metrics?.paperworkInstructions) {
+    officeLines.push(`Instructions: ${metrics.paperworkInstructions}`)
+  }
+  if (officeLines.length > 0) {
+    lines.push('', 'Filing office', ...officeLines)
+  }
+
+  return lines.join('\n')
+}

--- a/src/campaigns/services/campaigns.service.test.ts
+++ b/src/campaigns/services/campaigns.service.test.ts
@@ -36,6 +36,9 @@ const BR_POSITION_ID = 'br-position-456'
 // (overrideDistrictId, position-based) emit these as null; tests for those
 // paths spread this into their expected result.
 const EMPTY_RACE_CONTEXT_FIELDS = {
+  filingOfficeAddress: null,
+  filingPhoneNumber: null,
+  paperworkInstructions: null,
   registeredVoters: null,
   uniqueCellphones: null,
   uniqueLandlines: null,
@@ -1138,11 +1141,14 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
       })
     })
 
-    it('prefers race-hash result over position-side filingFee', async () => {
+    it('prefers race-hash result over position-side filingFee and surfaces office contact', async () => {
       vi.mocked(mockElections.fetchFilingFeeByRaceHash!).mockResolvedValue({
         filingFee: 75,
         filingRequirementsText: 'BR-hash text.',
         extractionSource: 'direct_dollar',
+        filingOfficeAddress: '123 Main St, Springfield, IL 62701',
+        filingPhoneNumber: '(217) 555-0100',
+        paperworkInstructions: 'File with the county clerk in person.',
       })
 
       const result =
@@ -1158,6 +1164,9 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
         filingFee: 75,
         filingRequirementsText: 'BR-hash text.',
         ...EMPTY_RACE_CONTEXT_FIELDS,
+        filingOfficeAddress: '123 Main St, Springfield, IL 62701',
+        filingPhoneNumber: '(217) 555-0100',
+        paperworkInstructions: 'File with the county clerk in person.',
       })
     })
 
@@ -1170,6 +1179,9 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
         filingFee: null,
         filingRequirementsText: 'Fee varies; see BR.',
         extractionSource: 'multi_value',
+        filingOfficeAddress: null,
+        filingPhoneNumber: null,
+        paperworkInstructions: null,
       })
 
       const result =
@@ -1219,6 +1231,9 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
         filingFee: 50,
         filingRequirementsText: 'BR-hash text.',
         extractionSource: 'direct_dollar',
+        filingOfficeAddress: null,
+        filingPhoneNumber: null,
+        paperworkInstructions: null,
       })
 
       const result =
@@ -1298,6 +1313,9 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
         filingFee: 100,
         filingRequirementsText: 'Filing fee: $100.',
         extractionSource: 'direct_dollar',
+        filingOfficeAddress: '500 Election Way, Sacramento, CA 95814',
+        filingPhoneNumber: '(916) 555-0199',
+        paperworkInstructions: 'Submit candidacy paperwork to the city clerk.',
       })
       vi.mocked(mockBallotReady.fetchMilestones!).mockResolvedValue({
         voter_registration: { start: '2026-06-01', end: '2026-10-19' },
@@ -1314,6 +1332,9 @@ describe('CampaignsService - fetchLiveRaceTargetMetrics', () => {
         projectedTurnout: 1200,
         filingFee: 100,
         filingRequirementsText: 'Filing fee: $100.',
+        filingOfficeAddress: '500 Election Way, Sacramento, CA 95814',
+        filingPhoneNumber: '(916) 555-0199',
+        paperworkInstructions: 'Submit candidacy paperwork to the city clerk.',
         registeredVoters: 5500,
         uniqueCellphones: 3300,
         uniqueLandlines: 1800,

--- a/src/campaigns/services/campaigns.service.ts
+++ b/src/campaigns/services/campaigns.service.ts
@@ -831,6 +831,10 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
         filingFee: filingFeeFromRaceHash?.filingFee ?? null,
         filingRequirementsText:
           filingFeeFromRaceHash?.filingRequirementsText ?? null,
+        filingOfficeAddress: filingFeeFromRaceHash?.filingOfficeAddress ?? null,
+        filingPhoneNumber: filingFeeFromRaceHash?.filingPhoneNumber ?? null,
+        paperworkInstructions:
+          filingFeeFromRaceHash?.paperworkInstructions ?? null,
         milestones,
       }
     }
@@ -869,6 +873,10 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
         filingFeeFromRaceHash !== null
           ? filingFeeFromRaceHash.filingRequirementsText
           : (filingRequirementsText ?? null),
+      filingOfficeAddress: filingFeeFromRaceHash?.filingOfficeAddress ?? null,
+      filingPhoneNumber: filingFeeFromRaceHash?.filingPhoneNumber ?? null,
+      paperworkInstructions:
+        filingFeeFromRaceHash?.paperworkInstructions ?? null,
       milestones,
     }
   }
@@ -892,6 +900,10 @@ export class CampaignsService extends createPrismaBase(MODELS.Campaign) {
       filingFee: filingFeeFromRaceHash?.filingFee ?? null,
       filingRequirementsText:
         filingFeeFromRaceHash?.filingRequirementsText ?? null,
+      filingOfficeAddress: filingFeeFromRaceHash?.filingOfficeAddress ?? null,
+      filingPhoneNumber: filingFeeFromRaceHash?.filingPhoneNumber ?? null,
+      paperworkInstructions:
+        filingFeeFromRaceHash?.paperworkInstructions ?? null,
       registeredVoters: context.registered_voters,
       uniqueCellphones: context.unique_cellphones,
       uniqueLandlines: context.unique_landlines,
@@ -971,6 +983,9 @@ const emptyContextFields = (): Omit<
   | 'voterContactGoal'
   | 'filingFee'
   | 'filingRequirementsText'
+  | 'filingOfficeAddress'
+  | 'filingPhoneNumber'
+  | 'paperworkInstructions'
 > => ({
   registeredVoters: null,
   uniqueCellphones: null,

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -49,6 +49,7 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
     delete: ReturnType<typeof vi.fn>
     deleteMany: ReturnType<typeof vi.fn>
     update: ReturnType<typeof vi.fn>
+    updateMany: ReturnType<typeof vi.fn>
   }
   let mockPrisma: {
     tcrCompliance: typeof mockModel
@@ -56,9 +57,12 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
   }
 
   const user = createMockUser({ clerkId: 'user_clerk_abc' })
+  // isPro: true — these cases exercise the already-Pro path, where the kickoff
+  // is enqueued immediately on submit (pro-upgrade1, post-payment resubmit).
   const campaign = createMockCampaign({
     userId: user.id,
     formattedAddress: '123 Main St',
+    isPro: true,
   })
 
   const basePayload = {
@@ -98,6 +102,7 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
       delete: vi.fn().mockResolvedValue(undefined),
       deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
       update: vi.fn().mockResolvedValue(undefined),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
     }
     mockPrisma = {
       tcrCompliance: mockModel,
@@ -170,13 +175,21 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
     })
   })
 
-  it('stamps kickoffSentAt after a successful kickoff send', async () => {
+  it('claims kickoffSentAt atomically before sending the kickoff', async () => {
     await service.createAgentic(user, campaign, basePayload)
 
-    expect(mockModel.update).toHaveBeenCalledWith({
-      where: { id: 'tcr-new' },
+    expect(mockModel.updateMany).toHaveBeenCalledWith({
+      where: { id: 'tcr-new', kickoffSentAt: null },
       data: { kickoffSentAt: expect.any(Date) },
     })
+  })
+
+  it('does not enqueue a second kickoff when the claim is already taken', async () => {
+    mockModel.updateMany.mockResolvedValueOnce({ count: 0 })
+
+    await service.createAgentic(user, campaign, basePayload)
+
+    expect(mockQueue.sendMessage).not.toHaveBeenCalled()
   })
 
   it('marks the record error and re-throws if SQS sendMessage fails', async () => {
@@ -187,6 +200,11 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
       service.createAgentic(user, campaign, basePayload),
     ).rejects.toBe(sqsErr)
 
+    // Claim is rolled back (kickoffSentAt back to null) so the sweep can retry
+    expect(mockModel.updateMany).toHaveBeenCalledWith({
+      where: { id: 'tcr-new', kickoffSentAt: expect.any(Date) },
+      data: { kickoffSentAt: null },
+    })
     expect(mockModel.update).toHaveBeenCalledWith({
       where: { id: 'tcr-new' },
       data: { status: TcrComplianceStatus.error },
@@ -388,6 +406,85 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
     await expect(
       service.createAgentic(userWithoutClerk, campaign, basePayload),
     ).rejects.toThrow(BadRequestException)
+  })
+
+  it('persists the record but defers the kickoff when the campaign is not Pro', async () => {
+    const nonProCampaign = createMockCampaign({
+      userId: user.id,
+      formattedAddress: '123 Main St',
+      isPro: false,
+    })
+
+    const result = await service.createAgentic(
+      user,
+      nonProCampaign,
+      basePayload,
+    )
+
+    expect(result.created).toBe(true)
+    expect(mockModel.create).toHaveBeenCalledTimes(1)
+    expect(mockModel.updateMany).not.toHaveBeenCalled()
+    expect(mockQueue.sendMessage).not.toHaveBeenCalled()
+  })
+
+  describe('enqueueAgenticKickoffIfNeeded', () => {
+    const paidRecord = {
+      id: 'tcr-paid',
+      campaignId: campaign.id,
+      kickoffSentAt: null,
+    }
+    const campaignWithClerk = { ...campaign, user: { clerkId: 'clerk_paid' } }
+
+    it('enqueues exactly one kickoff after payment for a deferred record', async () => {
+      mockModel.findUnique.mockResolvedValueOnce(paidRecord)
+      mockCampaigns.findUnique.mockResolvedValueOnce(campaignWithClerk)
+
+      await service.enqueueAgenticKickoffIfNeeded(campaign.id)
+
+      expect(mockModel.updateMany).toHaveBeenCalledWith({
+        where: { id: 'tcr-paid', kickoffSentAt: null },
+        data: { kickoffSentAt: expect.any(Date) },
+      })
+      expect(mockQueue.sendMessage).toHaveBeenCalledTimes(1)
+      const [message] = mockQueue.sendMessage.mock.calls[0]
+      expect(message.data).toEqual({
+        campaignId: campaign.id,
+        tcrComplianceId: 'tcr-paid',
+        clerkUserId: 'clerk_paid',
+      })
+    })
+
+    it('does not enqueue a second kickoff when the claim is already taken (replay)', async () => {
+      mockModel.findUnique.mockResolvedValueOnce(paidRecord)
+      mockCampaigns.findUnique.mockResolvedValueOnce(campaignWithClerk)
+      mockModel.updateMany.mockResolvedValueOnce({ count: 0 })
+
+      await service.enqueueAgenticKickoffIfNeeded(campaign.id)
+
+      expect(mockQueue.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when no TCR record exists yet (paid before filing)', async () => {
+      mockModel.findUnique.mockResolvedValueOnce(null)
+
+      await service.enqueueAgenticKickoffIfNeeded(campaign.id)
+
+      expect(mockModel.updateMany).not.toHaveBeenCalled()
+      expect(mockQueue.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when the campaign has no Clerk user', async () => {
+      mockModel.findUnique.mockResolvedValueOnce(paidRecord)
+      mockCampaigns.findUnique.mockResolvedValueOnce({
+        ...campaign,
+        user: { clerkId: null },
+      })
+
+      await service.enqueueAgenticKickoffIfNeeded(campaign.id)
+
+      expect(mockModel.updateMany).not.toHaveBeenCalled()
+      expect(mockQueue.sendMessage).not.toHaveBeenCalled()
+    })
   })
 
   describe('sweepStrandedAgenticKickoffs', () => {

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.test.ts
@@ -513,6 +513,7 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
             peerlyIdentityId: null,
             kickoffSentAt: null,
             createdAt: { lt: expect.any(Date) },
+            campaign: { isPro: true },
           },
         }),
       )
@@ -593,6 +594,18 @@ describe('CampaignTcrComplianceService - createAgentic', () => {
 
       expect(mockQueue.sendMessage).not.toHaveBeenCalled()
       expect(mockModel.update).not.toHaveBeenCalled()
+    })
+
+    it('only sweeps Pro campaigns so pre-payment submissions are not dispatched', async () => {
+      mockModel.findMany.mockResolvedValueOnce([])
+
+      await sweep(service)
+
+      expect(mockModel.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ campaign: { isPro: true } }),
+        }),
+      )
     })
   })
 })

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -104,6 +104,10 @@ export class CampaignTcrComplianceService extends createPrismaBase(
         peerlyIdentityId: null,
         kickoffSentAt: null,
         createdAt: { lt: cutoff },
+        // Pre-payment (pro-upgrade3) submissions intentionally sit with
+        // kickoffSentAt null until payment; only sweep campaigns that are
+        // already Pro so the agent never runs before the candidate pays.
+        campaign: { isPro: true },
       },
       include: {
         campaign: { include: { user: true } },

--- a/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
+++ b/src/campaigns/tcrCompliance/services/campaignTcrCompliance.service.ts
@@ -675,41 +675,28 @@ export class CampaignTcrComplianceService extends createPrismaBase(
       throw err
     }
 
-    try {
-      await this.queueService.sendMessage(
-        {
-          type: QueueType.AGENTIC_COMPLIANCE_KICKOFF,
-          data: {
-            campaignId: campaign.id,
-            tcrComplianceId: record.id,
-            clerkUserId: user.clerkId,
-          },
-        },
-        `${MessageGroup.agenticComplianceKickoff}-${campaign.id}`,
-        {
-          deduplicationId: `agentic-compliance-${record.id}`,
-          throwOnError: true,
-        },
-      )
-    } catch (err) {
+    // Pre-payment (pro-upgrade3) submissions defer dispatch to the payment
+    // webhook so the agent never provisions a domain/site for an unpaid
+    // candidate. Already-Pro submissions (pro-upgrade1, post-payment
+    // resubmission) enqueue immediately, as before.
+    if (campaign.isPro) {
       try {
-        await this.model.update({
-          where: { id: record.id },
-          data: { status: TcrComplianceStatus.error },
-        })
-      } catch (updateErr) {
-        this.logger.error(
-          { updateErr, tcrComplianceId: record.id },
-          '[TCR Compliance] Failed to mark record as error after SQS send failure; sweep will recover',
-        )
+        await this.claimAndEnqueueKickoff(record, user.clerkId)
+      } catch (err) {
+        try {
+          await this.model.update({
+            where: { id: record.id },
+            data: { status: TcrComplianceStatus.error },
+          })
+        } catch (updateErr) {
+          this.logger.error(
+            { updateErr, tcrComplianceId: record.id },
+            '[TCR Compliance] Failed to mark record as error after SQS send failure; sweep will recover',
+          )
+        }
+        throw err
       }
-      throw err
     }
-
-    await this.model.update({
-      where: { id: record.id },
-      data: { kickoffSentAt: new Date() },
-    })
 
     try {
       await this.crmCampaignsService.trackCampaign(campaign.id)
@@ -725,6 +712,82 @@ export class CampaignTcrComplianceService extends createPrismaBase(
     )
 
     return { record, created: true }
+  }
+
+  // Webhook entry point: enqueue the compliance_setup kickoff for a campaign
+  // that has already submitted its TCR record but deferred dispatch until
+  // payment (pro-upgrade3). No-ops when no record exists yet (candidate paid
+  // before filing) — the eventual createAgentic submit will enqueue because
+  // the campaign is now Pro.
+  async enqueueAgenticKickoffIfNeeded(campaignId: number) {
+    const record = await this.fetchByCampaignId(campaignId)
+    if (!record) {
+      return
+    }
+
+    const campaign = await this.campaignsService.findUnique({
+      where: { id: campaignId },
+      include: { user: true },
+    })
+    const clerkUserId = campaign?.user?.clerkId
+    if (!clerkUserId) {
+      this.logger.error(
+        { campaignId, tcrComplianceId: record.id },
+        '[TCR Compliance] Cannot enqueue agentic kickoff: ' +
+          'campaign has no Clerk user',
+      )
+      return
+    }
+
+    await this.claimAndEnqueueKickoff(record, clerkUserId)
+  }
+
+  // Single source of the kickoff SQS message shape, shared by createAgentic
+  // (already-Pro submit) and the payment webhook. The atomic claim on
+  // kickoffSentAt is the idempotency guard: a webhook replay or a
+  // submit->pay->submit race finds it already set and short-circuits, so the
+  // agent is dispatched exactly once.
+  private async claimAndEnqueueKickoff(
+    record: TcrCompliance,
+    clerkUserId: string,
+  ) {
+    // Claim before the send so concurrent callers can't both enqueue. Only the
+    // caller that flips kickoffSentAt from null wins the claim.
+    const claimTimestamp = new Date()
+    const claim = await this.model.updateMany({
+      where: { id: record.id, kickoffSentAt: null },
+      data: { kickoffSentAt: claimTimestamp },
+    })
+    if (claim.count === 0) {
+      return
+    }
+
+    try {
+      await this.queueService.sendMessage(
+        {
+          type: QueueType.AGENTIC_COMPLIANCE_KICKOFF,
+          data: {
+            campaignId: record.campaignId,
+            tcrComplianceId: record.id,
+            clerkUserId,
+          },
+        },
+        `${MessageGroup.agenticComplianceKickoff}-${record.campaignId}`,
+        {
+          deduplicationId: `agentic-compliance-${record.id}`,
+          throwOnError: true,
+        },
+      )
+    } catch (err) {
+      // Roll back only this caller's claim by matching the exact timestamp we
+      // wrote, leaving kickoffSentAt null so the stranded-kickoff sweep can
+      // re-enqueue it.
+      await this.model.updateMany({
+        where: { id: record.id, kickoffSentAt: claimTimestamp },
+        data: { kickoffSentAt: null },
+      })
+      throw err
+    }
   }
 
   async handleAgenticKickoff(message: AgenticComplianceKickoffMessage) {

--- a/src/chats/briefing-chats/evals/fixtures/hendersonvilleBriefing.fixture.ts
+++ b/src/chats/briefing-chats/evals/fixtures/hendersonvilleBriefing.fixture.ts
@@ -38,6 +38,7 @@ const annotation: Annotation = {
   noteId: null,
   chatConversationId: 'conv-hville-1',
   annotationBugReportId: null,
+  annotationReviewId: null,
 }
 
 const artifactContent = `# Briefing: Hendersonville, NC — Regular Council Meeting

--- a/src/chats/briefing-chats/services/systemPromptBuilder.test.ts
+++ b/src/chats/briefing-chats/services/systemPromptBuilder.test.ts
@@ -43,6 +43,7 @@ const baseAnnotation: Annotation = {
   noteId: null,
   chatConversationId: 'conv-1',
   annotationBugReportId: null,
+  annotationReviewId: null,
 }
 
 const artifactContent =

--- a/src/elections/types/elections.types.ts
+++ b/src/elections/types/elections.types.ts
@@ -158,14 +158,19 @@ export type PositionWithOptionalDistrict = {
 
 /**
  * Shape returned by election-api `GET /races/by-br-hash-id/:hashId/filing-fee`.
- * Mirrors `FilingFeeResult` on the election-api side so the shapes stay
- * aligned. `extractionSource` is informational (audit / debugging) and not
- * surfaced to clients today.
+ * Mirrors `FilingDetailsByBrHashResult` on the election-api side so the shapes
+ * stay aligned. `extractionSource` is informational (audit / debugging) and not
+ * surfaced to clients today. The three `filing*`/`paperwork*` office-contact
+ * fields are sourced straight off the matched BallotReady race row and feed the
+ * Pro-upgrade filing-instructions screen.
  */
 export type FilingFeeByBrHashResult = {
   filingFee: number | null
   filingRequirementsText: string | null
   extractionSource: string | null
+  filingOfficeAddress: string | null
+  filingPhoneNumber: string | null
+  paperworkInstructions: string | null
 }
 
 /**

--- a/src/meetings/controllers/meetingsBriefings.controller.test.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.test.ts
@@ -784,9 +784,16 @@ describe('POST /v1/meetings/briefings/dispatch', () => {
   it('with useImminenceGate, dispatches a briefing when a meeting is inside the 5-day window', async () => {
     const orgSlug = `eo-gate-in-${Date.now()}`
     const eo = await seedBriefingTarget(orgSlug, 'FREQ=DAILY')
+    const dispatchedRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.RUNNING,
+      },
+    })
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
+      .mockResolvedValue(dispatchedRun)
 
     const result = await service.client.post(
       '/v1/meetings/briefings/dispatch',
@@ -833,9 +840,16 @@ describe('POST /v1/meetings/briefings/dispatch', () => {
     try {
       const orgSlug = `eo-nogate-${Date.now()}`
       const eo = await seedBriefingTarget(orgSlug, 'FREQ=MONTHLY;BYMONTHDAY=20')
+      const dispatchedRun = await service.prisma.experimentRun.create({
+        data: {
+          organizationSlug: orgSlug,
+          experimentType: 'meeting_briefing',
+          status: ExperimentRunStatus.RUNNING,
+        },
+      })
       const dispatchSpy = vi
         .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-        .mockResolvedValue(undefined)
+        .mockResolvedValue(dispatchedRun)
 
       const result = await service.client.post(
         '/v1/meetings/briefings/dispatch',

--- a/src/meetings/controllers/meetingsBriefings.controller.test.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.test.ts
@@ -886,4 +886,33 @@ describe('POST /v1/meetings/briefings/dispatch', () => {
     expect(result.data).toEqual({ dispatched: false, kind: 'briefing' })
     expect(dispatchSpy).not.toHaveBeenCalled()
   })
+
+  it('403s a user session dispatching against an office it does not own', async () => {
+    const otherUser = await service.prisma.user.create({
+      data: {
+        clerkId: `other-${Date.now()}`,
+        email: `other-${Date.now()}@test.example`,
+        firstName: 'Other',
+        lastName: 'User',
+      },
+    })
+    const orgSlug = `eo-idor-${Date.now()}`
+    await service.prisma.organization.create({
+      data: { slug: orgSlug, ownerId: otherUser.id },
+    })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: otherUser.id },
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.client.post(
+      '/v1/meetings/briefings/dispatch',
+      { electedOfficeId: eo.id, kind: 'briefing', useImminenceGate: true },
+    )
+
+    expect(result.status).toBe(403)
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
 })

--- a/src/meetings/controllers/meetingsBriefings.controller.test.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.test.ts
@@ -55,6 +55,61 @@ const mockS3 = (responses: Record<string, string | undefined>) => {
   )
 }
 
+// Seed everything a briefing dispatch needs to resolve: org + position +
+// elected office + a COMPLETED meeting_schedule artifact in S3 whose RRULE
+// the caller controls (to land a meeting inside or outside the 5-day gate).
+const seedBriefingTarget = async (orgSlug: string, rrule: string) => {
+  await service.prisma.organization.create({
+    data: { slug: orgSlug, ownerId: service.user.id, positionId: 'br-pos-g' },
+  })
+  await service.prisma.campaign.create({
+    data: {
+      userId: service.user.id,
+      slug: `test-campaign-${orgSlug}`,
+      organizationSlug: orgSlug,
+      details: {},
+    },
+  })
+  const eo = await service.prisma.electedOffice.create({
+    data: { organizationSlug: orgSlug, userId: service.user.id },
+  })
+  vi.spyOn(
+    service.app.get(ElectionsService),
+    'getPositionById',
+  ).mockResolvedValue({
+    id: 'pos-real',
+    brPositionId: 'br-pos-g',
+    brDatabaseId: 'br-db-g',
+    state: 'MN',
+    name: 'City Council',
+  })
+  const artifactKey = `schedule-${orgSlug}.json`
+  await service.prisma.experimentRun.create({
+    data: {
+      organizationSlug: orgSlug,
+      experimentType: 'meeting_schedule',
+      status: ExperimentRunStatus.COMPLETED,
+      artifactBucket: 'schedule-bucket',
+      artifactKey,
+    },
+  })
+  mockS3({
+    [artifactKey]: JSON.stringify({
+      status: 'found',
+      rrule,
+      time: '23:59',
+      timezone: 'America/Chicago',
+      duration_minutes: 120,
+      meeting_name: 'City Council',
+      location: 'Council Chambers',
+      sources: [],
+      generated_at: new Date().toISOString(),
+      human: 'test schedule',
+    }),
+  })
+  return eo
+}
+
 describe('GET /v1/meetings', () => {
   it('returns 404 when user has no elected office', async () => {
     const result = await service.client.get('/v1/meetings', {
@@ -724,5 +779,111 @@ describe('POST /v1/meetings/briefings/dispatch', () => {
         office: 'City Council',
       },
     })
+  })
+
+  it('with useImminenceGate, dispatches a briefing when a meeting is inside the 5-day window', async () => {
+    const orgSlug = `eo-gate-in-${Date.now()}`
+    const eo = await seedBriefingTarget(orgSlug, 'FREQ=DAILY')
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.client.post(
+      '/v1/meetings/briefings/dispatch',
+      { electedOfficeId: eo.id, kind: 'briefing', useImminenceGate: true },
+    )
+
+    expect(result.status).toBe(201)
+    expect(result.data).toEqual({ dispatched: true, kind: 'briefing' })
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'meeting_briefing',
+        organizationSlug: orgSlug,
+      }),
+    )
+  })
+
+  it('with useImminenceGate, returns 201 dispatched:false (no dispatch) when the next meeting is outside the 5-day window', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date('2026-06-01T12:00:00Z'))
+    try {
+      const orgSlug = `eo-gate-out-${Date.now()}`
+      // Next occurrence is the 20th — ~19 days out: outside 5, inside 60.
+      const eo = await seedBriefingTarget(orgSlug, 'FREQ=MONTHLY;BYMONTHDAY=20')
+      const dispatchSpy = vi
+        .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+        .mockResolvedValue(undefined)
+
+      const result = await service.client.post(
+        '/v1/meetings/briefings/dispatch',
+        { electedOfficeId: eo.id, kind: 'briefing', useImminenceGate: true },
+      )
+
+      expect(result.status).toBe(201)
+      expect(result.data).toEqual({ dispatched: false, kind: 'briefing' })
+      expect(dispatchSpy).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('without the gate, still dispatches that same out-of-window meeting (60-day manual window)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date('2026-06-01T12:00:00Z'))
+    try {
+      const orgSlug = `eo-nogate-${Date.now()}`
+      const eo = await seedBriefingTarget(orgSlug, 'FREQ=MONTHLY;BYMONTHDAY=20')
+      const dispatchSpy = vi
+        .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+        .mockResolvedValue(undefined)
+
+      const result = await service.client.post(
+        '/v1/meetings/briefings/dispatch',
+        { electedOfficeId: eo.id, kind: 'briefing' },
+      )
+
+      expect(result.status).toBe(201)
+      expect(result.data).toEqual({ dispatched: true, kind: 'briefing' })
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'meeting_briefing' }),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('with useImminenceGate, skips when a future briefing already covers the official', async () => {
+    const orgSlug = `eo-gate-dedupe-${Date.now()}`
+    const eo = await seedBriefingTarget(orgSlug, 'FREQ=DAILY')
+    const existingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+      },
+    })
+    await service.prisma.meetingBriefing.create({
+      data: {
+        electedOfficeId: eo.id,
+        meetingDate: new Date('2099-12-31'),
+        meetingTime: '19:00',
+        meetingTimezone: 'America/Denver',
+        experimentRunId: existingRun.runId,
+        artifactBucket: 'b',
+        artifactKey: 'existing.json',
+      },
+    })
+    const dispatchSpy = vi
+      .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
+      .mockResolvedValue(undefined)
+
+    const result = await service.client.post(
+      '/v1/meetings/briefings/dispatch',
+      { electedOfficeId: eo.id, kind: 'briefing', useImminenceGate: true },
+    )
+
+    expect(result.status).toBe(201)
+    expect(result.data).toEqual({ dispatched: false, kind: 'briefing' })
+    expect(dispatchSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -7,11 +7,13 @@ import {
   Post,
 } from '@nestjs/common'
 import { ZodValidationPipe } from 'nestjs-zod'
-import { ElectedOffice } from '../../generated/prisma'
+import { ElectedOffice, User } from '../../generated/prisma'
 import { addMonths, subDays } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
 import { ReqElectedOffice } from '@/electedOffice/decorators/ReqElectedOffice.decorator'
 import { UseElectedOffice } from '@/electedOffice/decorators/UseElectedOffice.decorator'
+import { ReqUser } from '@/authentication/decorators/ReqUser.decorator'
+import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
 import { S3Service } from '@/vendors/aws/services/s3.service'
 import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import {
@@ -22,7 +24,18 @@ import {
   DispatchMeetingAgentDto,
   DispatchMeetingAgentSchema,
 } from '../schemas/dispatchMeetingAgent.schema'
+import {
+  UserAgendaFinalizeRequest,
+  UserAgendaFinalizeRequestSchema,
+  UserAgendaFinalizeResponseSchema,
+  UserAgendaPresignRequest,
+  UserAgendaPresignRequestSchema,
+  UserAgendaPresignResponseSchema,
+} from '../schemas/userAgendaUpload.schema'
 import { MeetingBriefingsService } from '../services/meetingBriefings.service'
+import { UserAgendaUploadService } from '../services/userAgendaUpload.service'
+
+type UserAgendaStatus = 'processing' | 'failed' | 'completed' | 'unknown'
 
 type MeetingListItem = {
   meetingDate: string
@@ -32,12 +45,14 @@ type MeetingListItem = {
   meetingName: string
   location: string
   hasBriefing: boolean
+  userAgendaStatus: UserAgendaStatus | null
 }
 
 @Controller('meetings')
 export class MeetingsBriefingsController {
   constructor(
     private readonly meetingBriefings: MeetingBriefingsService,
+    private readonly userAgendaUploads: UserAgendaUploadService,
     private readonly s3: S3Service,
   ) {}
 
@@ -90,6 +105,7 @@ export class MeetingsBriefingsController {
           meetingName: knownSchedule.meeting_name,
           location: knownSchedule.location,
           hasBriefing: false,
+          userAgendaStatus: null,
         })
       }
     }
@@ -116,6 +132,43 @@ export class MeetingsBriefingsController {
           knownSchedule?.location ||
           '',
         hasBriefing: true,
+        userAgendaStatus: existing?.userAgendaStatus ?? null,
+      })
+    }
+
+    // Layer in user-agenda statuses last so the GET row reflects the latest
+    // user-upload state regardless of whether a briefing row exists yet
+    // (the briefing row appears only AFTER the dispatched run completes).
+    // The query is scoped to the same window as the meeting projection so
+    // upload rows for off-list dates (no projected schedule entry, no
+    // briefing row yet) still appear as their own list rows. Past-date
+    // uploads within the window are also surfaced — the presign/finalize
+    // endpoints accept any meetingDate, so a user who uploaded for a
+    // recent meeting must still see its status (otherwise their submission
+    // silently disappears from the list).
+    const userAgendaStatuses =
+      await this.userAgendaUploads.getStatusForMeetings(electedOffice.id, {
+        from: windowFrom,
+        to: windowTo,
+      })
+    for (const [date, status] of userAgendaStatuses) {
+      const existing = byDate.get(date)
+      if (existing) {
+        byDate.set(date, { ...existing, userAgendaStatus: status })
+        continue
+      }
+      // Off-list date: user uploaded an agenda for a meeting we don't have a
+      // schedule entry or briefing row for. Surface as a row so the agenda is
+      // visible — fill the schedule-only fields with placeholders.
+      byDate.set(date, {
+        meetingDate: date,
+        meetingTime: '',
+        meetingTimezone: '',
+        durationMinutes: 0,
+        meetingName: '',
+        location: '',
+        hasBriefing: false,
+        userAgendaStatus: status,
       })
     }
 
@@ -187,5 +240,50 @@ export class MeetingsBriefingsController {
       )
     }
     return { dispatched: true, kind: body.kind }
+  }
+
+  /**
+   * Step 1 of user-supplied agenda upload: returns a presigned S3 PUT URL
+   * the browser uses to upload the PDF directly to the agent-run-inputs
+   * bucket. No DB row is created here — finalizeUserAgenda creates the row
+   * after the upload completes.
+   */
+  @UseElectedOffice()
+  @Post(':date/briefing/agenda/presign')
+  @ResponseSchema(UserAgendaPresignResponseSchema)
+  async presignUserAgenda(
+    @ReqElectedOffice() electedOffice: ElectedOffice,
+    @Param(new ZodValidationPipe(MeetingDateParamSchema))
+    { date }: MeetingDateParam,
+    @Body(new ZodValidationPipe(UserAgendaPresignRequestSchema))
+    body: UserAgendaPresignRequest,
+  ) {
+    return this.userAgendaUploads.createUploadPresign(electedOffice, date, body)
+  }
+
+  /**
+   * Step 2 of user-supplied agenda upload (or sole step for URL paste):
+   * persists the upload metadata and dispatches a fresh briefing run with
+   * `agendaPacketUrl` set.
+   */
+  @UseElectedOffice()
+  @Post(':date/briefing/agenda')
+  @ResponseSchema(UserAgendaFinalizeResponseSchema)
+  async finalizeUserAgenda(
+    @ReqElectedOffice() electedOffice: ElectedOffice,
+    @ReqUser() user: User,
+    @Param(new ZodValidationPipe(MeetingDateParamSchema))
+    { date }: MeetingDateParam,
+    @Body(new ZodValidationPipe(UserAgendaFinalizeRequestSchema))
+    body: UserAgendaFinalizeRequest,
+  ) {
+    const { experimentRunId } =
+      await this.userAgendaUploads.finalizeAndDispatch(
+        electedOffice,
+        user.id,
+        date,
+        body,
+      )
+    return { experimentRunId, status: 'processing' as const }
   }
 }

--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -5,6 +5,8 @@ import {
   NotFoundException,
   Param,
   Post,
+  Req,
+  UseGuards,
 } from '@nestjs/common'
 import { ZodValidationPipe } from 'nestjs-zod'
 import { ElectedOffice, User } from '../../generated/prisma'
@@ -14,6 +16,9 @@ import { ReqElectedOffice } from '@/electedOffice/decorators/ReqElectedOffice.de
 import { UseElectedOffice } from '@/electedOffice/decorators/UseElectedOffice.decorator'
 import { ReqUser } from '@/authentication/decorators/ReqUser.decorator'
 import { ResponseSchema } from '@/shared/decorators/ResponseSchema.decorator'
+import { UserOrM2MGuard } from '@/electedOffice/guards/UserOrM2M.guard'
+import { IncomingRequest } from '@/authentication/authentication.types'
+import { effectiveUser } from '@/authentication/util/effectiveUser.util'
 import { S3Service } from '@/vendors/aws/services/s3.service'
 import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import {
@@ -225,15 +230,23 @@ export class MeetingsBriefingsController {
     return { ...artifact, briefing_id: row.id }
   }
 
+  @UseGuards(UserOrM2MGuard)
   @Post('briefings/dispatch')
   async dispatchAgent(
     @Body(new ZodValidationPipe(DispatchMeetingAgentSchema))
     body: DispatchMeetingAgentDto,
+    @Req() req: IncomingRequest,
   ) {
+    // M2M callers (the bulk dispatch script, gp-admin) are trusted to dispatch
+    // for any office. A user session may only dispatch for an office it owns —
+    // passing the user id down enforces that and 403s an attempt against
+    // someone else's office. Undefined (M2M) skips the ownership check.
+    const requestingUserId = req.m2mToken ? undefined : effectiveUser(req)?.id
     const result = await this.meetingBriefings.dispatchManual(
       body.electedOfficeId,
       body.kind,
       body.useImminenceGate,
+      requestingUserId,
     )
     // With the imminence gate on, a non-dispatch is an expected skip (no meeting
     // inside the window, or one already briefed), so return it as a 200 and let

--- a/src/meetings/controllers/meetingsBriefings.controller.ts
+++ b/src/meetings/controllers/meetingsBriefings.controller.ts
@@ -233,13 +233,18 @@ export class MeetingsBriefingsController {
     const result = await this.meetingBriefings.dispatchManual(
       body.electedOfficeId,
       body.kind,
+      body.useImminenceGate,
     )
-    if (!result.dispatched) {
+    // With the imminence gate on, a non-dispatch is an expected skip (no meeting
+    // inside the window, or one already briefed), so return it as a 200 and let
+    // the bulk caller tell "skipped" from a hard failure. Without the gate (the
+    // UI button), a non-dispatch means context resolution failed → 404.
+    if (!result.dispatched && !body.useImminenceGate) {
       throw new NotFoundException(
         'Could not resolve dispatch context for that elected office',
       )
     }
-    return { dispatched: true, kind: body.kind }
+    return { dispatched: result.dispatched, kind: body.kind }
   }
 
   /**

--- a/src/meetings/meetings.module.ts
+++ b/src/meetings/meetings.module.ts
@@ -11,6 +11,7 @@ import { BriefingsPdfRateLimitGuard } from './controllers/briefingsPdfRateLimit.
 import { MeetingsBriefingsController } from './controllers/meetingsBriefings.controller'
 import { BriefingPdfService } from './services/briefingPdf.service'
 import { MeetingBriefingsService } from './services/meetingBriefings.service'
+import { UserAgendaUploadService } from './services/userAgendaUpload.service'
 
 @Module({
   imports: [
@@ -25,9 +26,10 @@ import { MeetingBriefingsService } from './services/meetingBriefings.service'
   controllers: [MeetingsBriefingsController, BriefingsPdfController],
   providers: [
     MeetingBriefingsService,
+    UserAgendaUploadService,
     BriefingPdfService,
     BriefingsPdfRateLimitGuard,
   ],
-  exports: [MeetingBriefingsService],
+  exports: [MeetingBriefingsService, UserAgendaUploadService],
 })
 export class MeetingsModule {}

--- a/src/meetings/schemas/dispatchMeetingAgent.schema.ts
+++ b/src/meetings/schemas/dispatchMeetingAgent.schema.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 export const DispatchMeetingAgentSchema = z.object({
   electedOfficeId: z.string().min(1),
   kind: z.enum(['schedule', 'briefing']),
+  useImminenceGate: z.boolean().optional(),
 })
 
 export type DispatchMeetingAgentDto = z.infer<typeof DispatchMeetingAgentSchema>

--- a/src/meetings/schemas/userAgendaUpload.schema.ts
+++ b/src/meetings/schemas/userAgendaUpload.schema.ts
@@ -1,0 +1,66 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+export const USER_AGENDA_MAX_BYTES = 75 * 1024 * 1024 // 75 MB
+
+const ALLOWED_CONTENT_TYPES = ['application/pdf'] as const
+
+export const UserAgendaPresignRequestSchema = z.object({
+  contentType: z.enum(ALLOWED_CONTENT_TYPES),
+  byteSize: z
+    .number()
+    .int()
+    .positive()
+    .max(USER_AGENDA_MAX_BYTES, {
+      message: `byteSize exceeds ${USER_AGENDA_MAX_BYTES} (75 MB)`,
+    }),
+})
+export type UserAgendaPresignRequest = z.infer<
+  typeof UserAgendaPresignRequestSchema
+>
+export class UserAgendaPresignRequestDto extends createZodDto(
+  UserAgendaPresignRequestSchema,
+) {}
+
+export const UserAgendaPresignResponseSchema = z.object({
+  uploadId: z.string(),
+  uploadKey: z.string(),
+  uploadUrl: z.string().url(),
+  expiresAt: z.string().datetime(),
+})
+
+/**
+ * The finalize endpoint takes EITHER a pasted URL OR a completed S3 upload —
+ * never both. discriminatedUnion enforces this at the schema level.
+ *
+ * Note: no `createZodDto` wrapper because nestjs-zod's DTO base requires a
+ * single ZodObject; a discriminated union doesn't fit that constraint.
+ * Controllers consume this via `@Body(new ZodValidationPipe(Schema)) body: Type`.
+ */
+export const UserAgendaFinalizeRequestSchema = z.discriminatedUnion('source', [
+  z
+    .object({
+      source: z.literal('URL'),
+      sourceUrl: z.string().url().max(2048),
+    })
+    .strict(),
+  z
+    .object({
+      source: z.literal('UPLOAD'),
+      // uploadId is the UUID returned by the presign endpoint. The server
+      // reconstructs the full S3 key from electedOffice.id + meetingDate +
+      // uploadId — never trust a client-supplied key, that's an IDOR vector.
+      // .strict() below rejects any extra field (e.g. a smuggled uploadKey)
+      // at the validation layer for fail-fast feedback.
+      uploadId: z.string().uuid(),
+    })
+    .strict(),
+])
+export type UserAgendaFinalizeRequest = z.infer<
+  typeof UserAgendaFinalizeRequestSchema
+>
+
+export const UserAgendaFinalizeResponseSchema = z.object({
+  experimentRunId: z.string(),
+  status: z.literal('processing'),
+})

--- a/src/meetings/services/meetingBriefings.service.test.ts
+++ b/src/meetings/services/meetingBriefings.service.test.ts
@@ -1,4 +1,5 @@
 import {
+  ExperimentRun,
   ExperimentRunStatus,
   MeetingResourceLocationType,
 } from '../../generated/prisma'
@@ -499,6 +500,53 @@ describe('MeetingBriefingsService.onExperimentRunCompleted', () => {
     expect(row).toBeNull()
   })
 
+  it('writes the row for agenda_provided_by_user even when meeting_time is empty', async () => {
+    const orgSlug = `eo-user-agenda-${Date.now()}`
+    await service.prisma.organization.create({
+      data: { slug: orgSlug, ownerId: service.user.id },
+    })
+    const eo = await service.prisma.electedOffice.create({
+      data: { organizationSlug: orgSlug, userId: service.user.id },
+    })
+    const briefingRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_briefing',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'briefing-bucket',
+        artifactKey: 'briefing.json',
+        params: { elected_office_id: eo.id },
+      },
+    })
+    mockS3({
+      'briefing.json': JSON.stringify({
+        briefing_status: 'agenda_provided_by_user',
+        meeting_date: '2026-06-08',
+        meeting_time: '',
+        meeting_timezone: '',
+        meeting_name: 'Special Session',
+      }),
+    })
+
+    await service.app
+      .get(MeetingBriefingsService)
+      .onExperimentRunCompleted(briefingRun)
+
+    const row = await service.prisma.meetingBriefing.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: eo.id,
+          meetingDate: new Date('2026-06-08'),
+        },
+      },
+    })
+    expect(row).not.toBeNull()
+    expect(row?.meetingTime).toBe('')
+    expect(row?.meetingTimezone).toBe('')
+    expect(row?.experimentRunId).toBe(briefingRun.runId)
+    expect(row?.artifact?.meeting_name).toBe('Special Session')
+  })
+
   it('does not write a MeetingBriefing row for placeholder briefing_status (awaiting_agenda)', async () => {
     const orgSlug = `eo-awaiting-${Date.now()}`
     await service.prisma.organization.create({
@@ -967,7 +1015,7 @@ describe('MeetingBriefingsService.dispatchManual', () => {
     await seedScheduleForOrg(orgSlug)
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
+      .mockResolvedValue({ runId: 'manual-dispatch-run' } as ExperimentRun)
 
     const result = await service.app
       .get(MeetingBriefingsService)
@@ -1034,7 +1082,7 @@ describe('MeetingBriefingsService.dispatchManual', () => {
     await seedScheduleForOrg(orgSlug)
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
+      .mockResolvedValue({ runId: 'manual-dispatch-run' } as ExperimentRun)
 
     const result = await service.app
       .get(MeetingBriefingsService)
@@ -1073,7 +1121,7 @@ describe('MeetingBriefingsService.dispatchManual', () => {
     await seedScheduleForOrg(orgSlug)
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
+      .mockResolvedValue({ runId: 'manual-dispatch-run' } as ExperimentRun)
 
     const result = await service.app
       .get(MeetingBriefingsService)
@@ -1193,7 +1241,7 @@ describe('MeetingBriefingsService location hints', () => {
     await seedScheduleForOrg(orgSlug)
     const dispatchSpy = vi
       .spyOn(service.app.get(ExperimentRunsService), 'dispatchRun')
-      .mockResolvedValue(undefined)
+      .mockResolvedValue({ runId: 'manual-dispatch-run' } as ExperimentRun)
 
     await service.app
       .get(MeetingBriefingsService)

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -456,8 +456,10 @@ export class MeetingBriefingsService extends createPrismaBase(
     )
     if (!target) return { dispatched: false }
 
-    await this.dispatchBriefing(ctx, target)
-    return { dispatched: true }
+    // dispatchBriefing returns undefined when the run wasn't enqueued (queue
+    // not configured); don't report success in that case.
+    const result = await this.dispatchBriefing(ctx, target)
+    return { dispatched: !!result }
   }
 
   async onExperimentRunCompleted(run: ExperimentRun): Promise<void> {
@@ -779,6 +781,48 @@ export class MeetingBriefingsService extends createPrismaBase(
     })
   }
 
+  // Resolve the (meetingTime, meetingTimezone) to persist. The platform path
+  // requires a valid HH:MM time and a timezone and returns null (skip the row)
+  // when either is malformed. The user-agenda path dispatches without those
+  // PARAMS — the meeting often isn't on any platform for the agent to read a
+  // time from (ad-hoc / small-jurisdiction meetings are the whole point of
+  // letting a user supply the packet) — so it persists with empty values
+  // rather than skipping. Blocking there would strand the user on a perpetual
+  // "processing" pill for exactly the meetings this feature targets.
+  private resolveMeetingTimeFields(
+    artifact: PrismaJson.MeetingBriefingArtifact,
+    userSuppliedAgenda: boolean,
+    runId: string,
+  ): { meetingTime: string; meetingTimezone: string } | null {
+    const rawTime =
+      typeof artifact.meeting_time === 'string' ? artifact.meeting_time : ''
+    const timeValid = /^([01][0-9]|2[0-3]):[0-5][0-9]$/.test(rawTime)
+    if (!timeValid && !userSuppliedAgenda) {
+      this.logger.error(
+        { runId, meetingTime: rawTime },
+        'meeting_briefing artifact has invalid meeting_time',
+      )
+      return null
+    }
+
+    const rawTimezone =
+      typeof artifact.meeting_timezone === 'string'
+        ? artifact.meeting_timezone
+        : ''
+    if (!rawTimezone && !userSuppliedAgenda) {
+      this.logger.error(
+        { runId },
+        'meeting_briefing artifact missing meeting_timezone',
+      )
+      return null
+    }
+
+    return {
+      meetingTime: timeValid ? rawTime : '',
+      meetingTimezone: rawTimezone,
+    }
+  }
+
   private async writeBriefingRowFromArtifact(
     run: ExperimentRun,
     electedOffice: { id: string; userId: number },
@@ -822,27 +866,13 @@ export class MeetingBriefingsService extends createPrismaBase(
       return
     }
 
-    const meetingTime =
-      typeof artifact.meeting_time === 'string' ? artifact.meeting_time : ''
-    if (!/^([01][0-9]|2[0-3]):[0-5][0-9]$/.test(meetingTime)) {
-      this.logger.error(
-        { runId: run.runId, meetingTime },
-        'meeting_briefing artifact has invalid meeting_time',
-      )
-      return
-    }
-
-    const meetingTimezone =
-      typeof artifact.meeting_timezone === 'string'
-        ? artifact.meeting_timezone
-        : ''
-    if (!meetingTimezone) {
-      this.logger.error(
-        { runId: run.runId },
-        'meeting_briefing artifact missing meeting_timezone',
-      )
-      return
-    }
+    const resolved = this.resolveMeetingTimeFields(
+      artifact,
+      briefingStatus === 'agenda_provided_by_user',
+      run.runId,
+    )
+    if (!resolved) return
+    const { meetingTime, meetingTimezone } = resolved
 
     const electedOfficeId = electedOffice.id
     await this.model.upsert({

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -10,6 +10,7 @@ import { S3Service } from '@/vendors/aws/services/s3.service'
 import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
 import {
   BadGatewayException,
+  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common'
@@ -432,11 +433,23 @@ export class MeetingBriefingsService extends createPrismaBase(
     electedOfficeId: string,
     kind: ManualDispatchKind,
     useImminenceGate = false,
+    requestingUserId?: number,
   ): Promise<{ dispatched: boolean }> {
     const electedOffice = await this.client.electedOffice.findUnique({
       where: { id: electedOfficeId },
     })
     if (!electedOffice) return { dispatched: false }
+
+    // A user session may only dispatch for an office it owns; M2M callers pass
+    // no requestingUserId and are trusted to dispatch for any office.
+    if (
+      requestingUserId !== undefined &&
+      electedOffice.userId !== requestingUserId
+    ) {
+      throw new ForbiddenException(
+        'You do not have access to this elected office',
+      )
+    }
 
     const ctx = await this.resolveDispatchContext(electedOffice)
     if (!ctx) return { dispatched: false }

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -8,7 +8,11 @@ import { parseIsoDateAsUTC } from '@/shared/util/date.util'
 import { getUserFullName } from '@/users/util/users.util'
 import { S3Service } from '@/vendors/aws/services/s3.service'
 import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
-import { Injectable } from '@nestjs/common'
+import {
+  BadGatewayException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
 import { Cron } from '@nestjs/schedule'
 import {
   ElectedOffice,
@@ -133,8 +137,8 @@ const IMMINENCE_WINDOW_DAYS = 5
 
 type TargetMeeting = {
   meetingDate: string // YYYY-MM-DD
-  meetingTime: string // HH:MM
-  meetingTimezone: string // IANA
+  meetingTime?: string // HH:MM (optional — user-supplied agenda path leaves it to the agent)
+  meetingTimezone?: string // IANA (optional — same reason)
 }
 
 @Injectable()
@@ -279,12 +283,22 @@ export class MeetingBriefingsService extends createPrismaBase(
   private async dispatchBriefing(
     ctx: DispatchContext,
     meeting: TargetMeeting,
-  ): Promise<void> {
+    options: {
+      // URL-paste path: user gave us a URL to an agenda. Travels in params as
+      // an ordinary string the agent reads + cites.
+      agendaPacketUrl?: string
+      // UPLOAD path: user uploaded a file. Travels in params under the
+      // reserved `_input_files` envelope key; the dispatch handler strips it
+      // out of params before agent validation/PARAMS_JSON and uses it to
+      // tell the runner to pre-fetch via the broker into /workspace/input/.
+      inputFiles?: Array<{ bucket: string; key: string; dest: string }>
+    } = {},
+  ): Promise<{ runId: string } | undefined> {
     const hint = await this.loadLocationHint(
       ctx.electedOfficeId,
       MeetingResourceLocationType.AGENDA,
     )
-    await this.experimentRuns.dispatchRun({
+    const run = await this.experimentRuns.dispatchRun({
       type: BRIEFING_EXPERIMENT_TYPE,
       organizationSlug: ctx.organizationSlug,
       clerkUserId: ctx.clerkUserId,
@@ -293,13 +307,74 @@ export class MeetingBriefingsService extends createPrismaBase(
         state: ctx.state,
         positionName: ctx.positionName,
         meetingDate: meeting.meetingDate,
-        meetingTime: meeting.meetingTime,
-        meetingTimezone: meeting.meetingTimezone,
+        ...(meeting.meetingTime ? { meetingTime: meeting.meetingTime } : {}),
+        ...(meeting.meetingTimezone
+          ? { meetingTimezone: meeting.meetingTimezone }
+          : {}),
         ...(ctx.l2DistrictType ? { l2DistrictType: ctx.l2DistrictType } : {}),
         ...(ctx.l2DistrictName ? { l2DistrictName: ctx.l2DistrictName } : {}),
         ...(hint ? { knownAgendaLocation: hint } : {}),
+        ...(options.agendaPacketUrl
+          ? { agendaPacketUrl: options.agendaPacketUrl }
+          : {}),
+        ...(options.inputFiles && options.inputFiles.length > 0
+          ? { _input_files: options.inputFiles }
+          : {}),
       },
     })
+    return run ? { runId: run.runId } : undefined
+  }
+
+  /**
+   * Public entry point for user-supplied agenda runs. Bypasses the imminence
+   * gate and the schedule lookup — the user is telling us "brief THIS meeting
+   * with THIS agenda." We still resolve the dispatch context (officialName,
+   * state, etc.) the normal way; the only PARAMS differences are
+   * `agendaPacketUrl` or `_input_files` set and `meetingTime`/`meetingTimezone`
+   * left to the agent to discover from the platform (we don't reliably know
+   * them for arbitrary user-supplied dates).
+   *
+   * Caller supplies exactly one of `agendaPacketUrl` (URL-paste path; user's
+   * own URL — never a presigned one) or `inputFiles` (UPLOAD path; runner
+   * pre-fetches via the broker before the agent boots). Not validated here:
+   * the caller is the upload service, which always sets exactly one.
+   */
+  async dispatchBriefingWithUserAgenda(args: {
+    electedOfficeId: string
+    meetingDate: string
+    agendaPacketUrl?: string
+    inputFiles?: Array<{ bucket: string; key: string; dest: string }>
+  }): Promise<{ runId: string }> {
+    const electedOffice = await this.client.electedOffice.findUnique({
+      where: { id: args.electedOfficeId },
+    })
+    if (!electedOffice) {
+      throw new NotFoundException(
+        `electedOffice not found: ${args.electedOfficeId}`,
+      )
+    }
+    const ctx = await this.resolveDispatchContext(electedOffice)
+    if (!ctx) {
+      throw new NotFoundException(
+        `could not resolve dispatch context for electedOffice ${args.electedOfficeId}`,
+      )
+    }
+    const result = await this.dispatchBriefing(
+      ctx,
+      { meetingDate: args.meetingDate },
+      {
+        ...(args.agendaPacketUrl
+          ? { agendaPacketUrl: args.agendaPacketUrl }
+          : {}),
+        ...(args.inputFiles ? { inputFiles: args.inputFiles } : {}),
+      },
+    )
+    if (!result) {
+      throw new BadGatewayException(
+        'dispatch queue not configured; briefing run was not enqueued',
+      )
+    }
+    return result
   }
 
   /**

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -959,10 +959,16 @@ export class MeetingBriefingsService extends createPrismaBase(
       leadInFallback: readLeadIn(artifact),
     })
 
-    const meetingDateTime = fromZonedTime(
-      `${dateString}T${meetingTime}:00`,
-      meetingTimezone,
-    ).getTime()
+    // The user-agenda path persists empty meetingTime/meetingTimezone, which
+    // would make fromZonedTime produce NaN. Only emit the exact-instant
+    // property when both are present so HubSpot's datetime field stays valid.
+    const meetingDateTime =
+      meetingTime && meetingTimezone
+        ? fromZonedTime(
+            `${dateString}T${meetingTime}:00`,
+            meetingTimezone,
+          ).getTime()
+        : null
 
     try {
       await this.analytics.track(
@@ -971,7 +977,7 @@ export class MeetingBriefingsService extends createPrismaBase(
         {
           agendaId: dateString,
           meetingDate: parseIsoDateAsUTC(dateString).getTime(),
-          meetingDateTime,
+          ...(meetingDateTime !== null ? { meetingDateTime } : {}),
           meetingTime,
           meetingTimezone,
           meetingPlace: artifact.location ?? '',

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -431,6 +431,7 @@ export class MeetingBriefingsService extends createPrismaBase(
   async dispatchManual(
     electedOfficeId: string,
     kind: ManualDispatchKind,
+    useImminenceGate = false,
   ): Promise<{ dispatched: boolean }> {
     const electedOffice = await this.client.electedOffice.findUnique({
       where: { id: electedOfficeId },
@@ -445,14 +446,25 @@ export class MeetingBriefingsService extends createPrismaBase(
       return { dispatched: true }
     }
 
-    // Manual briefing dispatch bypasses the 5-day imminence gate but still
-    // needs a meetingDate from the schedule. Project up to 60 days out so
-    // an operator can pre-brief a meeting that's still a few weeks away.
+    // A briefing needs a meetingDate from the schedule. With the imminence
+    // gate on, match the daily cron exactly: skip if a future briefing already
+    // covers the official, and only dispatch when the next meeting falls inside
+    // the 5-day window. With the gate off (the UI "brief now" button) widen to
+    // 60 days so an operator can pre-brief a meeting that's still weeks away.
+    const now = new Date()
+    if (useImminenceGate) {
+      const futureBriefing = await this.model.findFirst({
+        where: { electedOfficeId, meetingDate: { gte: now } },
+        select: { id: true },
+      })
+      if (futureBriefing) return { dispatched: false }
+    }
+
     const target = await this.resolveTargetMeeting(
       ctx.organizationSlug,
       ctx.electedOfficeId,
-      new Date(),
-      60,
+      now,
+      useImminenceGate ? IMMINENCE_WINDOW_DAYS : 60,
     )
     if (!target) return { dispatched: false }
 

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -23,7 +23,7 @@ import {
   Prisma,
 } from '../../generated/prisma'
 import { addDays } from 'date-fns'
-import { formatInTimeZone } from 'date-fns-tz'
+import { formatInTimeZone, fromZonedTime } from 'date-fns-tz'
 import { chunk } from 'es-toolkit'
 import ms from 'ms'
 import { ChatCompletionMessageParam } from 'openai/resources/chat/completions'
@@ -959,13 +959,19 @@ export class MeetingBriefingsService extends createPrismaBase(
       leadInFallback: readLeadIn(artifact),
     })
 
+    const meetingDateTime = fromZonedTime(
+      `${dateString}T${meetingTime}:00`,
+      meetingTimezone,
+    ).getTime()
+
     try {
       await this.analytics.track(
         userId,
         'Briefing Assistant - Agenda Created',
         {
           agendaId: dateString,
-          meetingDate: dateString,
+          meetingDate: parseIsoDateAsUTC(dateString).getTime(),
+          meetingDateTime,
           meetingTime,
           meetingTimezone,
           meetingPlace: artifact.location ?? '',

--- a/src/meetings/services/userAgendaUpload.controller.test.ts
+++ b/src/meetings/services/userAgendaUpload.controller.test.ts
@@ -1,0 +1,542 @@
+import { randomUUID } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ExperimentRunStatus, UserAgendaSource } from '../../generated/prisma'
+import { useTestService } from '@/test-service'
+import { S3Service } from '@/vendors/aws/services/s3.service'
+import { ExperimentRunsService } from '@/agentExperiments/services/experimentRuns.service'
+import { OrganizationsService } from '@/organizations/services/organizations.service'
+
+const service = useTestService()
+
+const orgHeader = (slug: string) => ({
+  headers: { 'x-organization-slug': slug },
+})
+
+const seedOrgAndElectedOffice = async (orgSlug: string) => {
+  await service.prisma.organization.create({
+    data: { slug: orgSlug, ownerId: service.user.id },
+  })
+  await service.prisma.campaign.create({
+    data: {
+      userId: service.user.id,
+      slug: `test-campaign-${orgSlug}`,
+      organizationSlug: orgSlug,
+      details: {},
+    },
+  })
+  return service.prisma.electedOffice.create({
+    data: { organizationSlug: orgSlug, userId: service.user.id },
+  })
+}
+
+const mockS3 = (opts?: {
+  objectExists?: boolean
+  contentLength?: number | null
+}) => {
+  const s3 = service.app.get(S3Service)
+  const headResult: { contentLength: number | null } | null =
+    opts?.objectExists === false
+      ? null
+      : { contentLength: opts?.contentLength ?? 1024 }
+  return {
+    upload: vi
+      .spyOn(s3, 'getSignedUrlForUpload')
+      .mockResolvedValue('https://s3.example/upload-url'),
+    view: vi
+      .spyOn(s3, 'getSignedUrlForViewing')
+      .mockResolvedValue('https://s3.example/view-url'),
+    exists: vi
+      .spyOn(s3, 'objectExists')
+      .mockResolvedValue(opts?.objectExists ?? true),
+    head: vi.spyOn(s3, 'headObject').mockResolvedValue(headResult),
+  }
+}
+
+const mockResolveServeContext = () => {
+  vi.spyOn(
+    service.app.get(OrganizationsService),
+    'resolveServeContext',
+  ).mockResolvedValue({
+    state: 'MN',
+    positionName: 'City Council',
+  })
+}
+
+const mockDispatchRun = () => {
+  const runs = service.app.get(ExperimentRunsService)
+  return vi.spyOn(runs, 'dispatchRun').mockImplementation(
+    // dispatchRun normally creates the row, enqueues to SQS, returns the row.
+    // We bypass SQS by creating the row directly and returning it.
+    async (input) => {
+      const runId = `test-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      return service.prisma.experimentRun.create({
+        data: {
+          runId,
+          experimentType: input.type,
+          organizationSlug: input.organizationSlug,
+          status: ExperimentRunStatus.RUNNING,
+          params: input.params,
+        },
+      })
+    },
+  )
+}
+
+beforeEach(() => {
+  vi.stubEnv('AGENT_RUN_INPUTS_BUCKET', 'gp-agent-run-inputs-test')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('POST /v1/meetings/:date/briefing/agenda/presign', () => {
+  it('returns a signed PUT URL with uploadId and uploadKey', async () => {
+    const orgSlug = `presign-ok-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    const s3 = mockS3()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda/presign',
+      { contentType: 'application/pdf', byteSize: 1_048_576 },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(201)
+    expect(result.data).toMatchObject({
+      uploadUrl: 'https://s3.example/upload-url',
+    })
+    expect(typeof result.data.uploadId).toBe('string')
+    expect(result.data.uploadKey).toContain(
+      `agendas/${result.data.uploadKey.split('/')[1]}/2026-07-15/`,
+    )
+    expect(s3.upload).toHaveBeenCalledOnce()
+  })
+
+  it('rejects byteSize over the 75 MB cap', async () => {
+    const orgSlug = `presign-too-big-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    mockS3()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda/presign',
+      { contentType: 'application/pdf', byteSize: 80 * 1024 * 1024 },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('rejects non-PDF content types', async () => {
+    const orgSlug = `presign-bad-type-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    mockS3()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda/presign',
+      { contentType: 'image/png', byteSize: 1024 },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('does NOT create a UserAgendaUpload row at presign time', async () => {
+    const orgSlug = `presign-no-row-${Date.now()}`
+    const eo = await seedOrgAndElectedOffice(orgSlug)
+    mockS3()
+
+    await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda/presign',
+      { contentType: 'application/pdf', byteSize: 1024 },
+      orgHeader(orgSlug),
+    )
+
+    const rows = await service.prisma.userAgendaUpload.findMany({
+      where: { electedOfficeId: eo.id },
+    })
+    expect(rows).toHaveLength(0)
+  })
+})
+
+describe('POST /v1/meetings/:date/briefing/agenda — UPLOAD source', () => {
+  it('creates the row, dispatches a briefing run, returns experimentRunId', async () => {
+    const orgSlug = `finalize-upload-${Date.now()}`
+    const eo = await seedOrgAndElectedOffice(orgSlug)
+    mockResolveServeContext()
+    mockS3({ objectExists: true })
+    const dispatchSpy = mockDispatchRun()
+    const uploadId = randomUUID()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'UPLOAD', uploadId },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(201)
+    expect(result.data).toMatchObject({ status: 'processing' })
+    expect(typeof result.data.experimentRunId).toBe('string')
+
+    const row = await service.prisma.userAgendaUpload.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: eo.id,
+          meetingDate: new Date('2026-07-15'),
+        },
+      },
+    })
+    expect(row).toMatchObject({
+      source: UserAgendaSource.UPLOAD,
+      // Server reconstructs the key from electedOffice.id + meetingDate +
+      // uploadId — the client never supplies it.
+      uploadKey: `agendas/${eo.id}/2026-07-15/${uploadId}.pdf`,
+      experimentRunId: result.data.experimentRunId,
+    })
+    // UPLOAD path sends `_input_files` envelope refs (stripped from params
+    // by the dispatch handler before agent boot) — never `agendaPacketUrl`,
+    // which would otherwise be a presigned URL vulnerable to IAM rotation.
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'meeting_briefing',
+        params: expect.objectContaining({
+          meetingDate: '2026-07-15',
+          _input_files: [
+            {
+              bucket: 'gp-agent-run-inputs-test',
+              key: `agendas/${eo.id}/2026-07-15/${uploadId}.pdf`,
+              dest: 'agenda.pdf',
+            },
+          ],
+        }),
+      }),
+    )
+    const params = dispatchSpy.mock.calls[0][0].params as Record<
+      string,
+      unknown
+    >
+    expect(params).not.toHaveProperty('agendaPacketUrl')
+  })
+
+  it('rejects a non-UUID uploadId', async () => {
+    const orgSlug = `finalize-bad-uuid-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    mockS3()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'UPLOAD', uploadId: 'not-a-uuid' },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('rejects a client-supplied uploadKey (IDOR defense)', async () => {
+    // additionalProperties on the discriminated union schema means any extra
+    // fields the caller appends (including a cross-office uploadKey) are
+    // rejected at the validation layer. Locks the contract: the server is
+    // the only producer of the S3 key.
+    const orgSlug = `finalize-extra-key-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    mockS3()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      {
+        source: 'UPLOAD',
+        uploadId: randomUUID(),
+        uploadKey: 'agendas/victim-office/2026-07-15/leaked.pdf',
+      },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('returns 400 when the S3 object does not exist', async () => {
+    const orgSlug = `finalize-no-s3-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    mockResolveServeContext()
+    mockS3({ objectExists: false })
+    mockDispatchRun()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'UPLOAD', uploadId: randomUUID() },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('returns 400 when the actual S3 object size exceeds the 75 MB cap', async () => {
+    // Defense against a malformed client uploading a body larger than the
+    // presigned byteSize. The presign-time Zod cap covers the REQUESTED
+    // size; this finalize-time HEAD check covers the ACTUAL size.
+    const orgSlug = `finalize-too-large-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    mockResolveServeContext()
+    mockS3({ objectExists: true, contentLength: 80 * 1024 * 1024 })
+    const dispatchSpy = mockDispatchRun()
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'UPLOAD', uploadId: randomUUID() },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+    // No dispatch — we rejected before reaching the dispatch step.
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('re-finalizing replaces the prior row and dispatches a new run', async () => {
+    const orgSlug = `finalize-reupload-${Date.now()}`
+    const eo = await seedOrgAndElectedOffice(orgSlug)
+    mockResolveServeContext()
+    mockS3({ objectExists: true })
+    mockDispatchRun()
+    const firstId = randomUUID()
+    const secondId = randomUUID()
+
+    const first = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'UPLOAD', uploadId: firstId },
+      orgHeader(orgSlug),
+    )
+    expect(first.status).toBe(201)
+
+    const second = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'UPLOAD', uploadId: secondId },
+      orgHeader(orgSlug),
+    )
+    expect(second.status).toBe(201)
+    expect(second.data.experimentRunId).not.toBe(first.data.experimentRunId)
+
+    const rows = await service.prisma.userAgendaUpload.findMany({
+      where: { electedOfficeId: eo.id },
+    })
+    expect(rows).toHaveLength(1)
+    expect(rows[0].uploadKey).toBe(
+      `agendas/${eo.id}/2026-07-15/${secondId}.pdf`,
+    )
+    expect(rows[0].experimentRunId).toBe(second.data.experimentRunId)
+  })
+})
+
+describe('POST /v1/meetings/:date/briefing/agenda — URL source', () => {
+  // Note: this endpoint deliberately does NOT HEAD-check the user-supplied
+  // URL. SSRF defense lives at the broker's egress-restricted network where
+  // the agent actually fetches the URL at run-time, not at gp-api's network
+  // position. Bad URLs (404, non-PDF, oversize) surface as a FAILED agent
+  // run rather than an immediate 400, which getStatusForMeetings reports as
+  // `status='failed'` so the user can retry.
+
+  it('dispatches with sourceUrl as agendaPacketUrl; no HEAD check', async () => {
+    const orgSlug = `finalize-url-${Date.now()}`
+    const eo = await seedOrgAndElectedOffice(orgSlug)
+    mockResolveServeContext()
+    mockS3()
+    const dispatchSpy = mockDispatchRun()
+    const fetchSpy = vi.spyOn(global, 'fetch')
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      {
+        source: 'URL',
+        sourceUrl: 'https://example.gov/agendas/2026-07-15-packet.pdf',
+      },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(201)
+    // Critical: gp-api must NOT fetch the user-supplied URL itself. SSRF
+    // defense lives at the broker. fetchSpy catches background calls
+    // (Clerk, etc.), so filter by URL to assert only the user URL wasn't hit.
+    const calledWithUserUrl = fetchSpy.mock.calls.some((call) => {
+      const arg0 = call[0]
+      const requestUrl =
+        typeof arg0 === 'string'
+          ? arg0
+          : arg0 instanceof URL
+            ? arg0.toString()
+            : ''
+      return requestUrl.startsWith('https://example.gov/')
+    })
+    expect(calledWithUserUrl).toBe(false)
+
+    const row = await service.prisma.userAgendaUpload.findUnique({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: eo.id,
+          meetingDate: new Date('2026-07-15'),
+        },
+      },
+    })
+    expect(row).toMatchObject({
+      source: UserAgendaSource.URL,
+      sourceUrl: 'https://example.gov/agendas/2026-07-15-packet.pdf',
+      // contentType/byteSize stay null for URL source — without HEADing the
+      // URL we don't know them, and we intentionally don't fetch.
+      contentType: null,
+      byteSize: null,
+    })
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          agendaPacketUrl: 'https://example.gov/agendas/2026-07-15-packet.pdf',
+        }),
+      }),
+    )
+    // URL paste path passes the user's own URL through; the envelope-strip
+    // `_input_files` key belongs to the UPLOAD path and must not appear here.
+    const params = dispatchSpy.mock.calls[0][0].params as Record<
+      string,
+      unknown
+    >
+    expect(params).not.toHaveProperty('_input_files')
+  })
+
+  it('rejects a non-URL string at the Zod boundary', async () => {
+    const orgSlug = `finalize-url-malformed-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      { source: 'URL', sourceUrl: 'not-a-url' },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+
+  it('rejects an oversized URL at the Zod boundary', async () => {
+    const orgSlug = `finalize-url-toolong-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+
+    const result = await service.client.post(
+      '/v1/meetings/2026-07-15/briefing/agenda',
+      {
+        source: 'URL',
+        sourceUrl: 'https://example.gov/' + 'a'.repeat(2100),
+      },
+      orgHeader(orgSlug),
+    )
+
+    expect(result.status).toBe(400)
+  })
+})
+
+describe('GET /v1/meetings userAgendaStatus derivation', () => {
+  it('returns null userAgendaStatus when no upload exists', async () => {
+    const orgSlug = `gm-no-upload-${Date.now()}`
+    await seedOrgAndElectedOffice(orgSlug)
+    // Seed a schedule so the date appears in the meetings list at all.
+    const scheduleRun = await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_schedule',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'schedule-bucket',
+        artifactKey: 'schedule.json',
+      },
+    })
+    vi.spyOn(service.app.get(S3Service), 'getFile').mockResolvedValue(
+      JSON.stringify({
+        status: 'found',
+        rrule: 'FREQ=DAILY',
+        time: '19:00',
+        timezone: 'America/Chicago',
+        duration_minutes: 120,
+        meeting_name: 'City Council',
+        location: 'Council Chambers',
+        sources: [],
+        generated_at: new Date().toISOString(),
+        human: 'Daily',
+      }),
+    )
+    expect(scheduleRun.runId).toBeTruthy()
+
+    const result = await service.client.get('/v1/meetings', orgHeader(orgSlug))
+    expect(result.status).toBe(200)
+    for (const meeting of result.data.meetings) {
+      expect(meeting.userAgendaStatus).toBeNull()
+    }
+  })
+
+  it('surfaces processing/failed/completed from the linked ExperimentRun', async () => {
+    const orgSlug = `gm-statuses-${Date.now()}`
+    const eo = await seedOrgAndElectedOffice(orgSlug)
+    // Schedule (FREQ=DAILY so several dates are projected)
+    await service.prisma.experimentRun.create({
+      data: {
+        organizationSlug: orgSlug,
+        experimentType: 'meeting_schedule',
+        status: ExperimentRunStatus.COMPLETED,
+        artifactBucket: 'schedule-bucket',
+        artifactKey: 'schedule.json',
+      },
+    })
+    vi.spyOn(service.app.get(S3Service), 'getFile').mockResolvedValue(
+      JSON.stringify({
+        status: 'found',
+        rrule: 'FREQ=DAILY',
+        time: '19:00',
+        timezone: 'America/Chicago',
+        duration_minutes: 120,
+        meeting_name: 'City Council',
+        location: 'Council Chambers',
+        sources: [],
+        generated_at: new Date().toISOString(),
+        human: 'Daily',
+      }),
+    )
+
+    // Three upload rows linked to runs at three different statuses.
+    const today = new Date()
+    const inDays = (n: number) => {
+      const d = new Date(today)
+      d.setUTCDate(d.getUTCDate() + n)
+      d.setUTCHours(0, 0, 0, 0)
+      return d
+    }
+    const seedUpload = async (date: Date, runStatus: ExperimentRunStatus) => {
+      const run = await service.prisma.experimentRun.create({
+        data: {
+          organizationSlug: orgSlug,
+          experimentType: 'meeting_briefing',
+          status: runStatus,
+        },
+      })
+      await service.prisma.userAgendaUpload.create({
+        data: {
+          electedOfficeId: eo.id,
+          meetingDate: date,
+          source: UserAgendaSource.UPLOAD,
+          uploadBucket: 'gp-agent-run-inputs-test',
+          uploadKey: `agendas/${eo.id}/x.pdf`,
+          uploadedByUserId: service.user.id,
+          experimentRunId: run.runId,
+        },
+      })
+      return run.runId
+    }
+    await seedUpload(inDays(1), ExperimentRunStatus.RUNNING)
+    await seedUpload(inDays(2), ExperimentRunStatus.FAILED)
+    await seedUpload(inDays(3), ExperimentRunStatus.COMPLETED)
+
+    const result = await service.client.get('/v1/meetings', orgHeader(orgSlug))
+    expect(result.status).toBe(200)
+
+    const byDate = new Map<string, string | null>()
+    for (const m of result.data.meetings) {
+      byDate.set(m.meetingDate, m.userAgendaStatus)
+    }
+    const iso = (d: Date) => d.toISOString().slice(0, 10)
+    expect(byDate.get(iso(inDays(1)))).toBe('processing')
+    expect(byDate.get(iso(inDays(2)))).toBe('failed')
+    expect(byDate.get(iso(inDays(3)))).toBe('completed')
+  })
+})

--- a/src/meetings/services/userAgendaUpload.service.ts
+++ b/src/meetings/services/userAgendaUpload.service.ts
@@ -1,0 +1,324 @@
+import { randomUUID } from 'node:crypto'
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common'
+import { ElectedOffice, UserAgendaSource } from '../../generated/prisma'
+import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
+import { S3Service } from '@/vendors/aws/services/s3.service'
+import { parseIsoDateAsUTC } from '@/shared/util/date.util'
+import {
+  USER_AGENDA_MAX_BYTES,
+  UserAgendaFinalizeRequest,
+  UserAgendaPresignRequest,
+} from '../schemas/userAgendaUpload.schema'
+import { MeetingBriefingsService } from './meetingBriefings.service'
+
+const PRESIGN_PUT_EXPIRES_IN = 60 * 15 // 15 min — upload itself
+
+// Canonical workspace path the agent reads. The runner pre-fetches each
+// authorized input file under /workspace/input/<dest>; instruction.md tells
+// the agent to read from that path. Hardcoded because meeting_briefing has
+// exactly one user-supplied input (the agenda).
+const AGENDA_WORKSPACE_DEST = 'agenda.pdf'
+
+@Injectable()
+export class UserAgendaUploadService extends createPrismaBase(
+  MODELS.UserAgendaUpload,
+) {
+  constructor(
+    private readonly s3: S3Service,
+    private readonly meetings: MeetingBriefingsService,
+  ) {
+    super()
+  }
+
+  private get bucket(): string {
+    const bucket = process.env.AGENT_RUN_INPUTS_BUCKET
+    if (!bucket) {
+      throw new InternalServerErrorException(
+        'AGENT_RUN_INPUTS_BUCKET is not configured',
+      )
+    }
+    return bucket
+  }
+
+  private buildUploadKey(
+    electedOfficeId: string,
+    meetingDate: string,
+    uploadId: string,
+  ): string {
+    return `agendas/${electedOfficeId}/${meetingDate}/${uploadId}.pdf`
+  }
+
+  /**
+   * Returns a presigned PUT URL for the browser to upload directly to S3.
+   * The row is created on finalize, not here — an abandoned presign leaves
+   * no DB row (only an orphan S3 object, which lifecycle cleans up).
+   */
+  async createUploadPresign(
+    electedOffice: ElectedOffice,
+    meetingDate: string,
+    input: UserAgendaPresignRequest,
+  ): Promise<{
+    uploadId: string
+    uploadKey: string
+    uploadUrl: string
+    expiresAt: string
+  }> {
+    // Defense in depth — Zod already caps byteSize, but keep the runtime
+    // assertion in case the schema relaxes.
+    if (input.byteSize > USER_AGENDA_MAX_BYTES) {
+      throw new BadRequestException('file_too_large')
+    }
+
+    const uploadId = randomUUID()
+    const uploadKey = this.buildUploadKey(
+      electedOffice.id,
+      meetingDate,
+      uploadId,
+    )
+
+    const uploadUrl = await this.s3.getSignedUrlForUpload(
+      this.bucket,
+      uploadKey,
+      {
+        expiresIn: PRESIGN_PUT_EXPIRES_IN,
+        contentType: input.contentType,
+      },
+    )
+
+    return {
+      uploadId,
+      uploadKey,
+      uploadUrl,
+      expiresAt: new Date(
+        Date.now() + PRESIGN_PUT_EXPIRES_IN * 1000,
+      ).toISOString(),
+    }
+  }
+
+  /**
+   * Persists the upload metadata (URL paste or completed S3 upload) and
+   * dispatches a fresh briefing run. The dispatch carries either
+   * `agendaPacketUrl` (URL paste; agent fetches the user's own URL via the
+   * broker proxy) or `_input_files` envelope refs (UPLOAD; the runner
+   * pre-fetches via broker /inputs/read and writes to /workspace/input/
+   * before the agent boots). The previous run's MeetingBriefing row (if any)
+   * is left in place and gets overwritten by the existing upsert path when
+   * the new run completes.
+   *
+   * Idempotent on (electedOfficeId, meetingDate) — re-finalizing replaces
+   * the prior upload row and dispatches a new run.
+   *
+   * NOTE: the URL-paste path does not HEAD-check the user-supplied URL.
+   * SSRF defense lives at the broker — the broker is the actual fetcher
+   * at agent-run time and runs in an egress-restricted network. Doing the
+   * pre-flight check at gp-api duplicated that defense in a less-secure
+   * network position. Bad URLs surface as a FAILED agent run, which
+   * `getStatusForMeetings` reports as `status='failed'` so the user can
+   * retry by re-uploading.
+   */
+  async finalizeAndDispatch(
+    electedOffice: ElectedOffice,
+    userId: number,
+    meetingDate: string,
+    input: UserAgendaFinalizeRequest,
+  ): Promise<{ experimentRunId: string }> {
+    const meetingDateUtc = parseIsoDateAsUTC(meetingDate)
+
+    let source: UserAgendaSource
+    let sourceUrl: string | null = null
+    let uploadBucket: string | null = null
+    let uploadKey: string | null = null
+    let contentType: string | null = null
+    let byteSize: number | null = null
+
+    if (input.source === 'URL') {
+      // No HEAD pre-flight — see method docstring. contentType/byteSize stay
+      // null for URL source; we don't know them without fetching, and we
+      // intentionally don't fetch.
+      source = UserAgendaSource.URL
+      sourceUrl = input.sourceUrl
+    } else {
+      // UPLOAD — reconstruct the key server-side from trusted parts. Never
+      // accept a client-supplied key: doing so would let one office claim
+      // another office's S3 object (IDOR). The uploadId is the only piece
+      // the client controls, and it's a UUID the server minted at presign.
+      const reconstructedKey = this.buildUploadKey(
+        electedOffice.id,
+        meetingDate,
+        input.uploadId,
+      )
+      // HEAD the object to verify existence AND validate its actual size
+      // against the 75 MB cap. The Zod schema at presign time enforces a
+      // byteSize cap on the REQUESTED size, but presigned PUTs don't
+      // intrinsically restrict the uploaded body to the requested size — a
+      // malformed client could upload a 500 MB file using a presign issued
+      // for 1 MB. Re-checking ContentLength here closes that gap before
+      // we hand the object off to the agent.
+      const head = await this.s3.headObject(this.bucket, reconstructedKey)
+      if (!head) {
+        throw new BadRequestException('upload_not_received')
+      }
+      if (
+        head.contentLength !== null &&
+        head.contentLength > USER_AGENDA_MAX_BYTES
+      ) {
+        throw new BadRequestException({
+          error: 'upload_too_large',
+          message:
+            `Uploaded file exceeds ${USER_AGENDA_MAX_BYTES}-byte cap ` +
+            `(actual size=${head.contentLength})`,
+        })
+      }
+      source = UserAgendaSource.UPLOAD
+      uploadBucket = this.bucket
+      uploadKey = reconstructedKey
+      contentType = 'application/pdf'
+      byteSize = head.contentLength
+    }
+
+    // Persist the upload row BEFORE dispatching the run. If we dispatched
+    // first and then the upsert threw, the run would be live with no
+    // tracking row — invisible to GET /meetings and impossible to clean up
+    // on re-finalize. Upsert with a null run-id, dispatch, then patch the
+    // run-id back in.
+    const upload = await this.client.userAgendaUpload.upsert({
+      where: {
+        electedOfficeId_meetingDate: {
+          electedOfficeId: electedOffice.id,
+          meetingDate: meetingDateUtc,
+        },
+      },
+      create: {
+        electedOfficeId: electedOffice.id,
+        meetingDate: meetingDateUtc,
+        source,
+        sourceUrl,
+        uploadBucket,
+        uploadKey,
+        contentType,
+        byteSize,
+        uploadedByUserId: userId,
+        experimentRunId: null,
+      },
+      update: {
+        source,
+        sourceUrl,
+        uploadBucket,
+        uploadKey,
+        contentType,
+        byteSize,
+        uploadedByUserId: userId,
+        experimentRunId: null,
+      },
+      select: { id: true },
+    })
+
+    const { runId } = await this.meetings.dispatchBriefingWithUserAgenda({
+      electedOfficeId: electedOffice.id,
+      meetingDate,
+      ...(source === UserAgendaSource.URL && sourceUrl
+        ? { agendaPacketUrl: sourceUrl }
+        : {}),
+      ...(source === UserAgendaSource.UPLOAD && uploadBucket && uploadKey
+        ? {
+            inputFiles: [
+              {
+                bucket: uploadBucket,
+                key: uploadKey,
+                dest: AGENDA_WORKSPACE_DEST,
+              },
+            ],
+          }
+        : {}),
+    })
+
+    // Conditional update: only set our runId if the row's experimentRunId
+    // is still null. A concurrent finalize call (same office + date) would
+    // have raced past us — its upsert ran AFTER ours, then it dispatched
+    // and patched the row first. In that case our run is orphan-but-bounded:
+    // it'll run to completion, FAILED, or AWAITING_RESUME timeout as normal,
+    // but won't be tracked by an upload row. We can't kill it from here
+    // (the agent's already in flight); log the orphan for observability
+    // and return the row's winning runId so the caller polls the right run.
+    const claim = await this.client.userAgendaUpload.updateMany({
+      where: { id: upload.id, experimentRunId: null },
+      data: { experimentRunId: runId },
+    })
+    if (claim.count === 0) {
+      const winner = await this.client.userAgendaUpload.findUnique({
+        where: { id: upload.id },
+        select: { experimentRunId: true },
+      })
+      this.logger.warn(
+        {
+          orphanedRunId: runId,
+          winningRunId: winner?.experimentRunId,
+          uploadId: upload.id,
+          electedOfficeId: electedOffice.id,
+          meetingDate,
+        },
+        'agenda finalize lost concurrency race; orphan run dispatched',
+      )
+      if (winner?.experimentRunId) {
+        return { experimentRunId: winner.experimentRunId }
+      }
+    }
+
+    return { experimentRunId: runId }
+  }
+
+  /**
+   * Surfaces a row-status string for GET /meetings consumers. Returns the
+   * map keyed by meeting date (YYYY-MM-DD) for every upload row in the window
+   * — including upload rows for meeting dates the caller didn't pre-list
+   * (off-list dates the user uploaded an agenda for despite there being no
+   * scheduled meeting / briefing row yet).
+   */
+  async getStatusForMeetings(
+    electedOfficeId: string,
+    window: { from: Date; to: Date },
+  ): Promise<Map<string, 'processing' | 'failed' | 'completed' | 'unknown'>> {
+    const rows = await this.client.userAgendaUpload.findMany({
+      where: {
+        electedOfficeId,
+        meetingDate: { gte: window.from, lte: window.to },
+      },
+      select: {
+        meetingDate: true,
+        experimentRunId: true,
+        experimentRun: { select: { status: true } },
+      },
+    })
+    const out = new Map<
+      string,
+      'processing' | 'failed' | 'completed' | 'unknown'
+    >()
+    for (const row of rows) {
+      const date = row.meetingDate.toISOString().slice(0, 10)
+      const runStatus = row.experimentRun?.status
+      if (runStatus === 'RUNNING' || runStatus === 'AWAITING_RESUME') {
+        out.set(date, 'processing')
+      } else if (runStatus === 'FAILED') {
+        out.set(date, 'failed')
+      } else if (runStatus === 'COMPLETED') {
+        out.set(date, 'completed')
+      } else if (row.experimentRunId === null) {
+        // Upload row exists with no run linked: dispatch failed (or is racing
+        // mid-finalize). From the user's POV the upload didn't kick off a
+        // briefing, so surface as `failed` rather than `unknown` — the modal
+        // re-opens for a retry. The brief window between row upsert and run
+        // linkage during a successful finalize is short; users seeing a
+        // momentary `failed` that flips to `processing` on next refresh is
+        // acceptable.
+        out.set(date, 'failed')
+      } else {
+        out.set(date, 'unknown')
+      }
+    }
+    return out
+  }
+}

--- a/src/payments/purchase.controller.test.ts
+++ b/src/payments/purchase.controller.test.ts
@@ -41,6 +41,7 @@ describe('PurchaseController', () => {
   let controller: PurchaseController
   let stripeService: {
     createCheckoutSession: ReturnType<typeof vi.fn>
+    createEmbeddedProSubscriptionCheckoutSession: ReturnType<typeof vi.fn>
     createPortalSession: ReturnType<typeof vi.fn>
   }
   let usersService: { patchUserMetaData: ReturnType<typeof vi.fn> }
@@ -53,6 +54,7 @@ describe('PurchaseController', () => {
   beforeEach(() => {
     stripeService = {
       createCheckoutSession: vi.fn(),
+      createEmbeddedProSubscriptionCheckoutSession: vi.fn(),
       createPortalSession: vi.fn(),
     }
     usersService = { patchUserMetaData: vi.fn() }
@@ -71,9 +73,11 @@ describe('PurchaseController', () => {
   })
 
   describe('createProCheckoutSession', () => {
+    const redirectUrl = 'https://stripe.test/checkout'
+
     it('creates the session and persists checkoutSessionId on the user', async () => {
       stripeService.createCheckoutSession.mockResolvedValue({
-        redirectUrl: 'https://stripe.test/checkout',
+        redirectUrl,
         checkoutSessionId: 'cs_test_123',
       })
 
@@ -86,7 +90,48 @@ describe('PurchaseController', () => {
       expect(usersService.patchUserMetaData).toHaveBeenCalledWith(userId, {
         checkoutSessionId: 'cs_test_123',
       })
-      expect(result).toEqual({ redirectUrl: 'https://stripe.test/checkout' })
+      expect(result).toEqual({ redirectUrl })
+    })
+
+    it('returns a client_secret and persists checkoutSessionId for the embedded path', async () => {
+      stripeService.createEmbeddedProSubscriptionCheckoutSession.mockResolvedValue(
+        {
+          clientSecret: 'cs_test_secret_abc',
+          checkoutSessionId: 'cs_test_embedded',
+        },
+      )
+
+      const result = await controller.createProCheckoutSession(mockUser, {
+        embedded: true,
+        returnUrl: 'https://app.test/dashboard/pro-upgrade',
+      })
+
+      expect(
+        stripeService.createEmbeddedProSubscriptionCheckoutSession,
+      ).toHaveBeenCalledWith(
+        userId,
+        mockUser.email,
+        'https://app.test/dashboard/pro-upgrade',
+      )
+      expect(stripeService.createCheckoutSession).not.toHaveBeenCalled()
+      expect(usersService.patchUserMetaData).toHaveBeenCalledWith(userId, {
+        checkoutSessionId: 'cs_test_embedded',
+      })
+      expect(result).toEqual({ clientSecret: 'cs_test_secret_abc' })
+    })
+
+    it('falls back to the redirect path when no body is supplied', async () => {
+      stripeService.createCheckoutSession.mockResolvedValue({
+        redirectUrl,
+        checkoutSessionId: 'cs_test_123',
+      })
+
+      const result = await controller.createProCheckoutSession(mockUser)
+
+      expect(
+        stripeService.createEmbeddedProSubscriptionCheckoutSession,
+      ).not.toHaveBeenCalled()
+      expect(result).toEqual({ redirectUrl })
     })
   })
 

--- a/src/payments/purchase.controller.ts
+++ b/src/payments/purchase.controller.ts
@@ -11,6 +11,7 @@ import {
   CompleteCheckoutSessionDto,
   CompleteFreePurchaseDto,
   CreateCheckoutSessionDto,
+  CreateProCheckoutSessionDto,
 } from './purchase.types'
 import { PurchaseService } from './services/purchase.service'
 import { UseOrganization } from '@/organizations/decorators/UseOrganization.decorator'
@@ -28,8 +29,25 @@ export class PurchaseController {
   }
 
   @Post('checkout-session')
-  async createProCheckoutSession(@ReqUser() user: User) {
+  async createProCheckoutSession(
+    @ReqUser() user: User,
+    @Body() dto: CreateProCheckoutSessionDto = {},
+  ) {
     const { email } = user
+
+    if (dto.embedded) {
+      const { clientSecret, checkoutSessionId } =
+        await this.stripeService.createEmbeddedProSubscriptionCheckoutSession(
+          user.id,
+          email,
+          dto.returnUrl,
+        )
+
+      await this.usersService.patchUserMetaData(user.id, { checkoutSessionId })
+
+      return { clientSecret }
+    }
+
     const { redirectUrl, checkoutSessionId } =
       await this.stripeService.createCheckoutSession(user.id, email)
 

--- a/src/payments/purchase.types.ts
+++ b/src/payments/purchase.types.ts
@@ -21,6 +21,14 @@ export interface CompleteCheckoutSessionDto {
   checkoutSessionId: string
 }
 
+export interface CreateProCheckoutSessionDto {
+  // When true, returns a client_secret for an in-wizard embedded checkout
+  //  instead of a redirect url (pro-upgrade3 cohort). isPro is still flipped
+  //  only by the checkout.session.completed webhook regardless of this flag.
+  embedded?: boolean
+  returnUrl?: string
+}
+
 export type FreePurchaseMetadata =
   | OutreachPurchaseMetadata
   | DomainPurchaseMetadata

--- a/src/payments/services/paymentEventsService.test.ts
+++ b/src/payments/services/paymentEventsService.test.ts
@@ -30,6 +30,7 @@ describe('PaymentEventsService', () => {
     resolvePositionNameByOrganizationSlug: vi.fn(),
   }
   const crm = { getCrmCompanyOwnerName: vi.fn() }
+  const tcrComplianceService = { enqueueAgenticKickoffIfNeeded: vi.fn() }
 
   const mockUser = { id: 1, email: 'test@example.com' } as User
   const mockCampaign = {
@@ -65,6 +66,9 @@ describe('PaymentEventsService', () => {
     analytics.track.mockResolvedValue(undefined)
     slackService.message.mockResolvedValue(undefined)
     voterFileDownloadAccess.downloadAccessAlert.mockResolvedValue(undefined)
+    tcrComplianceService.enqueueAgenticKickoffIfNeeded.mockResolvedValue(
+      undefined,
+    )
 
     service = new PaymentEventsService(
       usersService as never,
@@ -77,6 +81,7 @@ describe('PaymentEventsService', () => {
       {} as never,
       analytics as never,
       {} as never,
+      tcrComplianceService as never,
       logger,
     )
   })
@@ -118,6 +123,38 @@ describe('PaymentEventsService', () => {
         EVENTS.Account.ProUpgradeComplete,
         { pro: true },
       )
+    })
+
+    it('enqueues the agentic kickoff after marking the campaign Pro', async () => {
+      await service.handleEvent(subscriptionEvent)
+
+      expect(campaignsService.setIsPro).toHaveBeenCalledWith(mockCampaign.id)
+      expect(
+        tcrComplianceService.enqueueAgenticKickoffIfNeeded,
+      ).toHaveBeenCalledExactlyOnceWith(mockCampaign.id)
+      expect(
+        campaignsService.setIsPro.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        tcrComplianceService.enqueueAgenticKickoffIfNeeded.mock
+          .invocationCallOrder[0],
+      )
+    })
+
+    it('does not fail the webhook when the kickoff enqueue throws', async () => {
+      const enqueueError = new Error('SQS down')
+      tcrComplianceService.enqueueAgenticKickoffIfNeeded.mockRejectedValueOnce(
+        enqueueError,
+      )
+
+      await expect(
+        service.handleEvent(subscriptionEvent),
+      ).resolves.not.toThrow()
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ error: enqueueError }),
+        expect.stringContaining('agentic compliance kickoff'),
+      )
+      expect(usersService.patchUserMetaData).toHaveBeenCalled()
     })
   })
 })

--- a/src/payments/services/paymentEventsService.ts
+++ b/src/payments/services/paymentEventsService.ts
@@ -27,6 +27,7 @@ import { EVENTS } from 'src/vendors/segment/segment.types'
 import { WrapperType } from 'src/shared/types/utility.types'
 import { PurchaseService } from './purchase.service'
 import { PinoLogger } from 'nestjs-pino'
+import { CampaignTcrComplianceService } from '../../campaigns/tcrCompliance/services/campaignTcrCompliance.service'
 
 const { STRIPE_WEBSOCKET_SECRET } = process.env
 if (!STRIPE_WEBSOCKET_SECRET) {
@@ -47,6 +48,7 @@ export class PaymentEventsService {
     private readonly analytics: AnalyticsService,
     @Inject(forwardRef(() => PurchaseService))
     private readonly purchaseService: WrapperType<PurchaseService>,
+    private readonly tcrComplianceService: CampaignTcrComplianceService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(PaymentEventsService.name)
@@ -255,6 +257,19 @@ export class PaymentEventsService {
       subscriptionId: subscriptionId as string,
     })
     await this.campaignsService.setIsPro(campaignId)
+
+    // Pre-payment (pro-upgrade3) submissions defer the compliance_setup agent
+    // kickoff to here. No-ops when the candidate has no TCR record yet or the
+    // kickoff was already enqueued. Best-effort: a failure here must not fail
+    // the webhook (the stranded-kickoff sweep recovers a rolled-back claim).
+    try {
+      await this.tcrComplianceService.enqueueAgenticKickoffIfNeeded(campaignId)
+    } catch (error) {
+      this.logger.error(
+        { error },
+        `[WEBHOOK] Failed to enqueue agentic compliance kickoff - Campaign: ${campaignId}`,
+      )
+    }
 
     // Track analytics with proper error handling
     try {

--- a/src/vendors/aws/services/s3.service.ts
+++ b/src/vendors/aws/services/s3.service.ts
@@ -216,6 +216,31 @@ export class S3Service extends AwsService {
     }, 'objectExists')
   }
 
+  /**
+   * HEAD an object. Returns the object's metadata when present, null when
+   * absent. Useful for validating both existence AND properties (like size)
+   * in a single round-trip — callers that only need a boolean should use
+   * `objectExists` instead.
+   */
+  async headObject(
+    bucket: string,
+    key: string,
+  ): Promise<{ contentLength: number | null } | null> {
+    return this.executeAwsOperation(async () => {
+      try {
+        const { HeadObjectCommand } = await import('@aws-sdk/client-s3')
+        const response = await this.s3Client.send(
+          new HeadObjectCommand({ Bucket: bucket, Key: key }),
+        )
+        return { contentLength: response.ContentLength ?? null }
+      } catch (error: unknown) {
+        if (error instanceof NoSuchKey) return null
+        if (isHttpStatusError(error, 404)) return null
+        throw error
+      }
+    }, 'headObject')
+  }
+
   getFileUrl(
     bucket: string,
     key: string,

--- a/src/vendors/stripe/services/stripe.service.test.ts
+++ b/src/vendors/stripe/services/stripe.service.test.ts
@@ -1,0 +1,92 @@
+import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
+import { BadGatewayException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SlackService } from 'src/vendors/slack/services/slack.service'
+import { StripeService } from './stripe.service'
+
+const { sessionsCreate, productsRetrieve } = vi.hoisted(() => ({
+  sessionsCreate: vi.fn(),
+  productsRetrieve: vi.fn(),
+}))
+
+vi.mock('stripe', () => ({
+  default: class {
+    checkout = { sessions: { create: sessionsCreate } }
+    products = { retrieve: productsRetrieve }
+  },
+}))
+
+const userId = 7
+const email = 'buyer@example.com'
+const priceId = 'price_test_pro'
+
+describe('StripeService Pro subscription checkout', () => {
+  let service: StripeService
+
+  beforeEach(() => {
+    productsRetrieve.mockResolvedValue({ default_price: priceId })
+    service = new StripeService(
+      {} as unknown as SlackService,
+      createMockLogger(),
+    )
+  })
+
+  describe('createEmbeddedProSubscriptionCheckoutSession', () => {
+    it('builds an embedded subscription session and returns the client_secret', async () => {
+      sessionsCreate.mockResolvedValue({
+        id: 'cs_test_embedded',
+        client_secret: 'cs_test_embedded_secret_abc',
+      })
+
+      const result = await service.createEmbeddedProSubscriptionCheckoutSession(
+        userId,
+        email,
+        'https://app.test/dashboard/pro-upgrade?session_id={CHECKOUT_SESSION_ID}',
+      )
+
+      const args = sessionsCreate.mock.calls[0][0]
+      expect(args.ui_mode).toBe('custom')
+      expect(args.mode).toBe('subscription')
+      expect(args.return_url).toBe(
+        'https://app.test/dashboard/pro-upgrade?session_id={CHECKOUT_SESSION_ID}',
+      )
+      expect(args.success_url).toBeUndefined()
+      expect(args.metadata).toEqual({ userId })
+      expect(args.line_items).toEqual([{ price: priceId, quantity: 1 }])
+
+      expect(result).toEqual({
+        clientSecret: 'cs_test_embedded_secret_abc',
+        checkoutSessionId: 'cs_test_embedded',
+      })
+    })
+
+    it('throws BadGatewayException when Stripe returns no client_secret', async () => {
+      sessionsCreate.mockResolvedValue({
+        id: 'cs_test_embedded',
+        client_secret: null,
+      })
+
+      await expect(
+        service.createEmbeddedProSubscriptionCheckoutSession(userId, email),
+      ).rejects.toThrow(BadGatewayException)
+    })
+
+    it('carries the same userId metadata as the redirect subscription session', async () => {
+      sessionsCreate.mockResolvedValue({
+        id: 'cs_test',
+        client_secret: 'cs_test_secret',
+        url: 'https://stripe.test/checkout',
+      })
+
+      await service.createCheckoutSession(userId, email)
+      const redirectArgs = sessionsCreate.mock.calls[0][0]
+
+      await service.createEmbeddedProSubscriptionCheckoutSession(userId, email)
+      const embeddedArgs = sessionsCreate.mock.calls[1][0]
+
+      expect(embeddedArgs.metadata).toEqual(redirectArgs.metadata)
+      expect(embeddedArgs.mode).toBe(redirectArgs.mode)
+      expect(embeddedArgs.line_items).toEqual(redirectArgs.line_items)
+    })
+  })
+})

--- a/src/vendors/stripe/services/stripe.service.ts
+++ b/src/vendors/stripe/services/stripe.service.ts
@@ -2,6 +2,7 @@ import { BadGatewayException, Injectable } from '@nestjs/common'
 import { User } from '../../../generated/prisma'
 import { PinoLogger } from 'nestjs-pino'
 import {
+  CheckoutSessionMode,
   CustomCheckoutSessionPayload,
   PaymentIntentPayload,
   PaymentType,
@@ -89,37 +90,76 @@ export class StripeService {
     return await this.stripe.checkout.sessions.retrieve(sessionId)
   }
 
+  // Shared params for the Pro subscription Checkout Session, used by both the
+  //  redirect flow (createCheckoutSession) and the embedded flow
+  //  (createEmbeddedProSubscriptionCheckoutSession). The webhook
+  //  (checkout.session.completed) identifies the campaign and sets isPro from
+  //  metadata.userId, so both flows must carry it identically.
+  private getProSubscriptionSessionParams = async (
+    userId: number,
+    email: string | null,
+  ): Promise<Stripe.Checkout.SessionCreateParams> => ({
+    metadata: {
+      userId,
+    },
+    ...(email ? { customer_email: email } : {}),
+    billing_address_collection: 'auto',
+    line_items: [
+      {
+        // We should never have more than 1 price for Pro. But if we do, this
+        //  will need to be more intelligent.
+        // Stripe SDK uses broad union types — default_price is string | Price | null
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        price: (await this.getPrice()) as string,
+        quantity: 1,
+      },
+    ],
+    mode: CheckoutSessionMode.SUBSCRIPTION,
+    allow_promotion_codes: true,
+    // Expanding for Segment / analytics
+    expand: [
+      'subscription',
+      'subscription.items.data.price',
+      'payment_intent.payment_method',
+    ],
+  })
+
   async createCheckoutSession(userId: number, email: string | null = null) {
     const session = await this.stripe.checkout.sessions.create({
-      metadata: {
-        userId,
-      },
-      ...(email ? { customer_email: email } : {}),
-      billing_address_collection: 'auto',
-      line_items: [
-        {
-          // We should never have more than 1 price for Pro. But if we do, this
-          //  will need to be more intelligent.
-          // Stripe SDK uses broad union types — e.g. customer can be string | Customer | DeletedCustomer
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          price: (await this.getPrice()) as string,
-          quantity: 1,
-        },
-      ],
-      mode: 'subscription',
-      allow_promotion_codes: true,
-      // Expanding for Segment / analytics
-      expand: [
-        'subscription',
-        'subscription.items.data.price',
-        'payment_intent.payment_method',
-      ],
+      ...(await this.getProSubscriptionSessionParams(userId, email)),
       success_url: `${WEBAPP_ROOT_URL}/dashboard/pro-sign-up/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${WEBAPP_ROOT_URL}/dashboard`,
     })
 
     const { url: redirectUrl, id: checkoutSessionId } = session
     return { redirectUrl, checkoutSessionId }
+  }
+
+  // Embedded (in-wizard) variant of the Pro subscription checkout. Mirrors the
+  //  one-time embedded path (createCustomCheckoutSession): ui_mode 'custom' +
+  //  return_url, returns a client_secret instead of a redirect url. isPro is
+  //  still flipped only by the checkout.session.completed webhook.
+  async createEmbeddedProSubscriptionCheckoutSession(
+    userId: number,
+    email: string | null = null,
+    returnUrl: string = `${WEBAPP_ROOT_URL}/dashboard/pro-upgrade?session_id={CHECKOUT_SESSION_ID}`,
+  ) {
+    const session = await this.stripe.checkout.sessions.create({
+      ...(await this.getProSubscriptionSessionParams(userId, email)),
+      ui_mode: 'custom',
+      return_url: returnUrl,
+    })
+
+    if (!session.client_secret) {
+      throw new BadGatewayException(
+        'Failed to create checkout session: no client_secret returned',
+      )
+    }
+
+    return {
+      clientSecret: session.client_secret,
+      checkoutSessionId: session.id,
+    }
   }
 
   async createCustomCheckoutSession(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches payment-gated compliance dispatch, impersonation-scoped admin data, production briefing bulk dispatch with real cost, and several new DB migrations in one merge.
> 
> **Overview**
> Large release bundle spanning contracts **0.13.0**, gp-api behavior, Prisma migrations, and deploy config.
> 
> **Campaigns & Pro upgrade (ENG-10325):** `RaceTargetMetrics` and live metrics plumbing add nullable **filing office** fields (address, phone, paperwork instructions) from BallotReady. New **`POST campaigns/mine/filing-instructions/email`** emails a rendered plain-text summary (no Pro gate—pre-payment wizard). Stripe Pro checkout gains an **embedded** path (`client_secret`) alongside redirect.
> 
> **TCR / compliance:** Agentic kickoff is **deferred** for non-Pro campaigns at submit; **`enqueueAgenticKickoffIfNeeded`** runs after payment with an atomic `kickoffSentAt` claim. Stranded-kickoff sweep only targets **Pro** campaigns so pre-payment rows are not auto-dispatched.
> 
> **Briefings & meetings:** M2M **admin briefings** list/get with shared contract schemas. Briefing **dispatch** supports optional **`useImminenceGate`** (5-day window + dedupe), user-session **ownership** checks, and returns `dispatched: false` for expected skips. **User-supplied agendas** add `user_agenda_upload`, presign/finalize APIs, `AGENT_RUN_INPUTS_BUCKET`, `_input_files` / `agendaPacketUrl` on briefing runs, and **`userAgendaStatus`** on `GET /meetings`. Completion handling persists **`agenda_provided_by_user`** briefings even without valid meeting time/timezone. Ops script **`dispatch-imminent-briefings`** bulk-calls dispatch with M2M + cost cap.
> 
> **Annotations:** New **`review`** kind with `annotation_review` table; create/list/update/delete gated on **impersonation** (`actorSub`), default-deny for normal users; optional `kinds` query filter.
> 
> **Agent runs:** **`resumeRun`** mints a **new** run id, marks the old row superseded/failed, and hardens sweep error isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25c1e8b457cfde51b0791dbce104f72370861e7d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->