### PR TITLE
ENG-10337 Add analytics for onboarding flow

### DIFF
--- a/src/campaignStrategy/services/campaignStrategy.cap.test.ts
+++ b/src/campaignStrategy/services/campaignStrategy.cap.test.ts
@@ -52,7 +52,11 @@ describe('CampaignStrategyService', () => {
     persistOpportunitiesAndChallenges: ReturnType<typeof vi.fn>
   }
   let s3: { getFile: ReturnType<typeof vi.fn> }
-  let prisma: { campaignStrategy: Record<string, ReturnType<typeof vi.fn>> }
+  let analytics: { track: ReturnType<typeof vi.fn> }
+  let prisma: {
+    campaignStrategy: Record<string, ReturnType<typeof vi.fn>>
+    campaign: Record<string, ReturnType<typeof vi.fn>>
+  }
 
   const planRow = (overrides: Record<string, unknown> = {}) => ({
     id: 42,
@@ -76,6 +80,7 @@ describe('CampaignStrategyService', () => {
       persistOpportunitiesAndChallenges: vi.fn().mockResolvedValue(undefined),
     }
     s3 = { getFile: vi.fn() }
+    analytics = { track: vi.fn().mockResolvedValue(undefined) }
     prisma = {
       campaignStrategy: {
         upsert: vi.fn().mockResolvedValue(planRow()),
@@ -83,6 +88,9 @@ describe('CampaignStrategyService', () => {
         update: vi.fn().mockResolvedValue(undefined),
         updateMany: vi.fn().mockResolvedValue({ count: 1 }),
         findFirst: vi.fn().mockResolvedValue(planRow()),
+      },
+      campaign: {
+        findUnique: vi.fn().mockResolvedValue({ userId: 7 }),
       },
     }
     // The last three deps (communityEvents, electionApi, races) belong to the
@@ -97,6 +105,7 @@ describe('CampaignStrategyService', () => {
       { generate: vi.fn() } as never,
       { getRaceContext: vi.fn() } as never,
       { getZipCodesByRaceId: vi.fn() } as never,
+      analytics as never,
     )
     Object.defineProperty(service, '_prisma', { value: prisma })
     Object.assign(service, {

--- a/src/campaignStrategy/services/campaignStrategy.service.test.ts
+++ b/src/campaignStrategy/services/campaignStrategy.service.test.ts
@@ -17,6 +17,7 @@ import { S3Service } from '@/vendors/aws/services/s3.service'
 import { RacesService } from '@/elections/services/races.service'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
 import { RaceContextFromApi } from '../types/electionApi.types'
+import { AnalyticsService } from '@/analytics/analytics.service'
 
 // Strategic-landscape (CAP dispatch) behavior is covered in
 // campaignStrategy.cap.test.ts. This file covers the community-events pipeline
@@ -156,6 +157,10 @@ describe('CampaignStrategyService — community events', () => {
         { provide: ElectionApiService, useValue: mockElectionApi },
         { provide: RacesService, useValue: mockRaces },
         { provide: PinoLogger, useValue: createMockLogger() },
+        {
+          provide: AnalyticsService,
+          useValue: { track: vi.fn().mockResolvedValue(undefined) },
+        },
         CampaignStrategyService,
       ],
     }).compile()
@@ -306,7 +311,7 @@ describe('CampaignStrategyService — community events', () => {
       await service.drainInFlight()
 
       expect(mockRaces.getZipCodesByRaceId).toHaveBeenCalledWith('hash-abc')
-      const ctx = mockEvents.generate.mock.calls[0]?.[2]
+      const ctx = mockEvents.generate.mock.calls[0]?.[3]
       // All resolver zips join into a single comma-separated value so the
       // LLM has full geographic coverage of the district.
       expect(ctx?.zip).toBe('10025, 10026')
@@ -325,7 +330,7 @@ describe('CampaignStrategyService — community events', () => {
       )
       await service.drainInFlight()
 
-      const ctx = mockEvents.generate.mock.calls[0]?.[2]
+      const ctx = mockEvents.generate.mock.calls[0]?.[3]
       expect(ctx?.zip).toBe('94110')
     })
 
@@ -349,7 +354,7 @@ describe('CampaignStrategyService — community events', () => {
       )
       await service.drainInFlight()
 
-      const ctx = mockEvents.generate.mock.calls[0]?.[2]
+      const ctx = mockEvents.generate.mock.calls[0]?.[3]
       expect(ctx?.zip).toBe('')
     })
 
@@ -366,7 +371,7 @@ describe('CampaignStrategyService — community events', () => {
       )
       await service.drainInFlight()
 
-      const ctx = mockEvents.generate.mock.calls[0]?.[2]
+      const ctx = mockEvents.generate.mock.calls[0]?.[3]
       expect(ctx?.zip).toBe('94110')
     })
 
@@ -386,7 +391,7 @@ describe('CampaignStrategyService — community events', () => {
       )
       await service.drainInFlight()
 
-      const ctx = mockEvents.generate.mock.calls[0]?.[2]
+      const ctx = mockEvents.generate.mock.calls[0]?.[3]
       expect(ctx?.zip).toBe(districtZips.join(', '))
     })
   })

--- a/src/campaignStrategy/services/campaignStrategy.service.ts
+++ b/src/campaignStrategy/services/campaignStrategy.service.ts
@@ -39,6 +39,8 @@ import {
 } from './electionApi.service'
 import { StrategicLandscapeParamsService } from './strategicLandscapeParams.service'
 import { StrategicLandscapePersister } from './strategicLandscape.persister'
+import { AnalyticsService } from '@/analytics/analytics.service'
+import { EVENTS } from '@/vendors/segment/segment.types'
 
 const OPPOSITION = 'opposition_research'
 const OPPORTUNITIES = 'opportunities_and_challenges'
@@ -169,8 +171,19 @@ export class CampaignStrategyService
     private readonly communityEvents: CommunityEventsService,
     private readonly electionApi: ElectionApiService,
     private readonly races: RacesService,
+    private readonly analytics: AnalyticsService,
   ) {
     super()
+  }
+
+  private async resolveCampaignUserId(
+    campaignId: number,
+  ): Promise<number | null> {
+    const campaign = await this.client.campaign.findUnique({
+      where: { id: campaignId },
+      select: { userId: true },
+    })
+    return campaign?.userId ?? null
   }
 
   async getOrGenerateStrategicLandscape(
@@ -244,6 +257,8 @@ export class CampaignStrategyService
     })
     if (!plan) return
 
+    const userId = await this.resolveCampaignUserId(plan.campaignId)
+
     // If loading, parsing, or persisting the artifact fails, the run was
     // marked COMPLETED upstream but its section never landed. Flip it to
     // FAILED so the endpoint reports 'failed' rather than a permanent
@@ -254,6 +269,23 @@ export class CampaignStrategyService
 
       if (run.experimentType === OPPOSITION) {
         await this.persister.persistOpponents(plan.id, parseOpponents(raw))
+        if (userId !== null) {
+          void this.analytics
+            .track(
+              userId,
+              EVENTS.CampaignPlanV2.OppositionResearchGenerationCompleted,
+              {
+                campaignId: plan.campaignId,
+                planId: plan.id,
+                generationEngine: 'cap',
+                runId: run.runId,
+                durationSeconds: run.durationSeconds,
+                costUsd: run.costUsd,
+                outcome: run.status,
+              },
+            )
+            .catch(() => undefined)
+        }
       } else {
         const { opportunities, challenges } =
           parseOpportunitiesAndChallenges(raw)
@@ -262,6 +294,23 @@ export class CampaignStrategyService
           opportunities,
           challenges,
         )
+        if (userId !== null) {
+          void this.analytics
+            .track(
+              userId,
+              EVENTS.CampaignPlanV2.OpportunitiesChallengesGenerationCompleted,
+              {
+                campaignId: plan.campaignId,
+                planId: plan.id,
+                generationEngine: 'cap',
+                runId: run.runId,
+                durationSeconds: run.durationSeconds,
+                costUsd: run.costUsd,
+                outcome: run.status,
+              },
+            )
+            .catch(() => undefined)
+        }
       }
     } catch (error) {
       await this.experimentRuns.markFailed(
@@ -373,7 +422,12 @@ export class CampaignStrategyService
     electionDate: string,
   ): Promise<void> {
     const ctx = await this.buildEventsContext(campaign, brHashId, electionDate)
-    await this.communityEvents.generate(planId, campaign.id, ctx)
+    await this.communityEvents.generate(
+      planId,
+      campaign.id,
+      campaign.userId,
+      ctx,
+    )
   }
 
   // Build the community-events prompt context by combining election-api's
@@ -554,10 +608,10 @@ export class CampaignStrategyService
       states.opposition !== 'inflight' && states.opportunities !== 'inflight'
 
     const opposition = dispatchOpposition
-      ? await this.attemptOpposition(plan, base, freshStart)
+      ? await this.attemptOpposition(campaign.userId, plan, base, freshStart)
       : states.opposition
     const opportunities = dispatchOpportunities
-      ? await this.attemptOpportunities(plan, base, freshStart)
+      ? await this.attemptOpportunities(campaign.userId, plan, base, freshStart)
       : states.opportunities
 
     return this.statusFrom(opposition, opportunities)
@@ -568,6 +622,7 @@ export class CampaignStrategyService
   // most MAX_SECTION_ATTEMPTS slots in total — bounding the Fargate runs a
   // failing-and-retried (or maliciously hammered) section can spawn.
   private async attemptOpposition(
+    userId: number,
     plan: CampaignStrategy,
     base: DispatchBase,
     freshStart: boolean,
@@ -580,6 +635,22 @@ export class CampaignStrategyService
 
     const runId = await this.tryDispatch(OPPOSITION, base)
     if (!runId) return 'stalled'
+
+    if (freshStart) {
+      void this.analytics
+        .track(
+          userId,
+          EVENTS.CampaignPlanV2.OppositionResearchGenerationStarted,
+          {
+            campaignId: plan.campaignId,
+            planId: plan.id,
+            generationEngine: 'cap',
+            runId,
+            attempt: plan.oppositionAttempts + 1,
+          },
+        )
+        .catch(() => undefined)
+    }
 
     try {
       await this.client.campaignStrategy.update({
@@ -602,6 +673,7 @@ export class CampaignStrategyService
   }
 
   private async attemptOpportunities(
+    userId: number,
     plan: CampaignStrategy,
     base: DispatchBase,
     freshStart: boolean,
@@ -617,6 +689,22 @@ export class CampaignStrategyService
 
     const runId = await this.tryDispatch(OPPORTUNITIES, base)
     if (!runId) return 'stalled'
+
+    if (freshStart) {
+      void this.analytics
+        .track(
+          userId,
+          EVENTS.CampaignPlanV2.OpportunitiesChallengesGenerationStarted,
+          {
+            campaignId: plan.campaignId,
+            planId: plan.id,
+            generationEngine: 'cap',
+            runId,
+            attempt: plan.opportunitiesAttempts + 1,
+          },
+        )
+        .catch(() => undefined)
+    }
 
     try {
       await this.client.campaignStrategy.update({

--- a/src/campaignStrategy/services/communityEvents.service.test.ts
+++ b/src/campaignStrategy/services/communityEvents.service.test.ts
@@ -5,6 +5,7 @@ import { GeminiService } from 'src/vendors/google/services/gemini.service'
 import { CommunityEventsService } from './communityEvents.service'
 import { CommunityEventsPersister } from './communityEvents.persister'
 import { CommunityEventsPromptContext } from './communityEvents.prompts'
+import { AnalyticsService } from '@/analytics/analytics.service'
 
 const buildCtx = (
   overrides: Partial<CommunityEventsPromptContext> = {},
@@ -52,6 +53,9 @@ describe('CommunityEventsService', () => {
       gemini as unknown as GeminiService,
       braintrust as unknown as BraintrustService,
       persister as unknown as CommunityEventsPersister,
+      {
+        track: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AnalyticsService,
       createMockLogger(),
     )
   })
@@ -83,7 +87,7 @@ describe('CommunityEventsService', () => {
       ],
     })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events).toHaveLength(3)
     expect(result.events.map((e) => e.title)).toEqual(['A', 'B', 'C'])
@@ -106,7 +110,7 @@ describe('CommunityEventsService', () => {
       ],
     })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events.map((e) => e.title)).toEqual(['A', 'B', 'C'])
   })
@@ -120,7 +124,7 @@ describe('CommunityEventsService', () => {
       ],
     })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events.map((e) => e.title)).toEqual(['Future'])
   })
