### PR TITLE
QA <- Dev

### DIFF
--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -959,10 +959,16 @@ export class MeetingBriefingsService extends createPrismaBase(
       leadInFallback: readLeadIn(artifact),
     })
 
-    const meetingDateTime = fromZonedTime(
-      `${dateString}T${meetingTime}:00`,
-      meetingTimezone,
-    ).getTime()
+    // The user-agenda path persists empty meetingTime/meetingTimezone, which
+    // would make fromZonedTime produce NaN. Only emit the exact-instant
+    // property when both are present so HubSpot's datetime field stays valid.
+    const meetingDateTime =
+      meetingTime && meetingTimezone
+        ? fromZonedTime(
+            `${dateString}T${meetingTime}:00`,
+            meetingTimezone,
+          ).getTime()
+        : null
 
     try {
       await this.analytics.track(
@@ -971,7 +977,7 @@ export class MeetingBriefingsService extends createPrismaBase(
         {
           agendaId: dateString,
           meetingDate: parseIsoDateAsUTC(dateString).getTime(),
-          meetingDateTime,
+          ...(meetingDateTime !== null ? { meetingDateTime } : {}),
           meetingTime,
           meetingTimezone,
           meetingPlace: artifact.location ?? '',

--- a/src/meetings/services/meetingBriefings.service.ts
+++ b/src/meetings/services/meetingBriefings.service.ts
@@ -23,7 +23,7 @@ import {
   Prisma,
 } from '../../generated/prisma'
 import { addDays } from 'date-fns'
-import { formatInTimeZone } from 'date-fns-tz'
+import { formatInTimeZone, fromZonedTime } from 'date-fns-tz'
 import { chunk } from 'es-toolkit'
 import ms from 'ms'
 import { ChatCompletionMessageParam } from 'openai/resources/chat/completions'
@@ -959,13 +959,19 @@ export class MeetingBriefingsService extends createPrismaBase(
       leadInFallback: readLeadIn(artifact),
     })
 
+    const meetingDateTime = fromZonedTime(
+      `${dateString}T${meetingTime}:00`,
+      meetingTimezone,
+    ).getTime()
+
     try {
       await this.analytics.track(
         userId,
         'Briefing Assistant - Agenda Created',
         {
           agendaId: dateString,
-          meetingDate: dateString,
+          meetingDate: parseIsoDateAsUTC(dateString).getTime(),
+          meetingDateTime,
           meetingTime,
           meetingTimezone,
           meetingPlace: artifact.location ?? '',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Analytics payload shape change only; guarded omission of `meetingDateTime` avoids bad HubSpot values on the user-agenda path.
> 
> **Overview**
> Updates **Briefing Assistant - Agenda Created** analytics so HubSpot datetime fields get numeric timestamps instead of a bare `YYYY-MM-DD` string.
> 
> **`meetingDate`** is now UTC midnight in milliseconds via `parseIsoDateAsUTC(dateString).getTime()`. **`meetingDateTime`** is added only when both `meetingTime` and `meetingTimezone` are set, computed with `fromZonedTime` on the local date+time; user-supplied agenda briefings that persist empty time/timezone omit this property so invalid `NaN` values never reach HubSpot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df9f48919e28dec2ed48e26a6d345d063b1d6ad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->