### PR TITLE
Prod <- QA

### DIFF
--- a/src/campaignStrategy/services/campaignStrategy.cap.test.ts
+++ b/src/campaignStrategy/services/campaignStrategy.cap.test.ts
@@ -52,7 +52,11 @@ describe('CampaignStrategyService', () => {
     persistOpportunitiesAndChallenges: ReturnType<typeof vi.fn>
   }
   let s3: { getFile: ReturnType<typeof vi.fn> }
-  let prisma: { campaignStrategy: Record<string, ReturnType<typeof vi.fn>> }
+  let analytics: { track: ReturnType<typeof vi.fn> }
+  let prisma: {
+    campaignStrategy: Record<string, ReturnType<typeof vi.fn>>
+    campaign: Record<string, ReturnType<typeof vi.fn>>
+  }
 
   const planRow = (overrides: Record<string, unknown> = {}) => ({
     id: 42,
@@ -76,6 +80,7 @@ describe('CampaignStrategyService', () => {
       persistOpportunitiesAndChallenges: vi.fn().mockResolvedValue(undefined),
     }
     s3 = { getFile: vi.fn() }
+    analytics = { track: vi.fn().mockResolvedValue(undefined) }
     prisma = {
       campaignStrategy: {
         upsert: vi.fn().mockResolvedValue(planRow()),
@@ -83,6 +88,9 @@ describe('CampaignStrategyService', () => {
         update: vi.fn().mockResolvedValue(undefined),
         updateMany: vi.fn().mockResolvedValue({ count: 1 }),
         findFirst: vi.fn().mockResolvedValue(planRow()),
+      },
+      campaign: {
+        findUnique: vi.fn().mockResolvedValue({ userId: 7 }),
       },
     }
     // The last three deps (communityEvents, electionApi, races) belong to the
@@ -97,6 +105,7 @@ describe('CampaignStrategyService', () => {
       { generate: vi.fn() } as never,
       { getRaceContext: vi.fn() } as never,
       { getZipCodesByRaceId: vi.fn() } as never,
+      analytics as never,
     )
     Object.defineProperty(service, '_prisma', { value: prisma })
     Object.assign(service, {

--- a/src/campaignStrategy/services/campaignStrategy.service.test.ts
+++ b/src/campaignStrategy/services/campaignStrategy.service.test.ts
@@ -17,6 +17,7 @@ import { S3Service } from '@/vendors/aws/services/s3.service'
 import { RacesService } from '@/elections/services/races.service'
 import { createMockLogger } from '@/shared/test-utils/mockLogger.util'
 import { RaceContextFromApi } from '../types/electionApi.types'
+import { AnalyticsService } from '@/analytics/analytics.service'
 
 // Strategic-landscape (CAP dispatch) behavior is covered in
 // campaignStrategy.cap.test.ts. This file covers the community-events pipeline
@@ -156,6 +157,10 @@ describe('CampaignStrategyService — community events', () => {
         { provide: ElectionApiService, useValue: mockElectionApi },
         { provide: RacesService, useValue: mockRaces },
         { provide: PinoLogger, useValue: createMockLogger() },
+        {
+          provide: AnalyticsService,
+          useValue: { track: vi.fn().mockResolvedValue(undefined) },
+        },
         CampaignStrategyService,
       ],
     }).compile()
@@ -306,7 +311,7 @@ describe('CampaignStrategyService — community events', () => {
       await service.drainInFlight()
 
       expect(mockRaces.getZipCodesByRaceId).toHaveBeenCalledWith('hash-abc')
-      const ctx = mockEvents.generate.mock.calls[0]?.[2]
+      const ctx = mockEvents.generate.mock.calls[0]?.[3]
       // All resolver zips join into a single comma-separated value so the
       // LLM has full geographic coverage of the district.
       expect(ctx?.zip).toBe('10025, 10026')
@@ -325,7 +330,7 @@ describe('CampaignStrategyService — community events', () => {
       )
       await service.drainInFlight()
 
-      const ctx = mockEvents.generate.mock.calls[0]?.[2]
+      const ctx = mockEvents.generate.mock.calls[0]?.[3]
       expect(ctx?.zip).toBe('94110')
     })
 
@@ -349,7 +354,7 @@ describe('CampaignStrategyService — community events', () => {
       )
       await service.drainInFlight()
 
-      const ctx = mockEvents.generate.mock.calls[0]?.[2]
+      const ctx = mockEvents.generate.mock.calls[0]?.[3]
       expect(ctx?.zip).toBe('')
     })
 
@@ -366,7 +371,7 @@ describe('CampaignStrategyService — community events', () => {
       )
       await service.drainInFlight()
 
-      const ctx = mockEvents.generate.mock.calls[0]?.[2]
+      const ctx = mockEvents.generate.mock.calls[0]?.[3]
       expect(ctx?.zip).toBe('94110')
     })
 
@@ -386,7 +391,7 @@ describe('CampaignStrategyService — community events', () => {
       )
       await service.drainInFlight()
 
-      const ctx = mockEvents.generate.mock.calls[0]?.[2]
+      const ctx = mockEvents.generate.mock.calls[0]?.[3]
       expect(ctx?.zip).toBe(districtZips.join(', '))
     })
   })

--- a/src/campaignStrategy/services/campaignStrategy.service.ts
+++ b/src/campaignStrategy/services/campaignStrategy.service.ts
@@ -39,6 +39,8 @@ import {
 } from './electionApi.service'
 import { StrategicLandscapeParamsService } from './strategicLandscapeParams.service'
 import { StrategicLandscapePersister } from './strategicLandscape.persister'
+import { AnalyticsService } from '@/analytics/analytics.service'
+import { EVENTS } from '@/vendors/segment/segment.types'
 
 const OPPOSITION = 'opposition_research'
 const OPPORTUNITIES = 'opportunities_and_challenges'
@@ -169,8 +171,19 @@ export class CampaignStrategyService
     private readonly communityEvents: CommunityEventsService,
     private readonly electionApi: ElectionApiService,
     private readonly races: RacesService,
+    private readonly analytics: AnalyticsService,
   ) {
     super()
+  }
+
+  private async resolveCampaignUserId(
+    campaignId: number,
+  ): Promise<number | null> {
+    const campaign = await this.client.campaign.findUnique({
+      where: { id: campaignId },
+      select: { userId: true },
+    })
+    return campaign?.userId ?? null
   }
 
   async getOrGenerateStrategicLandscape(
@@ -244,6 +257,8 @@ export class CampaignStrategyService
     })
     if (!plan) return
 
+    const userId = await this.resolveCampaignUserId(plan.campaignId)
+
     // If loading, parsing, or persisting the artifact fails, the run was
     // marked COMPLETED upstream but its section never landed. Flip it to
     // FAILED so the endpoint reports 'failed' rather than a permanent
@@ -254,6 +269,23 @@ export class CampaignStrategyService
 
       if (run.experimentType === OPPOSITION) {
         await this.persister.persistOpponents(plan.id, parseOpponents(raw))
+        if (userId !== null) {
+          void this.analytics
+            .track(
+              userId,
+              EVENTS.CampaignPlanV2.OppositionResearchGenerationCompleted,
+              {
+                campaignId: plan.campaignId,
+                planId: plan.id,
+                generationEngine: 'cap',
+                runId: run.runId,
+                durationSeconds: run.durationSeconds,
+                costUsd: run.costUsd,
+                outcome: run.status,
+              },
+            )
+            .catch(() => undefined)
+        }
       } else {
         const { opportunities, challenges } =
           parseOpportunitiesAndChallenges(raw)
@@ -262,6 +294,23 @@ export class CampaignStrategyService
           opportunities,
           challenges,
         )
+        if (userId !== null) {
+          void this.analytics
+            .track(
+              userId,
+              EVENTS.CampaignPlanV2.OpportunitiesChallengesGenerationCompleted,
+              {
+                campaignId: plan.campaignId,
+                planId: plan.id,
+                generationEngine: 'cap',
+                runId: run.runId,
+                durationSeconds: run.durationSeconds,
+                costUsd: run.costUsd,
+                outcome: run.status,
+              },
+            )
+            .catch(() => undefined)
+        }
       }
     } catch (error) {
       await this.experimentRuns.markFailed(
@@ -373,7 +422,12 @@ export class CampaignStrategyService
     electionDate: string,
   ): Promise<void> {
     const ctx = await this.buildEventsContext(campaign, brHashId, electionDate)
-    await this.communityEvents.generate(planId, campaign.id, ctx)
+    await this.communityEvents.generate(
+      planId,
+      campaign.id,
+      campaign.userId,
+      ctx,
+    )
   }
 
   // Build the community-events prompt context by combining election-api's
@@ -554,10 +608,10 @@ export class CampaignStrategyService
       states.opposition !== 'inflight' && states.opportunities !== 'inflight'
 
     const opposition = dispatchOpposition
-      ? await this.attemptOpposition(plan, base, freshStart)
+      ? await this.attemptOpposition(campaign.userId, plan, base, freshStart)
       : states.opposition
     const opportunities = dispatchOpportunities
-      ? await this.attemptOpportunities(plan, base, freshStart)
+      ? await this.attemptOpportunities(campaign.userId, plan, base, freshStart)
       : states.opportunities
 
     return this.statusFrom(opposition, opportunities)
@@ -568,6 +622,7 @@ export class CampaignStrategyService
   // most MAX_SECTION_ATTEMPTS slots in total — bounding the Fargate runs a
   // failing-and-retried (or maliciously hammered) section can spawn.
   private async attemptOpposition(
+    userId: number,
     plan: CampaignStrategy,
     base: DispatchBase,
     freshStart: boolean,
@@ -580,6 +635,22 @@ export class CampaignStrategyService
 
     const runId = await this.tryDispatch(OPPOSITION, base)
     if (!runId) return 'stalled'
+
+    if (freshStart) {
+      void this.analytics
+        .track(
+          userId,
+          EVENTS.CampaignPlanV2.OppositionResearchGenerationStarted,
+          {
+            campaignId: plan.campaignId,
+            planId: plan.id,
+            generationEngine: 'cap',
+            runId,
+            attempt: plan.oppositionAttempts + 1,
+          },
+        )
+        .catch(() => undefined)
+    }
 
     try {
       await this.client.campaignStrategy.update({
@@ -602,6 +673,7 @@ export class CampaignStrategyService
   }
 
   private async attemptOpportunities(
+    userId: number,
     plan: CampaignStrategy,
     base: DispatchBase,
     freshStart: boolean,
@@ -617,6 +689,22 @@ export class CampaignStrategyService
 
     const runId = await this.tryDispatch(OPPORTUNITIES, base)
     if (!runId) return 'stalled'
+
+    if (freshStart) {
+      void this.analytics
+        .track(
+          userId,
+          EVENTS.CampaignPlanV2.OpportunitiesChallengesGenerationStarted,
+          {
+            campaignId: plan.campaignId,
+            planId: plan.id,
+            generationEngine: 'cap',
+            runId,
+            attempt: plan.opportunitiesAttempts + 1,
+          },
+        )
+        .catch(() => undefined)
+    }
 
     try {
       await this.client.campaignStrategy.update({

--- a/src/campaignStrategy/services/communityEvents.service.test.ts
+++ b/src/campaignStrategy/services/communityEvents.service.test.ts
@@ -5,6 +5,7 @@ import { GeminiService } from 'src/vendors/google/services/gemini.service'
 import { CommunityEventsService } from './communityEvents.service'
 import { CommunityEventsPersister } from './communityEvents.persister'
 import { CommunityEventsPromptContext } from './communityEvents.prompts'
+import { AnalyticsService } from '@/analytics/analytics.service'
 
 const buildCtx = (
   overrides: Partial<CommunityEventsPromptContext> = {},
@@ -52,6 +53,9 @@ describe('CommunityEventsService', () => {
       gemini as unknown as GeminiService,
       braintrust as unknown as BraintrustService,
       persister as unknown as CommunityEventsPersister,
+      {
+        track: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AnalyticsService,
       createMockLogger(),
     )
   })
@@ -83,7 +87,7 @@ describe('CommunityEventsService', () => {
       ],
     })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events).toHaveLength(3)
     expect(result.events.map((e) => e.title)).toEqual(['A', 'B', 'C'])
@@ -106,7 +110,7 @@ describe('CommunityEventsService', () => {
       ],
     })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events.map((e) => e.title)).toEqual(['A', 'B', 'C'])
   })
@@ -120,7 +124,7 @@ describe('CommunityEventsService', () => {
       ],
     })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events.map((e) => e.title)).toEqual(['Future'])
   })