@@ -139,7 +143,7 @@ describe('CommunityEventsService', () => {
       ],
     })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events.map((e) => e.title)).toEqual(['OK'])
   })
@@ -152,7 +156,7 @@ describe('CommunityEventsService', () => {
       ],
     })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events.map((e) => e.title)).toEqual(['OK'])
   })
@@ -160,7 +164,7 @@ describe('CommunityEventsService', () => {
   it('returns an empty events array when the model returns no qualifying events', async () => {
     gemini.generateStructured.mockResolvedValue({ events: [] })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events).toEqual([])
     // Persist still fires — the cache shape must distinguish "generated,
@@ -185,7 +189,7 @@ describe('CommunityEventsService', () => {
       ],
     })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events.map((e) => e.url)).toEqual([null, null])
     expect(result.events.map((e) => e.address)).toEqual([null, null])
@@ -199,7 +203,7 @@ describe('CommunityEventsService', () => {
     })
     gemini.generateStructured.mockResolvedValue({ events: [] })
 
-    await service.generate(42, 99, buildCtx())
+    await service.generate(42, 99, 7, buildCtx())
 
     const [structuredPrompt] = gemini.generateStructured.mock.calls[0]
     expect(structuredPrompt).toContain('EVENTS_FROM_BR')

--- a/src/campaignStrategy/services/communityEvents.service.ts
+++ b/src/campaignStrategy/services/communityEvents.service.ts
@@ -5,6 +5,8 @@ import { BraintrustService } from 'src/vendors/braintrust/braintrust.service'
 import { GEMINI_MODEL } from 'src/vendors/google/gemini.types'
 import { GeminiService } from 'src/vendors/google/services/gemini.service'
 import { CommunityEvent, CommunityEventsResult } from '@goodparty_org/contracts'
+import { AnalyticsService } from '@/analytics/analytics.service'
+import { EVENTS } from '@/vendors/segment/segment.types'
 import {
   CommunityEventsRaw,
   CommunityEventsRawSchema,
@@ -38,6 +40,7 @@ export class CommunityEventsService {
     private readonly gemini: GeminiService,
     private readonly braintrust: BraintrustService,
     private readonly persister: CommunityEventsPersister,
+    private readonly analytics: AnalyticsService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(CommunityEventsService.name)
@@ -46,9 +49,18 @@ export class CommunityEventsService {
   async generate(
     campaignStrategyId: number,
     campaignId: number,
+    userId: number,
     ctx: CommunityEventsPromptContext,
   ): Promise<CommunityEventsResult> {
     const variables = buildEventsPromptVariables(ctx)
+    const startedAtPerf = performance.now()
+    void this.analytics
+      .track(userId, EVENTS.CampaignPlanV2.CommunityEventsGenerationStarted, {
+        campaignId,
+        planId: campaignStrategyId,
+        generationEngine: 'gemini',
+      })
+      .catch(() => undefined)
 
     const result = await this.braintrust.tracedNested(
       'community-events:generate',
@@ -69,6 +81,15 @@ export class CommunityEventsService {
     )
 
     await this.persister.persist(campaignStrategyId, result)
+    void this.analytics
+      .track(userId, EVENTS.CampaignPlanV2.CommunityEventsGenerationCompleted, {
+        campaignId,
+        planId: campaignStrategyId,
+        generationEngine: 'gemini',
+        durationMs: Math.round(performance.now() - startedAtPerf),
+        eventCount: result.events.length,
+      })
+      .catch(() => undefined)
     return result
   }
 

--- a/src/onboarding/services/localNews.service.test.ts
+++ b/src/onboarding/services/localNews.service.test.ts
@@ -45,13 +45,15 @@ function makeService() {
     findFirst: vi.fn(),
     model,
   }
+  const analytics = { track: vi.fn().mockResolvedValue(undefined) }
   const service = new OnboardingLocalNewsService(
     gemini as never,
     braintrust as never,
     campaigns as never,
+    analytics as never,
     createMockLogger(),
   )
-  return { service, gemini, braintrust, campaigns, model }
+  return { service, gemini, braintrust, campaigns, model, analytics }
 }
 
 function readyOutlets(extra: { name: string }[] = []) {

--- a/src/onboarding/services/localNews.service.ts
+++ b/src/onboarding/services/localNews.service.ts
@@ -5,6 +5,8 @@ import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
 import { GEMINI_MODEL } from '@/vendors/google/gemini.types'
 import { GeminiService } from '@/vendors/google/services/gemini.service'
 import { CampaignsService } from '@/campaigns/services/campaigns.service'
+import { AnalyticsService } from '@/analytics/analytics.service'
+import { EVENTS } from '@/vendors/segment/segment.types'
 import {
   aiOutletsToolResultSchema,
   LocalNewsOutlet,
@@ -104,6 +106,7 @@ export class OnboardingLocalNewsService {
     private readonly gemini: GeminiService,
     private readonly braintrust: BraintrustService,
     private readonly campaigns: CampaignsService,
+    private readonly analytics: AnalyticsService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(OnboardingLocalNewsService.name)
@@ -155,28 +158,43 @@ export class OnboardingLocalNewsService {
       state,
     })
     if (claimed) {
-      void this.runFetch({ campaignId: campaign.id, city, state, office })
+      void this.runFetch({
+        campaignId: campaign.id,
+        userId: campaign.userId,
+        city,
+        state,
+        office,
+      })
     }
     return { status: 'pending' }
   }
 
   private async runFetch({
     campaignId,
+    userId,
     city,
     state,
     office,
   }: {
     campaignId: number
+    userId: number
     city?: string
     state: string
     office: string
   }): Promise<void> {
     const jurisdiction = city ? `${city}, ${state}` : state
     const startedAt = Date.now()
+    const startedAtPerf = performance.now()
     this.logger.info(
       { jurisdiction, office, campaignId },
       'getLocalNews background fetch started',
     )
+    void this.analytics
+      .track(userId, EVENTS.CampaignPlanV2.MediaGenerationStarted, {
+        campaignId,
+        generationEngine: 'gemini',
+      })
+      .catch(() => undefined)
 
     try {
       const result = await this.braintrust.tracedNested(
@@ -197,6 +215,14 @@ export class OnboardingLocalNewsService {
         { office, city: city ?? null, state },
         result.outlets,
       )
+      void this.analytics
+        .track(userId, EVENTS.CampaignPlanV2.MediaGenerationCompleted, {
+          campaignId,
+          generationEngine: 'gemini',
+          durationMs: Math.round(performance.now() - startedAtPerf),
+          outletCount: result.outlets.length,
+        })
+        .catch(() => undefined)
       this.logger.info(
         {
           jurisdiction,

--- a/src/vendors/segment/segment.types.ts
+++ b/src/vendors/segment/segment.types.ts
@@ -50,6 +50,26 @@ export const EVENTS = {
     //  ⚠️  DO NOT MODIFY - Used by HubSpot workflows for weekly task digest emails
     WeeklyTasksDigest: 'Campaign Plan - Weekly Tasks Digest',
   },
+  // Server-side generation for the V2 onboarding campaign plan. The strategic
+  // landscape (CAP/PMF engine) fans out into two independent agent jobs, so it
+  // gets four events. The webapp's view of these is tracked separately under
+  // `Onboarding V2 -` in gp-webapp.
+  CampaignPlanV2: {
+    MediaGenerationStarted: 'Campaign Plan V2 - Media Generation Started',
+    MediaGenerationCompleted: 'Campaign Plan V2 - Media Generation Completed',
+    CommunityEventsGenerationStarted:
+      'Campaign Plan V2 - Community Events Generation Started',
+    CommunityEventsGenerationCompleted:
+      'Campaign Plan V2 - Community Events Generation Completed',
+    OppositionResearchGenerationStarted:
+      'Campaign Plan V2 - Opposition Research Generation Started',
+    OppositionResearchGenerationCompleted:
+      'Campaign Plan V2 - Opposition Research Generation Completed',
+    OpportunitiesChallengesGenerationStarted:
+      'Campaign Plan V2 - Opportunities & Challenges Generation Started',
+    OpportunitiesChallengesGenerationCompleted:
+      'Campaign Plan V2 - Opportunities & Challenges Generation Completed',
+  },
 }
 
 export type UserContext = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only changes with swallowed analytics errors; no change to generation or persistence logic beyond an extra campaign lookup on CAP completion.
> 
> **Overview**
> Adds **server-side Segment analytics** for Campaign Plan V2 onboarding generation, via new `EVENTS.CampaignPlanV2.*` names in `segment.types.ts`.
> 
> **Strategic landscape (CAP):** `CampaignStrategyService` injects `AnalyticsService` and fires **started** events when opposition/opportunities dispatches begin on a fresh plan (`generationEngine: 'cap'`, run id, attempt). **Completed** events run after S3 artifact persist in `onExperimentRunCompleted`, with duration/cost from the experiment run; `userId` is resolved with a small `campaign.findUnique` when the queue consumer handles completion.
> 
> **Community events:** `CommunityEventsService.generate` now takes `userId` and emits **started** / **completed** (`generationEngine: 'gemini'`, `durationMs`, `eventCount`). The strategy service passes `campaign.userId` through.
> 
> **Local media:** `OnboardingLocalNewsService` tracks **media generation started/completed** on background Gemini fetch (`durationMs`, `outletCount`).
> 
> All tracks are **fire-and-forget** (`void …track(…).catch(() => undefined)`) so analytics failures do not block generation. Tests add `AnalyticsService` mocks and update `generate` arity / mock call indices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1432190d18913984155fc7f9145f9514d5cb16d3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->