### PR TITLE
fix(meetings): send briefing analytics dates as epoch ms for HubSpot

### DIFF
--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -959,10 +959,16 @@ export class MeetingBriefingsService extends createPrismaBase(
       leadInFallback: readLeadIn(artifact),
     })
 
-    const meetingDateTime = fromZonedTime(
-      `${dateString}T${meetingTime}:00`,
-      meetingTimezone,
-    ).getTime()
+    // The user-agenda path persists empty meetingTime/meetingTimezone, which
+    // would make fromZonedTime produce NaN. Only emit the exact-instant
+    // property when both are present so HubSpot's datetime field stays valid.
+    const meetingDateTime =
+      meetingTime && meetingTimezone
+        ? fromZonedTime(
+            `${dateString}T${meetingTime}:00`,
+            meetingTimezone,
+          ).getTime()
+        : null
 
     try {
       await this.analytics.track(
@@ -971,7 +977,7 @@ export class MeetingBriefingsService extends createPrismaBase(
         {
           agendaId: dateString,
           meetingDate: parseIsoDateAsUTC(dateString).getTime(),
-          meetingDateTime,
+          ...(meetingDateTime !== null ? { meetingDateTime } : {}),
           meetingTime,
           meetingTimezone,
           meetingPlace: artifact.location ?? '',

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -23,7 +23,7 @@ import {
   Prisma,
 } from '../../generated/prisma'
 import { addDays } from 'date-fns'
-import { formatInTimeZone } from 'date-fns-tz'
+import { formatInTimeZone, fromZonedTime } from 'date-fns-tz'
 import { chunk } from 'es-toolkit'
 import ms from 'ms'
 import { ChatCompletionMessageParam } from 'openai/resources/chat/completions'
@@ -959,13 +959,19 @@ export class MeetingBriefingsService extends createPrismaBase(
       leadInFallback: readLeadIn(artifact),
     })
 
+    const meetingDateTime = fromZonedTime(
+      `${dateString}T${meetingTime}:00`,
+      meetingTimezone,
+    ).getTime()
+
     try {
       await this.analytics.track(
         userId,
         'Briefing Assistant - Agenda Created',
         {
           agendaId: dateString,
-          meetingDate: dateString,
+          meetingDate: parseIsoDateAsUTC(dateString).getTime(),
+          meetingDateTime,
           meetingTime,
           meetingTimezone,
           meetingPlace: artifact.location ?? '',


### PR DESCRIPTION
The `Briefing Assistant - Agenda Created` event sent `meetingDate` as a `YYYY-MM-DD` string. HubSpot's date-typed properties only accept a Unix timestamp in milliseconds at midnight UTC, and HubSpot rejects the **entire** Segment payload when any single property value is invalid for its type — so once the HubSpot property was switched to a date field, the whole sync errored.

This emits the dates as numbers HubSpot's typed properties accept:

- `meetingDate` → midnight-UTC epoch ms (`parseIsoDateAsUTC(...).getTime()`), matching the instant already persisted on the `MeetingBriefing` row. Targets a HubSpot **date** property.
- `meetingDateTime` → the meeting's exact UTC instant, computed from the meeting's own timezone via `fromZonedTime`. Targets a HubSpot **datetime** property.

Requires the matching HubSpot property types (date / datetime) on the destination side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics payload shape only; no changes to briefing persistence, dispatch, or user-facing behavior.
> 
> **Overview**
> Fixes **Briefing Assistant - Agenda Created** Segment analytics so HubSpot date/datetime properties accept the payload instead of rejecting the whole sync.
> 
> **`meetingDate`** is now midnight-UTC epoch milliseconds via `parseIsoDateAsUTC(dateString).getTime()`, aligned with how `MeetingBriefing.meetingDate` is stored. **`meetingDateTime`** is a new property: the meeting’s instant in UTC from `fromZonedTime` using the artifact’s calendar date, wall time, and IANA timezone.
> 
> The change is limited to `trackAgendaPickedUp` in `meetingBriefings.service.ts` (plus importing `fromZonedTime`); other event fields are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3598dd22f7d58669ee8ac66004f58c1d713d34c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->