@@ -139,7 +143,7 @@ describe('CommunityEventsService', () => {
       ],
     })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events.map((e) => e.title)).toEqual(['OK'])
   })
@@ -152,7 +156,7 @@ describe('CommunityEventsService', () => {
       ],
     })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events.map((e) => e.title)).toEqual(['OK'])
   })
@@ -160,7 +164,7 @@ describe('CommunityEventsService', () => {
   it('returns an empty events array when the model returns no qualifying events', async () => {
     gemini.generateStructured.mockResolvedValue({ events: [] })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events).toEqual([])
     // Persist still fires — the cache shape must distinguish "generated,
@@ -185,7 +189,7 @@ describe('CommunityEventsService', () => {
       ],
     })
 
-    const result = await service.generate(42, 99, buildCtx())
+    const result = await service.generate(42, 99, 7, buildCtx())
 
     expect(result.events.map((e) => e.url)).toEqual([null, null])
     expect(result.events.map((e) => e.address)).toEqual([null, null])
@@ -199,7 +203,7 @@ describe('CommunityEventsService', () => {
     })
     gemini.generateStructured.mockResolvedValue({ events: [] })
 
-    await service.generate(42, 99, buildCtx())
+    await service.generate(42, 99, 7, buildCtx())
 
     const [structuredPrompt] = gemini.generateStructured.mock.calls[0]
     expect(structuredPrompt).toContain('EVENTS_FROM_BR')

--- a/src/campaignStrategy/services/communityEvents.service.ts
+++ b/src/campaignStrategy/services/communityEvents.service.ts
@@ -5,6 +5,8 @@ import { BraintrustService } from 'src/vendors/braintrust/braintrust.service'
 import { GEMINI_MODEL } from 'src/vendors/google/gemini.types'
 import { GeminiService } from 'src/vendors/google/services/gemini.service'
 import { CommunityEvent, CommunityEventsResult } from '@goodparty_org/contracts'
+import { AnalyticsService } from '@/analytics/analytics.service'
+import { EVENTS } from '@/vendors/segment/segment.types'
 import {
   CommunityEventsRaw,
   CommunityEventsRawSchema,
@@ -38,6 +40,7 @@ export class CommunityEventsService {
     private readonly gemini: GeminiService,
     private readonly braintrust: BraintrustService,
     private readonly persister: CommunityEventsPersister,
+    private readonly analytics: AnalyticsService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(CommunityEventsService.name)
@@ -46,9 +49,18 @@ export class CommunityEventsService {
   async generate(
     campaignStrategyId: number,
     campaignId: number,
+    userId: number,
     ctx: CommunityEventsPromptContext,
   ): Promise<CommunityEventsResult> {
     const variables = buildEventsPromptVariables(ctx)
+    const startedAtPerf = performance.now()
+    void this.analytics
+      .track(userId, EVENTS.CampaignPlanV2.CommunityEventsGenerationStarted, {
+        campaignId,
+        planId: campaignStrategyId,
+        generationEngine: 'gemini',
+      })
+      .catch(() => undefined)
 
     const result = await this.braintrust.tracedNested(
       'community-events:generate',
@@ -69,6 +81,15 @@ export class CommunityEventsService {
     )
 
     await this.persister.persist(campaignStrategyId, result)
+    void this.analytics
+      .track(userId, EVENTS.CampaignPlanV2.CommunityEventsGenerationCompleted, {
+        campaignId,
+        planId: campaignStrategyId,
+        generationEngine: 'gemini',
+        durationMs: Math.round(performance.now() - startedAtPerf),
+        eventCount: result.events.length,
+      })
+      .catch(() => undefined)
     return result
   }
 

--- a/src/elections/services/elections.service.test.ts
+++ b/src/elections/services/elections.service.test.ts
@@ -547,6 +547,19 @@ describe('ElectionsService', () => {
 
       expect(result).toBeNull()
     })
+
+    it('forwards the level query param when provided', async () => {
+      mockHttpGet.mockReturnValue(of({ data: [], status: 200 }))
+
+      await service.getVoterIssues({ districtId: 'd-1', level: 'local' })
+
+      expect(mockHttpGet).toHaveBeenCalledWith(
+        expect.stringContaining('voter-issues'),
+        expect.objectContaining({
+          params: { districtId: 'd-1', level: 'local' },
+        }),
+      )
+    })
   })
 
   describe('fetchFilingFeeByRaceHash', () => {

--- a/src/elections/services/elections.service.ts
+++ b/src/elections/services/elections.service.ts
@@ -28,6 +28,7 @@ import {
   RaceTargetDetailsResult,
   RaceTargetMetrics,
   VoterIssue,
+  VoterIssueLevel,
 } from '../types/elections.types'
 
 @Injectable()
@@ -249,11 +250,12 @@ export class ElectionsService {
 
   async getVoterIssues(params: {
     districtId: string
+    level?: VoterIssueLevel
   }): Promise<VoterIssue[] | null> {
-    return this.electionApiGet<VoterIssue[], { districtId: string }>(
-      'voter-issues',
-      params,
-    )
+    return this.electionApiGet<
+      VoterIssue[],
+      { districtId: string; level?: VoterIssueLevel }
+    >('voter-issues', params)
   }
 
   async getDistrictId(

--- a/src/elections/types/elections.types.ts
+++ b/src/elections/types/elections.types.ts
@@ -1,4 +1,7 @@
-import type { RaceTargetMetrics } from '@goodparty_org/contracts'
+import type {
+  BallotReadyPositionLevel,
+  RaceTargetMetrics,
+} from '@goodparty_org/contracts'
 export type { RaceTargetMetrics } from '@goodparty_org/contracts'
 
 export type BDElection = {
@@ -80,6 +83,8 @@ export type VoterIssue = {
   priority: 'high' | 'medium' | 'low'
 }
 
+export type VoterIssueLevel = 'local' | 'regional' | 'state' | 'federal'
+
 export enum ProjectedTurnoutSourceColumns {
   id = 'id',
   createdAt = 'createdAt',
@@ -150,6 +155,7 @@ export type PositionWithOptionalDistrict = {
   brDatabaseId: string
   state: string
   name: string
+  level?: BallotReadyPositionLevel | null
   district?: District
   filingFee?: number | null
   filingRequirementsText?: string | null

--- a/src/elections/util/getVoterIssueLevelFromPositionLevel.util.test.ts
+++ b/src/elections/util/getVoterIssueLevelFromPositionLevel.util.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { getVoterIssueLevelFromPositionLevel } from './getVoterIssueLevelFromPositionLevel.util'
+
+describe('getVoterIssueLevelFromPositionLevel', () => {
+  it.each([
+    ['CITY', 'local'] as const,
+    ['TOWNSHIP', 'local'] as const,
+    ['LOCAL', 'local'] as const,
+    ['COUNTY', 'regional'] as const,
+    ['REGIONAL', 'regional'] as const,
+    ['STATE', 'state'] as const,
+    ['FEDERAL', 'federal'] as const,
+  ])('maps position level %s to voter-issue level %s', (level, expected) => {
+    expect(getVoterIssueLevelFromPositionLevel(level)).toBe(expected)
+  })
+
+  it('returns null for null', () => {
+    expect(getVoterIssueLevelFromPositionLevel(null)).toBeNull()
+  })
+
+  it('returns null for undefined', () => {
+    expect(getVoterIssueLevelFromPositionLevel(undefined)).toBeNull()
+  })
+})

--- a/src/elections/util/getVoterIssueLevelFromPositionLevel.util.ts
+++ b/src/elections/util/getVoterIssueLevelFromPositionLevel.util.ts
@@ -1,0 +1,20 @@
+import { BallotReadyPositionLevel } from '@goodparty_org/contracts'
+import { VoterIssueLevel } from '../types/elections.types'
+
+// Collapse BallotReady's 7 position levels onto the 4 jurisdictional levels
+// the election-api voter-issues filter understands. Mirrors the DATA-1903
+// flag intent: municipal offices act on local issues, county/regional offices
+// on regional issues.
+const LEVEL_MAP: Record<BallotReadyPositionLevel, VoterIssueLevel> = {
+  CITY: 'local',
+  TOWNSHIP: 'local',
+  LOCAL: 'local',
+  COUNTY: 'regional',
+  REGIONAL: 'regional',
+  STATE: 'state',
+  FEDERAL: 'federal',
+}
+
+export const getVoterIssueLevelFromPositionLevel = (
+  level: BallotReadyPositionLevel | null | undefined,
+): VoterIssueLevel | null => (level ? LEVEL_MAP[level] : null)

--- a/src/onboarding/onboardingVoterIssues.controller.test.ts
+++ b/src/onboarding/onboardingVoterIssues.controller.test.ts
@@ -8,42 +8,43 @@ import { OnboardingVoterIssuesController } from './onboardingVoterIssues.control
 describe('OnboardingVoterIssuesController', () => {
   let controller: OnboardingVoterIssuesController
   let getVoterIssues: ReturnType<typeof vi.fn>
-  let getDistrictForOrgSlug: ReturnType<typeof vi.fn>
+  let getDistrictAndLevelForOrgSlug: ReturnType<typeof vi.fn>
 
   const organization = { slug: 'org-slug' } as Organization
 
   beforeEach(() => {
     getVoterIssues = vi.fn()
-    getDistrictForOrgSlug = vi.fn()
+    getDistrictAndLevelForOrgSlug = vi.fn()
     controller = new OnboardingVoterIssuesController(
       { getVoterIssues } as unknown as ElectionsService,
-      { getDistrictForOrgSlug } as unknown as OrganizationsService,
+      { getDistrictAndLevelForOrgSlug } as unknown as OrganizationsService,
     )
   })
 
-  it('resolves the district from the organization and forwards to elections service', async () => {
-    getDistrictForOrgSlug.mockResolvedValue({
-      id: 'd-1',
-      l2Type: 'City',
-      l2Name: 'Los Angeles',
+  it('forwards the district and office level to the elections service', async () => {
+    getDistrictAndLevelForOrgSlug.mockResolvedValue({
+      district: { id: 'd-1', l2Type: 'City', l2Name: 'Poway city' },
+      level: 'local',
     })
     const issues = [
-      { label: 'Education', score: 88, priority: 'high' as const },
+      { label: 'Development', score: 78, priority: 'high' as const },
     ]
     getVoterIssues.mockResolvedValue(issues)
 
     const result = await controller.getVoterIssues(organization)
 
-    expect(getDistrictForOrgSlug).toHaveBeenCalledWith('org-slug')
-    expect(getVoterIssues).toHaveBeenCalledWith({ districtId: 'd-1' })
+    expect(getDistrictAndLevelForOrgSlug).toHaveBeenCalledWith('org-slug')
+    expect(getVoterIssues).toHaveBeenCalledWith({
+      districtId: 'd-1',
+      level: 'local',
+    })
     expect(result).toEqual({ issues })
   })
 
   it('coerces a null upstream response to an empty issues array', async () => {
-    getDistrictForOrgSlug.mockResolvedValue({
-      id: 'd-1',
-      l2Type: 'City',
-      l2Name: 'Los Angeles',
+    getDistrictAndLevelForOrgSlug.mockResolvedValue({
+      district: { id: 'd-1', l2Type: 'City', l2Name: 'Poway city' },
+      level: 'local',
     })
     getVoterIssues.mockResolvedValue(null)
 
@@ -52,8 +53,23 @@ describe('OnboardingVoterIssuesController', () => {
     expect(result).toEqual({ issues: [] })
   })
 
+  it('returns no issues when the office level cannot be resolved', async () => {
+    getDistrictAndLevelForOrgSlug.mockResolvedValue({
+      district: { id: 'd-1', l2Type: 'City', l2Name: 'Poway city' },
+      level: null,
+    })
+
+    const result = await controller.getVoterIssues(organization)
+
+    expect(result).toEqual({ issues: [] })
+    expect(getVoterIssues).not.toHaveBeenCalled()
+  })
+
   it('throws NotFoundException when the organization has no district', async () => {
-    getDistrictForOrgSlug.mockResolvedValue(null)
+    getDistrictAndLevelForOrgSlug.mockResolvedValue({
+      district: null,
+      level: null,
+    })
 
     await expect(controller.getVoterIssues(organization)).rejects.toThrow(
       new NotFoundException(

--- a/src/onboarding/onboardingVoterIssues.controller.ts
+++ b/src/onboarding/onboardingVoterIssues.controller.ts
@@ -33,16 +33,20 @@ export class OnboardingVoterIssuesController {
   async getVoterIssues(
     @ReqOrganization() organization: Organization,
   ): Promise<VoterIssuesResponse> {
-    const district = await this.organizations.getDistrictForOrgSlug(
-      organization.slug,
-    )
+    const { district, level } =
+      await this.organizations.getDistrictAndLevelForOrgSlug(organization.slug)
     if (!district) {
       throw new NotFoundException(
         `No district associated with organization "${organization.slug}"`,
       )
     }
+    // Scope issues to the office's jurisdiction. Without a resolvable level we
+    // return nothing rather than the unfiltered national list, which would
+    // surface federal topics irrelevant to a local race.
+    if (!level) return { issues: [] }
     const issues = await this.elections.getVoterIssues({
       districtId: district.id,
+      level,
     })
     return { issues: issues ?? [] }
   }

--- a/src/onboarding/services/localNews.service.test.ts
+++ b/src/onboarding/services/localNews.service.test.ts
@@ -45,13 +45,15 @@ function makeService() {
     findFirst: vi.fn(),
     model,
   }
+  const analytics = { track: vi.fn().mockResolvedValue(undefined) }
   const service = new OnboardingLocalNewsService(
     gemini as never,
     braintrust as never,
     campaigns as never,
+    analytics as never,
     createMockLogger(),
   )
-  return { service, gemini, braintrust, campaigns, model }
+  return { service, gemini, braintrust, campaigns, model, analytics }
 }
 
 function readyOutlets(extra: { name: string }[] = []) {

--- a/src/onboarding/services/localNews.service.ts
+++ b/src/onboarding/services/localNews.service.ts
@@ -5,6 +5,8 @@ import { BraintrustService } from '@/vendors/braintrust/braintrust.service'
 import { GEMINI_MODEL } from '@/vendors/google/gemini.types'
 import { GeminiService } from '@/vendors/google/services/gemini.service'
 import { CampaignsService } from '@/campaigns/services/campaigns.service'
+import { AnalyticsService } from '@/analytics/analytics.service'
+import { EVENTS } from '@/vendors/segment/segment.types'
 import {
   aiOutletsToolResultSchema,
   LocalNewsOutlet,
@@ -104,6 +106,7 @@ export class OnboardingLocalNewsService {
     private readonly gemini: GeminiService,
     private readonly braintrust: BraintrustService,
     private readonly campaigns: CampaignsService,
+    private readonly analytics: AnalyticsService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(OnboardingLocalNewsService.name)
@@ -155,28 +158,43 @@ export class OnboardingLocalNewsService {
       state,
     })
     if (claimed) {
-      void this.runFetch({ campaignId: campaign.id, city, state, office })
+      void this.runFetch({
+        campaignId: campaign.id,
+        userId: campaign.userId,
+        city,
+        state,
+        office,
+      })
     }
     return { status: 'pending' }
   }
 
   private async runFetch({
     campaignId,
+    userId,
     city,
     state,
     office,
   }: {
     campaignId: number
+    userId: number
     city?: string
     state: string
     office: string
   }): Promise<void> {
     const jurisdiction = city ? `${city}, ${state}` : state
     const startedAt = Date.now()
+    const startedAtPerf = performance.now()
     this.logger.info(
       { jurisdiction, office, campaignId },
       'getLocalNews background fetch started',
     )
+    void this.analytics
+      .track(userId, EVENTS.CampaignPlanV2.MediaGenerationStarted, {
+        campaignId,
+        generationEngine: 'gemini',
+      })
+      .catch(() => undefined)
 
     try {
       const result = await this.braintrust.tracedNested(
@@ -197,6 +215,14 @@ export class OnboardingLocalNewsService {
         { office, city: city ?? null, state },
         result.outlets,
       )
+      void this.analytics
+        .track(userId, EVENTS.CampaignPlanV2.MediaGenerationCompleted, {
+          campaignId,
+          generationEngine: 'gemini',
+          durationMs: Math.round(performance.now() - startedAtPerf),
+          outletCount: result.outlets.length,
+        })
+        .catch(() => undefined)
       this.logger.info(
         {
           jurisdiction,

--- a/src/organizations/services/organizations.service.test.ts
+++ b/src/organizations/services/organizations.service.test.ts
@@ -520,6 +520,42 @@ describe('OrganizationsService', () => {
       expect(result).toEqual({ district: null, level: null })
       expect(mockGetPositionById).not.toHaveBeenCalled()
     })
+
+    it('takes the district from the override but the level from the position when both are set', async () => {
+      mockFindUnique.mockResolvedValue({
+        slug: 'poway',
+        positionId: 'gp-pos-id',
+        overrideDistrictId: 'override-district-1',
+      })
+      mockGetPositionById.mockResolvedValue({
+        id: 'gp-pos-id',
+        name: 'Poway City Council',
+        level: 'CITY',
+        district,
+      })
+      mockGetDistrict.mockResolvedValue({
+        id: 'override-district-1',
+        state: 'CA',
+        L2DistrictType: 'County',
+        L2DistrictName: 'San Diego county',
+      })
+
+      const result = await service.getDistrictAndLevelForOrgSlug('poway')
+
+      expect(result).toEqual({
+        district: {
+          id: 'override-district-1',
+          state: 'CA',
+          l2Type: 'County',
+          l2Name: 'San Diego county',
+        },
+        level: 'local',
+      })
+      expect(mockGetPositionById).toHaveBeenCalledWith('gp-pos-id', {
+        includeDistrict: true,
+      })
+      expect(mockGetDistrict).toHaveBeenCalledWith('override-district-1')
+    })
   })
 
   describe('extractCityFromDistrictName', () => {

--- a/src/organizations/services/organizations.service.test.ts
+++ b/src/organizations/services/organizations.service.test.ts
@@ -8,12 +8,14 @@ describe('OrganizationsService', () => {
   let mockGetPositionByBallotReadyId: ReturnType<typeof vi.fn>
   let mockGetPositionById: ReturnType<typeof vi.fn>
   let mockGetDistrictId: ReturnType<typeof vi.fn>
+  let mockGetDistrict: ReturnType<typeof vi.fn>
   let mockCleanDistrictName: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     mockGetPositionByBallotReadyId = vi.fn().mockResolvedValue(null)
     mockGetPositionById = vi.fn().mockResolvedValue(null)
     mockGetDistrictId = vi.fn().mockResolvedValue(null)
+    mockGetDistrict = vi.fn().mockResolvedValue(null)
     mockCleanDistrictName = vi.fn((name: string) => name)
 
     service = new OrganizationsService(
@@ -21,6 +23,7 @@ describe('OrganizationsService', () => {
         getPositionByBallotReadyId: mockGetPositionByBallotReadyId,
         getPositionById: mockGetPositionById,
         getDistrictId: mockGetDistrictId,
+        getDistrict: mockGetDistrict,
         cleanDistrictName: mockCleanDistrictName,
       } as unknown as ElectionsService,
       createMockClerkEnricher(),
@@ -422,6 +425,99 @@ describe('OrganizationsService', () => {
         ballotReadyPositionId: null,
         positionName: null,
       })
+      expect(mockGetPositionById).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getDistrictAndLevelForOrgSlug', () => {
+    let mockFindUnique: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      mockFindUnique = vi.fn().mockResolvedValue(null)
+      service.findUnique = mockFindUnique as typeof service.findUnique
+    })
+
+    const district = {
+      id: 'district-1',
+      state: 'CA',
+      L2DistrictType: 'City',
+      L2DistrictName: 'Poway city',
+    }
+
+    it('resolves the district and maps the position level', async () => {
+      mockFindUnique.mockResolvedValue({
+        slug: 'poway',
+        positionId: 'gp-pos-id',
+        overrideDistrictId: null,
+      })
+      mockGetPositionById.mockResolvedValue({
+        id: 'gp-pos-id',
+        name: 'Poway City Council',
+        level: 'CITY',
+        district,
+      })
+
+      const result = await service.getDistrictAndLevelForOrgSlug('poway')
+
+      expect(result).toEqual({
+        district: {
+          id: 'district-1',
+          state: 'CA',
+          l2Type: 'City',
+          l2Name: 'Poway city',
+        },
+        level: 'local',
+      })
+      expect(mockGetPositionById).toHaveBeenCalledWith('gp-pos-id', {
+        includeDistrict: true,
+      })
+    })
+
+    it('returns a null level when the position has no level', async () => {
+      mockFindUnique.mockResolvedValue({
+        slug: 'poway',
+        positionId: 'gp-pos-id',
+        overrideDistrictId: null,
+      })
+      mockGetPositionById.mockResolvedValue({
+        id: 'gp-pos-id',
+        name: 'Poway City Council',
+        level: null,
+        district,
+      })
+
+      const result = await service.getDistrictAndLevelForOrgSlug('poway')
+
+      expect(result.district).not.toBeNull()
+      expect(result.level).toBeNull()
+    })
+
+    it('resolves the override district with a null level when there is no position', async () => {
+      mockFindUnique.mockResolvedValue({
+        slug: 'poway',
+        positionId: null,
+        overrideDistrictId: 'district-1',
+      })
+      mockGetDistrict.mockResolvedValue(district)
+
+      const result = await service.getDistrictAndLevelForOrgSlug('poway')
+
+      expect(result).toEqual({
+        district: {
+          id: 'district-1',
+          state: 'CA',
+          l2Type: 'City',
+          l2Name: 'Poway city',
+        },
+        level: null,
+      })
+      expect(mockGetPositionById).not.toHaveBeenCalled()
+    })
+
+    it('returns null district and level when the org is not found', async () => {
+      const result = await service.getDistrictAndLevelForOrgSlug('missing')
+
+      expect(result).toEqual({ district: null, level: null })
       expect(mockGetPositionById).not.toHaveBeenCalled()
     })
   })

--- a/src/organizations/services/organizations.service.ts
+++ b/src/organizations/services/organizations.service.ts
@@ -1,4 +1,6 @@
 import { ElectionsService } from '@/elections/services/elections.service'
+import { VoterIssueLevel } from '@/elections/types/elections.types'
+import { getVoterIssueLevelFromPositionLevel } from '@/elections/util/getVoterIssueLevelFromPositionLevel.util'
 import {
   BadRequestException,
   Injectable,
@@ -419,6 +421,43 @@ export class OrganizationsService extends createPrismaBase(
     if (!org) return null
 
     return this.resolveDistrict(org)
+  }
+
+  // Resolves both the district and the office's voter-issue level in a single
+  // position fetch, so the onboarding voter-issues endpoint can scope issues to
+  // the candidate's jurisdiction without a second election-api round-trip.
+  async getDistrictAndLevelForOrgSlug(slug: string): Promise<{
+    district: OrgDistrict | null
+    level: VoterIssueLevel | null
+  }> {
+    const org = await this.findUnique({ where: { slug } })
+    if (!org) return { district: null, level: null }
+
+    const [position, overrideDistrict] = await Promise.all([
+      org.positionId
+        ? this.electionsService.getPositionById(org.positionId, {
+            includeDistrict: true,
+          })
+        : Promise.resolve(null),
+      org.overrideDistrictId
+        ? this.electionsService.getDistrict(org.overrideDistrictId)
+        : Promise.resolve(null),
+    ])
+
+    const rawDistrict = overrideDistrict ?? position?.district
+    const district: OrgDistrict | null = rawDistrict
+      ? {
+          id: rawDistrict.id,
+          state: rawDistrict.state,
+          l2Type: rawDistrict.L2DistrictType,
+          l2Name: rawDistrict.L2DistrictName,
+        }
+      : null
+
+    return {
+      district,
+      level: getVoterIssueLevelFromPositionLevel(position?.level),
+    }
   }
 
   async resolveServeContext(org: Organization): Promise<{

--- a/src/outreach/services/outreach.service.test.ts
+++ b/src/outreach/services/outreach.service.test.ts
@@ -34,6 +34,7 @@ const mockTcrFindFirstOrThrow = vi.fn()
 const mockPeerlyCreateJob = vi.fn()
 const mockResolveP2pJobGeography = vi.fn()
 const mockNotifySuccess = vi.fn()
+const mockFindVoterFileFilter = vi.fn()
 
 vi.mock('../util/campaignGeography.util', () => ({
   resolveP2pJobGeography: (
@@ -55,6 +56,7 @@ describe('OutreachService', () => {
   const mockCampaign = {
     id: 1,
     slug: 'jane-doe',
+    organizationSlug: 'org-test',
     aiContent: {},
     data: { hubspotId: 'hub-1' },
     details: null,
@@ -89,6 +91,7 @@ describe('OutreachService', () => {
     mockResolveP2pJobGeography.mockReset()
     mockNotifySuccess.mockReset()
     mockNotifySuccess.mockResolvedValue(undefined)
+    mockFindVoterFileFilter.mockReset()
 
     const mockPrismaService = {
       outreach: {
@@ -125,7 +128,7 @@ describe('OutreachService', () => {
         {
           provide: VoterFileFilterService,
           useValue: {
-            findByIdAndOrganizationSlug: vi.fn(),
+            findByIdAndOrganizationSlug: mockFindVoterFileFilter,
           },
         },
         OutreachService,
@@ -330,6 +333,53 @@ describe('OutreachService', () => {
       ).rejects.toThrow(/filename and MIME type|Peerly job setup/)
 
       expect(mockTcrFindFirstOrThrow).not.toHaveBeenCalled()
+      expect(mockOutreachCreate).not.toHaveBeenCalled()
+    })
+
+    it('succeeds when voterFileFilterId belongs to the campaign org', async () => {
+      const dto: CreateOutreachSchema = {
+        ...baseCreateDto,
+        voterFileFilterId: 42,
+      }
+      mockFindVoterFileFilter.mockResolvedValue({
+        id: 42,
+        organizationSlug: 'org-test',
+      })
+      const created = {
+        id: 1,
+        ...dto,
+        voterFileFilter: { id: 42 },
+      }
+      mockOutreachCreate.mockResolvedValue(created)
+
+      const result = await service.create(
+        mockUser,
+        mockCampaign,
+        dto,
+        undefined,
+        undefined,
+      )
+
+      expect(mockFindVoterFileFilter).toHaveBeenCalledWith(42, 'org-test')
+      expect(mockOutreachCreate).toHaveBeenCalledTimes(1)
+      expect(result).toEqual(created)
+    })
+
+    it('throws BadRequest when voterFileFilterId does not belong to the campaign org', async () => {
+      const dto: CreateOutreachSchema = {
+        ...baseCreateDto,
+        voterFileFilterId: 99,
+      }
+      mockFindVoterFileFilter.mockResolvedValue(null)
+
+      await expect(
+        service.create(mockUser, mockCampaign, dto, undefined, undefined),
+      ).rejects.toThrow(BadRequestException)
+      await expect(
+        service.create(mockUser, mockCampaign, dto, undefined, undefined),
+      ).rejects.toThrow(/Voter file filter not found/)
+
+      expect(mockFindVoterFileFilter).toHaveBeenCalledWith(99, 'org-test')
       expect(mockOutreachCreate).not.toHaveBeenCalled()
     })
 

--- a/src/outreach/services/outreach.service.test.ts
+++ b/src/outreach/services/outreach.service.test.ts
@@ -384,8 +384,8 @@ describe('OutreachService', () => {
         service.create(mockUser, mockCampaign, dto, undefined, undefined),
       ).rejects.toThrow(/Voter file filter not found/)
 
+      expect(mockFilterAccessCheck).toHaveBeenCalledWith('org-test')
       expect(mockFindVoterFileFilter).toHaveBeenCalledWith(99, 'org-test')
-      expect(mockFilterAccessCheck).not.toHaveBeenCalled()
       expect(mockOutreachCreate).not.toHaveBeenCalled()
     })
 
@@ -394,10 +394,6 @@ describe('OutreachService', () => {
         ...baseCreateDto,
         voterFileFilterId: 42,
       }
-      mockFindVoterFileFilter.mockResolvedValue({
-        id: 42,
-        organizationSlug: 'org-test',
-      })
       mockFilterAccessCheck.mockRejectedValue(
         new BadRequestException('Campaign is not pro'),
       )
@@ -409,6 +405,7 @@ describe('OutreachService', () => {
         service.create(mockUser, mockCampaign, dto, undefined, undefined),
       ).rejects.toThrow(/Campaign is not pro/)
 
+      expect(mockFindVoterFileFilter).not.toHaveBeenCalled()
       expect(mockOutreachCreate).not.toHaveBeenCalled()
     })
 

--- a/src/outreach/services/outreach.service.test.ts
+++ b/src/outreach/services/outreach.service.test.ts
@@ -17,6 +17,7 @@ import { AreaCodeFromZipService } from 'src/ai/util/areaCodeFromZip.util'
 import { CampaignTcrComplianceService } from 'src/campaigns/tcrCompliance/services/campaignTcrCompliance.service'
 import { PrismaService } from 'src/prisma/prisma.service'
 import { GooglePlacesService } from 'src/vendors/google/services/google-places.service'
+import { VoterFileFilterService } from 'src/voters/services/voterFileFilter.service'
 import { PeerlyP2pJobService } from 'src/vendors/peerly/services/peerlyP2pJob.service'
 import type {
   CampaignGeographyInput,
@@ -120,6 +121,12 @@ describe('OutreachService', () => {
         {
           provide: OutreachNotificationService,
           useValue: { notifySuccess: mockNotifySuccess },
+        },
+        {
+          provide: VoterFileFilterService,
+          useValue: {
+            findByIdAndOrganizationSlug: vi.fn(),
+          },
         },
         OutreachService,
       ],

--- a/src/outreach/services/outreach.service.test.ts
+++ b/src/outreach/services/outreach.service.test.ts
@@ -35,6 +35,7 @@ const mockPeerlyCreateJob = vi.fn()
 const mockResolveP2pJobGeography = vi.fn()
 const mockNotifySuccess = vi.fn()
 const mockFindVoterFileFilter = vi.fn()
+const mockFilterAccessCheck = vi.fn()
 
 vi.mock('../util/campaignGeography.util', () => ({
   resolveP2pJobGeography: (
@@ -92,6 +93,8 @@ describe('OutreachService', () => {
     mockNotifySuccess.mockReset()
     mockNotifySuccess.mockResolvedValue(undefined)
     mockFindVoterFileFilter.mockReset()
+    mockFilterAccessCheck.mockReset()
+    mockFilterAccessCheck.mockResolvedValue(undefined)
 
     const mockPrismaService = {
       outreach: {
@@ -129,6 +132,7 @@ describe('OutreachService', () => {
           provide: VoterFileFilterService,
           useValue: {
             findByIdAndOrganizationSlug: mockFindVoterFileFilter,
+            filterAccessCheck: mockFilterAccessCheck,
           },
         },
         OutreachService,
@@ -361,11 +365,12 @@ describe('OutreachService', () => {
       )
 
       expect(mockFindVoterFileFilter).toHaveBeenCalledWith(42, 'org-test')
+      expect(mockFilterAccessCheck).toHaveBeenCalledWith('org-test')
       expect(mockOutreachCreate).toHaveBeenCalledTimes(1)
       expect(result).toEqual(created)
     })
 
-    it('throws BadRequest when voterFileFilterId does not belong to the campaign org', async () => {
+    it('throws NotFoundException when voterFileFilterId does not belong to the campaign org', async () => {
       const dto: CreateOutreachSchema = {
         ...baseCreateDto,
         voterFileFilterId: 99,
@@ -374,12 +379,36 @@ describe('OutreachService', () => {
 
       await expect(
         service.create(mockUser, mockCampaign, dto, undefined, undefined),
-      ).rejects.toThrow(BadRequestException)
+      ).rejects.toThrow(NotFoundException)
       await expect(
         service.create(mockUser, mockCampaign, dto, undefined, undefined),
       ).rejects.toThrow(/Voter file filter not found/)
 
       expect(mockFindVoterFileFilter).toHaveBeenCalledWith(99, 'org-test')
+      expect(mockFilterAccessCheck).not.toHaveBeenCalled()
+      expect(mockOutreachCreate).not.toHaveBeenCalled()
+    })
+
+    it('throws BadRequest when filterAccessCheck rejects a non-pro campaign', async () => {
+      const dto: CreateOutreachSchema = {
+        ...baseCreateDto,
+        voterFileFilterId: 42,
+      }
+      mockFindVoterFileFilter.mockResolvedValue({
+        id: 42,
+        organizationSlug: 'org-test',
+      })
+      mockFilterAccessCheck.mockRejectedValue(
+        new BadRequestException('Campaign is not pro'),
+      )
+
+      await expect(
+        service.create(mockUser, mockCampaign, dto, undefined, undefined),
+      ).rejects.toThrow(BadRequestException)
+      await expect(
+        service.create(mockUser, mockCampaign, dto, undefined, undefined),
+      ).rejects.toThrow(/Campaign is not pro/)
+
       expect(mockOutreachCreate).not.toHaveBeenCalled()
     })
 

--- a/src/outreach/services/outreach.service.ts
+++ b/src/outreach/services/outreach.service.ts
@@ -16,6 +16,7 @@ import { DateFormats, formatDate } from 'src/shared/util/date.util'
 import { GooglePlacesService } from 'src/vendors/google/services/google-places.service'
 import { PeerlyP2pJobService } from 'src/vendors/peerly/services/peerlyP2pJob.service'
 import { Readable } from 'stream'
+import { VoterFileFilterService } from 'src/voters/services/voterFileFilter.service'
 import { CreateOutreachSchema } from '../schemas/createOutreachSchema'
 import {
   resolveP2pJobGeography as resolveP2pJobGeographyUtil,
@@ -42,6 +43,7 @@ export class OutreachService extends createPrismaBase(MODELS.Outreach) {
     private readonly tcrComplianceService: CampaignTcrComplianceService,
     private readonly peerlyP2pJobService: PeerlyP2pJobService,
     private readonly notificationService: OutreachNotificationService,
+    private readonly voterFileFilterService: VoterFileFilterService,
   ) {
     super()
   }
@@ -137,6 +139,17 @@ export class OutreachService extends createPrismaBase(MODELS.Outreach) {
     imageUrl?: string,
     p2pImage?: P2pOutreachImageInput,
   ) {
+    if (createOutreachDto.voterFileFilterId) {
+      const filter =
+        await this.voterFileFilterService.findByIdAndOrganizationSlug(
+          createOutreachDto.voterFileFilterId,
+          campaign.organizationSlug,
+        )
+      if (!filter) {
+        throw new BadRequestException('Voter file filter not found')
+      }
+    }
+
     const isP2p = createOutreachDto.outreachType === OutreachType.p2p
 
     if (isP2p) {

--- a/src/outreach/services/outreach.service.ts
+++ b/src/outreach/services/outreach.service.ts
@@ -140,6 +140,9 @@ export class OutreachService extends createPrismaBase(MODELS.Outreach) {
     p2pImage?: P2pOutreachImageInput,
   ) {
     if (createOutreachDto.voterFileFilterId) {
+      await this.voterFileFilterService.filterAccessCheck(
+        campaign.organizationSlug,
+      )
       const filter =
         await this.voterFileFilterService.findByIdAndOrganizationSlug(
           createOutreachDto.voterFileFilterId,
@@ -148,9 +151,6 @@ export class OutreachService extends createPrismaBase(MODELS.Outreach) {
       if (!filter) {
         throw new NotFoundException('Voter file filter not found')
       }
-      await this.voterFileFilterService.filterAccessCheck(
-        campaign.organizationSlug,
-      )
     }
 
     const isP2p = createOutreachDto.outreachType === OutreachType.p2p

--- a/src/outreach/services/outreach.service.ts
+++ b/src/outreach/services/outreach.service.ts
@@ -146,8 +146,11 @@ export class OutreachService extends createPrismaBase(MODELS.Outreach) {
           campaign.organizationSlug,
         )
       if (!filter) {
-        throw new BadRequestException('Voter file filter not found')
+        throw new NotFoundException('Voter file filter not found')
       }
+      await this.voterFileFilterService.filterAccessCheck(
+        campaign.organizationSlug,
+      )
     }
 
     const isP2p = createOutreachDto.outreachType === OutreachType.p2p

--- a/src/vendors/segment/segment.types.ts
+++ b/src/vendors/segment/segment.types.ts
@@ -50,6 +50,26 @@ export const EVENTS = {
     //  ⚠️  DO NOT MODIFY - Used by HubSpot workflows for weekly task digest emails
     WeeklyTasksDigest: 'Campaign Plan - Weekly Tasks Digest',
   },
+  // Server-side generation for the V2 onboarding campaign plan. The strategic
+  // landscape (CAP/PMF engine) fans out into two independent agent jobs, so it
+  // gets four events. The webapp's view of these is tracked separately under
+  // `Onboarding V2 -` in gp-webapp.
+  CampaignPlanV2: {
+    MediaGenerationStarted: 'Campaign Plan V2 - Media Generation Started',
+    MediaGenerationCompleted: 'Campaign Plan V2 - Media Generation Completed',
+    CommunityEventsGenerationStarted:
+      'Campaign Plan V2 - Community Events Generation Started',
+    CommunityEventsGenerationCompleted:
+      'Campaign Plan V2 - Community Events Generation Completed',
+    OppositionResearchGenerationStarted:
+      'Campaign Plan V2 - Opposition Research Generation Started',
+    OppositionResearchGenerationCompleted:
+      'Campaign Plan V2 - Opposition Research Generation Completed',
+    OpportunitiesChallengesGenerationStarted:
+      'Campaign Plan V2 - Opportunities & Challenges Generation Started',
+    OpportunitiesChallengesGenerationCompleted:
+      'Campaign Plan V2 - Opportunities & Challenges Generation Completed',
+  },
 }
 
 export type UserContext = {


### PR DESCRIPTION
This PR releases gp-api to Prod.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding voter-issues product behavior and adds outreach authorization around voter file filters; analytics and async tracking are low risk but touch multiple user-facing flows.
> 
> **Overview**
> Adds **Campaign Plan V2** server-side Segment analytics for CAP strategic landscape (opposition research and opportunities/challenges start on fresh dispatch, completion after S3 persist), Gemini community events, and onboarding local media generation. Tracking is fire-and-forget and does not block generation paths.
> 
> **Onboarding voter issues** are now scoped by office jurisdiction: organizations resolve district plus a mapped BallotReady position level (`getDistrictAndLevelForOrgSlug`), election-api `getVoterIssues` receives an optional `level`, and the API returns an empty list when level cannot be resolved instead of an unfiltered issue set.
> 
> **Outreach create** validates optional `voterFileFilterId` with pro-campaign access checks and org-scoped filter lookup before persisting outreach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c01fa2f4164825346b4f2f279f829537d4a1834d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->