### PR TITLE
fix: localize onboarding voter issues to the office's jurisdiction

### DIFF
--- a/src/elections/services/elections.service.test.ts
+++ b/src/elections/services/elections.service.test.ts
@@ -547,6 +547,19 @@ describe('ElectionsService', () => {
 
       expect(result).toBeNull()
     })
+
+    it('forwards the level query param when provided', async () => {
+      mockHttpGet.mockReturnValue(of({ data: [], status: 200 }))
+
+      await service.getVoterIssues({ districtId: 'd-1', level: 'local' })
+
+      expect(mockHttpGet).toHaveBeenCalledWith(
+        expect.stringContaining('voter-issues'),
+        expect.objectContaining({
+          params: { districtId: 'd-1', level: 'local' },
+        }),
+      )
+    })
   })
 
   describe('fetchFilingFeeByRaceHash', () => {

--- a/src/elections/services/elections.service.ts
+++ b/src/elections/services/elections.service.ts
@@ -28,6 +28,7 @@ import {
   RaceTargetDetailsResult,
   RaceTargetMetrics,
   VoterIssue,
+  VoterIssueLevel,
 } from '../types/elections.types'
 
 @Injectable()
@@ -249,11 +250,12 @@ export class ElectionsService {
 
   async getVoterIssues(params: {
     districtId: string
+    level?: VoterIssueLevel
   }): Promise<VoterIssue[] | null> {
-    return this.electionApiGet<VoterIssue[], { districtId: string }>(
-      'voter-issues',
-      params,
-    )
+    return this.electionApiGet<
+      VoterIssue[],
+      { districtId: string; level?: VoterIssueLevel }
+    >('voter-issues', params)
   }
 
   async getDistrictId(

--- a/src/elections/types/elections.types.ts
+++ b/src/elections/types/elections.types.ts
@@ -1,4 +1,7 @@
-import type { RaceTargetMetrics } from '@goodparty_org/contracts'
+import type {
+  BallotReadyPositionLevel,
+  RaceTargetMetrics,
+} from '@goodparty_org/contracts'
 export type { RaceTargetMetrics } from '@goodparty_org/contracts'
 
 export type BDElection = {
@@ -80,6 +83,8 @@ export type VoterIssue = {
   priority: 'high' | 'medium' | 'low'
 }
 
+export type VoterIssueLevel = 'local' | 'regional' | 'state' | 'federal'
+
 export enum ProjectedTurnoutSourceColumns {
   id = 'id',
   createdAt = 'createdAt',
@@ -150,6 +155,7 @@ export type PositionWithOptionalDistrict = {
   brDatabaseId: string
   state: string
   name: string
+  level?: BallotReadyPositionLevel | null
   district?: District
   filingFee?: number | null
   filingRequirementsText?: string | null

--- a/src/elections/util/getVoterIssueLevelFromPositionLevel.util.test.ts
+++ b/src/elections/util/getVoterIssueLevelFromPositionLevel.util.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { getVoterIssueLevelFromPositionLevel } from './getVoterIssueLevelFromPositionLevel.util'
+
+describe('getVoterIssueLevelFromPositionLevel', () => {
+  it.each([
+    ['CITY', 'local'] as const,
+    ['TOWNSHIP', 'local'] as const,
+    ['LOCAL', 'local'] as const,
+    ['COUNTY', 'regional'] as const,
+    ['REGIONAL', 'regional'] as const,
+    ['STATE', 'state'] as const,
+    ['FEDERAL', 'federal'] as const,
+  ])('maps position level %s to voter-issue level %s', (level, expected) => {
+    expect(getVoterIssueLevelFromPositionLevel(level)).toBe(expected)
+  })
+
+  it('returns null for null', () => {
+    expect(getVoterIssueLevelFromPositionLevel(null)).toBeNull()
+  })
+
+  it('returns null for undefined', () => {
+    expect(getVoterIssueLevelFromPositionLevel(undefined)).toBeNull()
+  })
+})

--- a/src/elections/util/getVoterIssueLevelFromPositionLevel.util.ts
+++ b/src/elections/util/getVoterIssueLevelFromPositionLevel.util.ts
@@ -1,0 +1,20 @@
+import { BallotReadyPositionLevel } from '@goodparty_org/contracts'
+import { VoterIssueLevel } from '../types/elections.types'
+
+// Collapse BallotReady's 7 position levels onto the 4 jurisdictional levels
+// the election-api voter-issues filter understands. Mirrors the DATA-1903
+// flag intent: municipal offices act on local issues, county/regional offices
+// on regional issues.
+const LEVEL_MAP: Record<BallotReadyPositionLevel, VoterIssueLevel> = {
+  CITY: 'local',
+  TOWNSHIP: 'local',
+  LOCAL: 'local',
+  COUNTY: 'regional',
+  REGIONAL: 'regional',
+  STATE: 'state',
+  FEDERAL: 'federal',
+}
+
+export const getVoterIssueLevelFromPositionLevel = (
+  level: BallotReadyPositionLevel | null | undefined,
+): VoterIssueLevel | null => (level ? LEVEL_MAP[level] : null)

--- a/src/onboarding/onboardingVoterIssues.controller.test.ts
+++ b/src/onboarding/onboardingVoterIssues.controller.test.ts
@@ -8,42 +8,43 @@ import { OnboardingVoterIssuesController } from './onboardingVoterIssues.control
 describe('OnboardingVoterIssuesController', () => {
   let controller: OnboardingVoterIssuesController
   let getVoterIssues: ReturnType<typeof vi.fn>
-  let getDistrictForOrgSlug: ReturnType<typeof vi.fn>
+  let getDistrictAndLevelForOrgSlug: ReturnType<typeof vi.fn>
 
   const organization = { slug: 'org-slug' } as Organization
 
   beforeEach(() => {
     getVoterIssues = vi.fn()
-    getDistrictForOrgSlug = vi.fn()
+    getDistrictAndLevelForOrgSlug = vi.fn()
     controller = new OnboardingVoterIssuesController(
       { getVoterIssues } as unknown as ElectionsService,
-      { getDistrictForOrgSlug } as unknown as OrganizationsService,
+      { getDistrictAndLevelForOrgSlug } as unknown as OrganizationsService,
     )
   })
 
-  it('resolves the district from the organization and forwards to elections service', async () => {
-    getDistrictForOrgSlug.mockResolvedValue({
-      id: 'd-1',
-      l2Type: 'City',
-      l2Name: 'Los Angeles',
+  it('forwards the district and office level to the elections service', async () => {
+    getDistrictAndLevelForOrgSlug.mockResolvedValue({
+      district: { id: 'd-1', l2Type: 'City', l2Name: 'Poway city' },
+      level: 'local',
     })
     const issues = [
-      { label: 'Education', score: 88, priority: 'high' as const },
+      { label: 'Development', score: 78, priority: 'high' as const },
     ]
     getVoterIssues.mockResolvedValue(issues)
 
     const result = await controller.getVoterIssues(organization)
 
-    expect(getDistrictForOrgSlug).toHaveBeenCalledWith('org-slug')
-    expect(getVoterIssues).toHaveBeenCalledWith({ districtId: 'd-1' })
+    expect(getDistrictAndLevelForOrgSlug).toHaveBeenCalledWith('org-slug')
+    expect(getVoterIssues).toHaveBeenCalledWith({
+      districtId: 'd-1',
+      level: 'local',
+    })
     expect(result).toEqual({ issues })
   })
 
   it('coerces a null upstream response to an empty issues array', async () => {
-    getDistrictForOrgSlug.mockResolvedValue({
-      id: 'd-1',
-      l2Type: 'City',
-      l2Name: 'Los Angeles',
+    getDistrictAndLevelForOrgSlug.mockResolvedValue({
+      district: { id: 'd-1', l2Type: 'City', l2Name: 'Poway city' },
+      level: 'local',
     })
     getVoterIssues.mockResolvedValue(null)
 
@@ -52,8 +53,23 @@ describe('OnboardingVoterIssuesController', () => {
     expect(result).toEqual({ issues: [] })
   })
 
+  it('returns no issues when the office level cannot be resolved', async () => {
+    getDistrictAndLevelForOrgSlug.mockResolvedValue({
+      district: { id: 'd-1', l2Type: 'City', l2Name: 'Poway city' },
+      level: null,
+    })
+
+    const result = await controller.getVoterIssues(organization)
+
+    expect(result).toEqual({ issues: [] })
+    expect(getVoterIssues).not.toHaveBeenCalled()
+  })
+
   it('throws NotFoundException when the organization has no district', async () => {
-    getDistrictForOrgSlug.mockResolvedValue(null)
+    getDistrictAndLevelForOrgSlug.mockResolvedValue({
+      district: null,
+      level: null,
+    })
 
     await expect(controller.getVoterIssues(organization)).rejects.toThrow(
       new NotFoundException(

--- a/src/onboarding/onboardingVoterIssues.controller.ts
+++ b/src/onboarding/onboardingVoterIssues.controller.ts
@@ -33,16 +33,20 @@ export class OnboardingVoterIssuesController {
   async getVoterIssues(
     @ReqOrganization() organization: Organization,
   ): Promise<VoterIssuesResponse> {
-    const district = await this.organizations.getDistrictForOrgSlug(
-      organization.slug,
-    )
+    const { district, level } =
+      await this.organizations.getDistrictAndLevelForOrgSlug(organization.slug)
     if (!district) {
       throw new NotFoundException(
         `No district associated with organization "${organization.slug}"`,
       )
     }
+    // Scope issues to the office's jurisdiction. Without a resolvable level we
+    // return nothing rather than the unfiltered national list, which would
+    // surface federal topics irrelevant to a local race.
+    if (!level) return { issues: [] }
     const issues = await this.elections.getVoterIssues({
       districtId: district.id,
+      level,
     })
     return { issues: issues ?? [] }
   }

--- a/src/organizations/services/organizations.service.test.ts
+++ b/src/organizations/services/organizations.service.test.ts
@@ -520,6 +520,42 @@ describe('OrganizationsService', () => {
       expect(result).toEqual({ district: null, level: null })
       expect(mockGetPositionById).not.toHaveBeenCalled()
     })
+
+    it('takes the district from the override but the level from the position when both are set', async () => {
+      mockFindUnique.mockResolvedValue({
+        slug: 'poway',
+        positionId: 'gp-pos-id',
+        overrideDistrictId: 'override-district-1',
+      })
+      mockGetPositionById.mockResolvedValue({
+        id: 'gp-pos-id',
+        name: 'Poway City Council',
+        level: 'CITY',
+        district,
+      })
+      mockGetDistrict.mockResolvedValue({
+        id: 'override-district-1',
+        state: 'CA',
+        L2DistrictType: 'County',
+        L2DistrictName: 'San Diego county',
+      })
+
+      const result = await service.getDistrictAndLevelForOrgSlug('poway')
+
+      expect(result).toEqual({
+        district: {
+          id: 'override-district-1',
+          state: 'CA',
+          l2Type: 'County',
+          l2Name: 'San Diego county',
+        },
+        level: 'local',
+      })
+      expect(mockGetPositionById).toHaveBeenCalledWith('gp-pos-id', {
+        includeDistrict: true,
+      })
+      expect(mockGetDistrict).toHaveBeenCalledWith('override-district-1')
+    })
   })
 
   describe('extractCityFromDistrictName', () => {

--- a/src/organizations/services/organizations.service.test.ts
+++ b/src/organizations/services/organizations.service.test.ts
@@ -8,12 +8,14 @@ describe('OrganizationsService', () => {
   let mockGetPositionByBallotReadyId: ReturnType<typeof vi.fn>
   let mockGetPositionById: ReturnType<typeof vi.fn>
   let mockGetDistrictId: ReturnType<typeof vi.fn>
+  let mockGetDistrict: ReturnType<typeof vi.fn>
   let mockCleanDistrictName: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     mockGetPositionByBallotReadyId = vi.fn().mockResolvedValue(null)
     mockGetPositionById = vi.fn().mockResolvedValue(null)
     mockGetDistrictId = vi.fn().mockResolvedValue(null)
+    mockGetDistrict = vi.fn().mockResolvedValue(null)
     mockCleanDistrictName = vi.fn((name: string) => name)
 
     service = new OrganizationsService(
@@ -21,6 +23,7 @@ describe('OrganizationsService', () => {
         getPositionByBallotReadyId: mockGetPositionByBallotReadyId,
         getPositionById: mockGetPositionById,
         getDistrictId: mockGetDistrictId,
+        getDistrict: mockGetDistrict,
         cleanDistrictName: mockCleanDistrictName,
       } as unknown as ElectionsService,
       createMockClerkEnricher(),
@@ -422,6 +425,99 @@ describe('OrganizationsService', () => {
         ballotReadyPositionId: null,
         positionName: null,
       })
+      expect(mockGetPositionById).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getDistrictAndLevelForOrgSlug', () => {
+    let mockFindUnique: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      mockFindUnique = vi.fn().mockResolvedValue(null)
+      service.findUnique = mockFindUnique as typeof service.findUnique
+    })
+
+    const district = {
+      id: 'district-1',
+      state: 'CA',
+      L2DistrictType: 'City',
+      L2DistrictName: 'Poway city',
+    }
+
+    it('resolves the district and maps the position level', async () => {
+      mockFindUnique.mockResolvedValue({
+        slug: 'poway',
+        positionId: 'gp-pos-id',
+        overrideDistrictId: null,
+      })
+      mockGetPositionById.mockResolvedValue({
+        id: 'gp-pos-id',
+        name: 'Poway City Council',
+        level: 'CITY',
+        district,
+      })
+
+      const result = await service.getDistrictAndLevelForOrgSlug('poway')
+
+      expect(result).toEqual({
+        district: {
+          id: 'district-1',
+          state: 'CA',
+          l2Type: 'City',
+          l2Name: 'Poway city',
+        },
+        level: 'local',
+      })
+      expect(mockGetPositionById).toHaveBeenCalledWith('gp-pos-id', {
+        includeDistrict: true,
+      })
+    })
+
+    it('returns a null level when the position has no level', async () => {
+      mockFindUnique.mockResolvedValue({
+        slug: 'poway',
+        positionId: 'gp-pos-id',
+        overrideDistrictId: null,
+      })
+      mockGetPositionById.mockResolvedValue({
+        id: 'gp-pos-id',
+        name: 'Poway City Council',
+        level: null,
+        district,
+      })
+
+      const result = await service.getDistrictAndLevelForOrgSlug('poway')
+
+      expect(result.district).not.toBeNull()
+      expect(result.level).toBeNull()
+    })
+
+    it('resolves the override district with a null level when there is no position', async () => {
+      mockFindUnique.mockResolvedValue({
+        slug: 'poway',
+        positionId: null,
+        overrideDistrictId: 'district-1',
+      })
+      mockGetDistrict.mockResolvedValue(district)
+
+      const result = await service.getDistrictAndLevelForOrgSlug('poway')
+
+      expect(result).toEqual({
+        district: {
+          id: 'district-1',
+          state: 'CA',
+          l2Type: 'City',
+          l2Name: 'Poway city',
+        },
+        level: null,
+      })
+      expect(mockGetPositionById).not.toHaveBeenCalled()
+    })
+
+    it('returns null district and level when the org is not found', async () => {
+      const result = await service.getDistrictAndLevelForOrgSlug('missing')
+
+      expect(result).toEqual({ district: null, level: null })
       expect(mockGetPositionById).not.toHaveBeenCalled()
     })
   })

--- a/src/organizations/services/organizations.service.ts
+++ b/src/organizations/services/organizations.service.ts
@@ -1,4 +1,6 @@
 import { ElectionsService } from '@/elections/services/elections.service'
+import { VoterIssueLevel } from '@/elections/types/elections.types'
+import { getVoterIssueLevelFromPositionLevel } from '@/elections/util/getVoterIssueLevelFromPositionLevel.util'
 import {
   BadRequestException,
   Injectable,
@@ -419,6 +421,43 @@ export class OrganizationsService extends createPrismaBase(
     if (!org) return null
 
     return this.resolveDistrict(org)
+  }
+
+  // Resolves both the district and the office's voter-issue level in a single
+  // position fetch, so the onboarding voter-issues endpoint can scope issues to
+  // the candidate's jurisdiction without a second election-api round-trip.
+  async getDistrictAndLevelForOrgSlug(slug: string): Promise<{
+    district: OrgDistrict | null
+    level: VoterIssueLevel | null
+  }> {
+    const org = await this.findUnique({ where: { slug } })
+    if (!org) return { district: null, level: null }
+
+    const [position, overrideDistrict] = await Promise.all([
+      org.positionId
+        ? this.electionsService.getPositionById(org.positionId, {
+            includeDistrict: true,
+          })
+        : Promise.resolve(null),
+      org.overrideDistrictId
+        ? this.electionsService.getDistrict(org.overrideDistrictId)
+        : Promise.resolve(null),
+    ])
+
+    const rawDistrict = overrideDistrict ?? position?.district
+    const district: OrgDistrict | null = rawDistrict
+      ? {
+          id: rawDistrict.id,
+          state: rawDistrict.state,
+          l2Type: rawDistrict.L2DistrictType,
+          l2Name: rawDistrict.L2DistrictName,
+        }
+      : null
+
+    return {
+      district,
+      level: getVoterIssueLevelFromPositionLevel(position?.level),
+    }
   }
 
   async resolveServeContext(org: Organization): Promise<{


### PR DESCRIPTION
## Problem

The onboarding "Voter insights" step (and the success-page plan) showed a district's **unfiltered** top voter issues, surfacing nationalized federal topics (Independent Redistricting Commissions, DOGE, Mass Deportations, Border Wall, etc.) to candidates running for local offices. For a Poway City Council candidate these have no bearing on the municipal terrain they actually run on (development, growth/Prop FF, traffic, fire service, water), which damages credibility.

## Root cause

`election-api` already supports jurisdiction filtering: `GET /v1/voter-issues` accepts `?level=local|regional|state|federal` and filters `DistrictTopIssue` by the matching `is_local/is_regional/is_state/is_federal` flag. `gp-api` simply never passed a `level`.

## Change

- New `getVoterIssueLevelFromPositionLevel` util maps the 7 BallotReady `PositionLevel` values onto election-api's 4 voter-issue levels (`CITY/TOWNSHIP/LOCAL → local`, `COUNTY/REGIONAL → regional`, `STATE → state`, `FEDERAL → federal`).
- New `OrganizationsService.getDistrictAndLevelForOrgSlug` resolves the district **and** the office level in a single position fetch (no extra election-api round-trip).
- `ElectionsService.getVoterIssues` now accepts and forwards an optional `level`.
- The onboarding controller scopes issues to the office level. When no level can be resolved, it returns **no issues** rather than the unfiltered national list.

Strictly the office's level (per stakeholder decision) — cross-level issues still surface because the flags are non-exclusive.

## Rollout dependency ⚠️

`DistrictTopIssue.is_local/is_regional/is_state/is_federal` are nullable and populated by an in-flight gp-data-platform Airflow sync (**DATA-1903**). Until that data lands, level-filtered queries return `[]` and the onboarding section is **hidden for everyone** (the chosen behavior). Verify flag population against a real district (e.g. the Poway district) before merging to prod.

## Tests

- Mapping util across all 7 levels + null
- `getVoterIssues` forwards `level`
- `getDistrictAndLevelForOrgSlug` (position level, null level, override-district-only, org-not-found)
- Controller derives + forwards the level, returns `[]` when unresolvable, 404 when no district

117 tests pass across the touched files.

## Paired with

gp-webapp PR: ranked-list display of the localized issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding product behavior and depends on election-api level filtering plus DATA-1903 data; until flags exist, most orgs may see no voter issues.
> 
> **Overview**
> Onboarding voter insights now scope district top issues to the **office’s jurisdiction** instead of returning an unfiltered district list that surfaced irrelevant federal/national topics for local races.
> 
> `ElectionsService.getVoterIssues` accepts an optional `level` (`local` | `regional` | `state` | `federal`) and passes it through to election-api’s `voter-issues` endpoint. A new `getVoterIssueLevelFromPositionLevel` helper collapses BallotReady’s seven `PositionLevel` values into those four levels. `OrganizationsService.getDistrictAndLevelForOrgSlug` resolves district plus mapped level in one position fetch (with override-district support). The onboarding `GET onboarding/voter-issues` handler uses that helper: it still 404s without a district, but returns **`{ issues: [] }`** when the office level cannot be resolved (skipping the API) rather than showing the national list.
> 
> `PositionWithOptionalDistrict` now includes optional `level` from contracts. Tests cover param forwarding, mapping, org resolution paths, and controller behavior.
> 
> **Rollout note:** level-filtered results depend on upstream `DistrictTopIssue` jurisdiction flags (DATA-1903); until populated, filtered calls may return empty and hide the section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80a3c17cc98d9539e910981192aed1b5ab43056b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->